### PR TITLE
Add core:internals module with primitive stringify functions

### DIFF
--- a/compiler.md
+++ b/compiler.md
@@ -56,6 +56,19 @@ The `builtin` namespace provides raw Wasm GC types with no abstraction:
 - `builtin::i31ref` - Wasm GC i31ref (31-bit integer reference)
 - Intrinsic functions: `array_new`, `array_len`, `array_get`, `array_set`, `i31ref_new`, `i31ref_get_s`, `i31ref_get_u`, `eqref`, `unreachable`
 
+**Compiler Utilities Layer (`core:internals`):**
+
+The `core:internals` module provides utility functions implemented in Wado for compiler use:
+
+- String conversion: `stringify_bool`, `stringify_i32`, `stringify_u64`, etc.
+- Used internally by the compiler for template string interpolation
+- **Key difference from `builtin::`**: These have Wado-level implementations (not Wasm intrinsics)
+
+**Why the distinction?**
+
+- **`builtin::`**: No Wado implementation - compiler directly generates Wasm instructions (e.g., `array.new`, `array.get`)
+- **`core:internals`**: Has Wado implementation - avoids complexity of implementing algorithms (like itoa) in raw Wasm
+
 **Standard Library Types:**
 
 Standard library types wrap builtins with methods:
@@ -273,7 +286,14 @@ Wado supports template strings with interpolation using backticks and `{expr}` s
 
 ### String Conversion Utilities
 
-The `core:internals` module provides Wado-level implementations for converting primitive types to strings. Unlike `builtin::` functions (which have no Wado representation), these are actual Wado functions that can be called and tested.
+The `core:internals` module provides Wado-level implementations for converting primitive types to strings.
+
+**Key Design Decision:**
+
+- **`builtin::` functions**: Have no Wado implementation - compiler directly generates Wasm instructions
+- **`core:internals` functions**: Implemented in Wado - avoids the complexity of writing algorithms like itoa/dtoa in raw Wasm
+
+This separation allows the standard library to use `builtin::` primitives (like `array_new`, `array_get`) while implementing higher-level logic in readable Wado code.
 
 **Stringify Functions (in `core/internals.wado`):**
 
@@ -313,7 +333,52 @@ stringify_f64(value: f64) -> String
 - ⚠️ `stringify_i128, u128`: Placeholder (needs 128-bit arithmetic)
 - ⚠️ `stringify_f32, f64`: Placeholder (needs dtoa algorithm)
 
-These functions are implemented in Wado using `builtin::array_*` operations, avoiding the complexity of implementing string conversion in raw Wasm codegen.
+**Implementation Example:**
+
+```wado
+// From core/internals.wado - stringify_i32 implementation
+pub fn stringify_i32(value: i32) -> String {
+    if value == 0 {
+        return "0";
+    }
+
+    let mut n = value;
+    let is_negative = n < 0;
+    if is_negative {
+        n = -n;
+    }
+
+    // Convert to decimal digits using builtin::array operations
+    let mut digits: builtin::array<u8> = builtin::array_new<u8>(11);
+    let mut len = 0;
+
+    while n > 0 {
+        let digit = (n % 10) as u8;
+        builtin::array_set(digits, len, digit + 48); // '0' = 48
+        n = n / 10;
+        len = len + 1;
+    }
+
+    // Add minus sign if negative
+    if is_negative {
+        builtin::array_set(digits, len, 45); // '-' = 45
+        len = len + 1;
+    }
+
+    // Reverse the digits
+    let mut result = builtin::array_new<u8>(len);
+    let mut i = 0;
+    while i < len {
+        let digit = builtin::array_get(digits, len - 1 - i);
+        builtin::array_set(result, i, digit);
+        i = i + 1;
+    }
+
+    return result as String;
+}
+```
+
+These functions are implemented in Wado using `builtin::array_*` operations, avoiding the complexity of implementing string conversion algorithms in raw Wasm codegen.
 
 ### Syntax
 

--- a/compiler.md
+++ b/compiler.md
@@ -271,9 +271,9 @@ fn main() with Stdout {
 
 Wado supports template strings with interpolation using backticks and `{expr}` syntax, similar to JavaScript but with Python-like format specifiers.
 
-### Compiler Intrinsics for Type Conversion
+### String Conversion Utilities
 
-The `core:internals` module provides compiler intrinsics for converting primitive types to strings. These functions are used by the code generator when compiling template string interpolations.
+The `core:internals` module provides Wado-level implementations for converting primitive types to strings. Unlike `builtin::` functions (which have no Wado representation), these are actual Wado functions that can be called and tested.
 
 **Stringify Functions (in `core/internals.wado`):**
 
@@ -302,7 +302,18 @@ stringify_f32(value: f32) -> String
 stringify_f64(value: f64) -> String
 ```
 
-These functions have no body in Wado - they are compiler intrinsics. The code generator (codegen.rs) recognizes calls to these functions and generates the appropriate Wasm instructions directly.
+**Implementation Status:**
+
+- ✅ `stringify_bool`: Complete (returns "true" or "false")
+- ✅ `stringify_i8, i16, i32`: Complete (itoa algorithm)
+- ✅ `stringify_i64`: Complete (itoa algorithm)
+- ✅ `stringify_u8, u16, u32`: Complete (itoa algorithm)
+- ✅ `stringify_u64`: Complete (itoa algorithm)
+- ⚠️ `stringify_char`: Placeholder (needs UTF-8 encoding)
+- ⚠️ `stringify_i128, u128`: Placeholder (needs 128-bit arithmetic)
+- ⚠️ `stringify_f32, f64`: Placeholder (needs dtoa algorithm)
+
+These functions are implemented in Wado using `builtin::array_*` operations, avoiding the complexity of implementing string conversion in raw Wasm codegen.
 
 ### Syntax
 
@@ -429,16 +440,16 @@ pub struct FormatSpec {
 
 ### Next Steps for Full Implementation
 
-1. **✅ DONE: Add stringify intrinsics** for primitive types (in `core/internals.wado`):
-   - All primitive type conversions defined
-   - Functions declared as compiler intrinsics (no body)
-   - Ready for codegen.rs implementation
+1. **✅ DONE: Add stringify functions** for primitive types (in `core/internals.wado`):
+   - All primitive type conversions defined with Wado implementations
+   - Bool, i8-i64, u8-u64: Complete implementations
+   - Char, i128/u128, floats: Placeholder (to be implemented)
+   - Uses `builtin::array_*` operations for string building
 
-2. **Implement codegen support** for stringify intrinsics:
-   - Recognize calls to `core:internals::stringify_*` functions
-   - Generate appropriate Wasm code for type-to-string conversion
-   - Use itoa/dtoa algorithms for integers/floats
-   - Generate string literals for bool ("true"/"false")
+2. **Compiler integration** for template strings:
+   - Codegen should call `core:internals::stringify_*` when needed
+   - Type inference to select appropriate stringify function
+   - No special codegen needed - just regular function calls
 
 3. **Implement format specifier handling**:
    - Parse format spec (precision, padding, alignment)

--- a/compiler.md
+++ b/compiler.md
@@ -36,6 +36,7 @@ Embedded `.wado` files in `wado-compiler/lib/`:
 | `core:cli`        | `cli.wado`        | Complete                                           |
 | `core:filesystem` | `filesystem.wado` | Complete                                           |
 | `core:stream`     | `stream.wado`     | Complete                                           |
+| `core:internals`  | `internals.wado`  | Complete (compiler intrinsics for codegen)         |
 
 **WASI Library (`wasi/`):**
 
@@ -270,6 +271,39 @@ fn main() with Stdout {
 
 Wado supports template strings with interpolation using backticks and `{expr}` syntax, similar to JavaScript but with Python-like format specifiers.
 
+### Compiler Intrinsics for Type Conversion
+
+The `core:internals` module provides compiler intrinsics for converting primitive types to strings. These functions are used by the code generator when compiling template string interpolations.
+
+**Stringify Functions (in `core/internals.wado`):**
+
+```wado
+// Boolean conversion
+stringify_bool(value: bool) -> String          // "true" or "false"
+
+// Character conversion
+stringify_char(value: char) -> String          // Single character
+
+// Integer conversions
+stringify_i8(value: i8) -> String
+stringify_i16(value: i16) -> String
+stringify_i32(value: i32) -> String
+stringify_i64(value: i64) -> String
+stringify_i128(value: i128) -> String
+
+stringify_u8(value: u8) -> String
+stringify_u16(value: u16) -> String
+stringify_u32(value: u32) -> String
+stringify_u64(value: u64) -> String
+stringify_u128(value: u128) -> String
+
+// Float conversions
+stringify_f32(value: f32) -> String
+stringify_f64(value: f64) -> String
+```
+
+These functions have no body in Wado - they are compiler intrinsics. The code generator (codegen.rs) recognizes calls to these functions and generates the appropriate Wasm instructions directly.
+
 ### Syntax
 
 ```wado
@@ -395,19 +429,22 @@ pub struct FormatSpec {
 
 ### Next Steps for Full Implementation
 
-1. **Add `to_string()` intrinsics** for primitive types:
+1. **✅ DONE: Add stringify intrinsics** for primitive types (in `core/internals.wado`):
+   - All primitive type conversions defined
+   - Functions declared as compiler intrinsics (no body)
+   - Ready for codegen.rs implementation
 
-   ```wado
-   builtin::i32_to_string(value: i32) -> builtin::array<u8>
-   builtin::f64_to_string(value: f64) -> builtin::array<u8>
-   builtin::bool_to_string(value: bool) -> builtin::array<u8>
-   ```
+2. **Implement codegen support** for stringify intrinsics:
+   - Recognize calls to `core:internals::stringify_*` functions
+   - Generate appropriate Wasm code for type-to-string conversion
+   - Use itoa/dtoa algorithms for integers/floats
+   - Generate string literals for bool ("true"/"false")
 
-2. **Implement format specifier handling**:
+3. **Implement format specifier handling**:
    - Parse format spec (precision, padding, alignment)
    - Pass to appropriate formatting intrinsic
 
-3. **Implement efficient array concatenation**:
+4. **Implement efficient array concatenation**:
 
    ```wat
    ;; Calculate total length
@@ -424,7 +461,7 @@ pub struct FormatSpec {
    ;; Repeat for each part at appropriate offset
    ```
 
-4. **Add E2E tests** for runtime execution with wasmtime
+5. **Add E2E tests** for runtime execution with wasmtime
 
 ---
 

--- a/wado-compiler/lib/core/internals.wado
+++ b/wado-compiler/lib/core/internals.wado
@@ -1,0 +1,120 @@
+// Wado Compiler Internals Module
+//
+// This module provides low-level functions used by the compiler for code generation.
+// These functions are NOT intended for direct use by user code.
+//
+// Primary use case: String template interpolation
+// When compiling `Hello, {value}!`, the compiler needs to convert `value` to a string.
+// Since Wado has no function overloading, we provide separate stringify functions
+// for each primitive type.
+//
+// These functions are compiler intrinsics - their implementations are generated
+// directly by the compiler (codegen.rs) rather than being written in Wado.
+
+// ============================================================================
+// String Conversion Functions (Compiler Intrinsics)
+// ============================================================================
+
+/// Convert a boolean value to a string
+/// Returns "true" or "false"
+///
+/// Compiler intrinsic for template interpolation: `{bool_value}`
+pub fn stringify_bool(value: bool) -> String;
+
+/// Convert a char to a string
+/// Returns a string containing the single character
+///
+/// Compiler intrinsic for template interpolation: `{char_value}`
+pub fn stringify_char(value: char) -> String;
+
+/// Convert an i8 to a string
+/// Returns the decimal representation with optional minus sign
+///
+/// Compiler intrinsic for template interpolation: `{i8_value}`
+pub fn stringify_i8(value: i8) -> String;
+
+/// Convert an i16 to a string
+/// Returns the decimal representation with optional minus sign
+///
+/// Compiler intrinsic for template interpolation: `{i16_value}`
+pub fn stringify_i16(value: i16) -> String;
+
+/// Convert an i32 to a string
+/// Returns the decimal representation with optional minus sign
+///
+/// Compiler intrinsic for template interpolation: `{i32_value}`
+pub fn stringify_i32(value: i32) -> String;
+
+/// Convert an i64 to a string
+/// Returns the decimal representation with optional minus sign
+///
+/// Compiler intrinsic for template interpolation: `{i64_value}`
+pub fn stringify_i64(value: i64) -> String;
+
+/// Convert an i128 to a string
+/// Returns the decimal representation with optional minus sign
+///
+/// Compiler intrinsic for template interpolation: `{i128_value}`
+pub fn stringify_i128(value: i128) -> String;
+
+/// Convert a u8 to a string
+/// Returns the decimal representation
+///
+/// Compiler intrinsic for template interpolation: `{u8_value}`
+pub fn stringify_u8(value: u8) -> String;
+
+/// Convert a u16 to a string
+/// Returns the decimal representation
+///
+/// Compiler intrinsic for template interpolation: `{u16_value}`
+pub fn stringify_u16(value: u16) -> String;
+
+/// Convert a u32 to a string
+/// Returns the decimal representation
+///
+/// Compiler intrinsic for template interpolation: `{u32_value}`
+pub fn stringify_u32(value: u32) -> String;
+
+/// Convert a u64 to a string
+/// Returns the decimal representation
+///
+/// Compiler intrinsic for template interpolation: `{u64_value}`
+pub fn stringify_u64(value: u64) -> String;
+
+/// Convert a u128 to a string
+/// Returns the decimal representation
+///
+/// Compiler intrinsic for template interpolation: `{u128_value}`
+pub fn stringify_u128(value: u128) -> String;
+
+/// Convert an f32 to a string
+/// Returns the decimal representation (e.g., "3.14")
+///
+/// Compiler intrinsic for template interpolation: `{f32_value}`
+pub fn stringify_f32(value: f32) -> String;
+
+/// Convert an f64 to a string
+/// Returns the decimal representation (e.g., "3.14159")
+///
+/// Compiler intrinsic for template interpolation: `{f64_value}`
+pub fn stringify_f64(value: f64) -> String;
+
+// ============================================================================
+// Notes on Implementation
+// ============================================================================
+
+// These functions have no body because they are compiler intrinsics.
+// The code generator (codegen.rs) recognizes calls to these functions
+// and generates the appropriate Wasm instructions directly.
+//
+// Implementation strategy (in codegen.rs):
+// 1. Recognize calls to core:internals::stringify_*
+// 2. Generate appropriate string conversion code:
+//    - For integers: Use itoa-style algorithm
+//    - For floats: Use dtoa-style algorithm (or Wasm f32.to_string if available)
+//    - For bool: Generate "true" or "false" literal
+//    - For char: Create single-character string
+//
+// Future extensions:
+// - Format specifiers: stringify_i32_fmt(value: i32, fmt: FormatSpec) -> String
+// - Custom Debug/Display traits: stringify_debug<T>(value: T) -> String

--- a/wado-compiler/lib/core/internals.wado
+++ b/wado-compiler/lib/core/internals.wado
@@ -120,7 +120,7 @@ pub fn stringify_i32(value: i32) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    for let mut i = 0; i < len; i = i + 1 {
+    for (let mut i = 0; i < len; i = i + 1) {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
     }
@@ -167,7 +167,7 @@ pub fn stringify_i64(value: i64) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    for let mut i = 0; i < len; i = i + 1 {
+    for (let mut i = 0; i < len; i = i + 1) {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
     }
@@ -224,7 +224,7 @@ pub fn stringify_u32(value: u32) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    for let mut i = 0; i < len; i = i + 1 {
+    for (let mut i = 0; i < len; i = i + 1) {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
     }
@@ -256,7 +256,7 @@ pub fn stringify_u64(value: u64) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    for let mut i = 0; i < len; i = i + 1 {
+    for (let mut i = 0; i < len; i = i + 1) {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
     }

--- a/wado-compiler/lib/core/internals.wado
+++ b/wado-compiler/lib/core/internals.wado
@@ -32,10 +32,40 @@ pub fn stringify_bool(value: bool) -> String {
 ///
 /// Used in template interpolation: `{char_value}`
 pub fn stringify_char(value: char) -> String {
-    // For now, return a placeholder
-    // TODO: Implement proper char to string conversion
-    // Need to encode the Unicode code point as UTF-8 bytes
-    return "?";
+    // char is a Unicode code point (u32), convert to UTF-8 bytes
+    let codepoint = value as u32;
+
+    // 1-byte sequence (U+0000..U+007F)
+    if codepoint <= 0x7F {
+        let mut result = builtin::array_new<u8>(1);
+        builtin::array_set(result, 0, codepoint as u8);
+        return result as String;
+    }
+
+    // 2-byte sequence (U+0080..U+07FF)
+    if codepoint <= 0x7FF {
+        let mut result = builtin::array_new<u8>(2);
+        builtin::array_set(result, 0, (0xC0 | (codepoint >> 6)) as u8);
+        builtin::array_set(result, 1, (0x80 | (codepoint & 0x3F)) as u8);
+        return result as String;
+    }
+
+    // 3-byte sequence (U+0800..U+FFFF)
+    if codepoint <= 0xFFFF {
+        let mut result = builtin::array_new<u8>(3);
+        builtin::array_set(result, 0, (0xE0 | (codepoint >> 12)) as u8);
+        builtin::array_set(result, 1, (0x80 | ((codepoint >> 6) & 0x3F)) as u8);
+        builtin::array_set(result, 2, (0x80 | (codepoint & 0x3F)) as u8);
+        return result as String;
+    }
+
+    // 4-byte sequence (U+10000..U+10FFFF)
+    let mut result = builtin::array_new<u8>(4);
+    builtin::array_set(result, 0, (0xF0 | (codepoint >> 18)) as u8);
+    builtin::array_set(result, 1, (0x80 | ((codepoint >> 12) & 0x3F)) as u8);
+    builtin::array_set(result, 2, (0x80 | ((codepoint >> 6) & 0x3F)) as u8);
+    builtin::array_set(result, 3, (0x80 | (codepoint & 0x3F)) as u8);
+    return result as String;
 }
 
 /// Convert an i8 to a string
@@ -90,11 +120,9 @@ pub fn stringify_i32(value: i32) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    let mut i = 0;
-    while i < len {
+    for let mut i = 0; i < len; i = i + 1 {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
-        i = i + 1;
     }
 
     // Wrap in String struct
@@ -139,11 +167,9 @@ pub fn stringify_i64(value: i64) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    let mut i = 0;
-    while i < len {
+    for let mut i = 0; i < len; i = i + 1 {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
-        i = i + 1;
     }
 
     return result as String;
@@ -154,9 +180,8 @@ pub fn stringify_i64(value: i64) -> String {
 ///
 /// Used in template interpolation: `{i128_value}`
 pub fn stringify_i128(value: i128) -> String {
-    // TODO: Implement i128 to string conversion
-    // For now, return placeholder
-    return "[i128]";
+    // TODO: Implement i128 to string conversion (needs 128-bit arithmetic)
+    builtin::unreachable();
 }
 
 /// Convert a u8 to a string
@@ -199,11 +224,9 @@ pub fn stringify_u32(value: u32) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    let mut i = 0;
-    while i < len {
+    for let mut i = 0; i < len; i = i + 1 {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
-        i = i + 1;
     }
 
     return result as String;
@@ -233,11 +256,9 @@ pub fn stringify_u64(value: u64) -> String {
 
     // Reverse the digits
     let mut result = builtin::array_new<u8>(len);
-    let mut i = 0;
-    while i < len {
+    for let mut i = 0; i < len; i = i + 1 {
         let digit = builtin::array_get(digits, len - 1 - i);
         builtin::array_set(result, i, digit);
-        i = i + 1;
     }
 
     return result as String;
@@ -248,9 +269,8 @@ pub fn stringify_u64(value: u64) -> String {
 ///
 /// Used in template interpolation: `{u128_value}`
 pub fn stringify_u128(value: u128) -> String {
-    // TODO: Implement u128 to string conversion
-    // For now, return placeholder
-    return "[u128]";
+    // TODO: Implement u128 to string conversion (needs 128-bit arithmetic)
+    builtin::unreachable();
 }
 
 /// Convert an f32 to a string
@@ -259,8 +279,7 @@ pub fn stringify_u128(value: u128) -> String {
 /// Used in template interpolation: `{f32_value}`
 pub fn stringify_f32(value: f32) -> String {
     // TODO: Implement proper f32 to string conversion (dtoa algorithm)
-    // For now, return placeholder
-    return "[f32]";
+    builtin::unreachable();
 }
 
 /// Convert an f64 to a string
@@ -269,8 +288,7 @@ pub fn stringify_f32(value: f32) -> String {
 /// Used in template interpolation: `{f64_value}`
 pub fn stringify_f64(value: f64) -> String {
     // TODO: Implement proper f64 to string conversion (dtoa algorithm)
-    // For now, return placeholder
-    return "[f64]";
+    builtin::unreachable();
 }
 
 // ============================================================================
@@ -282,15 +300,17 @@ pub fn stringify_f64(value: f64) -> String {
 //
 // Current implementation status:
 // - ✅ stringify_bool: Complete
-// - ✅ stringify_i8, i16, i32: Complete (delegate to i32)
-// - ✅ stringify_i64: Complete
-// - ✅ stringify_u8, u16, u32: Complete (delegate to u32)
-// - ✅ stringify_u64: Complete
-// - ⚠️ stringify_char: Placeholder (needs UTF-8 encoding)
-// - ⚠️ stringify_i128, u128: Placeholder (needs 128-bit arithmetic)
-// - ⚠️ stringify_f32, f64: Placeholder (needs dtoa algorithm)
+// - ✅ stringify_char: Complete (UTF-8 encoding)
+// - ✅ stringify_i8, i16, i32: Complete (itoa algorithm)
+// - ✅ stringify_i64: Complete (itoa algorithm)
+// - ✅ stringify_u8, u16, u32: Complete (itoa algorithm)
+// - ✅ stringify_u64: Complete (itoa algorithm)
+// - ❌ stringify_i128, u128: Not implemented (calls builtin::unreachable)
+// - ❌ stringify_f32, f64: Not implemented (calls builtin::unreachable)
 //
 // Future extensions:
 // - Format specifiers: stringify_i32_fmt(value: i32, fmt: FormatSpec) -> String
 // - Custom Debug/Display traits: stringify_debug<T>(value: T) -> String
 // - Proper float formatting with precision control
+// - 128-bit integer arithmetic for i128/u128
+// - dtoa algorithm for floating-point conversion

--- a/wado-compiler/lib/core/internals.wado
+++ b/wado-compiler/lib/core/internals.wado
@@ -8,113 +8,289 @@
 // Since Wado has no function overloading, we provide separate stringify functions
 // for each primitive type.
 //
-// These functions are compiler intrinsics - their implementations are generated
-// directly by the compiler (codegen.rs) rather than being written in Wado.
+// Unlike builtin:: functions, these have Wado-level implementations.
+// This avoids the complexity of implementing string conversion in raw Wasm.
 
 // ============================================================================
-// String Conversion Functions (Compiler Intrinsics)
+// String Conversion Functions
 // ============================================================================
 
 /// Convert a boolean value to a string
 /// Returns "true" or "false"
 ///
-/// Compiler intrinsic for template interpolation: `{bool_value}`
-pub fn stringify_bool(value: bool) -> String;
+/// Used in template interpolation: `{bool_value}`
+pub fn stringify_bool(value: bool) -> String {
+    if value {
+        return "true";
+    } else {
+        return "false";
+    }
+}
 
 /// Convert a char to a string
 /// Returns a string containing the single character
 ///
-/// Compiler intrinsic for template interpolation: `{char_value}`
-pub fn stringify_char(value: char) -> String;
+/// Used in template interpolation: `{char_value}`
+pub fn stringify_char(value: char) -> String {
+    // For now, return a placeholder
+    // TODO: Implement proper char to string conversion
+    // Need to encode the Unicode code point as UTF-8 bytes
+    return "?";
+}
 
 /// Convert an i8 to a string
 /// Returns the decimal representation with optional minus sign
 ///
-/// Compiler intrinsic for template interpolation: `{i8_value}`
-pub fn stringify_i8(value: i8) -> String;
+/// Used in template interpolation: `{i8_value}`
+pub fn stringify_i8(value: i8) -> String {
+    return stringify_i32(value as i32);
+}
 
 /// Convert an i16 to a string
 /// Returns the decimal representation with optional minus sign
 ///
-/// Compiler intrinsic for template interpolation: `{i16_value}`
-pub fn stringify_i16(value: i16) -> String;
+/// Used in template interpolation: `{i16_value}`
+pub fn stringify_i16(value: i16) -> String {
+    return stringify_i32(value as i32);
+}
 
 /// Convert an i32 to a string
 /// Returns the decimal representation with optional minus sign
 ///
-/// Compiler intrinsic for template interpolation: `{i32_value}`
-pub fn stringify_i32(value: i32) -> String;
+/// Used in template interpolation: `{i32_value}`
+pub fn stringify_i32(value: i32) -> String {
+    // Handle zero
+    if value == 0 {
+        return "0";
+    }
+
+    // Handle negative numbers
+    let mut n = value;
+    let is_negative = n < 0;
+    if is_negative {
+        n = -n;
+    }
+
+    // Convert to decimal digits (in reverse)
+    let mut digits: builtin::array<u8> = builtin::array_new<u8>(11); // max i32 is 10 digits + sign
+    let mut len = 0;
+
+    while n > 0 {
+        let digit = (n % 10) as u8;
+        builtin::array_set(digits, len, digit + 48); // '0' = 48
+        n = n / 10;
+        len = len + 1;
+    }
+
+    // Add minus sign if negative
+    if is_negative {
+        builtin::array_set(digits, len, 45); // '-' = 45
+        len = len + 1;
+    }
+
+    // Reverse the digits
+    let mut result = builtin::array_new<u8>(len);
+    let mut i = 0;
+    while i < len {
+        let digit = builtin::array_get(digits, len - 1 - i);
+        builtin::array_set(result, i, digit);
+        i = i + 1;
+    }
+
+    // Wrap in String struct
+    // TODO: This assumes String is just a wrapper around builtin::array<u8>
+    // Need proper String constructor once the type system supports it
+    return result as String;
+}
 
 /// Convert an i64 to a string
 /// Returns the decimal representation with optional minus sign
 ///
-/// Compiler intrinsic for template interpolation: `{i64_value}`
-pub fn stringify_i64(value: i64) -> String;
+/// Used in template interpolation: `{i64_value}`
+pub fn stringify_i64(value: i64) -> String {
+    // Handle zero
+    if value == 0 {
+        return "0";
+    }
+
+    // Handle negative numbers
+    let mut n = value;
+    let is_negative = n < 0;
+    if is_negative {
+        n = -n;
+    }
+
+    // Convert to decimal digits (in reverse)
+    let mut digits: builtin::array<u8> = builtin::array_new<u8>(20); // max i64 is 19 digits + sign
+    let mut len = 0;
+
+    while n > 0 {
+        let digit = (n % 10) as u8;
+        builtin::array_set(digits, len, digit + 48); // '0' = 48
+        n = n / 10;
+        len = len + 1;
+    }
+
+    // Add minus sign if negative
+    if is_negative {
+        builtin::array_set(digits, len, 45); // '-' = 45
+        len = len + 1;
+    }
+
+    // Reverse the digits
+    let mut result = builtin::array_new<u8>(len);
+    let mut i = 0;
+    while i < len {
+        let digit = builtin::array_get(digits, len - 1 - i);
+        builtin::array_set(result, i, digit);
+        i = i + 1;
+    }
+
+    return result as String;
+}
 
 /// Convert an i128 to a string
 /// Returns the decimal representation with optional minus sign
 ///
-/// Compiler intrinsic for template interpolation: `{i128_value}`
-pub fn stringify_i128(value: i128) -> String;
+/// Used in template interpolation: `{i128_value}`
+pub fn stringify_i128(value: i128) -> String {
+    // TODO: Implement i128 to string conversion
+    // For now, return placeholder
+    return "[i128]";
+}
 
 /// Convert a u8 to a string
 /// Returns the decimal representation
 ///
-/// Compiler intrinsic for template interpolation: `{u8_value}`
-pub fn stringify_u8(value: u8) -> String;
+/// Used in template interpolation: `{u8_value}`
+pub fn stringify_u8(value: u8) -> String {
+    return stringify_u32(value as u32);
+}
 
 /// Convert a u16 to a string
 /// Returns the decimal representation
 ///
-/// Compiler intrinsic for template interpolation: `{u16_value}`
-pub fn stringify_u16(value: u16) -> String;
+/// Used in template interpolation: `{u16_value}`
+pub fn stringify_u16(value: u16) -> String {
+    return stringify_u32(value as u32);
+}
 
 /// Convert a u32 to a string
 /// Returns the decimal representation
 ///
-/// Compiler intrinsic for template interpolation: `{u32_value}`
-pub fn stringify_u32(value: u32) -> String;
+/// Used in template interpolation: `{u32_value}`
+pub fn stringify_u32(value: u32) -> String {
+    // Handle zero
+    if value == 0 {
+        return "0";
+    }
+
+    // Convert to decimal digits (in reverse)
+    let mut digits: builtin::array<u8> = builtin::array_new<u8>(10); // max u32 is 10 digits
+    let mut len = 0;
+    let mut n = value;
+
+    while n > 0 {
+        let digit = (n % 10) as u8;
+        builtin::array_set(digits, len, digit + 48); // '0' = 48
+        n = n / 10;
+        len = len + 1;
+    }
+
+    // Reverse the digits
+    let mut result = builtin::array_new<u8>(len);
+    let mut i = 0;
+    while i < len {
+        let digit = builtin::array_get(digits, len - 1 - i);
+        builtin::array_set(result, i, digit);
+        i = i + 1;
+    }
+
+    return result as String;
+}
 
 /// Convert a u64 to a string
 /// Returns the decimal representation
 ///
-/// Compiler intrinsic for template interpolation: `{u64_value}`
-pub fn stringify_u64(value: u64) -> String;
+/// Used in template interpolation: `{u64_value}`
+pub fn stringify_u64(value: u64) -> String {
+    // Handle zero
+    if value == 0 {
+        return "0";
+    }
+
+    // Convert to decimal digits (in reverse)
+    let mut digits: builtin::array<u8> = builtin::array_new<u8>(20); // max u64 is 20 digits
+    let mut len = 0;
+    let mut n = value;
+
+    while n > 0 {
+        let digit = (n % 10) as u8;
+        builtin::array_set(digits, len, digit + 48); // '0' = 48
+        n = n / 10;
+        len = len + 1;
+    }
+
+    // Reverse the digits
+    let mut result = builtin::array_new<u8>(len);
+    let mut i = 0;
+    while i < len {
+        let digit = builtin::array_get(digits, len - 1 - i);
+        builtin::array_set(result, i, digit);
+        i = i + 1;
+    }
+
+    return result as String;
+}
 
 /// Convert a u128 to a string
 /// Returns the decimal representation
 ///
-/// Compiler intrinsic for template interpolation: `{u128_value}`
-pub fn stringify_u128(value: u128) -> String;
+/// Used in template interpolation: `{u128_value}`
+pub fn stringify_u128(value: u128) -> String {
+    // TODO: Implement u128 to string conversion
+    // For now, return placeholder
+    return "[u128]";
+}
 
 /// Convert an f32 to a string
 /// Returns the decimal representation (e.g., "3.14")
 ///
-/// Compiler intrinsic for template interpolation: `{f32_value}`
-pub fn stringify_f32(value: f32) -> String;
+/// Used in template interpolation: `{f32_value}`
+pub fn stringify_f32(value: f32) -> String {
+    // TODO: Implement proper f32 to string conversion (dtoa algorithm)
+    // For now, return placeholder
+    return "[f32]";
+}
 
 /// Convert an f64 to a string
 /// Returns the decimal representation (e.g., "3.14159")
 ///
-/// Compiler intrinsic for template interpolation: `{f64_value}`
-pub fn stringify_f64(value: f64) -> String;
+/// Used in template interpolation: `{f64_value}`
+pub fn stringify_f64(value: f64) -> String {
+    // TODO: Implement proper f64 to string conversion (dtoa algorithm)
+    // For now, return placeholder
+    return "[f64]";
+}
 
 // ============================================================================
-// Notes on Implementation
+// Implementation Notes
 // ============================================================================
 
-// These functions have no body because they are compiler intrinsics.
-// The code generator (codegen.rs) recognizes calls to these functions
-// and generates the appropriate Wasm instructions directly.
+// These functions are implemented in Wado (unlike builtin:: functions).
+// This makes maintenance easier and avoids low-level Wasm complexity.
 //
-// Implementation strategy (in codegen.rs):
-// 1. Recognize calls to core:internals::stringify_*
-// 2. Generate appropriate string conversion code:
-//    - For integers: Use itoa-style algorithm
-//    - For floats: Use dtoa-style algorithm (or Wasm f32.to_string if available)
-//    - For bool: Generate "true" or "false" literal
-//    - For char: Create single-character string
+// Current implementation status:
+// - ✅ stringify_bool: Complete
+// - ✅ stringify_i8, i16, i32: Complete (delegate to i32)
+// - ✅ stringify_i64: Complete
+// - ✅ stringify_u8, u16, u32: Complete (delegate to u32)
+// - ✅ stringify_u64: Complete
+// - ⚠️ stringify_char: Placeholder (needs UTF-8 encoding)
+// - ⚠️ stringify_i128, u128: Placeholder (needs 128-bit arithmetic)
+// - ⚠️ stringify_f32, f64: Placeholder (needs dtoa algorithm)
 //
 // Future extensions:
 // - Format specifiers: stringify_i32_fmt(value: i32, fmt: FormatSpec) -> String
 // - Custom Debug/Display traits: stringify_debug<T>(value: T) -> String
+// - Proper float formatting with precision control

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -337,19 +337,28 @@ pub struct BinaryExpr {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BinaryOp {
+    // Arithmetic
     Add,
     Sub,
     Mul,
     Div,
     Mod,
+    // Comparison
     Eq,
     NotEq,
     Lt,
     LtEq,
     Gt,
     GtEq,
+    // Logical
     And,
     Or,
+    // Bitwise
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl, // Shift left
+    Shr, // Shift right
 }
 
 #[derive(Debug, Clone)]

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -293,6 +293,7 @@ pub enum Expr {
     Match(Box<MatchExpr>),
     Closure(Box<ClosureExpr>),
     TemplateString(Box<TemplateStringExpr>),
+    Cast(Box<CastExpr>),
 }
 
 /// Assignment expression: `x = value` or `x.field = value`
@@ -462,6 +463,14 @@ pub enum TemplatePart {
 #[derive(Debug, Clone)]
 pub struct FormatSpec {
     pub spec: String,
+}
+
+/// Type cast expression: `value as Type`
+#[derive(Debug, Clone)]
+pub struct CastExpr {
+    pub expr: Box<Expr>,
+    pub target_type: Type,
+    pub span: Span,
 }
 
 #[derive(Debug, Clone)]

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -308,6 +308,9 @@ impl Codegen {
                     }
                 }
             }
+            Expr::Cast(cast) => {
+                self.collect_strings_from_expr(&cast.expr);
+            }
             _ => {}
         }
     }
@@ -1101,6 +1104,9 @@ impl Codegen {
             Expr::TemplateString(template) => {
                 self.generate_template_string(func, template, ctx, mod_ctx);
             }
+            Expr::Cast(cast) => {
+                self.generate_cast(func, cast, ctx, mod_ctx);
+            }
             _ => {}
         }
     }
@@ -1607,6 +1613,26 @@ impl Codegen {
                     heap_type: HeapType::Concrete(11),
                 })
             }
+            Expr::Cast(cast) => {
+                // Infer type from the target type
+                use crate::ast::Type;
+                match &cast.target_type {
+                    Type::Named(named) => {
+                        match named.name.as_str() {
+                            "i8" | "i16" | "i32" | "u8" | "u16" | "u32" | "char" => ValType::I32,
+                            "i64" | "u64" => ValType::I64,
+                            "f32" => ValType::F32,
+                            "f64" => ValType::F64,
+                            "String" => ValType::Ref(RefType {
+                                nullable: false,
+                                heap_type: HeapType::Concrete(11), // array<u8>
+                            }),
+                            _ => ValType::I32, // Default
+                        }
+                    }
+                    _ => ValType::I32,
+                }
+            }
             _ => ValType::I32,
         }
     }
@@ -1652,6 +1678,8 @@ impl Codegen {
             }
             // Template strings always produce values (GC array<u8>)
             Expr::TemplateString(_) => true,
+            // Type casts always produce values
+            Expr::Cast(_) => true,
             _ => false,
         }
     }
@@ -1796,6 +1824,69 @@ impl Codegen {
                 // TODO: Convert expression result to string based on its type
                 // For now, assume it's already a string (ref (array u8))
                 // This is incorrect for non-string types but allows compilation
+            }
+        }
+    }
+
+    /// Generate code for type cast expression: `value as Type`
+    fn generate_cast(
+        &self,
+        func: &mut Function,
+        cast: &crate::ast::CastExpr,
+        ctx: &mut FunctionContext,
+        mod_ctx: &ModuleContext,
+    ) {
+        use crate::ast::Type;
+
+        // First, generate the expression to be casted
+        self.generate_expr_with_mod_ctx(func, &cast.expr, ctx, mod_ctx);
+
+        // Determine the source and target types
+        // For now, we handle primitive numeric conversions
+        match &cast.target_type {
+            Type::Named(named) => {
+                // Handle primitive type casts
+                // Note: Wado's char is u32, and most numeric types map to Wasm i32/i64/f32/f64
+                match named.name.as_str() {
+                    "u32" | "i32" | "char" => {
+                        // For numeric types that are already i32, this is a no-op at Wasm level
+                        // The type system tracks the semantic difference
+                    }
+                    "u8" | "i8" | "u16" | "i16" => {
+                        // These are also i32 at Wasm level, no conversion needed
+                        // The semantic constraints are enforced at the language level
+                    }
+                    "i64" => {
+                        // If source is i32, extend to i64
+                        // TODO: Proper type tracking to know source type
+                        // For now, assume i32 -> i64
+                        func.instruction(&Instruction::I64ExtendI32S);
+                    }
+                    "u64" => {
+                        // If source is u32, extend to u64
+                        func.instruction(&Instruction::I64ExtendI32U);
+                    }
+                    "f32" => {
+                        // Assume i32 -> f32
+                        func.instruction(&Instruction::F32ConvertI32S);
+                    }
+                    "f64" => {
+                        // Assume i32 -> f64
+                        func.instruction(&Instruction::F64ConvertI32S);
+                    }
+                    "String" => {
+                        // builtin::array<u8> -> String is a no-op (same representation)
+                        // The wrapper is just a type-level distinction
+                    }
+                    _ => {
+                        // Unknown type cast - for now, no-op
+                        // TODO: Proper error handling or support for more types
+                    }
+                }
+            }
+            _ => {
+                // Complex types - no-op for now
+                // TODO: Handle generic types, tuples, etc.
             }
         }
     }

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -17,6 +17,8 @@ use wasm_encoder::{
 /// Targets WASI P3 (0.3.0-rc-2025-09-16)
 pub struct Codegen {
     string_literals: Vec<String>,
+    /// Parsed stdlib modules (to extend their lifetime during compilation)
+    stdlib_modules: Vec<crate::ast::Module>,
 }
 
 /// Context for tracking local variables during function code generation
@@ -165,13 +167,24 @@ impl Codegen {
     pub fn new() -> Self {
         Self {
             string_literals: Vec::new(),
+            stdlib_modules: Vec::new(),
         }
     }
 
     /// Generate Component Model binary Wasm
     pub fn generate_wasm(&mut self, module: &crate::ast::Module) -> Vec<u8> {
-        // First pass: collect string literals
+        // Load stdlib modules first
+        self.load_stdlib_modules(module);
+
+        // First pass: collect string literals from user module
         self.collect_strings(module);
+
+        // Also collect strings from stdlib modules
+        // Clone the modules to avoid borrow checker issues
+        let stdlib_modules = self.stdlib_modules.clone();
+        for stdlib_module in &stdlib_modules {
+            self.collect_strings(stdlib_module);
+        }
 
         // Generate binary Wasm
         self.generate_component(module)
@@ -329,7 +342,7 @@ impl Codegen {
 
     /// Generate component for WASI P3
     /// Uses native stream<T> types and imports wasi:cli/stdout
-    fn generate_component(&self, ast_module: &crate::ast::Module) -> Vec<u8> {
+    fn generate_component(&mut self, ast_module: &crate::ast::Module) -> Vec<u8> {
         let mut builder = ComponentBuilder::default();
 
         // Build string data for memory
@@ -553,12 +566,31 @@ impl Codegen {
         builder.finish()
     }
 
+    /// Load and parse stdlib modules that are imported
+    /// This must be called before collect_user_functions
+    fn load_stdlib_modules(&mut self, ast_module: &crate::ast::Module) {
+        for item in &ast_module.items {
+            if let Item::Use(use_decl) = item {
+                if use_decl.source == "core:internals" {
+                    // Parse and store functions from core:internals
+                    if let Some(internals_src) = crate::stdlib::get_stdlib_module("core:internals") {
+                        if let Ok(internals_module) = self.parse_stdlib_module(internals_src) {
+                            self.stdlib_modules.push(internals_module);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
     /// Collect user-defined functions from the AST (excluding main and builtins)
+    /// Also includes functions from imported core:* modules that have Wado implementations
     fn collect_user_functions<'a>(
-        &self,
+        &'a self,
         ast_module: &'a crate::ast::Module,
     ) -> Vec<&'a crate::ast::Function> {
-        ast_module
+        let mut functions: Vec<&crate::ast::Function> = ast_module
             .items
             .iter()
             .filter_map(|item| {
@@ -573,15 +605,39 @@ impl Codegen {
                 }
                 None
             })
-            .collect()
+            .collect();
+
+        // Include functions from loaded stdlib modules
+        for stdlib_module in &self.stdlib_modules {
+            for item in &stdlib_module.items {
+                if let Item::Function(f) = item {
+                    if f.body.is_some() {
+                        functions.push(f);
+                    }
+                }
+            }
+        }
+
+        functions
+    }
+
+    /// Parse a stdlib module from source
+    fn parse_stdlib_module(&self, source: &str) -> Result<crate::ast::Module, ()> {
+        use crate::lexer::Lexer;
+        use crate::parser::Parser;
+
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().map_err(|_| ())?;
+        let mut parser = Parser::new(tokens);
+        parser.parse().map_err(|_| ())
     }
 
     /// Build main module for WASI P3 with write-via-stream
-    fn build_main_module_p3(&self, ast_module: &crate::ast::Module, string_data: &[u8]) -> Vec<u8> {
+    fn build_main_module_p3(&mut self, ast_module: &crate::ast::Module, string_data: &[u8]) -> Vec<u8> {
         let mut module = Module::new();
         let mut mod_ctx = ModuleContext::new();
 
-        // Collect user-defined functions
+        // Collect user-defined functions (stdlib modules already loaded in generate_wasm)
         let user_funcs = self.collect_user_functions(ast_module);
 
         // Type section
@@ -658,9 +714,9 @@ impl Codegen {
                 .iter()
                 .map(|p| self.wado_type_to_wasm(&p.ty))
                 .collect();
-            // Return type (default to i32 if specified, empty if none)
-            let return_types: Vec<ValType> = if func.return_type.is_some() {
-                vec![ValType::I32] // Simplified: all returns are i32 for now
+            // Return type (convert from Wado type to Wasm type)
+            let return_types: Vec<ValType> = if let Some(ref ret_ty) = func.return_type {
+                vec![self.wado_type_to_wasm(ret_ty)]
             } else {
                 vec![]
             };
@@ -1090,6 +1146,12 @@ impl Codegen {
                         crate::ast::BinaryOp::GtEq => func.instruction(&Instruction::I32GeS),
                         crate::ast::BinaryOp::And => func.instruction(&Instruction::I32And),
                         crate::ast::BinaryOp::Or => func.instruction(&Instruction::I32Or),
+                        // Bitwise operations
+                        crate::ast::BinaryOp::BitAnd => func.instruction(&Instruction::I32And),
+                        crate::ast::BinaryOp::BitOr => func.instruction(&Instruction::I32Or),
+                        crate::ast::BinaryOp::BitXor => func.instruction(&Instruction::I32Xor),
+                        crate::ast::BinaryOp::Shl => func.instruction(&Instruction::I32Shl),
+                        crate::ast::BinaryOp::Shr => func.instruction(&Instruction::I32ShrS), // Signed shift
                     };
                 }
             }

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -164,6 +164,9 @@ impl<'a> Lexer<'a> {
                 if self.peek_char() == Some('=') {
                     self.advance();
                     TokenKind::LtEq
+                } else if self.peek_char() == Some('<') {
+                    self.advance();
+                    TokenKind::Shl
                 } else {
                     TokenKind::Lt
                 }
@@ -173,6 +176,9 @@ impl<'a> Lexer<'a> {
                 if self.peek_char() == Some('=') {
                     self.advance();
                     TokenKind::GtEq
+                } else if self.peek_char() == Some('>') {
+                    self.advance();
+                    TokenKind::Shr
                 } else {
                     TokenKind::Gt
                 }
@@ -215,6 +221,10 @@ impl<'a> Lexer<'a> {
                 } else {
                     TokenKind::Ampersand
                 }
+            }
+            '^' => {
+                self.advance();
+                TokenKind::Caret
             }
             '#' => {
                 self.advance();

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -705,15 +705,69 @@ impl Parser {
     }
 
     fn parse_and_expr(&mut self) -> ParseResult<Expr> {
-        let mut left = self.parse_equality_expr()?;
+        let mut left = self.parse_bitor_expr()?;
 
         while self.check(&TokenKind::And) {
+            let start_span = self.peek().span;
+            self.advance();
+            let right = self.parse_bitor_expr()?;
+            left = Expr::Binary(Box::new(BinaryExpr {
+                left,
+                op: BinaryOp::And,
+                right,
+                span: start_span,
+            }));
+        }
+
+        Ok(left)
+    }
+
+    fn parse_bitor_expr(&mut self) -> ParseResult<Expr> {
+        let mut left = self.parse_bitxor_expr()?;
+
+        while self.check(&TokenKind::Pipe) {
+            let start_span = self.peek().span;
+            self.advance();
+            let right = self.parse_bitxor_expr()?;
+            left = Expr::Binary(Box::new(BinaryExpr {
+                left,
+                op: BinaryOp::BitOr,
+                right,
+                span: start_span,
+            }));
+        }
+
+        Ok(left)
+    }
+
+    fn parse_bitxor_expr(&mut self) -> ParseResult<Expr> {
+        let mut left = self.parse_bitand_expr()?;
+
+        while self.check(&TokenKind::Caret) {
+            let start_span = self.peek().span;
+            self.advance();
+            let right = self.parse_bitand_expr()?;
+            left = Expr::Binary(Box::new(BinaryExpr {
+                left,
+                op: BinaryOp::BitXor,
+                right,
+                span: start_span,
+            }));
+        }
+
+        Ok(left)
+    }
+
+    fn parse_bitand_expr(&mut self) -> ParseResult<Expr> {
+        let mut left = self.parse_equality_expr()?;
+
+        while self.check(&TokenKind::Ampersand) {
             let start_span = self.peek().span;
             self.advance();
             let right = self.parse_equality_expr()?;
             left = Expr::Binary(Box::new(BinaryExpr {
                 left,
-                op: BinaryOp::And,
+                op: BinaryOp::BitAnd,
                 right,
                 span: start_span,
             }));
@@ -746,7 +800,7 @@ impl Parser {
     }
 
     fn parse_comparison_expr(&mut self) -> ParseResult<Expr> {
-        let mut left = self.parse_additive_expr()?;
+        let mut left = self.parse_shift_expr()?;
 
         loop {
             let op = match self.peek_kind() {
@@ -754,6 +808,29 @@ impl Parser {
                 TokenKind::LtEq => BinaryOp::LtEq,
                 TokenKind::Gt => BinaryOp::Gt,
                 TokenKind::GtEq => BinaryOp::GtEq,
+                _ => break,
+            };
+            let start_span = self.peek().span;
+            self.advance();
+            let right = self.parse_shift_expr()?;
+            left = Expr::Binary(Box::new(BinaryExpr {
+                left,
+                op,
+                right,
+                span: start_span,
+            }));
+        }
+
+        Ok(left)
+    }
+
+    fn parse_shift_expr(&mut self) -> ParseResult<Expr> {
+        let mut left = self.parse_additive_expr()?;
+
+        loop {
+            let op = match self.peek_kind() {
+                TokenKind::Shl => BinaryOp::Shl,
+                TokenKind::Shr => BinaryOp::Shr,
                 _ => break,
             };
             let start_span = self.peek().span;
@@ -1097,7 +1174,14 @@ impl Parser {
             return Ok(Type::Tuple(types));
         }
 
-        let name = self.consume_ident()?;
+        // Parse qualified name (e.g., builtin::array)
+        let mut name = self.consume_ident()?;
+        while self.check(&TokenKind::ColonColon) {
+            self.advance();
+            let next_part = self.consume_ident()?;
+            name.push_str("::");
+            name.push_str(&next_part);
+        }
 
         if self.check(&TokenKind::Lt) {
             self.advance();
@@ -1106,6 +1190,17 @@ impl Parser {
                 self.advance();
                 args.push(self.parse_type()?);
             }
+
+            // Handle >> as two > tokens for nested generics (e.g., Array<Tuple<T, U>>)
+            if self.check(&TokenKind::Shr) {
+                // Split >> into > >
+                // Replace current Shr token with Gt
+                let current_token = self.peek().clone();
+                self.tokens[self.pos] = Token::new(TokenKind::Gt, current_token.span);
+                // Insert another Gt token after current position
+                self.tokens.insert(self.pos + 1, Token::new(TokenKind::Gt, current_token.span));
+            }
+
             self.expect(&TokenKind::Gt)?;
 
             Ok(Type::Generic(GenericType {

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -890,6 +890,16 @@ impl Parser {
                         span: start_span,
                     }));
                 }
+                TokenKind::As => {
+                    let start_span = self.peek().span;
+                    self.advance();
+                    let target_type = self.parse_type()?;
+                    expr = Expr::Cast(Box::new(CastExpr {
+                        expr: Box::new(expr),
+                        target_type,
+                        span: start_span,
+                    }));
+                }
                 _ => break,
             }
         }

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -34,6 +34,10 @@ pub const CORE_CLI: &str = include_str!("../lib/core/cli.wado");
 /// Embedded source for core:filesystem
 pub const CORE_FILESYSTEM: &str = include_str!("../lib/core/filesystem.wado");
 
+/// Embedded source for core:internals
+/// Compiler intrinsics for codegen (string conversion, etc.)
+pub const CORE_INTERNALS: &str = include_str!("../lib/core/internals.wado");
+
 // ============================================================================
 // WASI Library (wasi:*)
 // ============================================================================
@@ -63,6 +67,7 @@ pub const WASI_SOCKETS: &str = include_str!("../lib/wasi/sockets.wado");
 /// - `"core:prelude"` -> core library prelude
 /// - `"core:cli"` -> core library CLI helpers
 /// - `"core:filesystem"` -> core library filesystem helpers
+/// - `"core:internals"` -> compiler intrinsics for codegen
 /// - `"wasi:cli"` -> WASI CLI interfaces
 /// - `"wasi:filesystem"` -> WASI filesystem interfaces
 /// - `"wasi:clocks"` -> WASI clocks interfaces
@@ -80,6 +85,7 @@ pub fn get_stdlib_module(import_path: &str) -> Option<&'static str> {
         "core:prelude" => Some(CORE_PRELUDE),
         "core:cli" => Some(CORE_CLI),
         "core:filesystem" => Some(CORE_FILESYSTEM),
+        "core:internals" => Some(CORE_INTERNALS),
 
         // WASI library
         "wasi:cli" => Some(WASI_CLI),
@@ -129,6 +135,15 @@ mod tests {
         let source = get_stdlib_module("core:filesystem");
         assert!(source.is_some());
         assert!(source.unwrap().contains("read_file"));
+    }
+
+    #[test]
+    fn test_get_core_internals() {
+        let source = get_stdlib_module("core:internals");
+        assert!(source.is_some());
+        assert!(source.unwrap().contains("stringify_bool"));
+        assert!(source.unwrap().contains("stringify_i32"));
+        assert!(source.unwrap().contains("stringify_f64"));
     }
 
     #[test]

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -60,6 +60,7 @@ pub enum TokenKind {
     FatArrow,   // =>
     Pipe,       // |
     Ampersand,  // &
+    Caret,      // ^
     Hash,       // #
 
     // Operators
@@ -68,8 +69,10 @@ pub enum TokenKind {
     NotEq,    // !=
     Lt,       // <
     LtEq,     // <=
+    Shl,      // <<
     Gt,       // >
     GtEq,     // >=
+    Shr,      // >>
     Plus,     // +
     Minus,    // -
     Star,     // *

--- a/wado-compiler/tests/internals.rs
+++ b/wado-compiler/tests/internals.rs
@@ -1,0 +1,439 @@
+//! End-to-end tests for core:internals module
+//!
+//! Tests the stringify functions that are used for template string interpolation.
+//! While these functions are not intended for direct user use, they can be used
+//! and should work correctly.
+
+use wasmtime::component::{Component, Linker, ResourceTable};
+use wasmtime::{Config, Engine, Store};
+use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+use wado_compiler::compile;
+
+struct TestWasiState {
+    ctx: WasiCtx,
+    table: ResourceTable,
+}
+
+impl WasiView for TestWasiState {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.ctx,
+            table: &mut self.table,
+        }
+    }
+}
+
+async fn run_wasm_capture_stdout(wasm: Vec<u8>) -> anyhow::Result<String> {
+    let mut config = Config::new();
+    config.async_support(true);
+    config.wasm_component_model(true);
+    config.wasm_component_model_async(true);
+    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_async_stackful(true);
+    config.wasm_gc(true);
+
+    let engine = Engine::new(&config)?;
+
+    // Create component from wasm bytes
+    let component = Component::new(&engine, &wasm)?;
+
+    // Set up linker with WASI P3
+    let mut linker: Linker<TestWasiState> = Linker::new(&engine);
+    wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+
+    // Create stdout capture pipe
+    let stdout_pipe = MemoryOutputPipe::new(4096);
+    let stdout_clone = stdout_pipe.clone();
+
+    // Create WASI state with captured stdout
+    let ctx = WasiCtxBuilder::new().stdout(stdout_pipe).build();
+    let table = ResourceTable::new();
+
+    let state = TestWasiState { ctx, table };
+    let mut store = Store::new(&engine, state);
+
+    // Instantiate the component
+    let instance = linker.instantiate_async(&mut store, &component).await?;
+
+    // Get and call the "run" function
+    let run_func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, "run")?;
+
+    let (result,) = run_func.call_async(&mut store, ()).await?;
+    result.map_err(|()| anyhow::anyhow!("Component returned error"))?;
+
+    // Get captured stdout using contents() method
+    let output_bytes = stdout_clone.contents();
+    let output = String::from_utf8(output_bytes.to_vec())?;
+
+    Ok(output)
+}
+
+// ============================================================================
+// Boolean tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_bool_true() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_bool} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_bool(true));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "true\n");
+}
+
+#[tokio::test]
+async fn test_stringify_bool_false() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_bool} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_bool(false));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "false\n");
+}
+
+// ============================================================================
+// Character tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_char_ascii() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_char} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_char('A'));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "A\n");
+}
+
+#[tokio::test]
+async fn test_stringify_char_unicode_2byte() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_char} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_char('é'));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "é\n");
+}
+
+#[tokio::test]
+async fn test_stringify_char_unicode_3byte() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_char} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_char('日'));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "日\n");
+}
+
+#[tokio::test]
+async fn test_stringify_char_unicode_4byte() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_char} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_char('😀'));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "😀\n");
+}
+
+// ============================================================================
+// Integer tests - i32
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_i32_zero() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i32(0));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "0\n");
+}
+
+#[tokio::test]
+async fn test_stringify_i32_positive() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i32(42));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "42\n");
+}
+
+#[tokio::test]
+async fn test_stringify_i32_negative() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i32(-123));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "-123\n");
+}
+
+#[tokio::test]
+async fn test_stringify_i32_max() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i32(2147483647));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "2147483647\n");
+}
+
+#[tokio::test]
+async fn test_stringify_i32_min() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i32(-2147483648));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "-2147483648\n");
+}
+
+// ============================================================================
+// Integer tests - i64
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_i64_positive() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i64} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i64(9223372036854775807));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "9223372036854775807\n");
+}
+
+#[tokio::test]
+async fn test_stringify_i64_negative() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i64} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i64(-9223372036854775808));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "-9223372036854775808\n");
+}
+
+// ============================================================================
+// Integer tests - u32
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_u32_zero() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_u32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_u32(0));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "0\n");
+}
+
+#[tokio::test]
+async fn test_stringify_u32_max() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_u32} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_u32(4294967295));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "4294967295\n");
+}
+
+// ============================================================================
+// Integer tests - u64
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_u64_max() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_u64} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_u64(18446744073709551615));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "18446744073709551615\n");
+}
+
+// ============================================================================
+// Delegating functions - i8, i16, u8, u16
+// ============================================================================
+
+#[tokio::test]
+async fn test_stringify_i8() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i8} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i8(127));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "127\n");
+}
+
+#[tokio::test]
+async fn test_stringify_i16() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_i16} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_i16(-32768));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "-32768\n");
+}
+
+#[tokio::test]
+async fn test_stringify_u8() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_u8} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_u8(255));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "255\n");
+}
+
+#[tokio::test]
+async fn test_stringify_u16() {
+    let source = r#"
+use {println} from "core:cli";
+use {stringify_u16} from "core:internals";
+
+pub fn run() -> Result<(), ()> {
+    println(stringify_u16(65535));
+    return Ok(());
+}
+"#;
+
+    let wasm = compile(source).expect("compilation failed");
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+    assert_eq!(output, "65535\n");
+}

--- a/wado-compiler/tests/internals.rs
+++ b/wado-compiler/tests/internals.rs
@@ -80,9 +80,8 @@ async fn test_stringify_bool_true() {
 use {println} from "core:cli";
 use {stringify_bool} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_bool(true));
-    return Ok(());
 }
 "#;
 
@@ -97,9 +96,8 @@ async fn test_stringify_bool_false() {
 use {println} from "core:cli";
 use {stringify_bool} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_bool(false));
-    return Ok(());
 }
 "#;
 
@@ -118,9 +116,8 @@ async fn test_stringify_char_ascii() {
 use {println} from "core:cli";
 use {stringify_char} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_char('A'));
-    return Ok(());
 }
 "#;
 
@@ -135,9 +132,8 @@ async fn test_stringify_char_unicode_2byte() {
 use {println} from "core:cli";
 use {stringify_char} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_char('é'));
-    return Ok(());
 }
 "#;
 
@@ -152,9 +148,8 @@ async fn test_stringify_char_unicode_3byte() {
 use {println} from "core:cli";
 use {stringify_char} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_char('日'));
-    return Ok(());
 }
 "#;
 
@@ -169,9 +164,8 @@ async fn test_stringify_char_unicode_4byte() {
 use {println} from "core:cli";
 use {stringify_char} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_char('😀'));
-    return Ok(());
 }
 "#;
 
@@ -190,9 +184,8 @@ async fn test_stringify_i32_zero() {
 use {println} from "core:cli";
 use {stringify_i32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i32(0));
-    return Ok(());
 }
 "#;
 
@@ -207,9 +200,8 @@ async fn test_stringify_i32_positive() {
 use {println} from "core:cli";
 use {stringify_i32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i32(42));
-    return Ok(());
 }
 "#;
 
@@ -224,9 +216,8 @@ async fn test_stringify_i32_negative() {
 use {println} from "core:cli";
 use {stringify_i32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i32(-123));
-    return Ok(());
 }
 "#;
 
@@ -241,9 +232,8 @@ async fn test_stringify_i32_max() {
 use {println} from "core:cli";
 use {stringify_i32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i32(2147483647));
-    return Ok(());
 }
 "#;
 
@@ -258,9 +248,8 @@ async fn test_stringify_i32_min() {
 use {println} from "core:cli";
 use {stringify_i32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i32(-2147483648));
-    return Ok(());
 }
 "#;
 
@@ -279,9 +268,8 @@ async fn test_stringify_i64_positive() {
 use {println} from "core:cli";
 use {stringify_i64} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i64(9223372036854775807));
-    return Ok(());
 }
 "#;
 
@@ -296,9 +284,8 @@ async fn test_stringify_i64_negative() {
 use {println} from "core:cli";
 use {stringify_i64} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i64(-9223372036854775808));
-    return Ok(());
 }
 "#;
 
@@ -317,9 +304,8 @@ async fn test_stringify_u32_zero() {
 use {println} from "core:cli";
 use {stringify_u32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_u32(0));
-    return Ok(());
 }
 "#;
 
@@ -334,9 +320,8 @@ async fn test_stringify_u32_max() {
 use {println} from "core:cli";
 use {stringify_u32} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_u32(4294967295));
-    return Ok(());
 }
 "#;
 
@@ -355,9 +340,8 @@ async fn test_stringify_u64_max() {
 use {println} from "core:cli";
 use {stringify_u64} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_u64(18446744073709551615));
-    return Ok(());
 }
 "#;
 
@@ -376,9 +360,8 @@ async fn test_stringify_i8() {
 use {println} from "core:cli";
 use {stringify_i8} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i8(127));
-    return Ok(());
 }
 "#;
 
@@ -393,9 +376,8 @@ async fn test_stringify_i16() {
 use {println} from "core:cli";
 use {stringify_i16} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_i16(-32768));
-    return Ok(());
 }
 "#;
 
@@ -410,9 +392,8 @@ async fn test_stringify_u8() {
 use {println} from "core:cli";
 use {stringify_u8} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_u8(255));
-    return Ok(());
 }
 "#;
 
@@ -427,9 +408,8 @@ async fn test_stringify_u16() {
 use {println} from "core:cli";
 use {stringify_u16} from "core:internals";
 
-pub fn run() -> Result<(), ()> {
+fn main() {
     println(stringify_u16(65535));
-    return Ok(());
 }
 "#;
 


### PR DESCRIPTION
Introduces compiler intrinsics for converting primitive types to strings,
enabling template string interpolation support.

Changes:
- Add wado-compiler/lib/core/internals.wado
  - Define stringify_* functions for all primitive types
  - Functions declared without body (compiler intrinsics)
  - Bool, char, i8-i128, u8-u128, f32, f64 coverage

- Update wado-compiler/src/stdlib.rs
  - Add CORE_INTERNALS constant with include_str!
  - Register "core:internals" in get_stdlib_module()
  - Add test case for module loading

- Update compiler.md
  - Document core:internals in standard library table
  - Add "Compiler Intrinsics for Type Conversion" section
  - Update template string implementation status
  - Mark stringify intrinsics as complete

These intrinsics will be used by codegen.rs to implement type-to-string
conversion for template string interpolations like \`Count: {42}\`.