### PR TITLE
Fix user-defined function calls and local variable management

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -550,7 +550,7 @@ impl Codegen {
         builder.finish()
     }
 
-    /// Collect user-defined functions from the AST (excluding main and builtins)
+    /// Collect user-defined functions from the AST (excluding main, run, and builtins)
     fn collect_user_functions<'a>(
         &self,
         ast_module: &'a crate::ast::Module,
@@ -560,8 +560,8 @@ impl Codegen {
             .iter()
             .filter_map(|item| {
                 if let Item::Function(f) = item {
-                    // Skip main (handled separately as run)
-                    if f.name == "main" {
+                    // Skip main and run (handled separately as entry point)
+                    if f.name == "main" || f.name == "run" {
                         return None;
                     }
                     // Skip bodyless functions (builtins)
@@ -759,21 +759,21 @@ impl Codegen {
         // ============================================
         // run function - user entry point
         // ============================================
-        // Find main function to collect locals
-        let main_func = ast_module.items.iter().find_map(|item| {
+        // Find main or run function to collect locals
+        let entry_func = ast_module.items.iter().find_map(|item| {
             if let Item::Function(f) = item
-                && f.name == "main"
+                && (f.name == "main" || f.name == "run")
             {
                 return Some(f);
             }
             None
         });
 
-        // Collect locals from main function body
-        let local_decls = if let Some(main) = main_func {
-            if let Some(body) = &main.body {
-                let mut func_ctx = FunctionContext::new(main.params.len() as u32);
-                for param in &main.params {
+        // Collect locals from entry function body
+        let local_decls = if let Some(entry) = entry_func {
+            if let Some(body) = &entry.body {
+                let mut func_ctx = FunctionContext::new(entry.params.len() as u32);
+                for param in &entry.params {
                     func_ctx.add_param(&param.name);
                 }
                 self.collect_locals_from_block(body, &mut func_ctx);
@@ -890,16 +890,10 @@ impl Codegen {
         let local_decls = func_ctx.get_local_decls();
         let mut wasm_func = Function::new(local_decls);
 
-        // Reset context for code generation (keep param mappings, reset locals)
-        let mut gen_ctx = FunctionContext::new(ast_func.params.len() as u32);
-        for param in &ast_func.params {
-            gen_ctx.add_param(&param.name);
-        }
-
-        // Generate function body
+        // Generate function body using the same context (which has both params and locals)
         if let Some(body) = &ast_func.body {
             for stmt in &body.stmts {
-                self.generate_stmt_with_mod_ctx(&mut wasm_func, stmt, &mut gen_ctx, mod_ctx);
+                self.generate_stmt_with_mod_ctx(&mut wasm_func, stmt, &mut func_ctx, mod_ctx);
             }
         }
 
@@ -918,23 +912,77 @@ impl Codegen {
     fn collect_locals_from_stmt(&self, stmt: &Stmt, ctx: &mut FunctionContext) {
         match stmt {
             Stmt::Let(let_stmt) => {
+                // Collect locals from the value expression first (for template strings, etc.)
+                self.collect_locals_from_expr(&let_stmt.value, ctx);
                 let val_type = self.infer_expr_type_with_ctx(&let_stmt.value, ctx);
                 ctx.alloc_local(&let_stmt.name, val_type);
+            }
+            Stmt::Expr(expr_stmt) => {
+                self.collect_locals_from_expr(&expr_stmt.expr, ctx);
+            }
+            Stmt::Return(ret_stmt) => {
+                if let Some(value) = &ret_stmt.value {
+                    self.collect_locals_from_expr(value, ctx);
+                }
             }
             Stmt::For(for_stmt) => {
                 if let Some(init) = &for_stmt.init {
                     self.collect_locals_from_stmt(init, ctx);
                 }
+                if let Some(condition) = &for_stmt.condition {
+                    self.collect_locals_from_expr(condition, ctx);
+                }
+                if let Some(update) = &for_stmt.update {
+                    self.collect_locals_from_expr(update, ctx);
+                }
                 self.collect_locals_from_block(&for_stmt.body, ctx);
             }
             Stmt::While(while_stmt) => {
+                self.collect_locals_from_expr(&while_stmt.condition, ctx);
                 self.collect_locals_from_block(&while_stmt.body, ctx);
             }
             Stmt::If(if_stmt) => {
+                self.collect_locals_from_expr(&if_stmt.condition, ctx);
                 self.collect_locals_from_block(&if_stmt.then_block, ctx);
                 if let Some(else_block) = &if_stmt.else_block {
                     self.collect_locals_from_block(else_block, ctx);
                 }
+            }
+            _ => {}
+        }
+    }
+
+    /// Collect local variables from an expression (for template strings, etc.)
+    fn collect_locals_from_expr(&self, expr: &Expr, ctx: &mut FunctionContext) {
+        match expr {
+            Expr::TemplateString(template) => {
+                // Allocate a local for template result
+                let temp_name = format!("__template_result_{}", ctx.next_local);
+                ctx.alloc_local(
+                    &temp_name,
+                    ValType::Ref(RefType {
+                        nullable: false,
+                        heap_type: HeapType::Concrete(11), // array<u8>
+                    }),
+                );
+                // Recursively collect locals from interpolated expressions
+                for part in &template.parts {
+                    if let crate::ast::TemplatePart::Interpolation { expr, .. } = part {
+                        self.collect_locals_from_expr(expr, ctx);
+                    }
+                }
+            }
+            Expr::Binary(bin) => {
+                self.collect_locals_from_expr(&bin.left, ctx);
+                self.collect_locals_from_expr(&bin.right, ctx);
+            }
+            Expr::Call(call) => {
+                for arg in &call.args {
+                    self.collect_locals_from_expr(arg, ctx);
+                }
+            }
+            Expr::Assign(assign) => {
+                self.collect_locals_from_expr(&assign.value, ctx);
             }
             _ => {}
         }
@@ -958,8 +1006,11 @@ impl Codegen {
                 }
             }
             Stmt::Let(let_stmt) => {
-                let val_type = self.infer_expr_type_with_ctx(&let_stmt.value, ctx);
-                let local_idx = ctx.alloc_local(&let_stmt.name, val_type);
+                // Local variable was already allocated during collect_locals_from_block
+                // Just get its index
+                let local_idx = ctx
+                    .get_local(&let_stmt.name)
+                    .expect("local variable should have been allocated during collection");
                 self.generate_expr_with_mod_ctx(func, &let_stmt.value, ctx, mod_ctx);
                 func.instruction(&Instruction::LocalSet(local_idx));
             }
@@ -1392,24 +1443,31 @@ impl Codegen {
         ast_module: &crate::ast::Module,
         mod_ctx: &ModuleContext,
     ) {
-        // Find main function
-        let main_func = ast_module.items.iter().find_map(|item| {
+        // Find main function or run function
+        let entry_func = ast_module.items.iter().find_map(|item| {
             if let Item::Function(f) = item
-                && f.name == "main"
+                && (f.name == "main" || f.name == "run")
             {
                 return Some(f);
             }
             None
         });
 
-        if let Some(main) = main_func
-            && let Some(body) = &main.body
+        if let Some(entry) = entry_func
+            && let Some(body) = &entry.body
         {
-            let mut ctx = FunctionContext::new(main.params.len() as u32);
-            for param in &main.params {
+            let mut ctx = FunctionContext::new(entry.params.len() as u32);
+            for param in &entry.params {
                 ctx.add_param(&param.name);
             }
+            // Collect locals from the body first
+            self.collect_locals_from_block(body, &mut ctx);
+            // Generate statements (skip return statements in run function)
             for stmt in &body.stmts {
+                // Skip return statements in run function - task.return will be added later
+                if matches!(stmt, Stmt::Return(_)) {
+                    continue;
+                }
                 self.generate_stmt_with_mod_ctx(func, stmt, &mut ctx, mod_ctx);
             }
         }
@@ -1729,15 +1787,12 @@ impl Codegen {
         // - For each part, generate the string representation
         // - Use array operations to concatenate
 
-        // Allocate a local to accumulate the result
-        let temp_name = format!("__template_result_{}", ctx.next_local);
-        let result_local = ctx.alloc_local(
-            &temp_name,
-            ValType::Ref(RefType {
-                nullable: false,
-                heap_type: HeapType::Concrete(11), // array<u8>
-            }),
-        );
+        // Get the local that was already allocated during collection
+        // Find the template result local by checking which temp var has the right type
+        let result_local = ctx.locals.iter()
+            .find(|(name, _)| name.starts_with("__template_result_"))
+            .map(|(_, &idx)| idx)
+            .expect("template result local should have been allocated during collection");
 
         // Start with empty array or first part
         if let Some(first_part) = template.parts.first() {

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -293,3 +293,28 @@ async fn test_local_bools_mut() {
     // Verify output - mutable booleans with reassignment
     assert_eq!(output, "flag is false\nflag is true\n");
 }
+
+// ============================================================================
+// User-defined function tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_user_defined_function() {
+    let source = include_str!("fixtures/user_defined_function.wado");
+
+    // Compile the source
+    let wasm = compile(source).expect("compilation failed");
+
+    // Debug: print WAT for inspection
+    if let Ok(wat) = wasmprinter::print_bytes(&wasm) {
+        eprintln!("=== Generated WAT ===");
+        eprintln!("{}", wat);
+        eprintln!("=== End WAT ===");
+    }
+
+    // Run and capture output
+    let output = run_wasm_capture_stdout(wasm).await.expect("runtime error");
+
+    // Verify output - user-defined function call
+    assert_eq!(output, "User-defined function works!\n");
+}

--- a/wado-compiler/tests/fixtures/user_defined_function.wado
+++ b/wado-compiler/tests/fixtures/user_defined_function.wado
@@ -1,0 +1,13 @@
+use {println} from "core:cli";
+
+fn add(x: i32, y: i32) -> i32 {
+    return x + y;
+}
+
+pub fn run() -> Result<(), ()> {
+    let result = add(10, 32);
+    if result == 42 {
+        println("User-defined function works!");
+    }
+    return Ok(());
+}


### PR DESCRIPTION
This commit resolves several critical issues in the code generation:

1. **Fixed double allocation of local variables**: `Stmt::Let` was
   calling `alloc_local` during both collection and generation phases,
   causing index mismatches. Now uses `get_local` during generation.

2. **Added expression-level local collection**: Template strings and
   other expressions that require temporary locals are now properly
   collected during the `collect_locals_from_expr` phase.

3. **Fixed function context reuse**: `generate_user_function` now
   reuses the same `FunctionContext` for both collection and generation
   instead of creating a new one, preserving variable mappings.

4. **Excluded `run` from user-defined functions**: The `run` function
   is now properly excluded from the user-defined functions list to
   avoid duplicate generation.

5. **Support for both `main` and `run` entry points**: Updated entry
   point detection to support both naming conventions.

6. **Skip `return` in run function**: Return statements are now
   skipped in the run function body since `task.return` is added
   separately.

Tests: Added e2e test for user-defined function calls with add(i32, i32).
All 15 e2e tests now pass.