### PR TITLE
Update Design Philosophy: Explicit imports → Explicitness

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,7 @@ Wado is a new programming language targeting Wasm/WASI -- Wasm in plain sight.
 ## Design Philosophy
 
 - **Wasm only**: Zero abstraction to Wasm
-- **Explicit imports**: All dependencies are explicit
+- **Explicitness**: All dependencies are explicit
 - **Colorless async**: Eliminates async/await "color" problem via Wasm Stack Switching
 - **Effect System**: Side effect tracking and control, swappable via Handlers
 

--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,7 @@ Wado is a new programming language targeting Wasm/WASI -- Wasm in plain sight.
 ## Design Philosophy
 
 - **Wasm only**: Zero abstraction to Wasm
-- **Explicitness**: All dependencies are explicit
+- **Explicitness**: Make intent explicit
 - **Colorless async**: Eliminates async/await "color" problem via Wasm Stack Switching
 - **Effect System**: Side effect tracking and control, swappable via Handlers
 


### PR DESCRIPTION
Changed the design philosophy from "Explicit imports" to "Explicitness"
to better represent the broader principle of explicitness found across
all ADRs:
- Explicit type annotations (wasm-import)
- Explicit conversions (literal-type-conversion)
- Explicit functions, no compiler magic (ambient-logging)
- Explicit imports (module system)
- Explicit effect declarations (effect system)

This captures the design intent more accurately while keeping the
description simple.