### PR TITLE
feat: implement __DATA__ section and rewrite E2E tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +121,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +173,12 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cap-fs-ext"
@@ -508,6 +538,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "datatest-stable"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a867d7322eb69cf3a68a5426387a25b45cb3b9c5ee41023ee6cea92e2afadd82"
+dependencies = [
+ "camino",
+ "fancy-regex",
+ "libtest-mimic",
+ "walkdir",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,10 +644,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -1083,6 +1142,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libtest-mimic"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap",
+ "escape8259",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1438,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1513,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1871,6 +1968,9 @@ name = "wado-compiler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "datatest-stable",
+ "serde",
+ "serde_json",
  "tokio",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
@@ -1888,6 +1988,16 @@ dependencies = [
  "clap",
  "heck",
  "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT"
 [workspace.dependencies]
 anyhow = { version = "1" }
 ryu = { version = "1.0.22" }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1" }
 tokio = { version = "1", features = ["rt", "macros"] }
 wat = { version = "1.244" }
 wasm-encoder = { version = "0.244" }
@@ -15,3 +17,4 @@ wasmparser = { version = "0.244" }
 wasmprinter = { version = "0.244" }
 wasmtime = { version = "40", features = ["async", "component-model", "component-model-async"] }
 wasmtime-wasi = { version = "40", features = ["p3"] }
+datatest-stable = { version = "0.3" }

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -12,19 +12,19 @@ Source (.wado) → Lexer → Parser → Analyzer → Codegen → Component Model
 
 ### Modules
 
-| Module   | File                  | Description                                     |
-| -------- | --------------------- | ----------------------------------------------- |
-| Lexer    | `lexer.rs`            | Tokenizes source code                           |
-| Parser   | `parser.rs`           | Recursive descent parser, builds AST            |
-| AST      | `ast.rs`              | AST node definitions                            |
-| Token    | `token.rs`            | Token types and spans                           |
-| Analyzer | `analyze.rs`          | Semantic analysis, symbol table construction    |
-| Symbol   | `symbol.rs`           | Symbol table data structures                    |
-| Resolver | `resolver.rs`         | Module resolution, loads core library           |
-| Stdlib   | `stdlib.rs`           | Embedded core library sources                   |
-| Codegen  | `codegen.rs`          | Generates Component Model Wasm via wasm-encoder |
-| Bundled  | `bundled.rs`          | Loads pre-compiled Wasm builtins (wado-bundled) |
-| Postproc | `wasm_postprocess.rs` | Wasm binary transformations                     |
+| Module   | File                  | Description                                        |
+| -------- | --------------------- | -------------------------------------------------- |
+| Lexer    | `lexer.rs`            | Tokenizes source code, extracts `__DATA__` section |
+| Parser   | `parser.rs`           | Recursive descent parser, builds AST               |
+| AST      | `ast.rs`              | AST node definitions, `Module::data_section()` API |
+| Token    | `token.rs`            | Token types and spans                              |
+| Analyzer | `analyze.rs`          | Semantic analysis, symbol table construction       |
+| Symbol   | `symbol.rs`           | Symbol table data structures                       |
+| Resolver | `resolver.rs`         | Module resolution, loads core library              |
+| Stdlib   | `stdlib.rs`           | Embedded core library sources                      |
+| Codegen  | `codegen.rs`          | Generates Component Model Wasm via wasm-encoder    |
+| Bundled  | `bundled.rs`          | Loads pre-compiled Wasm builtins (wado-bundled)    |
+| Postproc | `wasm_postprocess.rs` | Wasm binary transformations                        |
 
 ### Bundled Builtins (wado-bundled)
 
@@ -229,6 +229,7 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [x] Bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`)
 - [x] Punctuation (`(`, `)`, `{`, `}`, `[`, `]`, `,`, `:`, `;`, `::`, `.`, `->`, `=>`, `|`, `&`, `#`, `?`)
 - [x] Comments (`//`)
+- [x] Data section (`__DATA__` marker)
 - [ ] Block comments (`/* */`)
 - [ ] Doc comments (`///`, `//!`)
 
@@ -247,6 +248,7 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [x] `resource` declarations
 - [x] `world` declarations (with imports/exports)
 - [x] Attributes (`#[...]`)
+- [ ] `#[data]` attribute for data section injection
 - [ ] `variant` declarations (with payloads)
 - [ ] `flags` declarations (bit flags)
 - [ ] Inner attributes (`#![...]`)
@@ -367,6 +369,7 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [x] Analyzer unit tests
 - [x] Codegen unit tests
 - [x] Template string tests (20 comprehensive tests)
+- [x] E2E tests with `__DATA__` sections (JSON test specs, auto-discovered via `datatest-stable`)
 - [x] E2E test: hello world (with wasmtime)
 - [x] E2E test: multiple println
 - [x] E2E test: bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`)

--- a/spec.md
+++ b/spec.md
@@ -51,6 +51,53 @@ Block comments do not nest.
 
 TODO: the parser keeps comments in the AST.
 
+### Data Section
+
+The `__DATA__` marker separates source code from embedded data. Everything after `__DATA__` on its own line is captured as raw text and is not parsed as Wado code.
+
+```wado
+use {println} from "core:cli";
+
+fn run() with Stdout {
+    println("Hello!");
+}
+
+__DATA__
+This is raw data that can be accessed via the compiler API.
+It can contain any text, including JSON, YAML, or test expectations.
+```
+
+**Syntax Rules:**
+
+- `__DATA__` must appear at the start of a line (after any preceding newline)
+- The line must contain only `__DATA__` followed by a newline (no trailing content on the same line)
+- Everything after the `__DATA__` line becomes the data section
+- The data section is optional; most modules won't have one
+
+**Accessing Data:**
+
+The data section is accessible via the compiler API through `Module::data_section()`, which returns `Option<&str>`. This enables tooling like test frameworks to embed expected results directly in source files.
+
+```rust
+// Compiler API example
+let result = wado_compiler::compile_file(path)?;
+if let Some(data) = result.module.data_section() {
+    // Process the data section content
+}
+```
+
+**Future: `#[data]` Attribute (TODO):**
+
+A future `#[data]` attribute will allow injecting the data section content into code:
+
+```wado
+#[data]
+const TEST_DATA: String;  // Injected from __DATA__ section
+
+#[data("json")]
+const CONFIG: Config;     // Parsed as JSON from __DATA__ section
+```
+
 ### Identifiers
 
 Identifiers match the pattern `[a-zA-Z_][a-zA-Z0-9_]*`:

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -136,7 +136,7 @@ pub fn parse_args(args: &[String]) -> CompileOptions {
 /// Compile a Wado source file and return the Wasm binary
 pub fn compile(filename: &str) -> Vec<u8> {
     match wado_compiler::compile_file(Path::new(filename)) {
-        Ok(wasm) => wasm,
+        Ok(result) => result.wasm,
         Err(e) => {
             eprintln!("{e}");
             process::exit(1);

--- a/wado-compiler/Cargo.toml
+++ b/wado-compiler/Cargo.toml
@@ -17,6 +17,13 @@ wat = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+datatest-stable = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 tokio = { workspace = true }
+
+[[test]]
+name = "e2e"
+harness = false

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -5,6 +5,32 @@ use crate::token::Span;
 #[derive(Debug, Clone)]
 pub struct Module {
     pub items: Vec<Item>,
+    /// Content of the __DATA__ section, if present in the source file.
+    /// This is available after parsing for tooling (test harnesses, IDEs).
+    data_section: Option<String>,
+}
+
+impl Module {
+    /// Creates a new module with the given items and no data section.
+    pub fn new(items: Vec<Item>) -> Self {
+        Self {
+            items,
+            data_section: None,
+        }
+    }
+
+    /// Creates a new module with the given items and data section.
+    pub fn with_data_section(items: Vec<Item>, data_section: Option<String>) -> Self {
+        Self {
+            items,
+            data_section,
+        }
+    }
+
+    /// Returns the content of the __DATA__ section, if present.
+    pub fn data_section(&self) -> Option<&str> {
+        self.data_section.as_deref()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -8,6 +8,8 @@ pub struct Lexer<'a> {
     pos: usize,
     line: usize,
     column: usize,
+    /// Content of the __DATA__ section, if present
+    data_section: Option<String>,
 }
 
 #[derive(Debug)]
@@ -24,7 +26,19 @@ impl<'a> Lexer<'a> {
             pos: 0,
             line: 1,
             column: 1,
+            data_section: None,
         }
+    }
+
+    /// Returns the content of the __DATA__ section, if present.
+    /// This is available after calling `tokenize()`.
+    pub fn data_section(&self) -> Option<&str> {
+        self.data_section.as_deref()
+    }
+
+    /// Consumes the lexer and returns the data section content.
+    pub fn into_data_section(self) -> Option<String> {
+        self.data_section
     }
 
     pub fn tokenize(&mut self) -> Result<Vec<Token>, LexError> {
@@ -287,6 +301,11 @@ impl<'a> Lexer<'a> {
                 }
             }
 
+            // Check for __DATA__ at the start of a line
+            if self.column == 1 && self.check_data_section() {
+                return;
+            }
+
             // Skip line comments
             if let Some((_, '/')) = self.peek() {
                 let mut chars = self.chars.clone();
@@ -307,6 +326,55 @@ impl<'a> Lexer<'a> {
 
             break;
         }
+    }
+
+    /// Check if we're at __DATA__ marker and capture the data section if so.
+    /// __DATA__ must be on its own line (^__DATA__$), followed by newline or EOF.
+    /// Returns true if __DATA__ was found and processed.
+    fn check_data_section(&mut self) -> bool {
+        const DATA_MARKER: &str = "__DATA__";
+
+        // Check if we have enough characters and they match __DATA__
+        let remaining = &self.input[self.pos..];
+        if !remaining.starts_with(DATA_MARKER) {
+            return false;
+        }
+
+        // Check that __DATA__ is followed by end of input or newline (must be on its own line)
+        let after_marker = &remaining[DATA_MARKER.len()..];
+        if !after_marker.is_empty() {
+            let next_char = after_marker.chars().next().unwrap();
+            // Only allow newline (\n or \r) or EOF after __DATA__
+            if next_char != '\n' && next_char != '\r' {
+                return false;
+            }
+        }
+
+        // Found __DATA__ marker - consume it
+        for _ in 0..DATA_MARKER.len() {
+            self.advance();
+        }
+
+        // Skip to the end of the __DATA__ line (consume the newline)
+        while let Some((_, ch)) = self.peek() {
+            self.advance();
+            if ch == '\n' {
+                break;
+            }
+        }
+
+        // Capture everything after __DATA__ as the data section
+        let data_content = &self.input[self.pos..];
+        self.data_section = if data_content.is_empty() {
+            Some(String::new())
+        } else {
+            Some(data_content.to_string())
+        };
+
+        // Move position to end of input
+        while self.advance().is_some() {}
+
+        true
     }
 
     fn lex_ident_or_keyword(&mut self) -> TokenKind {
@@ -983,5 +1051,123 @@ mod tests {
         let tokens = lexer.tokenize().unwrap();
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
+    }
+
+    #[test]
+    fn test_data_section_basic() {
+        let source = r#"fn main() { }
+__DATA__
+hello world"#;
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().unwrap();
+
+        // Should have parsed the function tokens and EOF
+        assert!(matches!(tokens[0].kind, TokenKind::Fn));
+        assert!(matches!(tokens.last().unwrap().kind, TokenKind::Eof));
+
+        // Should have captured the data section
+        assert_eq!(lexer.data_section(), Some("hello world"));
+    }
+
+    #[test]
+    fn test_data_section_multiline() {
+        let source = r#"fn main() { }
+__DATA__
+line 1
+line 2
+line 3"#;
+        let mut lexer = Lexer::new(source);
+        lexer.tokenize().unwrap();
+
+        assert_eq!(lexer.data_section(), Some("line 1\nline 2\nline 3"));
+    }
+
+    #[test]
+    fn test_data_section_json() {
+        let source = r#"fn main() { }
+__DATA__
+{
+  "exit": 0,
+  "stdout": "Hello\n"
+}"#;
+        let mut lexer = Lexer::new(source);
+        lexer.tokenize().unwrap();
+
+        let data = lexer.data_section().unwrap();
+        assert!(data.contains("\"exit\": 0"));
+        assert!(data.contains("\"stdout\": \"Hello\\n\""));
+    }
+
+    #[test]
+    fn test_data_section_empty() {
+        let source = "fn main() { }\n__DATA__\n";
+        let mut lexer = Lexer::new(source);
+        lexer.tokenize().unwrap();
+
+        // Empty data section should be Some("")
+        assert_eq!(lexer.data_section(), Some(""));
+    }
+
+    #[test]
+    fn test_no_data_section() {
+        let source = "fn main() { }";
+        let mut lexer = Lexer::new(source);
+        lexer.tokenize().unwrap();
+
+        assert_eq!(lexer.data_section(), None);
+    }
+
+    #[test]
+    fn test_data_section_not_at_start_of_line() {
+        // __DATA__ in the middle of a line should not be recognized
+        let source = "let x = __DATA__;";
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().unwrap();
+
+        // Should parse __DATA__ as an identifier
+        assert!(
+            tokens
+                .iter()
+                .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "__DATA__"))
+        );
+        assert_eq!(lexer.data_section(), None);
+    }
+
+    #[test]
+    fn test_data_section_with_trailing_content() {
+        // __DATA__ with content on the same line should not be recognized
+        let source = "fn main() { }\n__DATA__ some content";
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().unwrap();
+
+        // Should parse __DATA__ as an identifier since it's not on its own line
+        assert!(
+            tokens
+                .iter()
+                .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "__DATA__"))
+        );
+        assert_eq!(lexer.data_section(), None);
+    }
+
+    #[test]
+    fn test_data_section_after_comment() {
+        let source = r#"// some comment
+fn main() { }
+__DATA__
+test data"#;
+        let mut lexer = Lexer::new(source);
+        lexer.tokenize().unwrap();
+
+        assert_eq!(lexer.data_section(), Some("test data"));
+    }
+
+    #[test]
+    fn test_into_data_section() {
+        let source = "fn main() { }\n__DATA__\nowned data";
+        let mut lexer = Lexer::new(source);
+        lexer.tokenize().unwrap();
+
+        let data = lexer.into_data_section();
+        assert_eq!(data, Some("owned data".to_string()));
     }
 }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -18,6 +18,15 @@ pub use token::Span;
 
 use std::path::Path;
 
+/// Result of compiling a Wado source file
+#[derive(Debug)]
+pub struct CompileResult {
+    /// Compiled WebAssembly component bytes
+    pub wasm: Vec<u8>,
+    /// Parsed module AST (includes data section if present)
+    pub module: ast::Module,
+}
+
 /// Compile Wado source code to Component Model WebAssembly bytes.
 ///
 /// This is a convenience function that runs the full compilation pipeline:
@@ -38,19 +47,20 @@ use std::path::Path;
 /// assert_eq!(&wasm[0..4], b"\0asm");
 /// ```
 pub fn compile(source: &str) -> Result<Vec<u8>, CompileError> {
-    compile_impl(source, None, None)
+    compile_impl(source, None, None).map(|r| r.wasm)
 }
 
 /// Compile Wado source code with a base path for relative imports.
 pub fn compile_with_base_path(source: &str, base_path: &Path) -> Result<Vec<u8>, CompileError> {
-    compile_impl(source, None, Some(base_path))
+    compile_impl(source, None, Some(base_path)).map(|r| r.wasm)
 }
 
-/// Compile a Wado source file to Component Model WebAssembly bytes.
+/// Compile a Wado source file to Component Model WebAssembly.
 ///
 /// Like [`compile`], but reads source from a file and includes the filename
 /// in error messages. Also supports relative imports from the file's directory.
-pub fn compile_file(path: &Path) -> Result<Vec<u8>, CompileError> {
+/// Returns a [`CompileResult`] containing both the wasm bytes and the parsed module.
+pub fn compile_file(path: &Path) -> Result<CompileResult, CompileError> {
     let source = std::fs::read_to_string(path).map_err(|e| CompileError::Io {
         path: path.display().to_string(),
         message: e.to_string(),
@@ -70,7 +80,7 @@ fn compile_impl(
     source: &str,
     filename: Option<String>,
     base_path: Option<&Path>,
-) -> Result<Vec<u8>, CompileError> {
+) -> Result<CompileResult, CompileError> {
     // Lexer
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize().map_err(|e| CompileError::Lexer {
@@ -79,9 +89,10 @@ fn compile_impl(
         column: e.span.column,
         filename: filename.clone(),
     })?;
+    let data_section = lexer.into_data_section();
 
-    // Parser
-    let mut parser = Parser::new(tokens);
+    // Parser (with data section from lexer)
+    let mut parser = Parser::with_data_section(tokens, data_section);
     let ast = parser.parse().map_err(|e| CompileError::Parser {
         message: e.message,
         line: e.span.line,
@@ -119,7 +130,7 @@ fn compile_impl(
     let mut codegen = Codegen::new_with_source(source.to_string());
     let wasm = codegen.generate_wasm_with_modules(&ast, &loaded_modules_vec, &symbols);
 
-    Ok(wasm)
+    Ok(CompileResult { wasm, module: ast })
 }
 
 /// Compilation error with structured location info

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -9,6 +9,8 @@ pub struct Parser {
     /// Tracks when we've split a GtGt into two Gt tokens for nested generics.
     /// When true, the next expect_gt call should succeed without consuming a token.
     pending_gt: bool,
+    /// Content of the __DATA__ section, passed from the lexer.
+    data_section: Option<String>,
 }
 
 #[derive(Debug)]
@@ -25,6 +27,17 @@ impl Parser {
             tokens,
             pos: 0,
             pending_gt: false,
+            data_section: None,
+        }
+    }
+
+    /// Creates a new parser with the given tokens and data section.
+    pub fn with_data_section(tokens: Vec<Token>, data_section: Option<String>) -> Self {
+        Self {
+            tokens,
+            pos: 0,
+            pending_gt: false,
+            data_section,
         }
     }
 
@@ -35,7 +48,7 @@ impl Parser {
             items.push(self.parse_item()?);
         }
 
-        Ok(Module { items })
+        Ok(Module::with_data_section(items, self.data_section.take()))
     }
 
     // Token handling
@@ -1816,7 +1829,8 @@ mod tests {
     fn parse(source: &str) -> ParseResult<Module> {
         let mut lexer = Lexer::new(source);
         let tokens = lexer.tokenize().expect("lexer error");
-        let mut parser = Parser::new(tokens);
+        let data_section = lexer.into_data_section();
+        let mut parser = Parser::with_data_section(tokens, data_section);
         parser.parse()
     }
 
@@ -2311,5 +2325,49 @@ mod tests {
                 panic!("expected assert statement");
             }
         }
+    }
+
+    #[test]
+    fn test_module_data_section() {
+        let source = r#"fn main() { }
+__DATA__
+{"exit": 0, "stdout": "Hello\n"}"#;
+
+        let module = parse(source).unwrap();
+
+        // Should have parsed the function
+        assert_eq!(module.items.len(), 1);
+        assert!(matches!(&module.items[0], Item::Function(f) if f.name == "main"));
+
+        // Should have captured the data section
+        let data = module.data_section().unwrap();
+        assert!(data.contains("\"exit\": 0"));
+        assert!(data.contains("\"stdout\": \"Hello\\n\""));
+    }
+
+    #[test]
+    fn test_module_no_data_section() {
+        let source = "fn main() { }";
+
+        let module = parse(source).unwrap();
+        assert!(module.data_section().is_none());
+    }
+
+    #[test]
+    fn test_module_data_section_preserves_content() {
+        let source = r#"fn run() { }
+__DATA__
+line 1
+line 2
+{
+  "key": "value"
+}"#;
+
+        let module = parse(source).unwrap();
+        let data = module.data_section().unwrap();
+
+        assert!(data.starts_with("line 1"));
+        assert!(data.contains("line 2"));
+        assert!(data.contains("\"key\": \"value\""));
     }
 }

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -1,15 +1,19 @@
 //! End-to-end tests for Wado compiler
 //!
-//! These tests compile Wado programs and run them with wasmtime,
-//! verifying the output matches expected values.
+//! These tests compile Wado programs from fixtures/*.wado and run them with wasmtime,
+//! verifying the output matches expected values defined in each file's __DATA__ section.
+//!
+//! Test fixtures in fixtures/*.wado must have a __DATA__ section with JSON specifying
+//! expected results. Library files that are imported by tests go in fixtures/lib/.
 
+use serde::Deserialize;
 use wasmtime::component::{Component, Linker, ResourceTable};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
-use std::path::PathBuf;
-use wado_compiler::{compile, compile_file};
+use std::path::Path;
+use wado_compiler::compile_file;
 
 struct TestWasiState {
     ctx: WasiCtx,
@@ -26,6 +30,7 @@ impl WasiView for TestWasiState {
 }
 
 /// Result of running a Wasm component with captured output
+#[derive(Debug)]
 struct WasmRunResult {
     /// Captured stdout
     stdout: String,
@@ -35,756 +40,189 @@ struct WasmRunResult {
     trapped: bool,
 }
 
-async fn run_wasm(wasm: Vec<u8>) -> anyhow::Result<WasmRunResult> {
-    let mut config = Config::new();
-    config.async_support(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_gc(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
-    config.wasm_component_model_async_stackful(true);
-    config.wasm_simd(true);
-    config.wasm_wide_arithmetic(true);
-    config.wasm_threads(true);
-    config.wasm_gc(true);
-    config.wasm_function_references(true);
+/// Expected test results from __DATA__ section (JSON format)
+#[derive(Debug, Deserialize, Default)]
+struct TestSpec {
+    /// Expected stdout (exact match)
+    #[serde(default)]
+    stdout: Option<String>,
 
-    let engine = Engine::new(&config)?;
+    /// Expected stderr (exact match)
+    #[serde(default)]
+    stderr: Option<String>,
 
-    // Create component from wasm bytes
-    let component = Component::new(&engine, &wasm)?;
+    /// Strings that must be contained in stdout
+    #[serde(default)]
+    stdout_contains: Vec<String>,
 
-    // Set up linker with WASI P3
-    let mut linker: Linker<TestWasiState> = Linker::new(&engine);
-    wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+    /// Strings that must be contained in stderr
+    #[serde(default)]
+    stderr_contains: Vec<String>,
 
-    // Create stdout and stderr capture pipes
-    let stdout_pipe = MemoryOutputPipe::new(4096);
-    let stdout_clone = stdout_pipe.clone();
-    let stderr_pipe = MemoryOutputPipe::new(4096);
-    let stderr_clone = stderr_pipe.clone();
+    /// Whether the program is expected to trap
+    #[serde(default)]
+    trapped: bool,
+}
 
-    // Create WASI state with captured stdout and stderr
-    let ctx = WasiCtxBuilder::new()
-        .stdout(stdout_pipe)
-        .stderr(stderr_pipe)
-        .build();
-    let table = ResourceTable::new();
+fn run_wasm(wasm: Vec<u8>) -> anyhow::Result<WasmRunResult> {
+    // Create a new tokio runtime for this test
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
 
-    let state = TestWasiState { ctx, table };
-    let mut store = Store::new(&engine, state);
+    rt.block_on(async {
+        let mut config = Config::new();
+        config.async_support(true);
+        config.wasm_component_model(true);
+        config.wasm_component_model_gc(true);
+        config.wasm_component_model_async(true);
+        config.wasm_component_model_async_builtins(true);
+        config.wasm_component_model_async_stackful(true);
+        config.wasm_simd(true);
+        config.wasm_wide_arithmetic(true);
+        config.wasm_threads(true);
+        config.wasm_gc(true);
+        config.wasm_function_references(true);
 
-    // Instantiate the component
-    let instance = linker.instantiate_async(&mut store, &component).await?;
+        let engine = Engine::new(&config)?;
 
-    // Get and call the "run" function
-    let run_func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, "run")?;
+        // Create component from wasm bytes
+        let component = Component::new(&engine, &wasm)?;
 
-    let trapped = match run_func.call_async(&mut store, ()).await {
-        Ok((result,)) => result.is_err(),
-        Err(_) => true, // Runtime error (trap)
-    };
+        // Set up linker with WASI P3
+        let mut linker: Linker<TestWasiState> = Linker::new(&engine);
+        wasmtime_wasi::p3::add_to_linker(&mut linker)?;
 
-    // Get captured output
-    let stdout_bytes = stdout_clone.contents();
-    let stdout = String::from_utf8(stdout_bytes.to_vec())?;
-    let stderr_bytes = stderr_clone.contents();
-    let stderr = String::from_utf8(stderr_bytes.to_vec())?;
+        // Create stdout and stderr capture pipes
+        let stdout_pipe = MemoryOutputPipe::new(4096);
+        let stdout_clone = stdout_pipe.clone();
+        let stderr_pipe = MemoryOutputPipe::new(4096);
+        let stderr_clone = stderr_pipe.clone();
 
-    Ok(WasmRunResult {
-        stdout,
-        stderr,
-        trapped,
+        // Create WASI state with captured stdout and stderr
+        let ctx = WasiCtxBuilder::new()
+            .stdout(stdout_pipe)
+            .stderr(stderr_pipe)
+            .build();
+        let table = ResourceTable::new();
+
+        let state = TestWasiState { ctx, table };
+        let mut store = Store::new(&engine, state);
+
+        // Instantiate the component
+        let instance = linker.instantiate_async(&mut store, &component).await?;
+
+        // Get and call the "run" function
+        let run_func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, "run")?;
+
+        let trapped = match run_func.call_async(&mut store, ()).await {
+            Ok((result,)) => result.is_err(),
+            Err(_) => true, // Runtime error (trap)
+        };
+
+        // Get captured output
+        let stdout_bytes = stdout_clone.contents();
+        let stdout = String::from_utf8(stdout_bytes.to_vec())?;
+        let stderr_bytes = stderr_clone.contents();
+        let stderr = String::from_utf8(stderr_bytes.to_vec())?;
+
+        Ok(WasmRunResult {
+            stdout,
+            stderr,
+            trapped,
+        })
     })
 }
 
-// ============================================================================
-// Basic hello world tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_hello_world() {
-    let source = include_str!("fixtures/hello.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output
-    assert_eq!(result.stdout, "Hello, world!\n");
+/// Parse test spec from __DATA__ section JSON
+fn parse_test_spec(data_section: &str, fixture_name: &str) -> TestSpec {
+    serde_json::from_str(data_section).unwrap_or_else(|e| {
+        panic!("[{fixture_name}] Failed to parse __DATA__ section as JSON: {e}\nContent:\n{data_section}");
+    })
 }
 
-#[tokio::test]
-async fn test_multiple_println() {
-    let source = include_str!("fixtures/multiple_println.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output
-    assert_eq!(result.stdout, "Line 1\nLine 2\nLine 3\n");
-}
-
-// ============================================================================
-// Effect function import tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_effect_import_demo() {
-    let source = include_str!("fixtures/effect_import_demo.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify stdout
-    assert_eq!(result.stdout, "Hello from imported Stdout!\n");
-}
-
-#[tokio::test]
-async fn test_effect_import_with_aliasing() {
-    let source = include_str!("fixtures/effect_import_aliasing.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output
-    assert!(result.stdout.contains("Aliased import works!"));
-    assert!(result.stdout.contains("Direct import also works!"));
-}
-
-#[tokio::test]
-async fn test_multiple_effect_imports() {
-    let source = include_str!("fixtures/multiple_effect_imports.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output
-    assert_eq!(result.stdout, "Testing multiple imports\n");
-}
-
-// ============================================================================
-// Local variable tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_local_let() {
-    let source = include_str!("fixtures/local_let.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output
-    assert_eq!(result.stdout, "Hello from let!\n");
-}
-
-#[tokio::test]
-async fn test_local_let_mut() {
-    let source = include_str!("fixtures/local_let_mut.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output
-    assert_eq!(result.stdout, "First message\nSecond message\n");
-}
-
-// ============================================================================
-// For loop tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_for_loop() {
-    let source = include_str!("fixtures/for_loop.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - loop runs 3 times, then "done"
-    assert_eq!(result.stdout, "loop\nloop\nloop\ndone\n");
-}
-
-// ============================================================================
-// Integer variable tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_local_integers() {
-    let source = include_str!("fixtures/local_integers.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - integer arithmetic works
-    assert_eq!(result.stdout, "integers work\n");
-}
-
-#[tokio::test]
-async fn test_local_integers_mut() {
-    let source = include_str!("fixtures/local_integers_mut.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - mutable integers with reassignment
-    assert_eq!(result.stdout, "x is 5\nx is 10\nx is 15\n");
-}
-
-// ============================================================================
-// Floating point variable tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_local_floats() {
-    let source = include_str!("fixtures/local_floats.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - float arithmetic works
-    assert_eq!(result.stdout, "floats work\n");
-}
-
-#[tokio::test]
-async fn test_local_floats_mut() {
-    let source = include_str!("fixtures/local_floats_mut.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - mutable floats with reassignment
-    assert_eq!(result.stdout, "x is 1.0\nx is 2.5\nx is 3.0\n");
-}
-
-#[tokio::test]
-async fn test_float_to_string() {
-    let source = include_str!("fixtures/float_to_string.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - float interpolation in template strings
+/// Verify the actual result matches the expected spec
+fn verify_result(result: &WasmRunResult, spec: &TestSpec, fixture_name: &str) {
+    // Check trapped status
     assert_eq!(
-        result.stdout,
-        "f is 1.23\npi is approximately 3.14159\n10.5 + 2.5 = 13.0\n"
-    );
-}
-
-// ============================================================================
-// User-defined function tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_user_function_call() {
-    let source = include_str!("fixtures/user_function_call.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - add(40, 2) should return 42
-    assert_eq!(result.stdout, "success\n");
-}
-
-// ============================================================================
-// Boolean variable tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_local_bools() {
-    let source = include_str!("fixtures/local_bools.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - boolean variables in conditions
-    assert_eq!(result.stdout, "t is true\nf is false\n");
-}
-
-#[tokio::test]
-async fn test_local_bools_mut() {
-    let source = include_str!("fixtures/local_bools_mut.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - mutable booleans with reassignment
-    assert_eq!(result.stdout, "flag is false\nflag is true\n");
-}
-
-// ============================================================================
-// Local module import tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_use_local_module() {
-    // Get the path to the test fixture
-    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("use_local_module.wado");
-
-    // Compile using compile_file which handles local imports
-    let wasm = compile_file(&fixture_path).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - add(40, 2) from imported module should return 42
-    assert_eq!(result.stdout, "success\n");
-}
-
-// ============================================================================
-// Bitwise operator tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_bitwise_and() {
-    let source = include_str!("fixtures/bitwise_and.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap (assertion uses unreachable on failure)
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-#[tokio::test]
-async fn test_bitwise_or() {
-    let source = include_str!("fixtures/bitwise_or.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-#[tokio::test]
-async fn test_bitwise_xor() {
-    let source = include_str!("fixtures/bitwise_xor.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-#[tokio::test]
-async fn test_bitwise_shift() {
-    let source = include_str!("fixtures/bitwise_shift.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-#[tokio::test]
-async fn test_bitwise_not() {
-    let source = include_str!("fixtures/bitwise_not.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-#[tokio::test]
-async fn test_bitwise_combined() {
-    let source = include_str!("fixtures/bitwise_combined.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-// ============================================================================
-// Parentheses precedence tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_parentheses_precedence() {
-    let source = include_str!("fixtures/parentheses_precedence.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run - test passes if no unreachable trap
-    run_wasm(wasm).await.expect("runtime error");
-}
-
-// ============================================================================
-// String template literal tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_template_string_empty() {
-    let source = include_str!("fixtures/template_string_empty.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - empty template produces empty string, println adds newline
-    assert_eq!(result.stdout, "\n");
-}
-
-#[tokio::test]
-async fn test_template_string_two_middle() {
-    let source = include_str!("fixtures/template_string_two_middle.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - template: `a {s1} b {s2} c`
-    assert_eq!(result.stdout, "a X b Y c\n");
-}
-
-#[tokio::test]
-async fn test_template_string_three_interp() {
-    let source = include_str!("fixtures/template_string_three_interp.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - template: `{s1} a {s2} c {s3}`
-    assert_eq!(result.stdout, "X a Y c Z\n");
-}
-
-#[tokio::test]
-async fn test_template_string_two_end() {
-    let source = include_str!("fixtures/template_string_two_end.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - template: `a {s1} b {s2}`
-    assert_eq!(result.stdout, "a X b Y\n");
-}
-
-#[tokio::test]
-async fn test_template_string_two_interp() {
-    let source = include_str!("fixtures/template_string_two_interp.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - template: `{s1} a {s2} c`
-    assert_eq!(result.stdout, "X a Y c\n");
-}
-
-// ============================================================================
-// Type cast tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_type_cast() {
-    let source = include_str!("fixtures/type_cast.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - all cast tests pass
-    assert_eq!(
-        result.stdout,
-        "i32 to f64 works\nf64 to i32 works\nchained casts work\ncast in arithmetic works\n"
-    );
-}
-
-// ============================================================================
-// Template string scalar interpolation tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_template_string_bool() {
-    let source = include_str!("fixtures/template_string_bool.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - bool values are converted to "true" and "false"
-    assert_eq!(result.stdout, "true: true\nfalse: false\n");
-}
-
-#[tokio::test]
-async fn test_template_string_char() {
-    let source = include_str!("fixtures/template_string_char.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - char values are converted to their string representation
-    assert_eq!(result.stdout, "char A: A\nchar Z: Z\n");
-}
-
-#[tokio::test]
-async fn test_template_string_i32() {
-    let source = include_str!("fixtures/template_string_i32.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - i32 values are converted to their string representation
-    assert_eq!(result.stdout, "positive: 42\nnegative: -17\nzero: 0\n");
-}
-
-#[tokio::test]
-async fn test_template_string_i64() {
-    let source = include_str!("fixtures/template_string_i64.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - i64 values are converted to their string representation
-    assert_eq!(
-        result.stdout,
-        "positive: 12345\nbig: 100000000000\nnegative: -9876\n"
-    );
-}
-
-#[tokio::test]
-async fn test_template_string_f64() {
-    let source = include_str!("fixtures/template_string_f64.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime error");
-
-    // Verify output - f64 values are converted to their string representation
-    assert_eq!(result.stdout, "pi: 3.14159\nnegative: -2.5\n");
-}
-
-// ============================================================================
-// Panic tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_eprintln_then_trap() {
-    let source = include_str!("fixtures/eprintln_then_trap.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime setup error");
-
-    // Verify the error message was printed to stderr
-    assert_eq!(result.stderr, "error message\n");
-
-    // Verify the program trapped (unreachable was executed)
-    assert!(result.trapped, "should cause a trap");
-}
-
-#[tokio::test]
-async fn test_panic_basic() {
-    let source = include_str!("fixtures/panic_basic.wado");
-
-    // Compile the source
-    let wasm = compile(source).expect("compilation failed");
-
-    // Run and capture output
-    let result = run_wasm(wasm).await.expect("runtime setup error");
-
-    // Verify the panic message was printed to stderr via log_error()
-    assert_eq!(result.stderr, "This is a panic message\n");
-
-    // Verify the program trapped (unreachable was executed)
-    assert!(result.trapped, "panic should cause a trap");
-}
-
-// ============================================================================
-// Power-assert failure tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_assert_fail_simple() {
-    let source = include_str!("fixtures/assert_fail_simple.wado");
-
-    let wasm = compile(source).expect("compilation failed");
-    let result = run_wasm(wasm).await.expect("runtime setup error");
-
-    // Verify the program trapped
-    assert!(result.trapped, "assert should cause a trap");
-
-    // Verify power-assert output in stderr
-    assert!(
-        result.stderr.contains("Assertion failed:"),
-        "should contain 'Assertion failed:'"
-    );
-    assert!(
-        result.stderr.contains("condition: x > 10"),
-        "should show the condition"
-    );
-    assert!(result.stderr.contains("x: 5"), "should show the value of x");
-}
-
-#[tokio::test]
-async fn test_assert_fail_with_message() {
-    let source = include_str!("fixtures/assert_fail_with_message.wado");
-
-    let wasm = compile(source).expect("compilation failed");
-    let result = run_wasm(wasm).await.expect("runtime setup error");
-
-    // Verify the program trapped
-    assert!(result.trapped, "assert should cause a trap");
-
-    // Verify power-assert output with custom message
-    assert!(
-        result
-            .stderr
-            .contains("Assertion failed: value must be positive"),
-        "should contain custom message"
-    );
-    assert!(
-        result.stderr.contains("condition: x > 0"),
-        "should show the condition"
-    );
-    assert!(
-        result.stderr.contains("x: -5"),
-        "should show the value of x"
-    );
-}
-
-#[tokio::test]
-async fn test_assert_fail_intermediate() {
-    let source = include_str!("fixtures/assert_fail_intermediate.wado");
-
-    let wasm = compile(source).expect("compilation failed");
-    let result = run_wasm(wasm).await.expect("runtime setup error");
-
-    // Verify the program trapped
-    assert!(result.trapped, "assert should cause a trap");
-
-    // Verify power-assert shows intermediate values
-    assert!(
-        result.stderr.contains("Assertion failed:"),
-        "should contain 'Assertion failed:'"
-    );
-    assert!(
-        result.stderr.contains("condition: x + y > 10"),
-        "should show the full condition"
-    );
-    assert!(result.stderr.contains("x: 3"), "should show value of x");
-    assert!(result.stderr.contains("y: 4"), "should show value of y");
-    assert!(
-        result.stderr.contains("x + y: 7"),
-        "should show intermediate expression value"
-    );
-}
-
-#[tokio::test]
-async fn test_assert_fail_side_effect() {
-    let source = include_str!("fixtures/assert_fail_side_effect.wado");
-
-    let wasm = compile(source).expect("compilation failed");
-    let result = run_wasm(wasm).await.expect("runtime setup error");
-
-    // Verify the program trapped
-    assert!(result.trapped, "assert should cause a trap");
-
-    // Verify the function was called exactly ONCE (side-effect test)
-    // If caching works correctly, "get_value called" appears only once
-    let call_count = result.stdout.matches("get_value called").count();
-    assert_eq!(
-        call_count, 1,
-        "function should be called exactly once (caching), but was called {} times",
-        call_count
+        result.trapped, spec.trapped,
+        "[{fixture_name}] trapped mismatch: expected {}, got {}",
+        spec.trapped, result.trapped
     );
 
-    // Verify power-assert output
-    assert!(
-        result.stderr.contains("Assertion failed:"),
-        "should contain 'Assertion failed:'"
-    );
-    assert!(
-        result.stderr.contains("condition: get_value() > 10"),
-        "should show the condition with function call"
-    );
-    assert!(
-        result.stderr.contains("get_value(): 5"),
-        "should show the cached return value"
-    );
+    // Check stdout exact match if specified
+    if let Some(expected_stdout) = &spec.stdout {
+        assert_eq!(
+            &result.stdout, expected_stdout,
+            "[{fixture_name}] stdout mismatch"
+        );
+    }
+
+    // Check stderr exact match if specified
+    if let Some(expected_stderr) = &spec.stderr {
+        assert_eq!(
+            &result.stderr, expected_stderr,
+            "[{fixture_name}] stderr mismatch"
+        );
+    }
+
+    // Check stdout contains
+    for expected in &spec.stdout_contains {
+        assert!(
+            result.stdout.contains(expected),
+            "[{fixture_name}] stdout should contain '{expected}', but got:\n{}",
+            result.stdout
+        );
+    }
+
+    // Check stderr contains
+    for expected in &spec.stderr_contains {
+        assert!(
+            result.stderr.contains(expected),
+            "[{fixture_name}] stderr should contain '{expected}', but got:\n{}",
+            result.stderr
+        );
+    }
+}
+
+/// Run a single fixture test by path
+fn run_fixture_test(fixture_path: &Path) {
+    let fixture_name = fixture_path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Compile the fixture (compile_file handles local imports and returns CompileResult)
+    let compile_result = compile_file(fixture_path).unwrap_or_else(|e| {
+        panic!("[{fixture_name}] compilation failed: {e}");
+    });
+
+    // Get the __DATA__ section - required for all fixtures
+    let data_section = compile_result.module.data_section().unwrap_or_else(|| {
+        panic!(
+            "[{fixture_name}] missing __DATA__ section - all fixtures must have test expectations"
+        );
+    });
+
+    // Parse the test spec from JSON
+    let spec = parse_test_spec(data_section, &fixture_name);
+
+    // Run and capture output
+    let result = run_wasm(compile_result.wasm).unwrap_or_else(|e| {
+        panic!("[{fixture_name}] runtime error: {e}");
+    });
+
+    // Verify the result matches expectations
+    verify_result(&result, &spec, &fixture_name);
+}
+
+/// Test function for datatest-stable - runs each .wado fixture file
+fn fixture_test(path: &Path) -> datatest_stable::Result<()> {
+    run_fixture_test(path);
+    Ok(())
+}
+
+datatest_stable::harness! {
+    { test = fixture_test, root = "tests/fixtures", pattern = r"\.wado$" },
 }

--- a/wado-compiler/tests/fixtures/assert_fail_intermediate.wado
+++ b/wado-compiler/tests/fixtures/assert_fail_intermediate.wado
@@ -1,13 +1,13 @@
 // Test: Assert failure with intermediate expressions
-// Expected output should contain:
-//   Assertion failed:
-//   condition: x + y > 10
-//   x: 3
-//   y: 4
-//   x + y: 7
 
 fn run() with Stdout, Stderr {
     let x = 3;
     let y = 4;
     assert x + y > 10;
+}
+
+__DATA__
+{
+    "trapped": true,
+    "stderr_contains": ["Assertion failed:", "condition: x + y > 10", "x: 3", "y: 4", "x + y: 7"]
 }

--- a/wado-compiler/tests/fixtures/assert_fail_side_effect.wado
+++ b/wado-compiler/tests/fixtures/assert_fail_side_effect.wado
@@ -1,11 +1,6 @@
 // Test: Assert failure with side-effect function
 // This verifies that the function is only called ONCE (for caching),
 // not twice (once for caching, once for condition evaluation).
-// Expected stdout: "get_value called" (exactly once)
-// Expected stderr should contain:
-//   Assertion failed:
-//   condition: get_value() > 10
-//   get_value(): 5
 
 use {println} from "core:cli";
 
@@ -16,4 +11,11 @@ fn get_value() -> i32 with Stdout {
 
 fn run() with Stdout, Stderr {
     assert get_value() > 10;
+}
+
+__DATA__
+{
+    "trapped": true,
+    "stdout": "get_value called\n",
+    "stderr_contains": ["Assertion failed:", "condition: get_value() > 10", "get_value(): 5"]
 }

--- a/wado-compiler/tests/fixtures/assert_fail_simple.wado
+++ b/wado-compiler/tests/fixtures/assert_fail_simple.wado
@@ -1,10 +1,12 @@
 // Test: Simple assert failure
-// Expected output should contain:
-//   Assertion failed:
-//   condition: x > 10
-//   x: 5
 
 fn run() with Stdout, Stderr {
     let x = 5;
     assert x > 10;
+}
+
+__DATA__
+{
+    "trapped": true,
+    "stderr_contains": ["Assertion failed:", "condition: x > 10", "x: 5"]
 }

--- a/wado-compiler/tests/fixtures/assert_fail_with_message.wado
+++ b/wado-compiler/tests/fixtures/assert_fail_with_message.wado
@@ -1,10 +1,12 @@
 // Test: Assert failure with custom message
-// Expected output should contain:
-//   Assertion failed: value must be positive
-//   condition: x > 0
-//   x: -5
 
 fn run() with Stdout, Stderr {
     let x = -5;
     assert x > 0, "value must be positive";
+}
+
+__DATA__
+{
+    "trapped": true,
+    "stderr_contains": ["Assertion failed: value must be positive", "condition: x > 0", "x: -5"]
 }

--- a/wado-compiler/tests/fixtures/assert_power.wado
+++ b/wado-compiler/tests/fixtures/assert_power.wado
@@ -11,3 +11,6 @@ fn run() with Stdout, Stderr {
 
     println("All assertions passed!");
 }
+
+__DATA__
+{"stdout": "All assertions passed!\n"}

--- a/wado-compiler/tests/fixtures/bitwise_and.wado
+++ b/wado-compiler/tests/fixtures/bitwise_and.wado
@@ -7,3 +7,6 @@ fn run() {
 
     assert result == 8;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/bitwise_combined.wado
+++ b/wado-compiler/tests/fixtures/bitwise_combined.wado
@@ -13,3 +13,6 @@ fn run() {
 
     assert result == 7;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/bitwise_not.wado
+++ b/wado-compiler/tests/fixtures/bitwise_not.wado
@@ -6,3 +6,6 @@ fn run() {
 
     assert result == -1;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/bitwise_or.wado
+++ b/wado-compiler/tests/fixtures/bitwise_or.wado
@@ -7,3 +7,6 @@ fn run() {
 
     assert result == 14;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/bitwise_shift.wado
+++ b/wado-compiler/tests/fixtures/bitwise_shift.wado
@@ -8,3 +8,6 @@ fn run() {
     assert left_shift == 8;
     assert right_shift == 4;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/bitwise_xor.wado
+++ b/wado-compiler/tests/fixtures/bitwise_xor.wado
@@ -7,3 +7,6 @@ fn run() {
 
     assert result == 6;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/effect_import_aliasing.wado
+++ b/wado-compiler/tests/fixtures/effect_import_aliasing.wado
@@ -6,3 +6,6 @@ fn run() with Stdout {
     println("Aliased import works!");
     println("Direct import also works!");
 }
+
+__DATA__
+{"stdout_contains": ["Aliased import works!", "Direct import also works!"]}

--- a/wado-compiler/tests/fixtures/effect_import_demo.wado
+++ b/wado-compiler/tests/fixtures/effect_import_demo.wado
@@ -6,3 +6,6 @@ use {println, Stdout} from "core:cli";
 fn run() with Stdout {
     println("Hello from imported Stdout!");
 }
+
+__DATA__
+{"stdout": "Hello from imported Stdout!\n"}

--- a/wado-compiler/tests/fixtures/eprintln_then_trap.wado
+++ b/wado-compiler/tests/fixtures/eprintln_then_trap.wado
@@ -8,3 +8,6 @@ fn run() with Stderr {
     builtin::effect_wait();
     builtin::unreachable();
 }
+
+__DATA__
+{"stderr": "error message\n", "trapped": true}

--- a/wado-compiler/tests/fixtures/float_to_string.wado
+++ b/wado-compiler/tests/fixtures/float_to_string.wado
@@ -12,3 +12,6 @@ fn run() with Stdout {
     let result = 10.5 + 2.5;
     println(`10.5 + 2.5 = {result}`);
 }
+
+__DATA__
+{"stdout": "f is 1.23\npi is approximately 3.14159\n10.5 + 2.5 = 13.0\n"}

--- a/wado-compiler/tests/fixtures/for_loop.wado
+++ b/wado-compiler/tests/fixtures/for_loop.wado
@@ -8,3 +8,6 @@ fn run() with Stdout {
     }
     println("done");
 }
+
+__DATA__
+{"stdout": "loop\nloop\nloop\ndone\n"}

--- a/wado-compiler/tests/fixtures/hello.wado
+++ b/wado-compiler/tests/fixtures/hello.wado
@@ -5,3 +5,6 @@ use {println, Stdout} from "core:cli";
 fn run() with Stdout {
     println("Hello, world!");
 }
+
+__DATA__
+{"stdout": "Hello, world!\n"}

--- a/wado-compiler/tests/fixtures/likely_unlikely.wado
+++ b/wado-compiler/tests/fixtures/likely_unlikely.wado
@@ -29,3 +29,6 @@ fn run() with Stdout {
     let r4 = check_unlikely(-1);
     println(`r1={r1}, r2={r2}, r3={r3}, r4={r4}`);
 }
+
+__DATA__
+{"stdout": "r1=1, r2=0, r3=0, r4=1\n"}

--- a/wado-compiler/tests/fixtures/local_bools.wado
+++ b/wado-compiler/tests/fixtures/local_bools.wado
@@ -16,3 +16,6 @@ fn run() with Stdout {
         println("f is false");
     }
 }
+
+__DATA__
+{"stdout": "t is true\nf is false\n"}

--- a/wado-compiler/tests/fixtures/local_bools_mut.wado
+++ b/wado-compiler/tests/fixtures/local_bools_mut.wado
@@ -19,3 +19,6 @@ fn run() with Stdout {
         println("flag is false");
     }
 }
+
+__DATA__
+{"stdout": "flag is false\nflag is true\n"}

--- a/wado-compiler/tests/fixtures/local_floats.wado
+++ b/wado-compiler/tests/fixtures/local_floats.wado
@@ -12,3 +12,6 @@ fn run() with Stdout {
         println("floats work");
     }
 }
+
+__DATA__
+{"stdout": "floats work\n"}

--- a/wado-compiler/tests/fixtures/local_floats_mut.wado
+++ b/wado-compiler/tests/fixtures/local_floats_mut.wado
@@ -21,3 +21,6 @@ fn run() with Stdout {
         println("x is 3.0");
     }
 }
+
+__DATA__
+{"stdout": "x is 1.0\nx is 2.5\nx is 3.0\n"}

--- a/wado-compiler/tests/fixtures/local_integers.wado
+++ b/wado-compiler/tests/fixtures/local_integers.wado
@@ -12,3 +12,6 @@ fn run() with Stdout {
         println("integers work");
     }
 }
+
+__DATA__
+{"stdout": "integers work\n"}

--- a/wado-compiler/tests/fixtures/local_integers_mut.wado
+++ b/wado-compiler/tests/fixtures/local_integers_mut.wado
@@ -21,3 +21,6 @@ fn run() with Stdout {
         println("x is 15");
     }
 }
+
+__DATA__
+{"stdout": "x is 5\nx is 10\nx is 15\n"}

--- a/wado-compiler/tests/fixtures/local_let.wado
+++ b/wado-compiler/tests/fixtures/local_let.wado
@@ -6,3 +6,6 @@ fn run() with Stdout {
     let msg = "Hello from let!";
     println(msg);
 }
+
+__DATA__
+{"stdout": "Hello from let!\n"}

--- a/wado-compiler/tests/fixtures/local_let_mut.wado
+++ b/wado-compiler/tests/fixtures/local_let_mut.wado
@@ -8,3 +8,6 @@ fn run() with Stdout {
     msg = "Second message";
     println(msg);
 }
+
+__DATA__
+{"stdout": "First message\nSecond message\n"}

--- a/wado-compiler/tests/fixtures/multiple_effect_imports.wado
+++ b/wado-compiler/tests/fixtures/multiple_effect_imports.wado
@@ -5,3 +5,6 @@ use {println, Stdout} from "core:cli";
 fn run() with Stdout {
     println("Testing multiple imports");
 }
+
+__DATA__
+{"stdout": "Testing multiple imports\n"}

--- a/wado-compiler/tests/fixtures/multiple_println.wado
+++ b/wado-compiler/tests/fixtures/multiple_println.wado
@@ -7,3 +7,6 @@ fn run() with Stdout {
     println("Line 2");
     println("Line 3");
 }
+
+__DATA__
+{"stdout": "Line 1\nLine 2\nLine 3\n"}

--- a/wado-compiler/tests/fixtures/panic_basic.wado
+++ b/wado-compiler/tests/fixtures/panic_basic.wado
@@ -5,3 +5,6 @@ use {panic} from "core:cli";
 fn run() {
     panic("This is a panic message");
 }
+
+__DATA__
+{"stderr": "This is a panic message\n", "trapped": true}

--- a/wado-compiler/tests/fixtures/parentheses_precedence.wado
+++ b/wado-compiler/tests/fixtures/parentheses_precedence.wado
@@ -10,3 +10,6 @@ fn run() {
     assert without_parens == 14;
     assert with_parens == 20;
 }
+
+__DATA__
+{}

--- a/wado-compiler/tests/fixtures/template_string_bool.wado
+++ b/wado-compiler/tests/fixtures/template_string_bool.wado
@@ -8,3 +8,6 @@ fn run() with Stdout {
     println(`true: {t}`);
     println(`false: {f}`);
 }
+
+__DATA__
+{"stdout": "true: true\nfalse: false\n"}

--- a/wado-compiler/tests/fixtures/template_string_char.wado
+++ b/wado-compiler/tests/fixtures/template_string_char.wado
@@ -8,3 +8,6 @@ fn run() with Stdout {
     println(`char A: {a}`);
     println(`char Z: {z}`);
 }
+
+__DATA__
+{"stdout": "char A: A\nchar Z: Z\n"}

--- a/wado-compiler/tests/fixtures/template_string_empty.wado
+++ b/wado-compiler/tests/fixtures/template_string_empty.wado
@@ -6,3 +6,6 @@ fn run() with Stdout {
     let s = ``;
     println(s);
 }
+
+__DATA__
+{"stdout": "\n"}

--- a/wado-compiler/tests/fixtures/template_string_f64.wado
+++ b/wado-compiler/tests/fixtures/template_string_f64.wado
@@ -8,3 +8,6 @@ fn run() with Stdout {
     println(`pi: {pi}`);
     println(`negative: {neg}`);
 }
+
+__DATA__
+{"stdout": "pi: 3.14159\nnegative: -2.5\n"}

--- a/wado-compiler/tests/fixtures/template_string_i32.wado
+++ b/wado-compiler/tests/fixtures/template_string_i32.wado
@@ -10,3 +10,6 @@ fn run() with Stdout {
     println(`negative: {neg}`);
     println(`zero: {zero}`);
 }
+
+__DATA__
+{"stdout": "positive: 42\nnegative: -17\nzero: 0\n"}

--- a/wado-compiler/tests/fixtures/template_string_i64.wado
+++ b/wado-compiler/tests/fixtures/template_string_i64.wado
@@ -11,3 +11,6 @@ fn run() with Stdout {
     println(`big: {big}`);
     println(`negative: {neg}`);
 }
+
+__DATA__
+{"stdout": "positive: 12345\nbig: 100000000000\nnegative: -9876\n"}

--- a/wado-compiler/tests/fixtures/template_string_three_interp.wado
+++ b/wado-compiler/tests/fixtures/template_string_three_interp.wado
@@ -8,3 +8,6 @@ fn run() with Stdout {
     let s3 = "Z";
     println(`{s1} a {s2} c {s3}`);
 }
+
+__DATA__
+{"stdout": "X a Y c Z\n"}

--- a/wado-compiler/tests/fixtures/template_string_two_end.wado
+++ b/wado-compiler/tests/fixtures/template_string_two_end.wado
@@ -7,3 +7,6 @@ fn run() with Stdout {
     let s2 = "Y";
     println(`a {s1} b {s2}`);
 }
+
+__DATA__
+{"stdout": "a X b Y\n"}

--- a/wado-compiler/tests/fixtures/template_string_two_interp.wado
+++ b/wado-compiler/tests/fixtures/template_string_two_interp.wado
@@ -7,3 +7,6 @@ fn run() with Stdout {
     let s2 = "Y";
     println(`{s1} a {s2} c`);
 }
+
+__DATA__
+{"stdout": "X a Y c\n"}

--- a/wado-compiler/tests/fixtures/template_string_two_middle.wado
+++ b/wado-compiler/tests/fixtures/template_string_two_middle.wado
@@ -7,3 +7,6 @@ fn run() with Stdout {
     let s2 = "Y";
     println(`a {s1} b {s2} c`);
 }
+
+__DATA__
+{"stdout": "a X b Y c\n"}

--- a/wado-compiler/tests/fixtures/type_cast.wado
+++ b/wado-compiler/tests/fixtures/type_cast.wado
@@ -34,3 +34,6 @@ fn run() with Stdout {
         println("cast in arithmetic works");
     }
 }
+
+__DATA__
+{"stdout": "i32 to f64 works\nf64 to i32 works\nchained casts work\ncast in arithmetic works\n"}

--- a/wado-compiler/tests/fixtures/use_local_module.wado
+++ b/wado-compiler/tests/fixtures/use_local_module.wado
@@ -12,3 +12,6 @@ fn run() with Stdout {
         println("failure");
     }
 }
+
+__DATA__
+{"stdout": "success\n"}

--- a/wado-compiler/tests/fixtures/user_function_call.wado
+++ b/wado-compiler/tests/fixtures/user_function_call.wado
@@ -15,3 +15,6 @@ fn run() with Stdout {
         println("failure");
     }
 }
+
+__DATA__
+{"stdout": "success\n"}


### PR DESCRIPTION
- Add __DATA__ section support to lexer (captures raw text after marker)
- Add data_section field to Module AST with accessor API
- Add CompileResult struct for extensible compile output
- Rewrite E2E tests to use __DATA__ sections with JSON test specs
- Use datatest-stable for auto-discovery and parallel test execution
- Add all fixture files with __DATA__ sections containing expected results
- Update spec.md with Data Section documentation
- Update compiler.md with implementation status