### PR TITLE
Add String type design specification

### DIFF
--- a/docs/adr-2026-01-15-string-type-design.md
+++ b/docs/adr-2026-01-15-string-type-design.md
@@ -1,0 +1,209 @@
+# ADR 2026-01-15: String Type Design
+
+## Status
+
+Accepted
+
+## Context
+
+Wado requires a string type design that balances several competing concerns:
+
+### Requirements
+
+1. **Efficient concatenation**: String concatenation must be efficient enough for typical use cases (loops, builders, etc.)
+2. **Value semantics**: Aligned with Wado's design philosophy for struct types
+3. **No separate StringBuilder**: Users shouldn't need a separate builder type for efficient string construction
+4. **Unicode correctness**: Proper handling of UTF-8 encoded Unicode
+5. **Component Model alignment**: Direct mapping to Component Model's `string` type (UTF-8)
+6. **GC compatibility**: Work well with Wasm GC
+
+### Design Challenges
+
+Different languages have taken different approaches:
+
+- **Rust**: Two types (`String`/`str`), value semantics, complex but explicit
+- **Go**: Single type, byte array semantics, simple but requires `strings.Builder` for efficiency
+- **TypeScript/JavaScript**: Immutable strings, reference semantics, requires concatenation patterns for efficiency
+- **Python/Swift**: Copy-on-Write strings, efficient but requires runtime reference counting
+
+For Wado, key tensions include:
+- Value semantics vs efficient mutation
+- Single type vs multiple types for different use cases
+- Explicitness vs hidden optimizations
+- Wasm GC constraints (no native reference count inspection)
+
+## Decision
+
+We adopt a **single String type with value semantics and specialized `+=` operator**:
+
+### Core Design
+
+```wado
+// String: value semantics, immutable content, GC-managed
+struct String {
+    data: GcArray<u8>,   // UTF-8 data
+    len: usize,
+    capacity: usize,     // Buffer for += operations
+}
+```
+
+### Key Features
+
+**1. Index access is prohibited**
+
+```wado
+// Prohibited
+s[i]      // Compile error
+s[i..j]   // Compile error
+
+// Explicit methods instead
+s.bytes() -> Array<u8>      // Get as byte array
+s.chars() -> Array<char>    // Get as character array
+s.len() -> usize
+s.is_empty() -> bool
+```
+
+**Rationale**:
+- Avoids ambiguity between byte indexing and character indexing
+- Follows Rust's precedent
+- Forces explicit choice between byte/character semantics
+
+**2. Value semantics with reference sharing**
+
+```wado
+let s1 = "hello";
+let s2 = s1;  // Semantics: value copy, Implementation: reference sharing (safe because immutable)
+```
+
+**3. Specialized `+=` operator**
+
+```wado
+let mut s = "hello";
+s += " world";  // Desugars to: String::add_assign(&mut s, " world")
+                // Efficient implementation with capacity management
+```
+
+**Implementation**:
+```wado
+fn add_assign(target: &mut String, suffix: String) {
+    if target.capacity >= target.len + suffix.len {
+        // In-place append (no allocation)
+    } else {
+        // Reallocation with growth factor (typically 2x)
+    }
+}
+// Amortized O(1) per operation in loops
+```
+
+**4. Regular `+` creates new String**
+
+```wado
+let s = "hello" + " world";  // Creates new String
+```
+
+**5. Pre-allocation support**
+
+```wado
+let mut s = String::with_capacity(1000);
+for item in items {
+    s += item;  // Efficient, no reallocations if within capacity
+}
+```
+
+### Consistency Considerations
+
+The `+=` operator is treated specially for String:
+
+```wado
+// For numeric types
+x += 5  ≡  x = x + 5  // Syntactic sugar
+
+// For String
+s += t  ≠  s = s + t  // Different implementation (but same semantic result)
+```
+
+**Mitigation**: This will be generalized through traits in the future:
+
+```wado
+trait AddAssign<Rhs> {
+    fn add_assign(&mut self, rhs: Rhs);
+}
+
+// All += operations desugar to:
+x += y  →  AddAssign::add_assign(&mut x, y)
+```
+
+This makes the special treatment a general mechanism available to user types.
+
+## Consequences
+
+### Positive
+
+1. **Simple mental model**: Single String type, value semantics
+2. **Efficient concatenation**: `+=` provides O(n) amortized complexity in loops
+3. **No StringBuilder needed**: Achieves the goal of avoiding a separate builder type
+4. **GC-friendly**: Immutable strings can be safely shared
+5. **Clear Unicode handling**: Explicit `bytes()` vs `chars()` methods
+6. **Future-proof**: Can add slices/iterators later without breaking changes
+
+### Negative
+
+1. **Operator inconsistency**: `+=` has different implementation than other types
+   - **Mitigation**: Will be generalized via traits
+   - **Precedent**: Common in other languages (Python, Java, C#)
+
+2. **Memory overhead**: All Strings carry `capacity` field (8-16 bytes)
+   - **Mitigation**: Small relative to typical string sizes
+   - **Future optimization**: Could use tagged pointer for small strings
+
+3. **bytes()/chars() copying**: Returns Array, requires full copy
+   - **Mitigation**: Temporary, will be improved with slices/iterators
+   - **Workaround**: Provide `byte_at(i)`, `char_at(i)` for single access
+
+### Trade-offs vs Alternatives
+
+**vs String/MutString split**:
+- ✓ Simpler (one type vs two)
+- ✓ Better UX (no mental overhead of choosing)
+- ✗ Less explicit separation of mutable/immutable
+
+**vs Copy-on-Write**:
+- ✓ More predictable performance
+- ✓ Feasible with current Wasm GC (no RC introspection needed)
+- ✗ Requires explicit `+=` (but this is our goal anyway)
+
+**vs Immutable-only (like JavaScript)**:
+- ✓ Efficient mutation via `+=`
+- ✓ No need for builder pattern
+- ✗ Slightly more complex implementation
+
+### Future Extensions
+
+1. **Trait-based operator overloading**: Generalize `+=` mechanism
+2. **Slices**: `s.bytes()` returns `&[u8]` instead of `Array<u8>`
+3. **Iterators**: `s.chars()` returns lazy iterator
+4. **Small String Optimization (SSO)**: Store short strings inline
+5. **String interpolation optimization**: Compile-time capacity estimation
+
+### Implementation Notes
+
+The `+=` operator implementation should:
+- Use growth factor (typically 2x) for reallocation
+- Provide `String::with_capacity(n)` for pre-allocation
+- Document performance characteristics clearly
+- Consider SSO for strings ≤15 bytes
+
+### Documentation Requirements
+
+User documentation must clarify:
+1. Why `s[i]` is prohibited (byte vs char ambiguity)
+2. Performance characteristics of `+=` vs `+`
+3. Recommended patterns for efficient string building
+4. When to use `with_capacity()`
+
+## Related Decisions
+
+- Operator precedence and overloading (to be designed)
+- Slice types (to be designed)
+- Iterator protocol (to be designed)
+- Memory model and move semantics (in progress)

--- a/spec.md
+++ b/spec.md
@@ -422,6 +422,167 @@ bool
 char
 ```
 
+### String Type
+
+`String` is a built-in type representing UTF-8 encoded text with value semantics and GC management.
+
+**Design Principles**:
+- Value semantics: Conceptually behaves like a value type
+- Immutable content: String data cannot be modified in-place
+- GC-managed: Memory is automatically managed by Wasm GC
+- UTF-8 encoding: Direct mapping to Component Model `string`
+
+**Internal Structure**:
+```wado
+// Conceptual representation (not user-visible)
+struct String {
+    data: GcArray<u8>,   // UTF-8 bytes
+    len: usize,          // Length in bytes
+    capacity: usize,     // Buffer capacity for += operations
+}
+```
+
+#### Index Access (Prohibited)
+
+Direct index access is prohibited to avoid ambiguity between byte and character indexing:
+
+```wado
+let s = "Hello世界";
+
+// Prohibited
+s[0]      // Compile error
+s[0..5]   // Compile error
+```
+
+Use explicit methods instead:
+
+```wado
+// Byte-level access
+let bytes: Array<u8> = s.bytes();
+let first_byte = bytes[0];
+
+// Character-level access
+let chars: Array<char> = s.chars();
+let first_char = chars[0];
+
+// Other methods
+s.len() -> usize           // Length in bytes
+s.is_empty() -> bool       // Check if empty
+```
+
+**Note**: `bytes()` and `chars()` currently return `Array<T>` (copy). Future versions will support slices and iterators for zero-copy access.
+
+#### Concatenation
+
+**New String (`+` operator)**:
+
+```wado
+let s1 = "hello";
+let s2 = " world";
+let s3 = s1 + s2;  // Creates new String
+```
+
+**Mutation (`+=` operator)**:
+
+The `+=` operator provides efficient in-place concatenation:
+
+```wado
+let mut s = "hello";
+s += " world";     // Efficient: uses internal capacity
+s += "!";          // May reallocate if capacity exceeded
+```
+
+**Implementation**: `+=` desugars to `String::add_assign(&mut s, suffix)` which manages an internal buffer with amortized O(1) complexity.
+
+**Pre-allocation**:
+
+```wado
+// Allocate capacity upfront for efficient building
+let mut result = String::with_capacity(1000);
+for item in items {
+    result += item;  // No reallocations if within capacity
+}
+```
+
+#### Semantic vs Implementation
+
+```wado
+// Semantically: value copy
+let s1 = "hello";
+let s2 = s1;  // s1 still usable
+
+// Implementation: reference sharing (safe because immutable)
+// No actual copy of string data occurs
+```
+
+**Explicit move**:
+
+```wado
+let s1 = "hello";
+let s2 = move s1;  // s1 invalidated, no copy
+// s1 is no longer accessible
+```
+
+**Implicit move optimization**:
+
+```wado
+let mut s = "hello";
+let temp = "world";
+s = temp;  // If temp is not used after, compiler may optimize to move
+```
+
+#### Operator Consistency
+
+The `+=` operator has special semantics for String:
+
+```wado
+// For numeric types
+x += 5  ≡  x = x + 5  // Exact equivalence
+
+// For String
+s += t  ≈  s = s + t  // Same result, different implementation
+                      // += is more efficient (no intermediate allocation)
+```
+
+This special treatment will be generalized via traits in the future, allowing user types to define their own `+=` behavior.
+
+#### Performance Guidelines
+
+**Efficient patterns**:
+
+```wado
+// 1. Pre-allocate when size is known
+let mut s = String::with_capacity(estimated_size);
+for item in items {
+    s += item;
+}
+
+// 2. Use += for repeated concatenation
+let mut result = String::new();
+result += "Line 1\n";
+result += "Line 2\n";
+result += "Line 3\n";
+
+// 3. Join arrays of strings (future)
+let parts = ["a", "b", "c"];
+let result = parts.join(",");
+```
+
+**Inefficient patterns**:
+
+```wado
+// Avoid: creates intermediate String objects
+let s = "a" + "b" + "c" + "d";
+
+// Prefer:
+let mut s = "a";
+s += "b";
+s += "c";
+s += "d";
+```
+
+See `docs/adr-2026-01-15-string-type-design.md` for design rationale.
+
 ### Primitive Literals
 
 #### Boolean Literals


### PR DESCRIPTION
- Add ADR for String type design with value semantics and += operator
- Add String Type section to spec.md covering:
  - Index access prohibition (use bytes()/chars() instead)
  - Concatenation operators (+ and +=)
  - Performance guidelines
  - Value semantics with reference sharing implementation