### PR TITLE
Add String semantics and encoding specification

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -610,6 +610,7 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [ ] Value semantics for Variant (blocked on Variant codegen)
 - [ ] Value semantics for Dict<K, V> (blocked on Dict codegen)
 - [x] Template string array concatenation
+- [ ] String UTF-8 validation (reject invalid byte sequences at construction)
 - [ ] Reactive signals (source values)
 - [ ] Reactive signals (derived values)
 - [ ] Reactive effect blocks (syntax TBD)

--- a/spec.md
+++ b/spec.md
@@ -487,6 +487,12 @@ char
 - GC-managed: Memory is automatically managed by Wasm GC
 - UTF-8 encoding: Direct mapping to Component Model `string`
 
+**Semantics and Encoding**:
+- Semantically, a `String` is a sequence of Unicode scalar values
+- Internally represented as a UTF-8 byte array (`Array<u8>`)
+- Invalid UTF-8 byte sequences are not allowed; all String values must be valid UTF-8
+- This ensures interoperability with Component Model `string` type and safe string operations
+
 **Internal Structure**:
 ```wado
 // Conceptual representation (not user-visible)


### PR DESCRIPTION
Clarify that String is semantically a sequence of Unicode scalar values,
internally represented as UTF-8, and invalid byte sequences are not allowed.