### PR TITLE
Add phase-based options to wado dump command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ wado dump --optimize file.wado       # show optimization hints
 ```
 
 Available phases (in compilation order):
+
 1. `--tokens` - Lexer output
 2. `--ast` - Parser output (supports `--unparse`)
 3. `--desugar` - Desugared AST (supports `--unparse`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,11 +89,27 @@ cargo run --bin wado -- run file.wado                     # run it directly usin
 Use `wado dump` to inspect compiler internal state for debugging:
 
 ```sh
-wado dump file.wado           # show all: modules, symbols, AST
-wado dump --modules file.wado # show loaded modules only
-wado dump --symbols file.wado # show symbol table only
-wado dump --ast file.wado     # show AST only
+wado dump file.wado                  # show all phases (Debug format)
+wado dump --ast file.wado            # show AST structure (Debug format)
+wado dump --ast --unparse file.wado  # show AST as Wado source code
+wado dump --desugar file.wado        # show desugared AST (Debug format)
+wado dump --desugar --unparse file.wado  # show desugared AST as source
+wado dump --modules file.wado        # show loaded modules only
+wado dump --symbols file.wado        # show symbol table only
+wado dump --tir file.wado            # show TIR (Typed IR)
+wado dump --lower file.wado          # show lowered TIR
+wado dump --optimize file.wado       # show optimization hints
 ```
+
+Available phases (in compilation order):
+1. `--tokens` - Lexer output
+2. `--ast` - Parser output (supports `--unparse`)
+3. `--desugar` - Desugared AST (supports `--unparse`)
+4. `--modules` - Loaded modules
+5. `--symbols` - Symbol table
+6. `--tir` - Typed IR (will support `--unparse` in future)
+7. `--lower` - Lowered TIR (will support `--unparse` in future)
+8. `--optimize` - Optimization hints
 
 ## Bundled Library
 

--- a/docs/adr-2026-01-15-string-type-design.md
+++ b/docs/adr-2026-01-15-string-type-design.md
@@ -27,6 +27,7 @@ Different languages have taken different approaches:
 - **Python/Swift**: Copy-on-Write strings, efficient but requires runtime reference counting
 
 For Wado, key tensions include:
+
 - Value semantics vs efficient mutation
 - Single type vs multiple types for different use cases
 - Explicitness vs hidden optimizations
@@ -64,6 +65,7 @@ s.is_empty() -> bool
 ```
 
 **Rationale**:
+
 - Avoids ambiguity between byte indexing and character indexing
 - Follows Rust's precedent
 - Forces explicit choice between byte/character semantics
@@ -84,6 +86,7 @@ s += " world";  // Desugars to: String::add_assign(&mut s, " world")
 ```
 
 **Implementation**:
+
 ```wado
 fn add_assign(target: &mut String, suffix: String) {
     if target.capacity >= target.len + suffix.len {
@@ -163,16 +166,19 @@ This makes the special treatment a general mechanism available to user types.
 ### Trade-offs vs Alternatives
 
 **vs String/MutString split**:
+
 - ✓ Simpler (one type vs two)
 - ✓ Better UX (no mental overhead of choosing)
 - ✗ Less explicit separation of mutable/immutable
 
 **vs Copy-on-Write**:
+
 - ✓ More predictable performance
 - ✓ Feasible with current Wasm GC (no RC introspection needed)
 - ✗ Requires explicit `+=` (but this is our goal anyway)
 
 **vs Immutable-only (like JavaScript)**:
+
 - ✓ Efficient mutation via `+=`
 - ✓ No need for builder pattern
 - ✗ Slightly more complex implementation
@@ -188,6 +194,7 @@ This makes the special treatment a general mechanism available to user types.
 ### Implementation Notes
 
 The `+=` operator implementation should:
+
 - Use growth factor (typically 2x) for reallocation
 - Provide `String::with_capacity(n)` for pre-allocation
 - Document performance characteristics clearly
@@ -196,6 +203,7 @@ The `+=` operator implementation should:
 ### Documentation Requirements
 
 User documentation must clarify:
+
 1. Why `s[i]` is prohibited (byte vs char ambiguity)
 2. Performance characteristics of `+=` vs `+`
 3. Recommended patterns for efficient string building

--- a/spec.md
+++ b/spec.md
@@ -482,12 +482,14 @@ char
 `String` is a built-in type representing UTF-8 encoded text with value semantics and GC management.
 
 **Design Principles**:
+
 - Value semantics: Conceptually behaves like a value type
 - Immutable content: String data cannot be modified in-place
 - GC-managed: Memory is automatically managed by Wasm GC
 - UTF-8 encoding: Direct mapping to Component Model `string`
 
 **Internal Structure**:
+
 ```wado
 // Conceptual representation (not user-visible)
 struct String {

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -5,9 +5,14 @@ use lexopt::prelude::*;
 
 pub struct DumpOptions {
     pub input: String,
+    pub show_tokens: bool,
     pub show_ast: bool,
+    pub show_desugar: bool,
     pub show_symbols: bool,
     pub show_modules: bool,
+    pub show_tir: bool,
+    pub show_lower: bool,
+    pub show_optimize: bool,
 }
 
 pub fn print_usage() {
@@ -16,18 +21,28 @@ pub fn print_usage() {
     eprintln!("Dump compiler internal state for debugging.");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --ast        Show the AST (abstract syntax tree)");
-    eprintln!("  --symbols    Show the symbol table");
+    eprintln!("  --tokens     Show tokens from lexer");
+    eprintln!("  --ast        Show AST from parser (unparsed to Wado source)");
+    eprintln!("  --desugar    Show desugared AST (unparsed to Wado source)");
+    eprintln!("  --symbols    Show symbol table from analyzer");
     eprintln!("  --modules    Show loaded modules");
+    eprintln!("  --tir        Show TIR (Typed IR) from resolver");
+    eprintln!("  --lower      Show lowered TIR");
+    eprintln!("  --optimize   Show optimization hints");
     eprintln!("  --all        Show all information (default if no options)");
     eprintln!("  --help       Show this help message");
 }
 
 pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     let mut input: Option<String> = None;
+    let mut show_tokens = false;
     let mut show_ast = false;
+    let mut show_desugar = false;
     let mut show_symbols = false;
     let mut show_modules = false;
+    let mut show_tir = false;
+    let mut show_lower = false;
+    let mut show_optimize = false;
 
     while let Some(arg) = parser.next().unwrap_or_else(|e| {
         eprintln!("Error: {e}");
@@ -38,8 +53,14 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
                 print_usage();
                 process::exit(0);
             }
+            Long("tokens") => {
+                show_tokens = true;
+            }
             Long("ast") => {
                 show_ast = true;
+            }
+            Long("desugar") => {
+                show_desugar = true;
             }
             Long("symbols") => {
                 show_symbols = true;
@@ -47,10 +68,24 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
             Long("modules") => {
                 show_modules = true;
             }
+            Long("tir") => {
+                show_tir = true;
+            }
+            Long("lower") => {
+                show_lower = true;
+            }
+            Long("optimize") => {
+                show_optimize = true;
+            }
             Long("all") => {
+                show_tokens = true;
                 show_ast = true;
+                show_desugar = true;
                 show_symbols = true;
                 show_modules = true;
+                show_tir = true;
+                show_lower = true;
+                show_optimize = true;
             }
             Value(val) => {
                 if input.is_some() {
@@ -77,17 +112,35 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     };
 
     // Default: show all
-    if !show_ast && !show_symbols && !show_modules {
+    if !show_tokens
+        && !show_ast
+        && !show_desugar
+        && !show_symbols
+        && !show_modules
+        && !show_tir
+        && !show_lower
+        && !show_optimize
+    {
+        show_tokens = true;
         show_ast = true;
+        show_desugar = true;
         show_symbols = true;
         show_modules = true;
+        show_tir = true;
+        show_lower = true;
+        show_optimize = true;
     }
 
     DumpOptions {
         input,
+        show_tokens,
         show_ast,
+        show_desugar,
         show_symbols,
         show_modules,
+        show_tir,
+        show_lower,
+        show_optimize,
     }
 }
 
@@ -100,9 +153,36 @@ pub fn run(opts: DumpOptions) {
         }
     };
 
-    // Modules section
+    // Tokens section (Lexer phase)
+    if opts.show_tokens {
+        println!("=== Tokens (Lexer) ===");
+        for (i, token) in result.tokens.iter().enumerate() {
+            println!("  [{}] {:?}", i, token);
+        }
+        println!();
+    }
+
+    // AST section (Parser phase)
+    if opts.show_ast {
+        println!("=== AST (Parser, unparsed) ===");
+        let unparser = wado_compiler::unparse::Unparser::new(&result.comments);
+        let unparsed = unparser.unparse(&result.ast);
+        println!("{}", unparsed);
+        println!();
+    }
+
+    // Desugared AST section (Desugar phase)
+    if opts.show_desugar {
+        println!("=== Desugared AST (Desugar, unparsed) ===");
+        let unparser = wado_compiler::unparse::Unparser::new(&result.comments);
+        let unparsed = unparser.unparse(&result.desugared_ast);
+        println!("{}", unparsed);
+        println!();
+    }
+
+    // Modules section (Load phase)
     if opts.show_modules {
-        println!("=== Loaded Modules ===");
+        println!("=== Loaded Modules (Load) ===");
         for module_path in &result.loaded_modules {
             let path_str = module_path.join("::");
             let is_implicit = result.implicit_modules.contains(module_path);
@@ -121,9 +201,9 @@ pub fn run(opts: DumpOptions) {
         println!();
     }
 
-    // Symbols section
+    // Symbols section (Analyze phase)
     if opts.show_symbols {
-        println!("=== Symbol Table ===");
+        println!("=== Symbol Table (Analyze) ===");
         for symbol in result.symbols.all_symbols() {
             let module_path = if symbol.module_path.is_empty() {
                 "(local)".to_string()
@@ -206,16 +286,48 @@ pub fn run(opts: DumpOptions) {
         println!();
     }
 
-    // AST section
-    if opts.show_ast {
-        println!("=== AST ===");
-        for (i, item) in result.ast.items.iter().enumerate() {
-            println!("  [{}] {:?}", i, item);
-        }
-        if let Some(data) = result.ast.data_section() {
+    // TIR section (Resolve phase)
+    if opts.show_tir {
+        if let Some(ref tir_modules) = result.tir_modules {
+            println!("=== TIR (Resolve) ===");
+            for (path, module) in tir_modules {
+                println!("--- Module: {} ---", path.join("::"));
+                println!("{:#?}", module);
+                println!();
+            }
+        } else {
+            println!("=== TIR (Resolve) ===");
+            println!("(TIR resolution failed or not available)");
             println!();
-            println!("=== Data Section ===");
-            println!("{}", data);
+        }
+    }
+
+    // Lowered TIR section (Lower phase)
+    if opts.show_lower {
+        if let Some(ref lowered_modules) = result.lowered_tir_modules {
+            println!("=== Lowered TIR (Lower) ===");
+            for (path, module) in lowered_modules {
+                println!("--- Module: {} ---", path.join("::"));
+                println!("{:#?}", module);
+                println!();
+            }
+        } else {
+            println!("=== Lowered TIR (Lower) ===");
+            println!("(TIR lowering failed or not available)");
+            println!();
+        }
+    }
+
+    // Optimization hints section (Optimize phase)
+    if opts.show_optimize {
+        if let Some(ref hints) = result.opt_hints {
+            println!("=== Optimization Hints (Optimize) ===");
+            println!("{:#?}", hints);
+            println!();
+        } else {
+            println!("=== Optimization Hints (Optimize) ===");
+            println!("(Optimization analysis failed or not available)");
+            println!();
         }
     }
 }

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -13,6 +13,7 @@ pub struct DumpOptions {
     pub show_tir: bool,
     pub show_lower: bool,
     pub show_optimize: bool,
+    pub unparse: bool,
 }
 
 pub fn print_usage() {
@@ -20,16 +21,22 @@ pub fn print_usage() {
     eprintln!();
     eprintln!("Dump compiler internal state for debugging.");
     eprintln!();
-    eprintln!("Options:");
-    eprintln!("  --tokens     Show tokens from lexer");
-    eprintln!("  --ast        Show AST from parser (unparsed to Wado source)");
-    eprintln!("  --desugar    Show desugared AST (unparsed to Wado source)");
-    eprintln!("  --symbols    Show symbol table from analyzer");
-    eprintln!("  --modules    Show loaded modules");
-    eprintln!("  --tir        Show TIR (Typed IR) from resolver");
-    eprintln!("  --lower      Show lowered TIR");
-    eprintln!("  --optimize   Show optimization hints");
-    eprintln!("  --all        Show all information (default if no options)");
+    eprintln!("Compilation Phases:");
+    eprintln!("  --tokens     (Phase 1: Lexer) Show tokens");
+    eprintln!("  --ast        (Phase 2: Parser) Show AST structure");
+    eprintln!("  --desugar    (Phase 3: Desugar) Show desugared AST");
+    eprintln!("  --modules    (Phase 4: Load) Show loaded modules");
+    eprintln!("  --symbols    (Phase 5: Analyze) Show symbol table");
+    eprintln!("  --tir        (Phase 6: Resolve) Show TIR (Typed IR)");
+    eprintln!("  --lower      (Phase 7: Lower) Show lowered TIR");
+    eprintln!("  --optimize   (Phase 8: Optimize) Show optimization hints");
+    eprintln!("  --all        Show all phases (default if no phase specified)");
+    eprintln!();
+    eprintln!("Display Options:");
+    eprintln!("  --unparse    Unparse to Wado source code (for ast/desugar/tir/lower)");
+    eprintln!("               Default: Debug/tree format");
+    eprintln!();
+    eprintln!("Other:");
     eprintln!("  --help       Show this help message");
 }
 
@@ -43,6 +50,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     let mut show_tir = false;
     let mut show_lower = false;
     let mut show_optimize = false;
+    let mut unparse = false;
 
     while let Some(arg) = parser.next().unwrap_or_else(|e| {
         eprintln!("Error: {e}");
@@ -76,6 +84,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
             }
             Long("optimize") => {
                 show_optimize = true;
+            }
+            Long("unparse") => {
+                unparse = true;
             }
             Long("all") => {
                 show_tokens = true;
@@ -141,6 +152,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
         show_tir,
         show_lower,
         show_optimize,
+        unparse,
     }
 }
 
@@ -164,19 +176,43 @@ pub fn run(opts: DumpOptions) {
 
     // AST section (Parser phase)
     if opts.show_ast {
-        println!("=== AST (Parser, unparsed) ===");
-        let unparser = wado_compiler::unparse::Unparser::new(&result.comments);
-        let unparsed = unparser.unparse(&result.ast);
-        println!("{}", unparsed);
+        if opts.unparse {
+            println!("=== AST (Parser, unparsed) ===");
+            let unparser = wado_compiler::unparse::Unparser::new(&result.comments);
+            let unparsed = unparser.unparse(&result.ast);
+            println!("{}", unparsed);
+        } else {
+            println!("=== AST (Parser) ===");
+            for (i, item) in result.ast.items.iter().enumerate() {
+                println!("  [{}] {:#?}", i, item);
+            }
+            if let Some(data) = result.ast.data_section() {
+                println!();
+                println!("--- Data Section ---");
+                println!("{}", data);
+            }
+        }
         println!();
     }
 
     // Desugared AST section (Desugar phase)
     if opts.show_desugar {
-        println!("=== Desugared AST (Desugar, unparsed) ===");
-        let unparser = wado_compiler::unparse::Unparser::new(&result.comments);
-        let unparsed = unparser.unparse(&result.desugared_ast);
-        println!("{}", unparsed);
+        if opts.unparse {
+            println!("=== Desugared AST (Desugar, unparsed) ===");
+            let unparser = wado_compiler::unparse::Unparser::new(&result.comments);
+            let unparsed = unparser.unparse(&result.desugared_ast);
+            println!("{}", unparsed);
+        } else {
+            println!("=== Desugared AST (Desugar) ===");
+            for (i, item) in result.desugared_ast.items.iter().enumerate() {
+                println!("  [{}] {:#?}", i, item);
+            }
+            if let Some(data) = result.desugared_ast.data_section() {
+                println!();
+                println!("--- Data Section ---");
+                println!("{}", data);
+            }
+        }
         println!();
     }
 
@@ -289,11 +325,17 @@ pub fn run(opts: DumpOptions) {
     // TIR section (Resolve phase)
     if opts.show_tir {
         if let Some(ref tir_modules) = result.tir_modules {
-            println!("=== TIR (Resolve) ===");
-            for (path, module) in tir_modules {
-                println!("--- Module: {} ---", path.join("::"));
-                println!("{:#?}", module);
+            if opts.unparse {
+                println!("=== TIR (Resolve, unparsed) ===");
+                println!("(TIR unparsing not yet implemented)");
                 println!();
+            } else {
+                println!("=== TIR (Resolve) ===");
+                for (path, module) in tir_modules {
+                    println!("--- Module: {} ---", path.join("::"));
+                    println!("{:#?}", module);
+                    println!();
+                }
             }
         } else {
             println!("=== TIR (Resolve) ===");
@@ -305,11 +347,17 @@ pub fn run(opts: DumpOptions) {
     // Lowered TIR section (Lower phase)
     if opts.show_lower {
         if let Some(ref lowered_modules) = result.lowered_tir_modules {
-            println!("=== Lowered TIR (Lower) ===");
-            for (path, module) in lowered_modules {
-                println!("--- Module: {} ---", path.join("::"));
-                println!("{:#?}", module);
+            if opts.unparse {
+                println!("=== Lowered TIR (Lower, unparsed) ===");
+                println!("(TIR unparsing not yet implemented)");
                 println!();
+            } else {
+                println!("=== Lowered TIR (Lower) ===");
+                for (path, module) in lowered_modules {
+                    println!("--- Module: {} ---", path.join("::"));
+                    println!("{:#?}", module);
+                    println!();
+                }
             }
         } else {
             println!("=== Lowered TIR (Lower) ===");

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -300,9 +300,9 @@ pub fn dump_file(path: &Path) -> Result<DumpResult, CompileError> {
     });
 
     // === Phase 9: Optimize ===
-    let opt_hints = lowered_tir_modules.as_ref().map(|modules| {
-        analyze_all_modules(modules, &load_result.entry_path)
-    });
+    let opt_hints = lowered_tir_modules
+        .as_ref()
+        .map(|modules| analyze_all_modules(modules, &load_result.entry_path));
 
     Ok(DumpResult {
         source,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -48,18 +48,30 @@ pub struct CompileResult {
 /// Result of dumping compiler internal state
 #[derive(Debug)]
 pub struct DumpResult {
-    /// The main module's AST
+    /// Source code
+    pub source: String,
+    /// Tokens from lexer
+    pub tokens: Vec<token::Token>,
+    /// The main module's AST (after parser)
     pub ast: ast::Module,
-    /// Desugared AST
+    /// Desugared AST (after desugar pass)
     pub desugared_ast: ast::Module,
     /// Symbol table after analysis
     pub symbols: symbol::SymbolTable,
-    /// Loaded module paths (in resolution order)
+    /// Loaded module paths
     pub loaded_modules: Vec<Vec<String>>,
     /// Modules loaded implicitly by the compiler
     pub implicit_modules: Vec<Vec<String>>,
-    /// TIR (Typed IR) after resolution
-    pub tir: Option<tir::TirModule>,
+    /// Entry module path
+    pub entry_path: Vec<String>,
+    /// All TIR modules after resolution
+    pub tir_modules: Option<std::collections::HashMap<Vec<String>, tir::TirModule>>,
+    /// All lowered TIR modules
+    pub lowered_tir_modules: Option<std::collections::HashMap<Vec<String>, tir::TirModule>>,
+    /// Optimization hints
+    pub opt_hints: Option<OptimizationHints>,
+    /// Comments for unparsing
+    pub comments: comment::CommentMap,
 }
 
 /// Compile Wado source code to Component Model WebAssembly bytes.
@@ -179,10 +191,10 @@ pub fn compile_file_with_opts(
 
 /// Dump compiler internal state for a Wado source file.
 ///
-/// This runs the compilation pipeline up through resolution (without code generation)
+/// This runs the compilation pipeline up through optimization (without code generation)
 /// and returns diagnostic information about the internal state.
 ///
-/// Pipeline: lexer -> parser -> bind -> desugar -> analyze -> resolve
+/// Pipeline: lexer -> parser -> bind -> desugar -> load -> analyze -> resolve -> lower -> optimize
 pub fn dump_file(path: &Path) -> Result<DumpResult, CompileError> {
     let source = std::fs::read_to_string(path).map_err(|e| CompileError::Io {
         path: path.display().to_string(),
@@ -192,7 +204,7 @@ pub fn dump_file(path: &Path) -> Result<DumpResult, CompileError> {
     let base_path = path.parent().map(|p| p.to_path_buf());
     let filename = Some(path.display().to_string());
 
-    // Lexer
+    // === Phase 1: Lexer ===
     let mut lexer = Lexer::new(&source);
     let tokens = lexer.tokenize().map_err(|e| CompileError::Lexer {
         message: e.message,
@@ -200,9 +212,14 @@ pub fn dump_file(path: &Path) -> Result<DumpResult, CompileError> {
         column: e.span.column,
         filename: filename.clone(),
     })?;
+    let comments = lexer.comments().to_vec();
     let data_section = lexer.into_data_section();
 
-    // Parser
+    // Build comment map
+    let comment_map = comment::CommentMap::from_comments(comments, &source);
+
+    // === Phase 2: Parser ===
+    let tokens_for_dump = tokens.clone();
     let mut parser = Parser::with_data_section(tokens, data_section);
     let ast = parser.parse().map_err(|e| CompileError::Parser {
         message: e.message,
@@ -211,7 +228,7 @@ pub fn dump_file(path: &Path) -> Result<DumpResult, CompileError> {
         filename: filename.clone(),
     })?;
 
-    // Bind (local name resolution)
+    // === Phase 3: Bind ===
     let mut binder = Binder::new();
     binder.bind_module(&ast).map_err(|errors| {
         let msg = errors
@@ -225,43 +242,81 @@ pub fn dump_file(path: &Path) -> Result<DumpResult, CompileError> {
         }
     })?;
 
-    // Desugar
+    // === Phase 4: Desugar ===
     let desugared_ast = desugar::desugar_module(&ast);
 
-    // Analyzer (module resolution + symbol table)
-    let mut analyzer = if let Some(base) = base_path.as_deref() {
-        Analyzer::with_base_path(base)
-    } else {
-        Analyzer::new()
+    // === Phase 5: Load all modules ===
+    let load_result = {
+        let module_loader = if let Some(base) = base_path.as_deref() {
+            loader::ModuleLoader::with_base_path(base)
+        } else {
+            loader::ModuleLoader::new()
+        };
+        module_loader
+            .load_all(&source)
+            .map_err(|e| CompileError::Analyzer {
+                message: e.to_string(),
+                filename: filename.clone(),
+            })?
     };
-    analyzer.analyze(&desugared_ast, &[]).map_err(|errors| {
-        let msg = errors
-            .into_iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        CompileError::Analyzer {
-            message: msg,
-            filename: filename.clone(),
-        }
-    })?;
 
-    // Get loaded modules, symbols, and implicit modules
-    let (symbols, loaded_modules, implicit_modules) = analyzer.into_parts();
+    // === Phase 6: Analyze all modules ===
+    let mut analyzer = Analyzer::new();
+    analyzer
+        .analyze_loaded_modules(
+            &load_result.modules,
+            &load_result.entry_path,
+            load_result.implicit_modules.clone(),
+        )
+        .map_err(|errors| {
+            let msg = errors
+                .into_iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ");
+            CompileError::Analyzer {
+                message: msg,
+                filename: filename.clone(),
+            }
+        })?;
 
-    // Resolve (type resolution -> TIR) - optional for now
-    let tir = {
-        let mut resolver = Resolver::new(&symbols, &loaded_modules, &source);
-        resolver.resolve_module(&desugared_ast, vec![]).ok()
-    };
+    let symbols = analyzer.into_symbols();
+
+    // === Phase 7: Resolve all modules to TIR ===
+    let tir_modules = Resolver::resolve_all_modules(
+        &symbols,
+        &load_result.modules,
+        &load_result.entry_path,
+        &source,
+    )
+    .ok();
+
+    // === Phase 8: Lower all modules ===
+    let lowered_tir_modules = tir_modules.as_ref().map(|modules| {
+        modules
+            .iter()
+            .map(|(path, module)| (path.clone(), lower(module.clone())))
+            .collect()
+    });
+
+    // === Phase 9: Optimize ===
+    let opt_hints = lowered_tir_modules.as_ref().map(|modules| {
+        analyze_all_modules(modules, &load_result.entry_path)
+    });
 
     Ok(DumpResult {
+        source,
+        tokens: tokens_for_dump,
         ast,
         desugared_ast,
         symbols,
-        loaded_modules: loaded_modules.keys().cloned().collect(),
-        implicit_modules: implicit_modules.into_iter().collect(),
-        tir,
+        loaded_modules: load_result.modules.keys().cloned().collect(),
+        implicit_modules: load_result.implicit_modules.into_iter().collect(),
+        entry_path: load_result.entry_path,
+        tir_modules,
+        lowered_tir_modules,
+        opt_hints,
+        comments: comment_map,
     })
 }
 

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -684,8 +684,7 @@ pub struct TirImpl {
 // Module
 // ============================================================================
 
-#[derive(Debug)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TirModule {
     pub path: Vec<String>,
     pub type_table: TypeTable,

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -685,6 +685,7 @@ pub struct TirImpl {
 // ============================================================================
 
 #[derive(Debug)]
+#[derive(Clone)]
 pub struct TirModule {
     pub path: Vec<String>,
     pub type_table: TypeTable,


### PR DESCRIPTION
This commit adds comprehensive phase-based options to the `wado dump` command,
allowing developers to inspect the compiler's internal state at each compilation phase.

Changes:
- Add new dump options: --tokens, --ast, --desugar, --tir, --lower, --optimize
- AST output now uses unparsing to show Wado source code instead of Debug format
- Desugared AST shows the expanded form (e.g., `x += 1` becomes `x = x + 1`)
- Update DumpResult to include all compilation phases
- Update dump_file() to run the full compilation pipeline (except codegen)
- Add Clone trait to TirModule to support phase inspection

Compilation phases now visible:
1. Lexer → tokens (--tokens)
2. Parser → AST as Wado source (--ast)
3. Desugar → desugared AST as Wado source (--desugar)
4. Load → loaded modules (--modules)
5. Analyze → symbol table (--symbols)
6. Resolve → TIR (--tir)
7. Lower → lowered TIR (--lower)
8. Optimize → optimization hints (--optimize)

The --all option (default) shows all phases.