### PR TITLE
Clarify Type Aliases

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -81,15 +81,12 @@ Result<T, E>            // result type (not yet implemented)
 ```wado
 type Kilometers = i32;    // alias - same type as i32
 type UserID = String;
-type Point2D = [f64, f64];
 
 let km: Kilometers = 100;
 let m: i32 = km;          // OK - interchangeable
 
 // For distinct types, use struct wrapper (newtype pattern)
-struct Miles {
-    value: i32,
-}
+struct Miles { value: i32 }
 ```
 
 ## Tuples and Arrays

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -76,6 +76,22 @@ Result<T, E>            // result type (not yet implemented)
 ()
 ```
 
+## Type Alias
+
+```wado
+type Kilometers = i32;    // alias - same type as i32
+type UserID = String;
+type Point2D = [f64, f64];
+
+let km: Kilometers = 100;
+let m: i32 = km;          // OK - interchangeable
+
+// For distinct types, use struct wrapper (newtype pattern)
+struct Miles {
+    value: i32,
+}
+```
+
 ## Tuples and Arrays
 
 ```wado

--- a/spec.md
+++ b/spec.md
@@ -972,6 +972,59 @@ let id = 42;
 let query = sql`SELECT * FROM users WHERE id = ${id}`;
 ```
 
+### Type Alias
+
+A type alias creates an alternative name for an existing type. The alias is **identical** to the original type for all purposes—they are interchangeable in type checking.
+
+```wado
+type Kilometers = i32;
+type UserID = String;
+type Point2D = [f64, f64];
+type Callback = fn(i32) -> bool;
+
+let distance: Kilometers = 100;
+let m: i32 = distance;  // OK - same type
+
+fn process(id: UserID) { /* ... */ }
+process("abc");  // OK - UserID is String
+```
+
+**Key characteristics:**
+
+- `type T = U` makes `T` and `U` completely interchangeable
+- No runtime overhead—purely a compile-time construct
+- Useful for documentation and readability
+
+**Type alias vs Newtype:**
+
+Type aliases do not provide type safety—they are just alternative names. For distinct types that should not be interchangeable, use a struct wrapper (newtype pattern):
+
+```wado
+// Type alias - interchangeable with i32
+type Kilometers = i32;
+
+// Newtype - distinct type, NOT interchangeable with i32
+struct Miles {
+    value: i32,
+}
+
+let km: Kilometers = 100;
+let m: i32 = km;           // OK - same type
+
+let miles = Miles { value: 50 };
+// let m: i32 = miles;     // Error - different types
+let m: i32 = miles.value;  // OK - explicit field access
+```
+
+Future versions will support tuple structs for more ergonomic newtype definitions:
+
+```wado
+// Future syntax (not yet implemented)
+struct Miles(i32);
+let miles = Miles(50);
+let m: i32 = miles.0;
+```
+
 ### Literal Types
 
 ```wado

--- a/spec.md
+++ b/spec.md
@@ -974,55 +974,23 @@ let query = sql`SELECT * FROM users WHERE id = ${id}`;
 
 ### Type Alias
 
-A type alias creates an alternative name for an existing type. The alias is **identical** to the original type for all purposes—they are interchangeable in type checking.
+`type T = U` creates an alias where `T` and `U` are identical types—completely interchangeable in type checking.
 
 ```wado
 type Kilometers = i32;
 type UserID = String;
-type Point2D = [f64, f64];
-type Callback = fn(i32) -> bool;
-
-let distance: Kilometers = 100;
-let m: i32 = distance;  // OK - same type
-
-fn process(id: UserID) { /* ... */ }
-process("abc");  // OK - UserID is String
-```
-
-**Key characteristics:**
-
-- `type T = U` makes `T` and `U` completely interchangeable
-- No runtime overhead—purely a compile-time construct
-- Useful for documentation and readability
-
-**Type alias vs Newtype:**
-
-Type aliases do not provide type safety—they are just alternative names. For distinct types that should not be interchangeable, use a struct wrapper (newtype pattern):
-
-```wado
-// Type alias - interchangeable with i32
-type Kilometers = i32;
-
-// Newtype - distinct type, NOT interchangeable with i32
-struct Miles {
-    value: i32,
-}
 
 let km: Kilometers = 100;
-let m: i32 = km;           // OK - same type
-
-let miles = Miles { value: 50 };
-// let m: i32 = miles;     // Error - different types
-let m: i32 = miles.value;  // OK - explicit field access
+let m: i32 = km;  // OK - same type
 ```
 
-Future versions will support tuple structs for more ergonomic newtype definitions:
+For distinct types that should not be interchangeable, use a struct wrapper (newtype pattern):
 
 ```wado
-// Future syntax (not yet implemented)
-struct Miles(i32);
-let miles = Miles(50);
-let m: i32 = miles.0;
+struct Miles { value: i32 }
+
+let miles = Miles { value: 50 };
+let m: i32 = miles.value;  // explicit access required
 ```
 
 ### Literal Types


### PR DESCRIPTION
Clarify that `type T = U` creates a true alias where T and U are completely interchangeable types. Also document the newtype pattern using struct wrappers for when distinct types are needed.