### PR TITLE
Implement generics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,8 @@
     "MECE",
     "Pollable",
     "Pollables",
+    "println",
+    "repr",
     "stdlib",
     "Wado",
     "waitable",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,9 @@ wado dump --desugar --unparse file.wado  # show desugared AST as source
 wado dump --modules file.wado        # show loaded modules only
 wado dump --symbols file.wado        # show symbol table only
 wado dump --tir file.wado            # show TIR (Typed IR)
+wado dump --tir --unparse file.wado  # show TIR as pseudo-Wado source
 wado dump --lower file.wado          # show lowered TIR
+wado dump --lower --unparse file.wado  # show lowered TIR as pseudo-Wado source
 wado dump --optimize file.wado       # show optimization hints
 ```
 
@@ -108,8 +110,8 @@ Available phases (in compilation order):
 3. `--desugar` - Desugared AST (supports `--unparse`)
 4. `--modules` - Loaded modules
 5. `--symbols` - Symbol table
-6. `--tir` - Typed IR (will support `--unparse` in future)
-7. `--lower` - Lowered TIR (will support `--unparse` in future)
+6. `--tir` - Typed IR (supports `--unparse`)
+7. `--lower` - Lowered TIR (supports `--unparse`)
 8. `--optimize` - Optimization hints
 
 ## Bundled Library

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "datatest-stable",
  "fluent-uri",
  "heck",
+ "indexmap",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [workspace.dependencies]
 anyhow = { version = "1" }
 fluent-uri = { version = "0.4" }
+indexmap = { version = "2" }
 ryu = { version = "1.0.22" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/docs/adr-2026-01-16-world-conformance-and-export.md
+++ b/docs/adr-2026-01-16-world-conformance-and-export.md
@@ -44,6 +44,7 @@ contract World;
 - Does NOT generate code by itself; purely declarative/verification
 
 **Multiple worlds example:**
+
 ```wado
 contract Command;
 contract HttpHandler;
@@ -60,6 +61,7 @@ export pub fn function_name() { ... }
 - Automatically maps to world export if function name matches
 
 **Explicit mapping for name conflicts:**
+
 ```wado
 export(World::export_name) pub fn wado_function_name() { ... }
 ```
@@ -115,15 +117,16 @@ export pub fn multiply(a: i32, b: i32) -> i32 {
 
 We evaluated multiple keyword options:
 
-| Keyword | Pros | Cons | Decision |
-|---------|------|------|----------|
-| `implements` | Most common in OOP languages | Strong class-level connotation | Rejected |
-| `conforms` | Clear protocol conformance meaning | Slightly verbose | Considered |
-| `satisfies` | TypeScript-like, emphasizes validation | Value-level connotation | Rejected |
-| `entrypoint` | Emphasizes CM connection point | Implies singularity | Rejected |
-| `contract` | Clear boundary contract semantics | N/A | **Accepted** |
+| Keyword      | Pros                                   | Cons                           | Decision     |
+| ------------ | -------------------------------------- | ------------------------------ | ------------ |
+| `implements` | Most common in OOP languages           | Strong class-level connotation | Rejected     |
+| `conforms`   | Clear protocol conformance meaning     | Slightly verbose               | Considered   |
+| `satisfies`  | TypeScript-like, emphasizes validation | Value-level connotation        | Rejected     |
+| `entrypoint` | Emphasizes CM connection point         | Implies singularity            | Rejected     |
+| `contract`   | Clear boundary contract semantics      | N/A                            | **Accepted** |
 
 **Why `contract`:**
+
 - Emphasizes the contract between component and runtime
 - Natural for multiple declarations: `contract A; contract B;`
 - Aligns with Component Model terminology

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -112,8 +112,14 @@ struct Point {
     y: i32,
 }
 
+// Generic struct
+struct Box<T> {
+    value: T,
+}
+
 // Construction
 let p = Point { x: 10, y: 20 };
+let b = Box { value: 42 };  // T is inferred as i32
 
 // Shorthand (variable name matches field)
 let x = 10;
@@ -122,6 +128,7 @@ let p: Point = { x, y };
 
 // Field access
 let sum = p.x + p.y;
+let v = b.value;
 ```
 
 ## Enums (parsing only, codegen not yet implemented)
@@ -318,6 +325,26 @@ use {now, MonotonicClock} from "core:clocks";
 let t = now();            // current time in nanoseconds
 ```
 
+## Generic Functions and Methods
+
+```wado
+// Generic function
+fn identity<T>(x: T) -> T {
+    return x;
+}
+
+// Generic method
+impl Container {
+    fn transform<T, U>(&self, a: T, b: U) -> T {
+        return a;
+    }
+}
+
+// Calling with turbofish syntax (explicit type arguments)
+let x = identity::<i32>(42);
+let y = container.transform::<i32, i64>(10, 20 as i64);
+```
+
 ## Not Yet Implemented
 
 - `enum` construction (parsed but no codegen)
@@ -331,8 +358,7 @@ let t = now();            // current time in nanoseconds
 - `Dict<K, V>`
 - postfix `?` operator (error propagation)
 - JSX
-- Generic type parameters on user-defined types
-- Generic functions and methods
+- Generic function/method type inference
 
 ## See Also
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -8,10 +8,10 @@ The compiler follows a multi-phase pipeline:
 
 ```
 Source (.wado) → Lexer → Parser → Bind → Desugar → Load → Analyze → Resolve → Lower → Optimize → Codegen
-                           ↓                                           ↓
-                       Unparser                                  TIR (Typed IR)
-                           ↓
-                   Formatted Source
+                           ↓                                           ↓         ↓
+                       Unparser                                  TIR (Typed IR) TIR Unparser
+                           ↓                                                        ↓
+                   Formatted Source                                         Pseudo-Wado Source
 ```
 
 ### Compilation Pipeline
@@ -41,14 +41,14 @@ Source (.wado) → Lexer → Parser → Bind → Desugar → Load → Analyze �
 | Bind            | `bind.rs`             | Local name binding, scope analysis, mutability check |
 | Loader          | `loader.rs`           | Module loading, dependency resolution                |
 | Desugar         | `desugar.rs`          | AST transformations (compound assign, etc.)          |
-| Unparser        | `unparse.rs`          | Converts AST back to canonical source code           |
+| Unparser        | `unparse.rs`          | Converts AST/TIR back to source code                 |
 | Analyzer        | `analyze.rs`          | Semantic analysis, symbol table construction         |
 | Symbol          | `symbol.rs`           | Symbol table data structures                         |
 | Name            | `name.rs`             | Name mangling utilities for methods and symbols      |
 | ModuleLoader    | `module_loader.rs`    | Module path resolution, loads core library           |
 | Resolver        | `resolver.rs`         | Type resolution, AST to TIR conversion               |
 | TIR             | `tir.rs`              | Typed Intermediate Representation                    |
-| Lower           | `lower.rs`            | TIR lowering (string collection, etc.)               |
+| Lower           | `lower.rs`            | Monomorphization, string collection, TIR lowering    |
 | Optimize        | `optimize.rs`         | DCE, optimization hints for codegen                  |
 | Stdlib          | `stdlib.rs`           | Embedded core library sources                        |
 | WasiRegistry    | `wasi_registry.rs`    | WASI import registry, type alias resolution          |
@@ -75,6 +75,37 @@ This separation ensures:
 - `wado format` outputs the original syntax (e.g., `x += 1` not `x = x + 1`)
 - Codegen receives simplified AST without syntactic variants
 
+### TIR Unparser
+
+The `unparse.rs` module also provides a TIR unparser that converts Typed IR back to pseudo-Wado source code. This is useful for debugging the lowering and monomorphization phases.
+
+**Usage:**
+
+```sh
+wado dump --tir --unparse file.wado    # Show TIR before lowering
+wado dump --lower --unparse file.wado  # Show TIR after monomorphization
+```
+
+**Output Characteristics:**
+
+- Shows monomorphized type names (e.g., `Box$i32` instead of `Box<T>`)
+- Includes fully qualified function calls (e.g., `core::cli::println`)
+- Preserves the `__DATA__` section if present
+- Output is pseudo-Wado (not compilable due to mangled names)
+
+**Example Output:**
+
+```wado
+struct Box$i32 {
+    value: i32,
+}
+
+fn run() with Stdout {
+    let b: Box$i32 = Box$i32 { value: 42 };
+    core::cli::println(core::internal::string_concat("value: ", b.value.to_string()));
+}
+```
+
 ### Bundled Builtins (wado-bundled)
 
 The `wado-bundled` crate provides pre-compiled Wasm functions for operations that are complex to implement in pure Wasm instructions. These are statically linked into the generated component.
@@ -96,6 +127,47 @@ make check-bundled    # Verify committed WAT is up-to-date (used in CI)
 ```
 
 The bundled module is stored as WAT in `wado-compiler/lib/builtins/wado-bundled.wat` for version control visibility. It's parsed at compile time using the `wat` crate.
+
+### Monomorphization
+
+The `lower.rs` module implements monomorphization for generic structs. Generic types like `Box<T>` are instantiated into concrete types like `Box$i32` at compile time.
+
+**Process:**
+
+1. **Collection**: Scan the type table for all `GenericInstance` types (e.g., `Box<i32>`)
+2. **Instantiation**: For each unique instantiation, create a concrete struct with substituted field types
+3. **Naming**: Mangle type names using `$` separator (e.g., `Box$i32`, `Pair$i32$String`)
+4. **Rewriting**: Replace all `GenericInstance` type references with concrete struct types
+5. **Container handling**: Recursively rewrite nested types in Array, Option, Tuple, Result
+
+**Supported Features:**
+
+| Feature                  | Example                      | Status |
+| ------------------------ | ---------------------------- | ------ |
+| Single type parameter    | `Box<i32>`                   | ✅     |
+| Multiple type parameters | `Pair<i32, String>`          | ✅     |
+| Nested generics          | `Box<Box<i32>>`              | ✅     |
+| Generics in Array        | `Array<Pair<i32, String>>`   | ✅     |
+| Struct type parameters   | `Box<Point>`                 | ✅     |
+| Impl on specialization   | `impl Box<i32> { fn get() }` | ✅     |
+| Generic functions        | `fn identity<T>(x: T) -> T`  | ✅     |
+| Generic methods          | `impl T { fn foo<U>(&self) }`| ✅     |
+
+**Name Mangling:**
+
+```
+// Struct types
+Box<i32>           → Box$i32
+Pair<i32, String>  → Pair$i32$String
+Box<Box<i32>>      → Box$Box$i32
+
+// Generic functions (suffix is unique instantiation ID)
+identity::<i32>    → identity$1
+identity::<i64>    → identity$2
+
+// Generic methods
+Container::transform::<i32, i64> → Container::transform$1
+```
 
 ### Optimizer
 
@@ -489,7 +561,7 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [ ] `variant` declarations (with payloads)
 - [ ] `flags` declarations (bit flags)
 - [ ] Inner attributes (`#![...]`)
-- [ ] Generic parameters on types
+- [x] Generic parameters on structs (monomorphization)
 
 #### Statements
 
@@ -595,6 +667,15 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [x] Array construction, index access, and iteration
 - [x] Reference types (`&T`, `&mut T`) for primitives, structs, tuples, and arrays
 - [x] Dereference operator (`*ref`)
+- [x] Generic structs with monomorphization (`Box<T>`, `Pair<A, B>`)
+- [x] Generic struct instantiation with type inference
+- [x] Generic struct field access
+- [x] Impl blocks on generic struct specializations (`impl Box<i32>`)
+- [x] Nested generic types (`Box<Box<i32>>`, `Array<Pair<i32, String>>`)
+- [x] Generic structs as function parameters and return types
+- [x] Generic functions with explicit turbofish syntax (`identity::<i32>(x)`)
+- [x] Generic methods with explicit turbofish syntax (`obj.method::<T, U>(...)`)
+- [ ] Generic function/method type inference
 - [ ] Enum/variant construction
 - [ ] Pattern matching
 - [ ] Closures
@@ -651,7 +732,8 @@ fn run() with Stdout {
 1. **Parser doesn't support generic resources**: `resource Stream<T>` in `prelude.wado` fails to parse
 2. **No `variant` keyword**: Parser doesn't recognize `variant` declarations (sum types with payloads)
 3. **No `flags` keyword**: Parser doesn't recognize `flags` declarations (bit flags). This prevents `wasi:filesystem` from being loaded by `build_wasi_registry_from_stdlib()` since it contains `flags` declarations.
-4. **Template strings - mostly implemented**:
+4. **Implicit struct literals don't work with generic structs**: `let b: Box<i32> = { value };` fails. Use explicit form: `let b: Box<i32> = Box { value };`
+5. **Template strings - mostly implemented**:
    - [x] Syntax parsing with interpolation `{expr}` works
    - [x] Format specifiers (`:`) vs scope resolution (`::`) correctly distinguished
    - [x] Nested template strings supported
@@ -661,9 +743,9 @@ fn run() with Stdout {
    - [x] Char interpolation (char → UTF-8 string)
    - [x] String concatenation with GC array copy
    - [ ] Format specifiers (`.2f`, etc.) not implemented in codegen
-5. **No type checking**: The analyzer doesn't perform type checking yet
-6. **GC arrays cannot be passed directly to streams**: As of wasmtime v40, `stream<u8>` operations require linear memory. GC arrays must be copied to linear memory before writing to streams. See [component-model#525](https://github.com/WebAssembly/component-model/issues/525)
-7. **Non-pub functions from other modules are skipped**: The codegen currently only includes `pub` functions from imported modules (`core::*`). Internal helper functions must be marked `pub` to be included in compilation. This limitation could be addressed later with proper internal dependency tracking.
+6. **No type checking**: The analyzer doesn't perform type checking yet
+7. **GC arrays cannot be passed directly to streams**: As of wasmtime v40, `stream<u8>` operations require linear memory. GC arrays must be copied to linear memory before writing to streams. See [component-model#525](https://github.com/WebAssembly/component-model/issues/525)
+8. **Non-pub functions from other modules are skipped**: The codegen currently only includes `pub` functions from imported modules (`core::*`). Internal helper functions must be marked `pub` to be included in compilation. This limitation could be addressed later with proper internal dependency tracking.
 
 ---
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -142,16 +142,16 @@ The `lower.rs` module implements monomorphization for generic structs. Generic t
 
 **Supported Features:**
 
-| Feature                  | Example                      | Status |
-| ------------------------ | ---------------------------- | ------ |
-| Single type parameter    | `Box<i32>`                   | ✅     |
-| Multiple type parameters | `Pair<i32, String>`          | ✅     |
-| Nested generics          | `Box<Box<i32>>`              | ✅     |
-| Generics in Array        | `Array<Pair<i32, String>>`   | ✅     |
-| Struct type parameters   | `Box<Point>`                 | ✅     |
-| Impl on specialization   | `impl Box<i32> { fn get() }` | ✅     |
-| Generic functions        | `fn identity<T>(x: T) -> T`  | ✅     |
-| Generic methods          | `impl T { fn foo<U>(&self) }`| ✅     |
+| Feature                  | Example                       | Status |
+| ------------------------ | ----------------------------- | ------ |
+| Single type parameter    | `Box<i32>`                    | ✅     |
+| Multiple type parameters | `Pair<i32, String>`           | ✅     |
+| Nested generics          | `Box<Box<i32>>`               | ✅     |
+| Generics in Array        | `Array<Pair<i32, String>>`    | ✅     |
+| Struct type parameters   | `Box<Point>`                  | ✅     |
+| Impl on specialization   | `impl Box<i32> { fn get() }`  | ✅     |
+| Generic functions        | `fn identity<T>(x: T) -> T`   | ✅     |
+| Generic methods          | `impl T { fn foo<U>(&self) }` | ✅     |
 
 **Name Mangling:**
 

--- a/spec.md
+++ b/spec.md
@@ -489,6 +489,7 @@ char
 - UTF-8 encoding: Direct mapping to Component Model `string`
 
 **Semantics and Encoding**:
+
 - Semantically, a `String` is a sequence of Unicode scalar values
 - Internally represented as a UTF-8 byte array (`Array<u8>`)
 - Invalid UTF-8 byte sequences are not allowed; all String values must be valid UTF-8

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -327,8 +327,11 @@ pub fn run(opts: DumpOptions) {
         if let Some(ref tir_modules) = result.tir_modules {
             if opts.unparse {
                 println!("=== TIR (Resolve, unparsed) ===");
-                println!("(TIR unparsing not yet implemented)");
-                println!();
+                for (path, module) in tir_modules {
+                    println!("// --- Module: {} ---", path.join("::"));
+                    let unparsed = wado_compiler::unparse::unparse_tir(module);
+                    println!("{}", unparsed);
+                }
             } else {
                 println!("=== TIR (Resolve) ===");
                 for (path, module) in tir_modules {
@@ -349,8 +352,11 @@ pub fn run(opts: DumpOptions) {
         if let Some(ref lowered_modules) = result.lowered_tir_modules {
             if opts.unparse {
                 println!("=== Lowered TIR (Lower, unparsed) ===");
-                println!("(TIR unparsing not yet implemented)");
-                println!();
+                for (path, module) in lowered_modules {
+                    println!("// --- Module: {} ---", path.join("::"));
+                    let unparsed = wado_compiler::unparse::unparse_tir(module);
+                    println!("{}", unparsed);
+                }
             } else {
                 println!("=== Lowered TIR (Lower) ===");
                 for (path, module) in lowered_modules {

--- a/wado-compiler/Cargo.toml
+++ b/wado-compiler/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 fluent-uri = { workspace = true }
 heck = { workspace = true }
+indexmap = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -75,17 +75,25 @@ fn i32_eqz(a: i32) -> i32;
 // GC Array Operations
 // ============================================================================
 
-/// Get the length of a GC array (String or Array<T>)
-fn array_len(arr: String) -> i32;
+/// Get the length of a GC array
+fn array_len(arr: builtin::array<u8>) -> i32;
 
 /// Get a byte from a u8 array at the given index
-fn array_get_u8(arr: String, idx: i32) -> i32;
+fn array_get_u8(arr: builtin::array<u8>, idx: i32) -> i32;
 
 /// Set a byte in a u8 array at the given index
-fn array_set_u8(arr: String, idx: i32, value: i32);
+fn array_set_u8(arr: builtin::array<u8>, idx: i32, value: i32);
 
-/// Create a new String (GC array<u8>) with given length, initialized to zeros
+/// Create a new builtin::array<u8> with given length, initialized to zeros
+fn array_u8_new(len: i32) -> builtin::array<u8>;
+
+/// Create a new String struct with given capacity
 fn string_new(len: i32) -> String;
+
+/// Wrap a raw string array into an Array<String> struct
+/// repr: the raw builtin::array<String>
+/// used: number of elements actually used
+fn array_wrap_string(repr: builtin::array<String>, used: i32) -> Array<String>;
 
 // ============================================================================
 // Linear Memory Operations

--- a/wado-compiler/lib/core/cli.wado
+++ b/wado-compiler/lib/core/cli.wado
@@ -25,14 +25,14 @@ pub use {Stdout, Stderr, Environment, Exit} from "wasi:cli";
 // Called AFTER write_via_stream has started the consumer
 // add_newline: if true, appends '\n' after the message
 pub fn write_to_stream(tx: i32, message: String, add_newline: bool) {
-    let len = builtin::array_len(message);
+    let len = message.len();
     let mut alloc_size = len;
     if add_newline {
         alloc_size = len + 1;
     }
     let ptr = builtin::realloc(0, 0, 1, alloc_size);
     for (let mut i = 0; i < len; i = i + 1) {
-        let byte = builtin::array_get_u8(message, i);
+        let byte = message.get(i);
         builtin::memory_store8(ptr + i, byte);
     }
     if add_newline {

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -8,23 +8,23 @@
 /// Concatenate two strings into a new string
 /// This is the core operation for template string building
 pub fn string_concat(a: String, b: String) -> String {
-    let len_a = builtin::array_len(a);
-    let len_b = builtin::array_len(b);
+    let len_a = a.len();
+    let len_b = b.len();
     let total = len_a + len_b;
 
-    // Create new array with total length
+    // Create new string with total length
     let result = builtin::string_new(total);
 
     // Copy bytes from a
     for (let mut i = 0; i < len_a; i += 1) {
-        let byte = builtin::array_get_u8(a, i);
-        builtin::array_set_u8(result, i, byte);
+        let byte = a.get(i);
+        result.set(i, byte);
     }
 
     // Copy bytes from b
     for (let mut i = 0; i < len_b; i += 1) {
-        let byte = builtin::array_get_u8(b, i);
-        builtin::array_set_u8(result, len_a + i, byte);
+        let byte = b.get(i);
+        result.set(len_a + i, byte);
     }
 
     return result;
@@ -38,11 +38,11 @@ pub fn f64_to_string(value: f64) -> String {
     // Convert float to bytes in linear memory
     let len = builtin::f64_to_buffer(value, ptr);
 
-    // Create GC array and copy from linear memory
+    // Create GC string and copy from linear memory
     let result = builtin::string_new(len);
     for (let mut i = 0; i < len; i += 1) {
         let byte = builtin::memory_load8_u(ptr + i);
-        builtin::array_set_u8(result, i, byte);
+        result.set(i, byte);
     }
 
     return result;
@@ -56,11 +56,11 @@ pub fn f32_to_string(value: f32) -> String {
     // Convert float to bytes in linear memory
     let len = builtin::f32_to_buffer(value, ptr);
 
-    // Create GC array and copy from linear memory
+    // Create GC string and copy from linear memory
     let result = builtin::string_new(len);
     for (let mut i = 0; i < len; i += 1) {
         let byte = builtin::memory_load8_u(ptr + i);
-        builtin::array_set_u8(result, i, byte);
+        result.set(i, byte);
     }
 
     return result;
@@ -110,7 +110,7 @@ pub fn i32_to_string(value: i32) -> String {
     let result = builtin::string_new(len);
     for (let mut i = 0; i < len; i += 1) {
         let byte = builtin::memory_load8_u(ptr + pos + i);
-        builtin::array_set_u8(result, i, byte);
+        result.set(i, byte);
     }
 
     return result;
@@ -151,7 +151,7 @@ pub fn u32_to_string(value: i32) -> String {
     let result = builtin::string_new(len);
     for (let mut i: i32 = 0; i < len; i += 1) {
         let byte = builtin::memory_load8_u(ptr + pos + i);
-        builtin::array_set_u8(result, i, byte);
+        result.set(i, byte);
     }
 
     return result;
@@ -206,7 +206,7 @@ pub fn i64_to_string(value: i64) -> String {
     let result = builtin::string_new(len);
     for (let mut i: i32 = 0; i < len; i += 1) {
         let byte: i32 = builtin::memory_load8_u(ptr + pos + i);
-        builtin::array_set_u8(result, i, byte);
+        result.set(i, byte);
     }
 
     return result;
@@ -273,7 +273,7 @@ pub fn u64_to_string(value: i64) -> String {
     let result = builtin::string_new(len);
     for (let mut i: i32 = 0; i < len; i += 1) {
         let byte: i32 = builtin::memory_load8_u(ptr + pos + i);
-        builtin::array_set_u8(result, i, byte);
+        result.set(i, byte);
     }
 
     return result;
@@ -295,47 +295,47 @@ pub fn char_to_string(value: char) -> String {
     if code < 0x80 {
         // ASCII: single byte
         let result = builtin::string_new(1);
-        builtin::array_set_u8(result, 0, code);
+        result.set(0, code);
         return result;
     }
 
     if code < 0x800 {
         // 2-byte UTF-8: 110xxxxx 10xxxxxx
         let result = builtin::string_new(2);
-        builtin::array_set_u8(result, 0, 0xC0 | (code >> 6));
-        builtin::array_set_u8(result, 1, 0x80 | (code & 0x3F));
+        result.set(0, 0xC0 | (code >> 6));
+        result.set(1, 0x80 | (code & 0x3F));
         return result;
     }
 
     if code < 0x10000 {
         // 3-byte UTF-8: 1110xxxx 10xxxxxx 10xxxxxx
         let result = builtin::string_new(3);
-        builtin::array_set_u8(result, 0, 0xE0 | (code >> 12));
-        builtin::array_set_u8(result, 1, 0x80 | ((code >> 6) & 0x3F));
-        builtin::array_set_u8(result, 2, 0x80 | (code & 0x3F));
+        result.set(0, 0xE0 | (code >> 12));
+        result.set(1, 0x80 | ((code >> 6) & 0x3F));
+        result.set(2, 0x80 | (code & 0x3F));
         return result;
     }
 
     // 4-byte UTF-8: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
     let result = builtin::string_new(4);
-    builtin::array_set_u8(result, 0, 0xF0 | (code >> 18));
-    builtin::array_set_u8(result, 1, 0x80 | ((code >> 12) & 0x3F));
-    builtin::array_set_u8(result, 2, 0x80 | ((code >> 6) & 0x3F));
-    builtin::array_set_u8(result, 3, 0x80 | (code & 0x3F));
+    result.set(0, 0xF0 | (code >> 18));
+    result.set(1, 0x80 | ((code >> 12) & 0x3F));
+    result.set(2, 0x80 | ((code >> 6) & 0x3F));
+    result.set(3, 0x80 | (code & 0x3F));
     return result;
 }
 
 /// Write a string to a stream handle with an optional newline
 /// Internal helper for log_stdout and log_stderr.
 pub fn write_string_to_stream(tx: i32, message: String, add_newline: bool) {
-    let len = builtin::array_len(message);
+    let len = message.len();
     let mut alloc_size = len;
     if add_newline {
         alloc_size = len + 1;
     }
     let ptr = builtin::realloc(0, 0, 1, alloc_size);
     for (let mut i = 0; i < len; i += 1) {
-        let byte = builtin::array_get_u8(message, i);
+        let byte = message.get(i);
         builtin::memory_store8(ptr + i, byte);
     }
     if add_newline {
@@ -380,8 +380,8 @@ pub fn cm_list_string_to_array(outptr: i32) -> Array<String> {
     let base_ptr = builtin::memory_load32(outptr);
     let count = builtin::memory_load32(outptr + 4);
 
-    // Create GC array of strings (nullable elements)
-    let result = builtin::array_new_string(count);
+    // Create raw GC array of strings (nullable elements)
+    let repr = builtin::array_new_string(count);
 
     // Convert each CM string to a GC string
     for (let mut i = 0; i < count; i += 1) {
@@ -392,13 +392,14 @@ pub fn cm_list_string_to_array(outptr: i32) -> Array<String> {
         let s = builtin::string_new(str_len);
         for (let mut j = 0; j < str_len; j += 1) {
             let byte = builtin::memory_load8_u(str_ptr + j);
-            builtin::array_set_u8(s, j, byte);
+            s.set(j, byte);
         }
 
-        builtin::array_set_string(result, i, s);
+        builtin::array_set_string(repr, i, s);
     }
 
-    return result;
+    // Wrap raw array into Array struct with used = count
+    return builtin::array_wrap_string(repr, count);
 }
 
 /// Convert a Component Model option<string> to a GC Option<String>
@@ -422,7 +423,7 @@ pub fn cm_option_string_to_option(outptr: i32) -> Option<String> {
     let s = builtin::string_new(str_len);
     for (let mut i = 0; i < str_len; i += 1) {
         let byte = builtin::memory_load8_u(str_ptr + i);
-        builtin::array_set_u8(s, i, byte);
+        s.set(i, byte);
     }
 
     return s;
@@ -431,16 +432,16 @@ pub fn cm_option_string_to_option(outptr: i32) -> Option<String> {
 /// Copy an Array<String> to a new array (deep copy of the array, shallow copy of strings)
 /// This is used by the compiler for tuple-to-array coercion and value semantics.
 pub fn array_copy_string(src: Array<String>) -> Array<String> {
-    let len = builtin::array_len(src);
+    let len = src.len();
 
     if len == 0 {
-        return builtin::array_new_string(0);
+        return builtin::array_wrap_string(builtin::array_new_string(0), 0);
     }
 
-    let dest = builtin::array_new_string(len);
+    let repr = builtin::array_new_string(len);
     for (let mut i = 0; i < len; i += 1) {
-        builtin::array_set_string(dest, i, src[i]);
+        builtin::array_set_string(repr, i, src[i]);
     }
 
-    return dest;
+    return builtin::array_wrap_string(repr, len);
 }

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -5,6 +5,46 @@
 
 use {log_stderr} from "core:internal";
 
+/// UTF-8 encoded string type
+pub struct String {
+    repr: builtin::array<u8>,
+}
+
+impl String {
+    /// Get the length of the string in bytes
+    pub fn len(&self) -> i32 {
+        return builtin::array_len(self.repr);
+    }
+
+    /// Get a byte at the given index
+    pub fn get(&self, index: i32) -> i32 {
+        return builtin::array_get_u8(self.repr, index);
+    }
+
+    /// Set a byte at the given index
+    pub fn set(&mut self, index: i32, value: i32) {
+        builtin::array_set_u8(self.repr, index, value);
+    }
+}
+
+/// Dynamic array type with O(1) amortized append
+pub struct Array<T> {
+    repr: builtin::array<T>,
+    used: i32,
+}
+
+impl Array<T> {
+    /// Get the number of elements in the array
+    pub fn len(&self) -> i32 {
+        return self.used;
+    }
+
+    /// Get the capacity (allocated size) of the array
+    pub fn capacity(&self) -> i32 {
+        return builtin::array_len(self.repr);
+    }
+}
+
 /// Traps with a message
 /// Logs the message to stderr (ambient, no effect required) and traps.
 pub fn panic(message: String) -> ! {

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -222,6 +222,8 @@ pub struct UseDecl {
 pub struct Function {
     pub name: String,
     pub is_pub: bool,
+    /// Generic type parameters: `fn swap<T>(a: T, b: T) -> T`
+    pub type_params: Vec<GenericParam>,
     pub attrs: Vec<Attribute>,
     pub params: Vec<Param>,
     pub return_type: Option<Type>,
@@ -578,6 +580,8 @@ pub enum UnaryOp {
 #[derive(Debug, Clone)]
 pub struct CallExpr {
     pub callee: Expr,
+    /// Explicit type arguments for generic functions: `foo::<i32>(x)`
+    pub type_args: Vec<Type>,
     pub args: Vec<Expr>,
     pub span: Span,
 }
@@ -586,6 +590,8 @@ pub struct CallExpr {
 pub struct MethodCallExpr {
     pub receiver: Expr,
     pub method: String,
+    /// Explicit type arguments for generic methods: `obj.foo::<i32>(x)`
+    pub type_args: Vec<Type>,
     pub args: Vec<Expr>,
     pub span: Span,
 }
@@ -677,6 +683,8 @@ pub struct FormatSpec {
 pub enum Type {
     Named(NamedType),
     Generic(GenericType),
+    /// Namespaced generic type like `builtin::array<T>`
+    NamespacedGeneric(NamespacedGenericType),
     Function(Box<FunctionType>),
     Tuple(Vec<Type>),
     Reference(Box<Type>),
@@ -692,6 +700,18 @@ pub struct NamedType {
 #[derive(Debug, Clone)]
 pub struct GenericType {
     pub name: String,
+    pub args: Vec<Type>,
+    pub span: Span,
+}
+
+/// Namespaced generic type like `builtin::array<T>`
+#[derive(Debug, Clone)]
+pub struct NamespacedGenericType {
+    /// Namespace (e.g., "builtin")
+    pub namespace: String,
+    /// Type name (e.g., "array")
+    pub name: String,
+    /// Generic arguments
     pub args: Vec<Type>,
     pub span: Span,
 }
@@ -723,10 +743,21 @@ pub struct EffectMethod {
     pub span: Span,
 }
 
+/// Generic type parameter declaration: `<T>`, `<T, U>`, `<T: Ord>`
+#[derive(Debug, Clone)]
+pub struct GenericParam {
+    pub name: String,
+    /// Trait bounds (e.g., `Ord`, `Clone`) - for future constraint checking
+    pub bounds: Vec<String>,
+    pub span: Span,
+}
+
 #[derive(Debug, Clone)]
 pub struct StructDecl {
     pub name: String,
     pub is_pub: bool,
+    /// Generic type parameters: `struct Pair<T, U> { ... }`
+    pub type_params: Vec<GenericParam>,
     pub fields: Vec<StructField>,
     pub span: Span,
 }
@@ -742,6 +773,8 @@ pub struct StructField {
 pub struct EnumDecl {
     pub name: String,
     pub is_pub: bool,
+    /// Generic type parameters: `enum Option<T> { Some(T), None }`
+    pub type_params: Vec<GenericParam>,
     pub variants: Vec<EnumVariant>,
     pub span: Span,
 }
@@ -763,6 +796,8 @@ pub struct TypeAlias {
 
 #[derive(Debug, Clone)]
 pub struct ImplBlock {
+    /// Generic type parameters: `impl<T> Box<T> { ... }`
+    pub type_params: Vec<GenericParam>,
     pub ty: Type,
     pub methods: Vec<Function>,
     pub span: Span,

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -165,6 +165,7 @@ mod tests {
         let func = Function {
             name: "stream_new".to_string(),
             is_pub: false,
+            type_params: vec![],
             attrs: vec![],
             params: vec![],
             return_type: Some(Type::Named(NamedType {
@@ -194,6 +195,7 @@ mod tests {
         let func = Function {
             name: "unreachable".to_string(),
             is_pub: false,
+            type_params: vec![],
             attrs: vec![],
             params: vec![],
             return_type: Some(Type::Named(NamedType {
@@ -218,6 +220,7 @@ mod tests {
         let func = Function {
             name: "stream_write".to_string(),
             is_pub: false,
+            type_params: vec![],
             attrs: vec![],
             params: vec![
                 Param {

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -20,8 +20,9 @@ use crate::wasm_builder::{ComponentModelContext, CoreModuleBuilder};
 use crate::wasm_postprocess;
 use crate::world_registry::{WorldExportInfo, WorldRegistry};
 use heck::ToKebabCase;
+use indexmap::IndexMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use wasm_encoder::{
     AbstractHeapType, Alias, BranchHint, BranchHints, CanonicalOption, CodeSection,
     ComponentBuilder, ComponentExportKind, ComponentOuterAliasKind, ComponentValType, ConstExpr,
@@ -32,11 +33,33 @@ use wasm_encoder::{
 };
 use wasmparser::{Validator, WasmFeatures};
 
+/// Module path for the String struct in core/prelude
+/// Used to avoid repeated allocations when looking up String type
+const STRING_MODULE_PATH: &[&str] = &["core", "prelude"];
+
+/// Helper to convert STRING_MODULE_PATH to Vec<String> (for APIs requiring owned strings)
+fn string_module_path() -> Vec<String> {
+    STRING_MODULE_PATH
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+}
+
 /// Information about a user-defined struct type
 #[derive(Debug, Clone)]
 struct StructTypeInfo {
     type_idx: u32,
     field_count: usize,
+}
+
+/// Parameters for building the main core module
+struct BuildMainModuleParams<'a> {
+    entry_tir: &'a TirModule,
+    all_tir_modules: &'a IndexMap<Vec<String>, TirModule>,
+    symbols: &'a SymbolTable,
+    string_data: &'a [u8],
+    hints: &'a OptimizationHints,
+    module_name: &'a str,
 }
 
 /// Code generator that produces Component Model components
@@ -56,8 +79,12 @@ pub struct Codegen {
     /// Registry of tuple types (keyed by element TypeIds, maps to GC struct type index)
     /// Uses RefCell for lazy registration during codegen
     tuple_types: RefCell<HashMap<Vec<TypeId>, u32>>,
-    /// Registry of array types (keyed by element TypeId, maps to GC array type index)
+    /// Registry of raw array types (keyed by element TypeId, maps to GC array type index)
+    /// These are the underlying builtin::array<T> types used in Array<T>.repr
     array_types: HashMap<TypeId, u32>,
+    /// Registry of Array<T> struct types (keyed by element TypeId, maps to GC struct type index)
+    /// Array<T> is a struct with fields: repr (ref to GC array), used (i32)
+    array_struct_types: HashMap<TypeId, u32>,
     /// Registry of box types for primitive references (keyed by ValType, maps to GC struct type index)
     /// Box types are single-field mutable structs that allow references to primitives
     box_types: HashMap<ValType, u32>,
@@ -271,6 +298,7 @@ impl Codegen {
             struct_types: HashMap::new(),
             tuple_types: RefCell::new(HashMap::new()),
             array_types: HashMap::new(),
+            array_struct_types: HashMap::new(),
             box_types: HashMap::new(),
         }
     }
@@ -313,11 +341,113 @@ impl Codegen {
         self.struct_types.get(&simple)
     }
 
+    /// Extract struct names that a type depends on (for field types)
+    fn get_struct_dependencies(type_table: &TypeTable, type_id: TypeId) -> Vec<String> {
+        match type_table.get(type_id) {
+            ResolvedType::Struct { name, .. } => vec![name.clone()],
+            ResolvedType::Array(inner)
+            | ResolvedType::BuiltinArray(inner)
+            | ResolvedType::Option(inner)
+            | ResolvedType::Ref(inner)
+            | ResolvedType::MutRef(inner)
+            | ResolvedType::Stream(inner)
+            | ResolvedType::Future(inner)
+            | ResolvedType::Reactive(inner) => Self::get_struct_dependencies(type_table, *inner),
+            ResolvedType::Result { ok, err }
+            | ResolvedType::Dict {
+                key: ok,
+                value: err,
+            } => {
+                let mut deps = Self::get_struct_dependencies(type_table, *ok);
+                deps.extend(Self::get_struct_dependencies(type_table, *err));
+                deps
+            }
+            ResolvedType::Tuple(elems) => elems
+                .iter()
+                .flat_map(|e| Self::get_struct_dependencies(type_table, *e))
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Sort structs topologically so dependencies are registered before dependents
+    fn sort_structs_topologically<'a>(
+        structs: &'a [crate::tir::TirStruct],
+        type_table: &TypeTable,
+    ) -> Vec<&'a crate::tir::TirStruct> {
+        // Build dependency graph: deps[A] = [B] means A depends on B (B must come before A)
+        let struct_names: HashSet<String> = structs.iter().map(|s| s.name.clone()).collect();
+        let mut deps: HashMap<String, Vec<String>> = HashMap::new();
+
+        for s in structs {
+            let mut struct_deps = Vec::new();
+            for field in &s.fields {
+                let field_deps = Self::get_struct_dependencies(type_table, field.type_id);
+                for dep in field_deps {
+                    // Only count dependencies on structs in our set
+                    if struct_names.contains(&dep) && dep != s.name {
+                        struct_deps.push(dep);
+                    }
+                }
+            }
+            deps.insert(s.name.clone(), struct_deps);
+        }
+
+        // Topological sort using Kahn's algorithm
+        // in_degree[A] = number of dependencies A has (structs that A needs)
+        let mut in_degree: HashMap<String, usize> = HashMap::new();
+        for s in structs {
+            let struct_deps = deps.get(&s.name).map(|d| d.len()).unwrap_or(0);
+            in_degree.insert(s.name.clone(), struct_deps);
+        }
+
+        // Build reverse mapping: dependents[B] = list of structs that depend on B
+        let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+        for (s_name, struct_deps) in &deps {
+            for dep in struct_deps {
+                dependents
+                    .entry(dep.clone())
+                    .or_default()
+                    .push(s_name.clone());
+            }
+        }
+
+        // Start with structs that have no dependencies
+        let mut queue: Vec<String> = in_degree
+            .iter()
+            .filter(|&(_, deg)| *deg == 0)
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        let mut sorted_names = Vec::new();
+        while let Some(name) = queue.pop() {
+            sorted_names.push(name.clone());
+            // For each struct that depends on 'name', decrement its in_degree
+            if let Some(deps_on_name) = dependents.get(&name) {
+                for dependent in deps_on_name {
+                    let deg = in_degree.get_mut(dependent).unwrap();
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push(dependent.clone());
+                    }
+                }
+            }
+        }
+
+        // Map names back to structs
+        let name_to_struct: HashMap<&str, &crate::tir::TirStruct> =
+            structs.iter().map(|s| (s.name.as_str(), s)).collect();
+        sorted_names
+            .iter()
+            .filter_map(|name| name_to_struct.get(name.as_str()).copied())
+            .collect()
+    }
+
     /// Generate Component Model binary Wasm
     pub fn generate_wasm(
         &mut self,
         entry_tir: &TirModule,
-        all_tir_modules: &HashMap<Vec<String>, TirModule>,
+        all_tir_modules: &IndexMap<Vec<String>, TirModule>,
         symbols: &SymbolTable,
         implicit_modules: &std::collections::HashSet<Vec<String>>,
         hints: &OptimizationHints,
@@ -350,16 +480,16 @@ impl Codegen {
 
     /// Build main core module from TIR
     /// Build the main core Wasm module containing user-defined functions.
-    fn build_main_module(
-        &mut self,
-        entry_tir: &TirModule,
-        all_tir_modules: &HashMap<Vec<String>, TirModule>,
-        symbols: &SymbolTable,
-        _implicit_modules: &std::collections::HashSet<Vec<String>>,
-        string_data: &[u8],
-        hints: &OptimizationHints,
-        module_name: &str,
-    ) -> Vec<u8> {
+    fn build_main_module(&mut self, params: BuildMainModuleParams<'_>) -> Vec<u8> {
+        let BuildMainModuleParams {
+            entry_tir,
+            all_tir_modules,
+            symbols,
+            string_data,
+            hints,
+            module_name,
+        } = params;
+
         let mut module = Module::new();
         let mut builder = CoreModuleBuilder::new();
         let type_table = &entry_tir.type_table;
@@ -461,6 +591,11 @@ impl Codegen {
                     if func.body.is_none() {
                         continue;
                     }
+                    // Skip Array<T> methods - they are inlined in codegen (MethodCall on Array type)
+                    // Array is generic so it's not registered in struct_types; it's in array_struct_types
+                    if struct_name == "Array" {
+                        continue;
+                    }
                     // Build function ID for DCE check: path/Struct::method
                     let method_id = FunctionId::Method(MethodName::new(
                         path.join("/"),
@@ -520,23 +655,32 @@ impl Codegen {
 
         let _string_array_idx_for_structs = builder.type_idx("string-array");
 
-        // Register main module structs from TIR (with simple names - empty module path)
-        // Note: main_module_struct_names was collected earlier for method collision detection
-        for tir_struct in &entry_tir.structs {
-            let struct_name = StructName::new(vec![], tir_struct.name.clone());
-            self.register_struct_type(struct_name, tir_struct, type_table, &mut builder);
+        // Register PRIMITIVE array types first (elements are primitives)
+        // These don't depend on struct types
+        self.register_primitive_array_types_from_table(type_table, &mut builder);
+        for (path, tir_mod) in all_tir_modules {
+            if path != &entry_tir.path {
+                self.register_primitive_array_types_from_table(&tir_mod.type_table, &mut builder);
+            }
         }
 
-        // Second pass: register loaded module structs with collision handling
+        // FIRST: Register loaded module structs (including String from core:prelude)
+        // This must come before main module structs because main module structs
+        // (like monomorphized Box$String) may depend on library structs
         // - If no collision: register with simple name (empty module path)
         // - If collision with main module: register with qualified name (full module path)
+        // Note: all_tir_modules is in topological order (dependency modules first)
         for (path, tir_mod) in all_tir_modules {
-            // Skip entry module (already handled)
+            // Skip entry module (handled separately)
             if path == &entry_tir.path {
                 continue;
             }
             for tir_struct in &tir_mod.structs {
                 if !tir_struct.is_pub {
+                    continue;
+                }
+                // Skip generic struct templates - they will be registered when monomorphized
+                if !tir_struct.type_params.is_empty() {
                     continue;
                 }
                 let struct_name = if main_module_struct_names.contains(&tir_struct.name) {
@@ -553,6 +697,22 @@ impl Codegen {
                     &mut builder,
                 );
             }
+        }
+
+        // SECOND: Register main module structs from TIR (with simple names - empty module path)
+        // Note: main_module_struct_names was collected earlier for method collision detection
+        // Skip generic struct templates - they will be registered when monomorphized
+        // Sort structs topologically to ensure dependencies are registered before dependents
+        let concrete_structs: Vec<_> = entry_tir
+            .structs
+            .iter()
+            .filter(|s| s.type_params.is_empty())
+            .cloned()
+            .collect();
+        let sorted_structs = Self::sort_structs_topologically(&concrete_structs, type_table);
+        for tir_struct in sorted_structs {
+            let struct_name = StructName::new(vec![], tir_struct.name.clone());
+            self.register_struct_type(struct_name, tir_struct, type_table, &mut builder);
         }
 
         // Register struct type aliases (e.g., `Point as OtherPoint`)
@@ -583,7 +743,8 @@ impl Codegen {
             }
         }
 
-        // Register array types from all TIR modules
+        // Now register ALL array types (including struct-based like Array<String>)
+        // This must happen after struct registration because Array<String> needs String type
         self.register_array_types_from_table(type_table, &mut builder);
         for (path, tir_mod) in all_tir_modules {
             if path != &entry_tir.path {
@@ -924,9 +1085,9 @@ impl Codegen {
     fn generate_component(
         &mut self,
         entry_tir: &TirModule,
-        all_tir_modules: &HashMap<Vec<String>, TirModule>,
+        all_tir_modules: &IndexMap<Vec<String>, TirModule>,
         symbols: &SymbolTable,
-        implicit_modules: &std::collections::HashSet<Vec<String>>,
+        _implicit_modules: &std::collections::HashSet<Vec<String>>,
         hints: &OptimizationHints,
         module_name: &str,
     ) -> Vec<u8> {
@@ -1184,15 +1345,14 @@ impl Codegen {
         // ========================================
         // Main core module
         // ========================================
-        let main_module = self.build_main_module(
+        let main_module = self.build_main_module(BuildMainModuleParams {
             entry_tir,
             all_tir_modules,
             symbols,
-            implicit_modules,
-            &string_data,
+            string_data: &string_data,
             hints,
             module_name,
-        );
+        });
         // Validate main module before embedding
         {
             let mut validator = Validator::new_with_features(WasmFeatures::all());
@@ -2293,15 +2453,53 @@ impl Codegen {
                 if matches!(type_table.get(*elem_type), ResolvedType::String) {
                     let copy_func_idx = builder.func_idx("core/internal/array_copy_string");
                     func.instruction(&Instruction::Call(copy_func_idx));
-                } else if let Some(&array_type_idx) = self.array_types.get(elem_type) {
-                    self.generate_array_copy(func, array_type_idx, false, ctx);
+                } else if let Some(&raw_array_type_idx) = self.array_types.get(elem_type) {
+                    // Get the Array struct type
+                    let array_struct_type_idx = *self
+                        .array_struct_types
+                        .get(elem_type)
+                        .expect("Array struct type should be registered");
+                    // Array is now a struct with (repr, used) fields
+                    // 1. Store the source struct
+                    let source_struct_local = ctx.alloc_local(
+                        &format!("__copy_array_struct_source_{}", raw_array_type_idx),
+                        ValType::Ref(RefType {
+                            nullable: true,
+                            heap_type: HeapType::Concrete(array_struct_type_idx),
+                        }),
+                    );
+                    func.instruction(&Instruction::LocalSet(source_struct_local));
+
+                    // 2. Get the repr field (raw array)
+                    func.instruction(&Instruction::LocalGet(source_struct_local));
+                    func.instruction(&Instruction::StructGet {
+                        struct_type_index: array_struct_type_idx,
+                        field_index: 0, // repr is field 0
+                    });
+
+                    // 3. Copy the raw array
+                    self.generate_array_copy(func, raw_array_type_idx, false, ctx);
+
+                    // 4. Get the used field from source
+                    func.instruction(&Instruction::LocalGet(source_struct_local));
+                    func.instruction(&Instruction::StructGet {
+                        struct_type_index: array_struct_type_idx,
+                        field_index: 1, // used is field 1
+                    });
+
+                    // 5. Create new Array struct with (copied_repr, used)
+                    func.instruction(&Instruction::StructNew(array_struct_type_idx));
                 } else {
                     panic!("unknown array type");
                 }
             }
             ResolvedType::String => {
-                // Strings are Array<u8> internally (packed i8 storage)
-                self.generate_array_copy(func, self.string_array_type_idx, true, ctx);
+                // String is now a struct, delegate to struct copy
+                if let Some(info) = self.lookup_struct_type("String", &string_module_path()) {
+                    self.generate_struct_copy(func, info.type_idx, info.field_count, ctx);
+                } else {
+                    panic!("String struct not found in generate_value_copy");
+                }
             }
             ResolvedType::Option(inner) => {
                 // Option<T> where T needs copying: conditionally copy the inner value
@@ -2652,18 +2850,163 @@ impl Codegen {
         type_idx
     }
 
-    /// Pre-register all array types found in a TypeTable.
-    fn register_array_types_from_table(
+    /// Get or create an Array<T> struct type for a given element TypeId.
+    /// Array<T> is a struct with fields: repr (ref to GC array), used (i32)
+    /// Returns the Wasm type index for the GC struct type.
+    fn get_or_create_array_struct_type(
+        &mut self,
+        element_type_id: TypeId,
+        type_table: &TypeTable,
+        builder: &mut CoreModuleBuilder,
+    ) -> u32 {
+        // Check if already registered
+        if let Some(&type_idx) = self.array_struct_types.get(&element_type_id) {
+            return type_idx;
+        }
+
+        // First ensure the raw array type exists
+        let raw_array_type_idx =
+            self.get_or_create_array_type(element_type_id, type_table, builder);
+
+        // Create struct type with two fields:
+        // - field 0: repr (ref to raw array, mutable for potential resize)
+        //   Note: Must be nullable to match Wasm GC subtyping rules
+        // - field 1: used (i32, mutable for append)
+        let fields = vec![
+            FieldType {
+                element_type: StorageType::Val(ValType::Ref(RefType {
+                    nullable: true,
+                    heap_type: HeapType::Concrete(raw_array_type_idx),
+                })),
+                mutable: true,
+            },
+            FieldType {
+                element_type: StorageType::Val(ValType::I32),
+                mutable: true,
+            },
+        ];
+
+        let type_name = format!("Array_{}", element_type_id);
+        let type_idx = builder.define_gc_struct_type(&type_name, &fields);
+
+        self.array_struct_types.insert(element_type_id, type_idx);
+        type_idx
+    }
+
+    /// Pre-register primitive array types (where element type is a primitive).
+    /// These can be registered before struct types since they don't depend on struct definitions.
+    fn register_primitive_array_types_from_table(
         &mut self,
         type_table: &TypeTable,
         builder: &mut CoreModuleBuilder,
     ) {
         for type_id in 0..type_table.len() as TypeId {
-            if let ResolvedType::Array(element_type_id) = type_table.get(type_id)
-                && !self.array_types.contains_key(element_type_id)
-            {
-                self.get_or_create_array_type(*element_type_id, type_table, builder);
+            let (element_type_id, is_array_struct) = match type_table.get(type_id) {
+                ResolvedType::Array(elem) => (*elem, true),
+                ResolvedType::BuiltinArray(elem) => (*elem, false),
+                _ => continue,
+            };
+            // Skip if element type is not a primitive
+            if !matches!(type_table.get(element_type_id), ResolvedType::Primitive(_)) {
+                continue;
             }
+            // Skip array types with type parameters (unmonomorphized generics)
+            if type_table.contains_type_param(element_type_id) {
+                continue;
+            }
+            // Register raw array type
+            if !self.array_types.contains_key(&element_type_id) {
+                self.get_or_create_array_type(element_type_id, type_table, builder);
+            }
+            // Also register Array struct type for Array<T>
+            if is_array_struct && !self.array_struct_types.contains_key(&element_type_id) {
+                self.get_or_create_array_struct_type(element_type_id, type_table, builder);
+            }
+        }
+    }
+
+    /// Pre-register all array types found in a TypeTable.
+    /// Registers both raw array types (for builtin::array<T>) and Array struct types (for Array<T>).
+    fn register_array_types_from_table(
+        &mut self,
+        type_table: &TypeTable,
+        builder: &mut CoreModuleBuilder,
+    ) {
+        // Collect all array types from the type table, including nested ones
+        let mut array_types_to_register: Vec<(TypeId, bool)> = Vec::new();
+        for type_id in 0..type_table.len() as TypeId {
+            self.collect_array_types_recursive(
+                type_id,
+                type_table,
+                &mut array_types_to_register,
+                &mut std::collections::HashSet::new(),
+            );
+        }
+
+        // Register all discovered array types
+        for (element_type_id, is_array_struct) in array_types_to_register {
+            // Skip array types with type parameters (unmonomorphized generics)
+            if type_table.contains_type_param(element_type_id) {
+                continue;
+            }
+            // Skip array types with Unknown/Error element types
+            if element_type_id == TypeTable::UNKNOWN || element_type_id == TypeTable::ERROR {
+                continue;
+            }
+            // Skip array types with GenericInstance element types (unmonomorphized)
+            if matches!(
+                type_table.get(element_type_id),
+                ResolvedType::GenericInstance { .. }
+            ) {
+                continue;
+            }
+            // Register raw array type (for builtin::array<T> and Array<T>.repr)
+            if !self.array_types.contains_key(&element_type_id) {
+                self.get_or_create_array_type(element_type_id, type_table, builder);
+            }
+            // Also register Array struct type for Array<T>
+            if is_array_struct && !self.array_struct_types.contains_key(&element_type_id) {
+                self.get_or_create_array_struct_type(element_type_id, type_table, builder);
+            }
+        }
+    }
+
+    /// Recursively collect array types from a type, including nested types in structs/tuples
+    fn collect_array_types_recursive(
+        &self,
+        type_id: TypeId,
+        type_table: &TypeTable,
+        found: &mut Vec<(TypeId, bool)>,
+        visited: &mut std::collections::HashSet<TypeId>,
+    ) {
+        if !visited.insert(type_id) {
+            return; // Already visited
+        }
+
+        match type_table.get(type_id) {
+            ResolvedType::Array(elem) => {
+                found.push((*elem, true));
+                self.collect_array_types_recursive(*elem, type_table, found, visited);
+            }
+            ResolvedType::BuiltinArray(elem) => {
+                found.push((*elem, false));
+                self.collect_array_types_recursive(*elem, type_table, found, visited);
+            }
+            ResolvedType::Struct { .. } => {
+                // Struct field types are stored in TirStruct, not ResolvedType::Struct
+                // We handle nested arrays by scanning all types in the table
+            }
+            ResolvedType::Tuple(elements) => {
+                for elem in elements {
+                    self.collect_array_types_recursive(*elem, type_table, found, visited);
+                }
+            }
+            ResolvedType::Option(inner)
+            | ResolvedType::Ref(inner)
+            | ResolvedType::MutRef(inner) => {
+                self.collect_array_types_recursive(*inner, type_table, found, visited);
+            }
+            _ => {}
         }
     }
 
@@ -2694,11 +3037,18 @@ impl Codegen {
             // Never type - functions that never return
             ResolvedType::Never => ValType::I32, // Placeholder, never actually used
 
-            // String type - GC array<u8>
-            ResolvedType::String => ValType::Ref(RefType {
-                nullable: false,
-                heap_type: HeapType::Concrete(self.string_array_type_idx),
-            }),
+            // String type - now a struct, delegate to struct lookup
+            ResolvedType::String => {
+                if let Some(struct_info) = self.lookup_struct_type("String", &string_module_path())
+                {
+                    ValType::Ref(RefType {
+                        nullable: false,
+                        heap_type: HeapType::Concrete(struct_info.type_idx),
+                    })
+                } else {
+                    panic!("String struct not found in type_id_to_valtype")
+                }
+            }
 
             // Struct type
             ResolvedType::Struct { name, module_path } => {
@@ -2712,9 +3062,26 @@ impl Codegen {
                 }
             }
 
-            // Array<T> - GC array
+            // Array<T> - GC struct with repr (raw array) and used (i32) fields
             ResolvedType::Array(element_type) => {
-                // Look up registered array type or fall back to string_array_type_idx
+                // Look up registered Array struct type
+                if let Some(&type_idx) = self.array_struct_types.get(element_type) {
+                    ValType::Ref(RefType {
+                        nullable: false,
+                        heap_type: HeapType::Concrete(type_idx),
+                    })
+                } else {
+                    // Fallback: this shouldn't happen if types are registered properly
+                    panic!(
+                        "Array struct type not registered for element type {}",
+                        element_type
+                    );
+                }
+            }
+
+            // builtin::array<T> - raw GC array intrinsic
+            ResolvedType::BuiltinArray(element_type) => {
+                // Same as Array<T> - look up registered array type
                 let type_idx = self
                     .array_types
                     .get(element_type)
@@ -2805,7 +3172,18 @@ impl Codegen {
 
             // Placeholder types (shouldn't appear in final TIR)
             ResolvedType::Unknown | ResolvedType::Error => {
+                eprintln!("DEBUG: Unknown/Error type found. type_id={}", type_id);
                 panic!("unexpected Unknown/Error type in codegen")
+            }
+
+            // Type parameters should be monomorphized before codegen
+            ResolvedType::TypeParam { name, .. } => {
+                panic!("type parameter '{name}' should be monomorphized before codegen")
+            }
+
+            // Generic instances should be monomorphized before codegen
+            ResolvedType::GenericInstance { name, .. } => {
+                panic!("generic instance '{name}' should be monomorphized before codegen")
             }
         }
     }
@@ -3098,6 +3476,8 @@ impl Codegen {
             }
 
             TirExprKind::StringLiteral(s) => {
+                // String is a struct with one field: repr (builtin::array<u8>)
+                // 1. Create the raw byte array
                 let offset = self.get_string_offset(s);
                 let len = s.len();
                 func.instruction(&Instruction::I32Const(offset as i32));
@@ -3106,6 +3486,12 @@ impl Codegen {
                     array_type_index: self.string_array_type_idx,
                     array_data_index: 0,
                 });
+
+                // 2. Create the String struct
+                let string_struct_info = self
+                    .lookup_struct_type("String", &string_module_path())
+                    .expect("String struct not found");
+                func.instruction(&Instruction::StructNew(string_struct_info.type_idx));
             }
 
             TirExprKind::Null => {
@@ -3338,13 +3724,24 @@ impl Codegen {
                             }
                             other => other,
                         };
-                        let array_type_idx = match base_type {
-                            ResolvedType::Array(element_type) => self
-                                .array_types
-                                .get(element_type)
-                                .copied()
-                                .unwrap_or(self.string_array_type_idx),
-                            ResolvedType::String => self.string_array_type_idx,
+                        enum ArrayKind {
+                            Array { struct_type_idx: u32 },
+                            String,
+                        }
+                        let (raw_array_type_idx, array_kind) = match base_type {
+                            ResolvedType::Array(element_type) => {
+                                let raw_type_idx = self
+                                    .array_types
+                                    .get(element_type)
+                                    .copied()
+                                    .unwrap_or(self.string_array_type_idx);
+                                let struct_type_idx = *self
+                                    .array_struct_types
+                                    .get(element_type)
+                                    .expect("Array struct type should be registered");
+                                (raw_type_idx, ArrayKind::Array { struct_type_idx })
+                            }
+                            ResolvedType::String => (self.string_array_type_idx, ArrayKind::String),
                             other => {
                                 panic!("index assignment on non-array type: {:?}", other);
                             }
@@ -3352,17 +3749,54 @@ impl Codegen {
 
                         // Generate array reference first
                         self.generate_expr(func, array_expr, type_table, ctx, builder);
+                        // Access the repr field to get the raw array
+                        match &array_kind {
+                            ArrayKind::Array { struct_type_idx } => {
+                                func.instruction(&Instruction::StructGet {
+                                    struct_type_index: *struct_type_idx,
+                                    field_index: 0, // repr is field 0
+                                });
+                            }
+                            ArrayKind::String => {
+                                if let Some(struct_info) =
+                                    self.lookup_struct_type("String", &string_module_path())
+                                {
+                                    func.instruction(&Instruction::StructGet {
+                                        struct_type_index: struct_info.type_idx,
+                                        field_index: 0, // repr is field 0
+                                    });
+                                }
+                            }
+                        }
                         // Then generate index
                         self.generate_expr(func, index_expr, type_table, ctx, builder);
                         // Then generate value
                         self.generate_expr(func, value, type_table, ctx, builder);
                         // Emit array.set (consumes all three values, leaves nothing)
-                        func.instruction(&Instruction::ArraySet(array_type_idx));
+                        func.instruction(&Instruction::ArraySet(raw_array_type_idx));
                         // Push the assigned value back for expression result
                         // (Regenerate the index access to get the value)
                         self.generate_expr(func, array_expr, type_table, ctx, builder);
+                        match &array_kind {
+                            ArrayKind::Array { struct_type_idx } => {
+                                func.instruction(&Instruction::StructGet {
+                                    struct_type_index: *struct_type_idx,
+                                    field_index: 0,
+                                });
+                            }
+                            ArrayKind::String => {
+                                if let Some(struct_info) =
+                                    self.lookup_struct_type("String", &string_module_path())
+                                {
+                                    func.instruction(&Instruction::StructGet {
+                                        struct_type_index: struct_info.type_idx,
+                                        field_index: 0,
+                                    });
+                                }
+                            }
+                        }
                         self.generate_expr(func, index_expr, type_table, ctx, builder);
-                        func.instruction(&Instruction::ArrayGet(array_type_idx));
+                        func.instruction(&Instruction::ArrayGet(raw_array_type_idx));
                     }
                     TirExprKind::Unary {
                         op: TirUnaryOp::Deref,
@@ -3436,6 +3870,7 @@ impl Codegen {
                 module_path,
                 func_name,
                 args,
+                ..
             } => {
                 // Helper to check if this is a specific builtin
                 let is_builtin = |name: &str| {
@@ -3476,11 +3911,20 @@ impl Codegen {
                     }
                     func.instruction(&Instruction::ArraySet(self.string_array_type_idx));
                 } else if is_builtin("string_new") {
-                    // builtin::string_new(len) -> array.new_default
-                    for arg in args {
-                        self.generate_expr(func, arg, type_table, ctx, builder);
+                    // builtin::string_new(len) -> String struct with new array
+                    // Get the length argument for array creation
+                    if let Some(len_arg) = args.first() {
+                        self.generate_expr(func, len_arg, type_table, ctx, builder);
+
+                        // 1. Create the raw byte array with the length
+                        func.instruction(&Instruction::ArrayNewDefault(self.string_array_type_idx));
+
+                        // 2. Create the String struct
+                        let string_struct_info = self
+                            .lookup_struct_type("String", &string_module_path())
+                            .expect("String struct not found");
+                        func.instruction(&Instruction::StructNew(string_struct_info.type_idx));
                     }
-                    func.instruction(&Instruction::ArrayNewDefault(self.string_array_type_idx));
                 } else if is_builtin("memory_store8") {
                     // builtin::memory_store8(addr, value) -> i32.store8
                     for arg in args {
@@ -3512,25 +3956,45 @@ impl Codegen {
                         memory_index: 0,
                     }));
                 } else if is_builtin("array_new_string") {
-                    // builtin::array_new_string(count) -> array.new_default for Array<String>
-                    // This creates a GC array of string references (nullable ref to string-array)
+                    // builtin::array_new_string(count) -> array.new_default for builtin::array<String>
+                    // This creates a raw GC array of String struct references
                     for arg in args {
                         self.generate_expr(func, arg, type_table, ctx, builder);
                     }
-                    // Get or create the Array<String> type
-                    // The element type is string (which is ref to string-array)
-                    let string_type_id = TypeTable::STRING;
+                    // Look up the String struct type_id
+                    let string_type_id = type_table
+                        .find_struct_type("String", &string_module_path())
+                        .expect("String struct should be defined in core/prelude");
                     let array_of_string_type = *self
                         .array_types
                         .get(&string_type_id)
-                        .expect("Array<String> type should be registered");
+                        .expect("Array<String> raw array type should be registered");
                     func.instruction(&Instruction::ArrayNewDefault(array_of_string_type));
+                } else if is_builtin("array_wrap_string") {
+                    // builtin::array_wrap_string(repr, used) -> Array<String> struct
+                    // Creates an Array struct from a raw array and used count
+                    for arg in args {
+                        self.generate_expr(func, arg, type_table, ctx, builder);
+                    }
+                    // Look up the String struct type_id
+                    let string_type_id = type_table
+                        .find_struct_type("String", &string_module_path())
+                        .expect("String struct should be defined in core/prelude");
+                    let array_struct_type = *self
+                        .array_struct_types
+                        .get(&string_type_id)
+                        .expect("Array<String> struct type should be registered");
+                    // Stack has: repr (raw array), used (i32)
+                    // Create the Array struct
+                    func.instruction(&Instruction::StructNew(array_struct_type));
                 } else if is_builtin("array_set_string") {
                     // builtin::array_set_string(arr, idx, str) -> array.set
                     for arg in args {
                         self.generate_expr(func, arg, type_table, ctx, builder);
                     }
-                    let string_type_id = TypeTable::STRING;
+                    let string_type_id = type_table
+                        .find_struct_type("String", &string_module_path())
+                        .expect("String struct should be defined in core/prelude");
                     let array_of_string_type = *self
                         .array_types
                         .get(&string_type_id)
@@ -3541,7 +4005,9 @@ impl Codegen {
                     for arg in args {
                         self.generate_expr(func, arg, type_table, ctx, builder);
                     }
-                    let string_type_id = TypeTable::STRING;
+                    let string_type_id = type_table
+                        .find_struct_type("String", &string_module_path())
+                        .expect("String struct should be defined in core/prelude");
                     let array_of_string_type = *self
                         .array_types
                         .get(&string_type_id)
@@ -3841,6 +4307,7 @@ impl Codegen {
                 receiver,
                 method_name,
                 args,
+                ..
             } => {
                 match type_table.get(receiver.type_id) {
                     // Struct method call
@@ -3855,7 +4322,25 @@ impl Codegen {
                         .to_string();
 
                         // Look up the method function index
-                        if let Some(idx) = builder.try_func_idx(&mangled_name) {
+                        // For monomorphized generics (e.g., Box$i32), also try base struct name (Box)
+                        let func_idx = builder.try_func_idx(&mangled_name).or_else(|| {
+                            // If struct name contains '$', try the base name
+                            if let Some(dollar_pos) = name.find('$') {
+                                let base_name = &name[..dollar_pos];
+                                let base_mangled = MethodName::new(
+                                    module_path.join("/"),
+                                    base_name.to_string(),
+                                    None,
+                                    method_name.to_string(),
+                                )
+                                .to_string();
+                                builder.try_func_idx(&base_mangled)
+                            } else {
+                                None
+                            }
+                        });
+
+                        if let Some(idx) = func_idx {
                             // Generate code for the receiver (self parameter)
                             self.generate_expr(func, receiver, type_table, ctx, builder);
 
@@ -3909,26 +4394,78 @@ impl Codegen {
                     }
 
                     // Array method calls (e.g., array.len())
-                    ResolvedType::Array(_) => {
+                    ResolvedType::Array(element_type) => {
                         if method_name == "len" {
-                            // Generate the receiver (the array)
+                            // Generate the receiver (the array struct)
                             self.generate_expr(func, receiver, type_table, ctx, builder);
-                            // array.len generates the Wasm array.len instruction directly
+                            // Get the Array struct type index
+                            let array_struct_type_idx = *self
+                                .array_struct_types
+                                .get(element_type)
+                                .expect("Array struct type should be registered");
+                            // Access the used field (field 1) for length
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: array_struct_type_idx,
+                                field_index: 1, // used is field 1
+                            });
+                        } else if method_name == "capacity" {
+                            // Generate the receiver (the array struct)
+                            self.generate_expr(func, receiver, type_table, ctx, builder);
+                            // Get the Array struct type index
+                            let array_struct_type_idx = *self
+                                .array_struct_types
+                                .get(element_type)
+                                .expect("Array struct type should be registered");
+                            // Access the repr field (field 0) and get its length
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: array_struct_type_idx,
+                                field_index: 0, // repr is field 0
+                            });
                             func.instruction(&Instruction::ArrayLen);
                         } else {
                             panic!("unknown method {} on Array type", method_name);
                         }
                     }
 
-                    // String method calls (e.g., string.len())
+                    // String method calls - String is now a struct, call the struct methods
                     ResolvedType::String => {
-                        if method_name == "len" {
-                            // Generate the receiver (the string)
-                            self.generate_expr(func, receiver, type_table, ctx, builder);
-                            // string.len generates the Wasm array.len instruction (strings are byte arrays)
-                            func.instruction(&Instruction::ArrayLen);
-                        } else {
-                            panic!("unknown method {} on String type", method_name);
+                        match method_name.as_str() {
+                            "len" => {
+                                // Generate the receiver (the string)
+                                self.generate_expr(func, receiver, type_table, ctx, builder);
+                                // Call String::len method
+                                let len_func_idx = builder.func_idx("core/prelude/String::len");
+                                func.instruction(&Instruction::Call(len_func_idx));
+                            }
+                            "get" => {
+                                // string.get(index) -> call String::get method
+                                // Generate receiver (string)
+                                self.generate_expr(func, receiver, type_table, ctx, builder);
+                                // Generate index argument
+                                if let Some(index_arg) = args.first() {
+                                    self.generate_expr(func, index_arg, type_table, ctx, builder);
+                                }
+                                let get_func_idx = builder.func_idx("core/prelude/String::get");
+                                func.instruction(&Instruction::Call(get_func_idx));
+                            }
+                            "set" => {
+                                // string.set(index, value) -> call String::set method
+                                // Generate receiver (string)
+                                self.generate_expr(func, receiver, type_table, ctx, builder);
+                                // Generate index argument
+                                if let Some(index_arg) = args.first() {
+                                    self.generate_expr(func, index_arg, type_table, ctx, builder);
+                                }
+                                // Generate value argument
+                                if let Some(value_arg) = args.get(1) {
+                                    self.generate_expr(func, value_arg, type_table, ctx, builder);
+                                }
+                                let set_func_idx = builder.func_idx("core/prelude/String::set");
+                                func.instruction(&Instruction::Call(set_func_idx));
+                            }
+                            _ => {
+                                panic!("unknown method {} on String type", method_name);
+                            }
                         }
                     }
 
@@ -3961,7 +4498,6 @@ impl Codegen {
             // === Index Access ===
             TirExprKind::Index { expr: array, index } => {
                 self.generate_expr(func, array, type_table, ctx, builder);
-                self.generate_expr(func, index, type_table, ctx, builder);
 
                 // Get the array type index from the array expression's type (unwrap reference if needed)
                 let base_type = match type_table.get(array.type_id) {
@@ -3970,7 +4506,7 @@ impl Codegen {
                     }
                     other => other,
                 };
-                let (array_type_idx, element_is_ref) = match base_type {
+                let (raw_array_type_idx, element_is_ref, need_repr_access) = match base_type {
                     ResolvedType::Array(element_type) => {
                         let is_ref = matches!(
                             type_table.get(*element_type),
@@ -3978,18 +4514,44 @@ impl Codegen {
                                 | ResolvedType::Array(_)
                                 | ResolvedType::Struct { .. }
                         );
+                        let array_struct_type_idx = self
+                            .array_struct_types
+                            .get(element_type)
+                            .expect("Array struct type should be registered");
+                        // Access the repr field (field 0) to get the raw array
+                        func.instruction(&Instruction::StructGet {
+                            struct_type_index: *array_struct_type_idx,
+                            field_index: 0, // repr is field 0
+                        });
                         (
                             self.array_types
                                 .get(element_type)
                                 .copied()
                                 .unwrap_or(self.string_array_type_idx),
                             is_ref,
+                            false, // already accessed
                         )
                     }
-                    ResolvedType::String => (self.string_array_type_idx, false),
-                    _ => (self.string_array_type_idx, false),
+                    ResolvedType::String => {
+                        // String is now a struct with repr field (field 0) containing the array
+                        // First access the repr field, then do array.get
+                        if let Some(struct_info) =
+                            self.lookup_struct_type("String", &string_module_path())
+                        {
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: struct_info.type_idx,
+                                field_index: 0, // repr is field 0
+                            });
+                        }
+                        (self.string_array_type_idx, false, false)
+                    }
+                    _ => (self.string_array_type_idx, false, false),
                 };
-                func.instruction(&Instruction::ArrayGet(array_type_idx));
+                let _ = need_repr_access; // silence unused warning
+
+                // Now generate index and do array access
+                self.generate_expr(func, index, type_table, ctx, builder);
+                func.instruction(&Instruction::ArrayGet(raw_array_type_idx));
                 // For reference element types, convert nullable to non-null
                 // (array elements are stored as nullable refs, but we expect non-null at usage)
                 if element_is_ref {
@@ -4068,17 +4630,29 @@ impl Codegen {
 
                 // Get the array type from the expression's type
                 if let ResolvedType::Array(element_type_id) = type_table.get(expr.type_id) {
-                    let array_type_idx = self
+                    let raw_array_type_idx = self
                         .array_types
                         .get(element_type_id)
                         .copied()
                         .unwrap_or(self.string_array_type_idx);
 
-                    // Create the array from values on stack
+                    let array_struct_type_idx = self
+                        .array_struct_types
+                        .get(element_type_id)
+                        .copied()
+                        .expect("Array struct type should be registered");
+
+                    // Create the raw array from values on stack
                     func.instruction(&Instruction::ArrayNewFixed {
-                        array_type_index: array_type_idx,
+                        array_type_index: raw_array_type_idx,
                         array_size: elements.len() as u32,
                     });
+
+                    // Push the `used` count (same as element count for literals)
+                    func.instruction(&Instruction::I32Const(elements.len() as i32));
+
+                    // Create the Array struct with (repr, used)
+                    func.instruction(&Instruction::StructNew(array_struct_type_idx));
                 } else {
                     panic!(
                         "expected array type for ArrayLiteral, got {:?}",
@@ -4719,8 +5293,8 @@ impl Codegen {
                 // block $exit        ; break target
                 //   loop $loop       ; for loop header
                 //     block $body    ; continue target
-                //       ;; Check: counter < array.len()
-                //       ;; Get element: array[counter]
+                //       ;; Check: counter < array.used
+                //       ;; Get element: array.repr[counter]
                 //       ;; body
                 //     end
                 //     ;; Increment counter
@@ -4732,15 +5306,23 @@ impl Codegen {
                 // - continue: br 0 (to end of $body, then counter++, then br $loop)
                 // - break: br 2 (to $exit)
 
-                // Get the array type index for array.get
-                let array_type_idx = match type_table.get(*iterable_type) {
-                    ResolvedType::Array(element_type) => self
-                        .array_types
-                        .get(element_type)
-                        .copied()
-                        .unwrap_or(self.string_array_type_idx),
-                    _ => self.string_array_type_idx,
-                };
+                // Get the raw array type index and Array struct type index for array.get
+                let (raw_array_type_idx, array_struct_type_idx) =
+                    match type_table.get(*iterable_type) {
+                        ResolvedType::Array(element_type) => {
+                            let raw_idx = self
+                                .array_types
+                                .get(element_type)
+                                .copied()
+                                .unwrap_or(self.string_array_type_idx);
+                            let struct_idx = *self
+                                .array_struct_types
+                                .get(element_type)
+                                .expect("Array struct type should be registered");
+                            (raw_idx, struct_idx)
+                        }
+                        _ => (self.string_array_type_idx, 0), // shouldn't happen
+                    };
 
                 // Get ValType for temporary locals (pre-allocated by preallocate_assert_locals_from_stmt)
                 let _ = binding_type; // binding_local is pre-allocated by resolver
@@ -4771,19 +5353,26 @@ impl Codegen {
                 // block $body
                 func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
 
-                // Check: counter < array.len()
+                // Check: counter < array.used (field 1)
                 func.instruction(&Instruction::LocalGet(counter_local));
                 func.instruction(&Instruction::LocalGet(array_local));
-                func.instruction(&Instruction::ArrayLen);
+                func.instruction(&Instruction::StructGet {
+                    struct_type_index: array_struct_type_idx,
+                    field_index: 1, // used is field 1
+                });
                 func.instruction(&Instruction::I32LtU);
                 func.instruction(&Instruction::I32Eqz);
                 // If counter >= length, exit (br 2 to $exit from inside $body block)
                 func.instruction(&Instruction::BrIf(2));
 
-                // Get element: array[counter] and store in binding_local
+                // Get element: array.repr[counter] and store in binding_local
                 func.instruction(&Instruction::LocalGet(array_local));
+                func.instruction(&Instruction::StructGet {
+                    struct_type_index: array_struct_type_idx,
+                    field_index: 0, // repr is field 0
+                });
                 func.instruction(&Instruction::LocalGet(counter_local));
-                func.instruction(&Instruction::ArrayGet(array_type_idx));
+                func.instruction(&Instruction::ArrayGet(raw_array_type_idx));
                 // Store in the binding local (pre-allocated by resolver via tir_func.local_types)
                 // Use the TIR's local index directly, same as TirStmtKind::Let
                 func.instruction(&Instruction::LocalSet(*binding_local));
@@ -4840,7 +5429,11 @@ impl Codegen {
                 // Power-assert: Cache intermediate values, then check condition
                 // If false, build detailed error message and panic
 
-                let string_array_type = builder.type_idx("string-array");
+                // Get String struct type for message locals
+                let string_struct_info = self
+                    .lookup_struct_type("String", &string_module_path())
+                    .expect("String struct not found");
+                let string_struct_type = string_struct_info.type_idx;
 
                 // 1. Allocate locals for intermediates (don't add to cache yet)
                 // Store TypeId (not ValType) so we can call the correct to_string function
@@ -4896,12 +5489,12 @@ impl Codegen {
                 func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
 
                 // 4. Build power-assert message
-                // Allocate result local for message accumulation
+                // Allocate result local for message accumulation (uses String struct type)
                 let result_local = ctx.alloc_local(
                     "__assert_msg",
                     ValType::Ref(RefType {
                         nullable: false,
-                        heap_type: HeapType::Concrete(string_array_type),
+                        heap_type: HeapType::Concrete(string_struct_type),
                     }),
                 );
 
@@ -5353,7 +5946,13 @@ impl Codegen {
         ctx: &mut FunctionContext,
         string_array_type: u32,
     ) {
-        // Scratch locals for stream handling builtins
+        // Get String struct type for template string locals
+        let string_struct_type = self
+            .lookup_struct_type("String", &string_module_path())
+            .map(|info| info.type_idx)
+            .unwrap_or(string_array_type); // fallback to array type if struct not found
+
+        // Scratch locals for stream handling builtins (uses raw array type)
         // Use nullable refs so they default to ref.null and don't require initialization
         ctx.alloc_local(
             "__arr_ref",
@@ -5374,18 +5973,19 @@ impl Codegen {
         ctx.alloc_local("__waitable_set", ValType::I32);
         // Scratch locals for template string accumulation and concatenation
         // Use nullable refs so they default to ref.null and don't require initialization
+        // These now use String struct type since String is a struct
         ctx.alloc_local(
             "__template_result",
             ValType::Ref(RefType {
                 nullable: true,
-                heap_type: HeapType::Concrete(string_array_type),
+                heap_type: HeapType::Concrete(string_struct_type),
             }),
         );
         ctx.alloc_local(
             "__concat_new",
             ValType::Ref(RefType {
                 nullable: true,
-                heap_type: HeapType::Concrete(string_array_type),
+                heap_type: HeapType::Concrete(string_struct_type),
             }),
         );
         ctx.alloc_local("__result_len", ValType::I32);
@@ -5430,56 +6030,54 @@ impl Codegen {
                     }
                 }
                 ResolvedType::Array(elem_type) => {
-                    if let Some(&array_type_idx) = self.array_types.get(elem_type) {
+                    if let Some(&raw_array_type_idx) = self.array_types.get(elem_type) {
+                        // Allocate locals for the Array struct wrapper
+                        if let Some(&array_struct_type_idx) = self.array_struct_types.get(elem_type)
+                        {
+                            ctx.alloc_local(
+                                &format!("__copy_array_struct_source_{}", raw_array_type_idx),
+                                ValType::Ref(RefType {
+                                    nullable: true,
+                                    heap_type: HeapType::Concrete(array_struct_type_idx),
+                                }),
+                            );
+                        }
+                        // Allocate locals for raw array copy operations
                         ctx.alloc_local(
-                            &format!("__copy_array_source_{}", array_type_idx),
+                            &format!("__copy_array_source_{}", raw_array_type_idx),
                             ValType::Ref(RefType {
                                 nullable: true,
-                                heap_type: HeapType::Concrete(array_type_idx),
+                                heap_type: HeapType::Concrete(raw_array_type_idx),
                             }),
                         );
                         ctx.alloc_local(
-                            &format!("__copy_array_dest_{}", array_type_idx),
+                            &format!("__copy_array_dest_{}", raw_array_type_idx),
                             ValType::Ref(RefType {
                                 nullable: true,
-                                heap_type: HeapType::Concrete(array_type_idx),
+                                heap_type: HeapType::Concrete(raw_array_type_idx),
                             }),
                         );
                         ctx.alloc_local(
-                            &format!("__copy_array_counter_{}", array_type_idx),
+                            &format!("__copy_array_counter_{}", raw_array_type_idx),
                             ValType::I32,
                         );
                         ctx.alloc_local(
-                            &format!("__copy_array_len_{}", array_type_idx),
+                            &format!("__copy_array_len_{}", raw_array_type_idx),
                             ValType::I32,
                         );
                     }
                 }
                 ResolvedType::String => {
-                    // Strings use string_array_type_idx
-                    let array_type_idx = self.string_array_type_idx;
-                    ctx.alloc_local(
-                        &format!("__copy_array_source_{}", array_type_idx),
-                        ValType::Ref(RefType {
-                            nullable: true,
-                            heap_type: HeapType::Concrete(array_type_idx),
-                        }),
-                    );
-                    ctx.alloc_local(
-                        &format!("__copy_array_dest_{}", array_type_idx),
-                        ValType::Ref(RefType {
-                            nullable: true,
-                            heap_type: HeapType::Concrete(array_type_idx),
-                        }),
-                    );
-                    ctx.alloc_local(
-                        &format!("__copy_array_counter_{}", array_type_idx),
-                        ValType::I32,
-                    );
-                    ctx.alloc_local(
-                        &format!("__copy_array_len_{}", array_type_idx),
-                        ValType::I32,
-                    );
+                    // String is now a struct, allocate struct copy local
+                    if let Some(info) = self.lookup_struct_type("String", &string_module_path()) {
+                        ctx.alloc_local(
+                            &format!("__copy_source_{}", info.type_idx),
+                            ValType::Ref(RefType {
+                                nullable: true,
+                                heap_type: HeapType::Concrete(info.type_idx),
+                            }),
+                        );
+                    }
                 }
                 _ => {}
             }
@@ -5678,11 +6276,16 @@ impl Codegen {
                 ctx.alloc_local("__assert_cond", ValType::I32);
 
                 // Pre-allocate message accumulator local (nullable ref)
+                // Use String struct type since String is now a struct
+                let string_struct_type = self
+                    .lookup_struct_type("String", &string_module_path())
+                    .map(|info| info.type_idx)
+                    .unwrap_or(string_array_type);
                 ctx.alloc_local(
                     "__assert_msg",
                     ValType::Ref(RefType {
                         nullable: true,
-                        heap_type: HeapType::Concrete(string_array_type),
+                        heap_type: HeapType::Concrete(string_struct_type),
                     }),
                 );
             }
@@ -5821,18 +6424,26 @@ impl Codegen {
         }
     }
 
-    /// Infer expression type with function context (for looking up variable types)
-    /// If builder is provided, can look up user function return types
+    /// Generate a String struct from static data
+    /// String is a struct with one field: repr (builtin::array<u8>)
     fn generate_string_from_data(&self, func: &mut Function, s: &str, builder: &CoreModuleBuilder) {
         let string_array_type = builder.type_idx("string-array");
         let offset = self.get_string_offset(s);
         let len = s.len();
+
+        // 1. Create the raw byte array
         func.instruction(&Instruction::I32Const(offset as i32));
         func.instruction(&Instruction::I32Const(len as i32));
         func.instruction(&Instruction::ArrayNewData {
             array_type_index: string_array_type,
             array_data_index: 0,
         });
+
+        // 2. Create the String struct
+        let string_struct_info = self
+            .lookup_struct_type("String", &string_module_path())
+            .expect("String struct not found");
+        func.instruction(&Instruction::StructNew(string_struct_info.type_idx));
     }
 
     /// Generate value to string conversion based on TypeId (semantic type)

--- a/wado-compiler/src/desugar.rs
+++ b/wado-compiler/src/desugar.rs
@@ -39,6 +39,7 @@ fn desugar_function(func: &Function) -> Function {
     Function {
         name: func.name.clone(),
         is_pub: func.is_pub,
+        type_params: func.type_params.clone(),
         attrs: func.attrs.clone(),
         params: func.params.clone(),
         return_type: func.return_type.clone(),
@@ -50,6 +51,7 @@ fn desugar_function(func: &Function) -> Function {
 
 fn desugar_impl(impl_block: &ImplBlock) -> ImplBlock {
     ImplBlock {
+        type_params: impl_block.type_params.clone(),
         ty: impl_block.ty.clone(),
         methods: impl_block.methods.iter().map(desugar_function).collect(),
         span: impl_block.span,
@@ -165,12 +167,14 @@ fn desugar_expr(expr: &Expr) -> Expr {
         })),
         Expr::Call(c) => Expr::Call(Box::new(CallExpr {
             callee: desugar_expr(&c.callee),
+            type_args: c.type_args.clone(),
             args: c.args.iter().map(desugar_expr).collect(),
             span: c.span,
         })),
         Expr::MethodCall(m) => Expr::MethodCall(Box::new(MethodCallExpr {
             receiver: desugar_expr(&m.receiver),
             method: m.method.clone(),
+            type_args: m.type_args.clone(),
             args: m.args.iter().map(desugar_expr).collect(),
             span: m.span,
         })),

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -36,6 +36,8 @@ pub use token::Span;
 
 use std::path::Path;
 
+use indexmap::IndexMap;
+
 /// Result of compiling a Wado source file
 #[derive(Debug)]
 pub struct CompileResult {
@@ -64,10 +66,10 @@ pub struct DumpResult {
     pub implicit_modules: Vec<Vec<String>>,
     /// Entry module path
     pub entry_path: Vec<String>,
-    /// All TIR modules after resolution
-    pub tir_modules: Option<std::collections::HashMap<Vec<String>, tir::TirModule>>,
-    /// All lowered TIR modules
-    pub lowered_tir_modules: Option<std::collections::HashMap<Vec<String>, tir::TirModule>>,
+    /// All TIR modules after resolution (in topological order)
+    pub tir_modules: Option<IndexMap<Vec<String>, tir::TirModule>>,
+    /// All lowered TIR modules (in topological order)
+    pub lowered_tir_modules: Option<IndexMap<Vec<String>, tir::TirModule>>,
     /// Optimization hints
     pub opt_hints: Option<OptimizationHints>,
     /// Comments for unparsing
@@ -416,7 +418,7 @@ fn compile_impl(
     })?;
 
     // === Phase 7: Lower all modules (string collection, etc.) ===
-    let tir_modules: std::collections::HashMap<Vec<String>, _> = tir_modules
+    let tir_modules: IndexMap<Vec<String>, _> = tir_modules
         .into_iter()
         .map(|(path, module)| (path, lower(module)))
         .collect();

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -8,13 +8,23 @@
 //! - Closure capture analysis
 //! - JSX element type binding (future)
 
-use crate::tir::{TirBlock, TirExpr, TirExprKind, TirModule, TirStmt, TirStmtKind};
+use std::collections::HashMap;
+
+use crate::tir::{
+    InstantiationKey, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirField,
+    TirFunction, TirModule, TirParam, TirStmt, TirStmtKind, TirStruct, TypeId, TypeTable,
+};
 
 /// Lower a TIR module
 ///
 /// Currently performs:
+/// - Monomorphization of generic types
 /// - String literal collection
 pub fn lower(mut module: TirModule) -> TirModule {
+    // Perform monomorphization
+    let mut monomorph = Monomorphizer::new();
+    module = monomorph.monomorphize(module);
+
     // Collect string literals
     let mut collector = StringCollector::new();
     collector.collect_module(&module);
@@ -26,6 +36,1361 @@ pub fn lower(mut module: TirModule) -> TirModule {
 /// Lower multiple modules
 pub fn lower_modules(modules: Vec<TirModule>) -> Vec<TirModule> {
     modules.into_iter().map(lower).collect()
+}
+
+// ============================================================================
+// Monomorphization
+// ============================================================================
+
+/// Monomorphizer collects generic instantiations and generates concrete types
+struct Monomorphizer {
+    /// Map from (generic_name, type_args) to mangled name for structs
+    instantiated: HashMap<InstantiationKey, String>,
+    /// Work queue of pending struct instantiations
+    pending: Vec<InstantiationKey>,
+    /// Map from GenericInstance TypeId to monomorphized Struct TypeId
+    type_substitutions: HashMap<TypeId, TypeId>,
+    /// Map from GenericInstance TypeId to mangled struct name
+    type_to_mangled_name: HashMap<TypeId, String>,
+    /// Map from (generic_func_name, type_args) to mangled function name
+    function_instantiated: HashMap<InstantiationKey, String>,
+    /// Work queue of pending function instantiations
+    function_pending: Vec<InstantiationKey>,
+}
+
+impl Monomorphizer {
+    fn new() -> Self {
+        Self {
+            instantiated: HashMap::new(),
+            pending: Vec::new(),
+            type_substitutions: HashMap::new(),
+            type_to_mangled_name: HashMap::new(),
+            function_instantiated: HashMap::new(),
+            function_pending: Vec::new(),
+        }
+    }
+
+    /// Perform monomorphization on a module
+    fn monomorphize(&mut self, mut module: TirModule) -> TirModule {
+        // ========================
+        // Struct Monomorphization
+        // ========================
+
+        // Phase 1: Collect all generic struct definitions
+        let generic_structs: HashMap<String, TirStruct> = module
+            .structs
+            .iter()
+            .filter(|s| !s.type_params.is_empty())
+            .map(|s| (s.name.clone(), s.clone()))
+            .collect();
+
+        // Store in module for later phases
+        module.generic_structs = generic_structs.clone();
+
+        // Phase 2: Collect all struct instantiation sites from the type table
+        self.collect_instantiation_sites(&module.type_table);
+
+        // Phase 3: Process struct instantiations and generate concrete structs
+        let mut new_structs = Vec::new();
+        while let Some(key) = self.pending.pop() {
+            if let Some(generic_struct) = generic_structs.get(&key.name)
+                && let Some(concrete) =
+                    self.instantiate_struct(generic_struct, &key, &mut module.type_table)
+            {
+                new_structs.push(concrete);
+            }
+        }
+
+        // Phase 4: Add monomorphized structs to module
+        module.structs.extend(new_structs);
+
+        // Phase 5: Remove generic structs from the concrete struct list
+        // (they stay in generic_structs for reference)
+        module
+            .structs
+            .retain(|s| s.type_params.is_empty() || s.monomorph_info.is_some());
+
+        // Phase 6: Rewrite all GenericInstance type_ids to concrete struct type_ids
+        self.rewrite_types_in_module(&mut module);
+
+        // ============================
+        // Function Monomorphization
+        // ============================
+
+        // Phase 7: Collect all generic function definitions
+        let generic_functions: HashMap<String, TirFunction> = module
+            .functions
+            .iter()
+            .filter(|f| !f.type_params.is_empty())
+            .map(|f| (f.name.clone(), f.clone()))
+            .collect();
+
+        // Store in module for later phases
+        module.generic_functions = generic_functions.clone();
+
+        // Phase 8: Collect function instantiation sites from Call expressions
+        self.collect_function_instantiation_sites(&module);
+
+        // Phase 9: Process function instantiations and generate concrete functions
+        let mut new_functions = Vec::new();
+        while let Some(key) = self.function_pending.pop() {
+            if let Some(generic_func) = generic_functions.get(&key.name)
+                && let Some(concrete) =
+                    self.instantiate_function(generic_func, &key, &mut module.type_table)
+            {
+                new_functions.push(concrete);
+            }
+        }
+
+        // Phase 10: Add monomorphized functions to module
+        module.functions.extend(new_functions);
+
+        // Phase 11: Remove generic functions from the functions list
+        // (they stay in generic_functions for reference)
+        module
+            .functions
+            .retain(|f| f.type_params.is_empty() || f.monomorph_info.is_some());
+
+        // Phase 12: Rewrite function calls to use monomorphized names
+        self.rewrite_function_calls_in_module(&mut module);
+
+        module
+    }
+
+    /// Rewrite all GenericInstance type_ids in expressions to use monomorphized struct types
+    fn rewrite_types_in_module(&self, module: &mut TirModule) {
+        // Rewrite struct field types
+        for strct in &mut module.structs {
+            for field in &mut strct.fields {
+                field.type_id = self.rewrite_type_id(field.type_id, &mut module.type_table);
+            }
+        }
+
+        // Rewrite function signatures and bodies
+        for func in &mut module.functions {
+            // Rewrite function parameters
+            for param in &mut func.params {
+                param.type_id = self.rewrite_type_id(param.type_id, &mut module.type_table);
+            }
+            // Rewrite return type
+            func.return_type = self.rewrite_type_id(func.return_type, &mut module.type_table);
+            // Rewrite local_types
+            for local_type in &mut func.local_types {
+                *local_type = self.rewrite_type_id(*local_type, &mut module.type_table);
+            }
+            // Rewrite function body
+            if let Some(body) = &mut func.body {
+                self.rewrite_types_in_block(body, &mut module.type_table);
+            }
+        }
+    }
+
+    fn rewrite_types_in_block(&self, block: &mut TirBlock, type_table: &mut TypeTable) {
+        for stmt in &mut block.stmts {
+            self.rewrite_types_in_stmt(stmt, type_table);
+        }
+    }
+
+    fn rewrite_types_in_stmt(&self, stmt: &mut TirStmt, type_table: &mut TypeTable) {
+        match &mut stmt.kind {
+            TirStmtKind::Let { type_id, value, .. } => {
+                *type_id = self.rewrite_type_id(*type_id, type_table);
+                self.rewrite_types_in_expr(value, type_table);
+            }
+            TirStmtKind::Expr(expr) => {
+                self.rewrite_types_in_expr(expr, type_table);
+            }
+            TirStmtKind::Return { value } => {
+                if let Some(expr) = value {
+                    self.rewrite_types_in_expr(expr, type_table);
+                }
+            }
+            TirStmtKind::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.rewrite_types_in_expr(condition, type_table);
+                self.rewrite_types_in_block(then_block, type_table);
+                if let Some(else_blk) = else_block {
+                    self.rewrite_types_in_block(else_blk, type_table);
+                }
+            }
+            TirStmtKind::While { condition, body } => {
+                self.rewrite_types_in_expr(condition, type_table);
+                self.rewrite_types_in_block(body, type_table);
+            }
+            TirStmtKind::For {
+                condition,
+                body,
+                update,
+            } => {
+                if let Some(cond) = condition {
+                    self.rewrite_types_in_expr(cond, type_table);
+                }
+                self.rewrite_types_in_block(body, type_table);
+                if let Some(upd) = update {
+                    self.rewrite_types_in_expr(upd, type_table);
+                }
+            }
+            TirStmtKind::Loop { body } => {
+                self.rewrite_types_in_block(body, type_table);
+            }
+            TirStmtKind::ForOf { iterable, body, .. } => {
+                self.rewrite_types_in_expr(iterable, type_table);
+                self.rewrite_types_in_block(body, type_table);
+            }
+            TirStmtKind::Break | TirStmtKind::Continue => {}
+            TirStmtKind::Assert {
+                condition,
+                message,
+                intermediates,
+                ..
+            } => {
+                self.rewrite_types_in_expr(condition, type_table);
+                if let Some(msg) = message {
+                    self.rewrite_types_in_expr(msg, type_table);
+                }
+                for (_, expr, _) in intermediates {
+                    self.rewrite_types_in_expr(expr, type_table);
+                }
+            }
+        }
+    }
+
+    fn rewrite_types_in_expr(&self, expr: &mut TirExpr, type_table: &mut TypeTable) {
+        // Rewrite the expression's own type_id
+        expr.type_id = self.rewrite_type_id(expr.type_id, type_table);
+
+        // Recursively rewrite types in sub-expressions
+        match &mut expr.kind {
+            TirExprKind::StructLiteral {
+                struct_type,
+                struct_name,
+                fields,
+            } => {
+                let original_type_id = *struct_type;
+                let new_type_id = self.rewrite_type_id(original_type_id, type_table);
+                *struct_type = new_type_id;
+                // Update struct_name if it was monomorphized (use original type_id to look up)
+                if let Some(mangled_name) = self.type_to_mangled_name.get(&original_type_id) {
+                    *struct_name = mangled_name.clone();
+                }
+                for field in fields {
+                    self.rewrite_types_in_expr(&mut field.value, type_table);
+                }
+            }
+            TirExprKind::Binary { left, right, .. } => {
+                self.rewrite_types_in_expr(left, type_table);
+                self.rewrite_types_in_expr(right, type_table);
+            }
+            TirExprKind::Unary { expr: inner, .. } => {
+                self.rewrite_types_in_expr(inner, type_table);
+            }
+            TirExprKind::Call { args, .. } => {
+                for arg in args {
+                    self.rewrite_types_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::MethodCall { receiver, args, .. } => {
+                self.rewrite_types_in_expr(receiver, type_table);
+                for arg in args {
+                    self.rewrite_types_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::EffectCall { args, .. } => {
+                for arg in args {
+                    self.rewrite_types_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::Block(block) => {
+                self.rewrite_types_in_block(block, type_table);
+            }
+            TirExprKind::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.rewrite_types_in_expr(condition, type_table);
+                self.rewrite_types_in_block(then_branch, type_table);
+                if let Some(else_blk) = else_branch {
+                    self.rewrite_types_in_block(else_blk, type_table);
+                }
+            }
+            TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
+                for elem in elements {
+                    self.rewrite_types_in_expr(elem, type_table);
+                }
+            }
+            TirExprKind::Assign { target, value } => {
+                self.rewrite_types_in_expr(target, type_table);
+                self.rewrite_types_in_expr(value, type_table);
+            }
+            TirExprKind::Cast { expr: inner, .. } => {
+                self.rewrite_types_in_expr(inner, type_table);
+            }
+            TirExprKind::FieldAccess { expr: inner, .. } => {
+                self.rewrite_types_in_expr(inner, type_table);
+            }
+            TirExprKind::Index { expr: array, index } => {
+                self.rewrite_types_in_expr(array, type_table);
+                self.rewrite_types_in_expr(index, type_table);
+            }
+            TirExprKind::Match {
+                expr: scrutinee,
+                arms,
+            } => {
+                self.rewrite_types_in_expr(scrutinee, type_table);
+                for arm in arms {
+                    self.rewrite_types_in_expr(&mut arm.body, type_table);
+                }
+            }
+            TirExprKind::Closure { body, .. } => {
+                self.rewrite_types_in_expr(body, type_table);
+            }
+            // Literals and simple expressions don't need rewriting
+            TirExprKind::IntLiteral { .. }
+            | TirExprKind::FloatLiteral { .. }
+            | TirExprKind::BoolLiteral(_)
+            | TirExprKind::CharLiteral(_)
+            | TirExprKind::StringLiteral(_)
+            | TirExprKind::Null
+            | TirExprKind::Unit
+            | TirExprKind::Local { .. }
+            | TirExprKind::Global { .. } => {}
+        }
+    }
+
+    /// Rewrite a single type_id: if it's a GenericInstance, return the concrete struct type_id.
+    /// Also handles container types (Array, Option, Tuple) that may contain GenericInstance.
+    fn rewrite_type_id(&self, type_id: TypeId, type_table: &mut TypeTable) -> TypeId {
+        // First check direct substitution
+        if let Some(&new_id) = self.type_substitutions.get(&type_id) {
+            return new_id;
+        }
+
+        // Handle container types that may contain GenericInstance
+        match type_table.get(type_id).clone() {
+            ResolvedType::Array(elem_id) => {
+                let new_elem_id = self.rewrite_type_id(elem_id, type_table);
+                if new_elem_id != elem_id {
+                    type_table.make_array(new_elem_id)
+                } else {
+                    type_id
+                }
+            }
+            ResolvedType::Option(inner_id) => {
+                let new_inner_id = self.rewrite_type_id(inner_id, type_table);
+                if new_inner_id != inner_id {
+                    type_table.make_option(new_inner_id)
+                } else {
+                    type_id
+                }
+            }
+            ResolvedType::Tuple(elem_ids) => {
+                let new_elem_ids: Vec<TypeId> = elem_ids
+                    .iter()
+                    .map(|&id| self.rewrite_type_id(id, type_table))
+                    .collect();
+                if new_elem_ids != elem_ids {
+                    type_table.make_tuple(new_elem_ids)
+                } else {
+                    type_id
+                }
+            }
+            ResolvedType::Result { ok, err } => {
+                let new_ok = self.rewrite_type_id(ok, type_table);
+                let new_err = self.rewrite_type_id(err, type_table);
+                if new_ok != ok || new_err != err {
+                    type_table.make_result(new_ok, new_err)
+                } else {
+                    type_id
+                }
+            }
+            _ => type_id,
+        }
+    }
+
+    /// Collect all GenericInstance types from the type table
+    fn collect_instantiation_sites(&mut self, type_table: &TypeTable) {
+        for id in 0..type_table.len() as TypeId {
+            if let ResolvedType::GenericInstance {
+                name, type_args, ..
+            } = type_table.get(id)
+            {
+                // Only process if all type args are concrete (no TypeParams)
+                let all_concrete = type_args
+                    .iter()
+                    .all(|&arg| !type_table.contains_type_param(arg));
+
+                if all_concrete {
+                    let key = InstantiationKey {
+                        name: name.clone(),
+                        type_args: type_args.clone(),
+                    };
+
+                    if !self.instantiated.contains_key(&key) {
+                        let mangled = self.mangle_name(&key, type_table);
+                        self.instantiated.insert(key.clone(), mangled);
+                        self.pending.push(key);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Generate mangled name for instantiation: Box<i32> -> Box$i32
+    fn mangle_name(&self, key: &InstantiationKey, type_table: &TypeTable) -> String {
+        let mut name = key.name.clone();
+        for type_arg in &key.type_args {
+            name.push('$');
+            name.push_str(&self.type_id_to_name_component(*type_arg, type_table));
+        }
+        name
+    }
+
+    /// Convert a TypeId to a mangled name component
+    fn type_id_to_name_component(&self, type_id: TypeId, type_table: &TypeTable) -> String {
+        match type_table.get(type_id) {
+            ResolvedType::Primitive(p) => format!("{:?}", p).to_lowercase(),
+            ResolvedType::String => "String".to_string(),
+            ResolvedType::Unit => "unit".to_string(),
+            ResolvedType::Struct { name, .. } => name.clone(),
+            ResolvedType::Array(elem) => {
+                format!(
+                    "Array${}",
+                    self.type_id_to_name_component(*elem, type_table)
+                )
+            }
+            ResolvedType::Option(inner) => {
+                format!(
+                    "Option${}",
+                    self.type_id_to_name_component(*inner, type_table)
+                )
+            }
+            ResolvedType::GenericInstance {
+                name, type_args, ..
+            } => {
+                let mut result = name.clone();
+                for arg in type_args {
+                    result.push('$');
+                    result.push_str(&self.type_id_to_name_component(*arg, type_table));
+                }
+                result
+            }
+            _ => format!("T{}", type_id),
+        }
+    }
+
+    /// Instantiate a generic struct with concrete type arguments
+    fn instantiate_struct(
+        &mut self,
+        generic: &TirStruct,
+        key: &InstantiationKey,
+        type_table: &mut TypeTable,
+    ) -> Option<TirStruct> {
+        let mangled_name = self.instantiated.get(key)?.clone();
+
+        // Build substitution map: type param index -> concrete type
+        let substitution: HashMap<u32, TypeId> = generic
+            .type_params
+            .iter()
+            .zip(key.type_args.iter())
+            .map(|(param, &arg)| (param.index, arg))
+            .collect();
+
+        // Substitute types in fields
+        let fields: Vec<TirField> = generic
+            .fields
+            .iter()
+            .map(|field| {
+                let new_type_id = self.substitute_type(field.type_id, &substitution, type_table);
+                TirField {
+                    name: field.name.clone(),
+                    type_id: new_type_id,
+                    index: field.index,
+                    span: field.span,
+                }
+            })
+            .collect();
+
+        // Create the monomorphized struct
+        let concrete = TirStruct {
+            name: mangled_name.clone(),
+            is_pub: generic.is_pub,
+            type_params: vec![], // Concrete struct has no type params
+            monomorph_info: Some(MonomorphInfo {
+                generic_name: generic.name.clone(),
+                type_args: key.type_args.clone(),
+            }),
+            fields,
+            span: generic.span,
+        };
+
+        // Register the concrete struct type in the type table
+        let concrete_type_id = type_table.make_struct(mangled_name, vec![]);
+
+        // Find the GenericInstance TypeId and record the substitution
+        for id in 0..type_table.len() as TypeId {
+            if let ResolvedType::GenericInstance {
+                name, type_args, ..
+            } = type_table.get(id)
+                && name == &key.name
+                && type_args == &key.type_args
+            {
+                self.type_substitutions.insert(id, concrete_type_id);
+                self.type_to_mangled_name
+                    .insert(id, self.instantiated.get(key).cloned().unwrap_or_default());
+            }
+        }
+
+        Some(concrete)
+    }
+
+    /// Substitute type parameters in a type with concrete types
+    fn substitute_type(
+        &self,
+        type_id: TypeId,
+        substitution: &HashMap<u32, TypeId>,
+        type_table: &mut TypeTable,
+    ) -> TypeId {
+        match type_table.get(type_id).clone() {
+            ResolvedType::TypeParam { index, .. } => {
+                // Direct substitution
+                *substitution.get(&index).unwrap_or(&type_id)
+            }
+            ResolvedType::Array(elem) => {
+                let new_elem = self.substitute_type(elem, substitution, type_table);
+                type_table.make_array(new_elem)
+            }
+            ResolvedType::Option(inner) => {
+                let new_inner = self.substitute_type(inner, substitution, type_table);
+                type_table.make_option(new_inner)
+            }
+            ResolvedType::Ref(inner) => {
+                let new_inner = self.substitute_type(inner, substitution, type_table);
+                type_table.make_ref(new_inner)
+            }
+            ResolvedType::MutRef(inner) => {
+                let new_inner = self.substitute_type(inner, substitution, type_table);
+                type_table.make_mut_ref(new_inner)
+            }
+            ResolvedType::Tuple(elems) => {
+                let new_elems: Vec<TypeId> = elems
+                    .iter()
+                    .map(|&e| self.substitute_type(e, substitution, type_table))
+                    .collect();
+                type_table.make_tuple(new_elems)
+            }
+            ResolvedType::Result { ok, err } => {
+                let new_ok = self.substitute_type(ok, substitution, type_table);
+                let new_err = self.substitute_type(err, substitution, type_table);
+                type_table.make_result(new_ok, new_err)
+            }
+            ResolvedType::GenericInstance {
+                name,
+                module_path,
+                type_args,
+            } => {
+                // Recursively substitute in nested generic instances
+                let new_args: Vec<TypeId> = type_args
+                    .iter()
+                    .map(|&arg| self.substitute_type(arg, substitution, type_table))
+                    .collect();
+                type_table.make_generic_instance(name, module_path, new_args)
+            }
+            // Other types don't contain type parameters
+            _ => type_id,
+        }
+    }
+
+    // ========================================================================
+    // Function Monomorphization
+    // ========================================================================
+
+    /// Collect function instantiation sites from Call/MethodCall expressions with type_args
+    fn collect_function_instantiation_sites(&mut self, module: &TirModule) {
+        for func in &module.functions {
+            if let Some(body) = &func.body {
+                self.collect_func_instantiation_sites_in_block(
+                    body,
+                    &module.generic_functions,
+                    &module.type_table,
+                );
+            }
+        }
+    }
+
+    fn collect_func_instantiation_sites_in_block(
+        &mut self,
+        block: &TirBlock,
+        generic_functions: &HashMap<String, TirFunction>,
+        type_table: &TypeTable,
+    ) {
+        for stmt in &block.stmts {
+            self.collect_func_instantiation_sites_in_stmt(stmt, generic_functions, type_table);
+        }
+    }
+
+    fn collect_func_instantiation_sites_in_stmt(
+        &mut self,
+        stmt: &TirStmt,
+        generic_functions: &HashMap<String, TirFunction>,
+        type_table: &TypeTable,
+    ) {
+        match &stmt.kind {
+            TirStmtKind::Let { value, .. } => {
+                self.collect_func_instantiation_sites_in_expr(value, generic_functions, type_table);
+            }
+            TirStmtKind::Expr(expr) => {
+                self.collect_func_instantiation_sites_in_expr(expr, generic_functions, type_table);
+            }
+            TirStmtKind::Return { value } => {
+                if let Some(expr) = value {
+                    self.collect_func_instantiation_sites_in_expr(
+                        expr,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirStmtKind::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.collect_func_instantiation_sites_in_expr(
+                    condition,
+                    generic_functions,
+                    type_table,
+                );
+                self.collect_func_instantiation_sites_in_block(
+                    then_block,
+                    generic_functions,
+                    type_table,
+                );
+                if let Some(else_blk) = else_block {
+                    self.collect_func_instantiation_sites_in_block(
+                        else_blk,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirStmtKind::While { condition, body } => {
+                self.collect_func_instantiation_sites_in_expr(
+                    condition,
+                    generic_functions,
+                    type_table,
+                );
+                self.collect_func_instantiation_sites_in_block(body, generic_functions, type_table);
+            }
+            TirStmtKind::For {
+                condition,
+                body,
+                update,
+            } => {
+                if let Some(cond) = condition {
+                    self.collect_func_instantiation_sites_in_expr(
+                        cond,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+                self.collect_func_instantiation_sites_in_block(body, generic_functions, type_table);
+                if let Some(upd) = update {
+                    self.collect_func_instantiation_sites_in_expr(
+                        upd,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirStmtKind::Loop { body } => {
+                self.collect_func_instantiation_sites_in_block(body, generic_functions, type_table);
+            }
+            TirStmtKind::ForOf { iterable, body, .. } => {
+                self.collect_func_instantiation_sites_in_expr(
+                    iterable,
+                    generic_functions,
+                    type_table,
+                );
+                self.collect_func_instantiation_sites_in_block(body, generic_functions, type_table);
+            }
+            TirStmtKind::Break | TirStmtKind::Continue | TirStmtKind::Assert { .. } => {}
+        }
+    }
+
+    fn collect_func_instantiation_sites_in_expr(
+        &mut self,
+        expr: &TirExpr,
+        generic_functions: &HashMap<String, TirFunction>,
+        type_table: &TypeTable,
+    ) {
+        match &expr.kind {
+            TirExprKind::Call {
+                func_name,
+                type_args,
+                args,
+                ..
+            } => {
+                // Check if this is a call to a generic function with explicit type args
+                if !type_args.is_empty() && generic_functions.contains_key(func_name) {
+                    let key = InstantiationKey {
+                        name: func_name.clone(),
+                        type_args: type_args.clone(),
+                    };
+                    if !self.function_instantiated.contains_key(&key) {
+                        let mangled = self.mangle_function_name(&key);
+                        self.function_instantiated.insert(key.clone(), mangled);
+                        self.function_pending.push(key);
+                    }
+                }
+                for arg in args {
+                    self.collect_func_instantiation_sites_in_expr(
+                        arg,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirExprKind::MethodCall {
+                receiver,
+                method_name,
+                type_args,
+                args,
+            } => {
+                // Check if this is a method call with explicit type args
+                if !type_args.is_empty() {
+                    // Get the struct name from the receiver type
+                    if let Some(struct_name) =
+                        self.get_struct_name_from_type(receiver.type_id, type_table)
+                    {
+                        // Construct the mangled method name: Struct::method
+                        let full_method_name = format!("{}::{}", struct_name, method_name);
+                        if generic_functions.contains_key(&full_method_name) {
+                            let key = InstantiationKey {
+                                name: full_method_name,
+                                type_args: type_args.clone(),
+                            };
+                            if !self.function_instantiated.contains_key(&key) {
+                                let mangled = self.mangle_function_name(&key);
+                                self.function_instantiated.insert(key.clone(), mangled);
+                                self.function_pending.push(key);
+                            }
+                        }
+                    }
+                }
+                self.collect_func_instantiation_sites_in_expr(
+                    receiver,
+                    generic_functions,
+                    type_table,
+                );
+                for arg in args {
+                    self.collect_func_instantiation_sites_in_expr(
+                        arg,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirExprKind::EffectCall { args, .. } => {
+                for arg in args {
+                    self.collect_func_instantiation_sites_in_expr(
+                        arg,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirExprKind::Binary { left, right, .. } => {
+                self.collect_func_instantiation_sites_in_expr(left, generic_functions, type_table);
+                self.collect_func_instantiation_sites_in_expr(right, generic_functions, type_table);
+            }
+            TirExprKind::Unary { expr: inner, .. } => {
+                self.collect_func_instantiation_sites_in_expr(inner, generic_functions, type_table);
+            }
+            TirExprKind::Block(block) => {
+                self.collect_func_instantiation_sites_in_block(
+                    block,
+                    generic_functions,
+                    type_table,
+                );
+            }
+            TirExprKind::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.collect_func_instantiation_sites_in_expr(
+                    condition,
+                    generic_functions,
+                    type_table,
+                );
+                self.collect_func_instantiation_sites_in_block(
+                    then_branch,
+                    generic_functions,
+                    type_table,
+                );
+                if let Some(else_blk) = else_branch {
+                    self.collect_func_instantiation_sites_in_block(
+                        else_blk,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
+                for elem in elements {
+                    self.collect_func_instantiation_sites_in_expr(
+                        elem,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirExprKind::Assign { target, value } => {
+                self.collect_func_instantiation_sites_in_expr(
+                    target,
+                    generic_functions,
+                    type_table,
+                );
+                self.collect_func_instantiation_sites_in_expr(value, generic_functions, type_table);
+            }
+            TirExprKind::Cast { expr: inner, .. } => {
+                self.collect_func_instantiation_sites_in_expr(inner, generic_functions, type_table);
+            }
+            TirExprKind::FieldAccess { expr: inner, .. } => {
+                self.collect_func_instantiation_sites_in_expr(inner, generic_functions, type_table);
+            }
+            TirExprKind::Index { expr: array, index } => {
+                self.collect_func_instantiation_sites_in_expr(array, generic_functions, type_table);
+                self.collect_func_instantiation_sites_in_expr(index, generic_functions, type_table);
+            }
+            TirExprKind::Match {
+                expr: scrutinee,
+                arms,
+            } => {
+                self.collect_func_instantiation_sites_in_expr(
+                    scrutinee,
+                    generic_functions,
+                    type_table,
+                );
+                for arm in arms {
+                    self.collect_func_instantiation_sites_in_expr(
+                        &arm.body,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            TirExprKind::Closure { body, .. } => {
+                self.collect_func_instantiation_sites_in_expr(body, generic_functions, type_table);
+            }
+            TirExprKind::StructLiteral { fields, .. } => {
+                for field in fields {
+                    self.collect_func_instantiation_sites_in_expr(
+                        &field.value,
+                        generic_functions,
+                        type_table,
+                    );
+                }
+            }
+            // Literals and simple expressions
+            TirExprKind::IntLiteral { .. }
+            | TirExprKind::FloatLiteral { .. }
+            | TirExprKind::BoolLiteral(_)
+            | TirExprKind::CharLiteral(_)
+            | TirExprKind::StringLiteral(_)
+            | TirExprKind::Null
+            | TirExprKind::Unit
+            | TirExprKind::Local { .. }
+            | TirExprKind::Global { .. } => {}
+        }
+    }
+
+    /// Get the struct name from a type_id, unwrapping references if needed
+    fn get_struct_name_from_type(&self, type_id: TypeId, type_table: &TypeTable) -> Option<String> {
+        match type_table.get(type_id) {
+            ResolvedType::Struct { name, .. } => Some(name.clone()),
+            ResolvedType::GenericInstance { name, .. } => Some(name.clone()),
+            ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
+                self.get_struct_name_from_type(*inner, type_table)
+            }
+            _ => None,
+        }
+    }
+
+    /// Generate mangled name for function instantiation: identity<i32> -> identity$i32
+    fn mangle_function_name(&self, key: &InstantiationKey) -> String {
+        let mut name = key.name.clone();
+        for type_arg in &key.type_args {
+            name.push('$');
+            // Use TypeId directly for now - we'll improve this later
+            name.push_str(&type_arg.to_string());
+        }
+        name
+    }
+
+    /// Instantiate a generic function with concrete type arguments
+    fn instantiate_function(
+        &mut self,
+        generic: &TirFunction,
+        key: &InstantiationKey,
+        type_table: &mut TypeTable,
+    ) -> Option<TirFunction> {
+        let mangled_name = self.function_instantiated.get(key)?.clone();
+
+        // Build substitution map: type param index -> concrete type
+        let substitution: HashMap<u32, TypeId> = generic
+            .type_params
+            .iter()
+            .zip(key.type_args.iter())
+            .map(|(param, &arg)| (param.index, arg))
+            .collect();
+
+        // Substitute types in parameters
+        let params: Vec<TirParam> = generic
+            .params
+            .iter()
+            .map(|param| TirParam {
+                name: param.name.clone(),
+                type_id: self.substitute_type(param.type_id, &substitution, type_table),
+                local_index: param.local_index,
+                span: param.span,
+            })
+            .collect();
+
+        // Substitute return type
+        let return_type = self.substitute_type(generic.return_type, &substitution, type_table);
+
+        // Substitute types in local_types
+        let local_types: Vec<TypeId> = generic
+            .local_types
+            .iter()
+            .map(|&t| self.substitute_type(t, &substitution, type_table))
+            .collect();
+
+        // Clone and substitute types in body
+        let body = generic.body.as_ref().map(|b| {
+            let mut new_body = b.clone();
+            self.substitute_types_in_block(&mut new_body, &substitution, type_table);
+            new_body
+        });
+
+        Some(TirFunction {
+            name: mangled_name,
+            is_pub: generic.is_pub,
+            type_params: vec![], // Concrete function has no type params
+            monomorph_info: Some(MonomorphInfo {
+                generic_name: generic.name.clone(),
+                type_args: key.type_args.clone(),
+            }),
+            params,
+            return_type,
+            effects: generic.effects.clone(),
+            body,
+            span: generic.span,
+            local_count: generic.local_count,
+            local_types,
+            address_taken_locals: generic.address_taken_locals.clone(),
+        })
+    }
+
+    /// Substitute type parameters in a block
+    fn substitute_types_in_block(
+        &self,
+        block: &mut TirBlock,
+        substitution: &HashMap<u32, TypeId>,
+        type_table: &mut TypeTable,
+    ) {
+        for stmt in &mut block.stmts {
+            self.substitute_types_in_stmt(stmt, substitution, type_table);
+        }
+    }
+
+    fn substitute_types_in_stmt(
+        &self,
+        stmt: &mut TirStmt,
+        substitution: &HashMap<u32, TypeId>,
+        type_table: &mut TypeTable,
+    ) {
+        match &mut stmt.kind {
+            TirStmtKind::Let { value, type_id, .. } => {
+                *type_id = self.substitute_type(*type_id, substitution, type_table);
+                self.substitute_types_in_expr(value, substitution, type_table);
+            }
+            TirStmtKind::Expr(expr) => {
+                self.substitute_types_in_expr(expr, substitution, type_table);
+            }
+            TirStmtKind::Return { value } => {
+                if let Some(expr) = value {
+                    self.substitute_types_in_expr(expr, substitution, type_table);
+                }
+            }
+            TirStmtKind::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.substitute_types_in_expr(condition, substitution, type_table);
+                self.substitute_types_in_block(then_block, substitution, type_table);
+                if let Some(else_blk) = else_block {
+                    self.substitute_types_in_block(else_blk, substitution, type_table);
+                }
+            }
+            TirStmtKind::While { condition, body } => {
+                self.substitute_types_in_expr(condition, substitution, type_table);
+                self.substitute_types_in_block(body, substitution, type_table);
+            }
+            TirStmtKind::For {
+                condition,
+                body,
+                update,
+            } => {
+                if let Some(cond) = condition {
+                    self.substitute_types_in_expr(cond, substitution, type_table);
+                }
+                self.substitute_types_in_block(body, substitution, type_table);
+                if let Some(upd) = update {
+                    self.substitute_types_in_expr(upd, substitution, type_table);
+                }
+            }
+            TirStmtKind::Loop { body } => {
+                self.substitute_types_in_block(body, substitution, type_table);
+            }
+            TirStmtKind::ForOf {
+                iterable,
+                body,
+                binding_type,
+                ..
+            } => {
+                *binding_type = self.substitute_type(*binding_type, substitution, type_table);
+                self.substitute_types_in_expr(iterable, substitution, type_table);
+                self.substitute_types_in_block(body, substitution, type_table);
+            }
+            TirStmtKind::Break | TirStmtKind::Continue | TirStmtKind::Assert { .. } => {}
+        }
+    }
+
+    fn substitute_types_in_expr(
+        &self,
+        expr: &mut TirExpr,
+        substitution: &HashMap<u32, TypeId>,
+        type_table: &mut TypeTable,
+    ) {
+        // Substitute the expression's own type
+        expr.type_id = self.substitute_type(expr.type_id, substitution, type_table);
+
+        // Recurse into sub-expressions
+        match &mut expr.kind {
+            TirExprKind::Call {
+                type_args, args, ..
+            } => {
+                // Substitute type args themselves
+                for type_arg in type_args.iter_mut() {
+                    *type_arg = self.substitute_type(*type_arg, substitution, type_table);
+                }
+                for arg in args {
+                    self.substitute_types_in_expr(arg, substitution, type_table);
+                }
+            }
+            TirExprKind::MethodCall {
+                receiver,
+                type_args,
+                args,
+                ..
+            } => {
+                self.substitute_types_in_expr(receiver, substitution, type_table);
+                for type_arg in type_args.iter_mut() {
+                    *type_arg = self.substitute_type(*type_arg, substitution, type_table);
+                }
+                for arg in args {
+                    self.substitute_types_in_expr(arg, substitution, type_table);
+                }
+            }
+            TirExprKind::EffectCall { args, .. } => {
+                for arg in args {
+                    self.substitute_types_in_expr(arg, substitution, type_table);
+                }
+            }
+            TirExprKind::Binary { left, right, .. } => {
+                self.substitute_types_in_expr(left, substitution, type_table);
+                self.substitute_types_in_expr(right, substitution, type_table);
+            }
+            TirExprKind::Unary { expr: inner, .. } => {
+                self.substitute_types_in_expr(inner, substitution, type_table);
+            }
+            TirExprKind::Block(block) => {
+                self.substitute_types_in_block(block, substitution, type_table);
+            }
+            TirExprKind::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.substitute_types_in_expr(condition, substitution, type_table);
+                self.substitute_types_in_block(then_branch, substitution, type_table);
+                if let Some(else_blk) = else_branch {
+                    self.substitute_types_in_block(else_blk, substitution, type_table);
+                }
+            }
+            TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
+                for elem in elements {
+                    self.substitute_types_in_expr(elem, substitution, type_table);
+                }
+            }
+            TirExprKind::Assign { target, value } => {
+                self.substitute_types_in_expr(target, substitution, type_table);
+                self.substitute_types_in_expr(value, substitution, type_table);
+            }
+            TirExprKind::Cast {
+                expr: inner,
+                target_type,
+            } => {
+                *target_type = self.substitute_type(*target_type, substitution, type_table);
+                self.substitute_types_in_expr(inner, substitution, type_table);
+            }
+            TirExprKind::FieldAccess { expr: inner, .. } => {
+                self.substitute_types_in_expr(inner, substitution, type_table);
+            }
+            TirExprKind::Index { expr: array, index } => {
+                self.substitute_types_in_expr(array, substitution, type_table);
+                self.substitute_types_in_expr(index, substitution, type_table);
+            }
+            TirExprKind::Match {
+                expr: scrutinee,
+                arms,
+            } => {
+                self.substitute_types_in_expr(scrutinee, substitution, type_table);
+                for arm in arms {
+                    self.substitute_types_in_expr(&mut arm.body, substitution, type_table);
+                }
+            }
+            TirExprKind::Closure { body, .. } => {
+                self.substitute_types_in_expr(body, substitution, type_table);
+            }
+            TirExprKind::StructLiteral {
+                struct_type,
+                fields,
+                ..
+            } => {
+                *struct_type = self.substitute_type(*struct_type, substitution, type_table);
+                for field in fields {
+                    self.substitute_types_in_expr(&mut field.value, substitution, type_table);
+                }
+            }
+            // Literals and other simple expressions
+            TirExprKind::IntLiteral { .. }
+            | TirExprKind::FloatLiteral { .. }
+            | TirExprKind::BoolLiteral(_)
+            | TirExprKind::CharLiteral(_)
+            | TirExprKind::StringLiteral(_)
+            | TirExprKind::Null
+            | TirExprKind::Unit
+            | TirExprKind::Local { .. }
+            | TirExprKind::Global { .. } => {}
+        }
+    }
+
+    /// Rewrite function calls in all functions to use monomorphized names
+    fn rewrite_function_calls_in_module(&self, module: &mut TirModule) {
+        for func in &mut module.functions {
+            if let Some(body) = &mut func.body {
+                self.rewrite_function_calls_in_block(body, &module.type_table);
+            }
+        }
+    }
+
+    fn rewrite_function_calls_in_block(&self, block: &mut TirBlock, type_table: &TypeTable) {
+        for stmt in &mut block.stmts {
+            self.rewrite_function_calls_in_stmt(stmt, type_table);
+        }
+    }
+
+    fn rewrite_function_calls_in_stmt(&self, stmt: &mut TirStmt, type_table: &TypeTable) {
+        match &mut stmt.kind {
+            TirStmtKind::Let { value, .. } => {
+                self.rewrite_function_calls_in_expr(value, type_table);
+            }
+            TirStmtKind::Expr(expr) => {
+                self.rewrite_function_calls_in_expr(expr, type_table);
+            }
+            TirStmtKind::Return { value } => {
+                if let Some(expr) = value {
+                    self.rewrite_function_calls_in_expr(expr, type_table);
+                }
+            }
+            TirStmtKind::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.rewrite_function_calls_in_expr(condition, type_table);
+                self.rewrite_function_calls_in_block(then_block, type_table);
+                if let Some(else_blk) = else_block {
+                    self.rewrite_function_calls_in_block(else_blk, type_table);
+                }
+            }
+            TirStmtKind::While { condition, body } => {
+                self.rewrite_function_calls_in_expr(condition, type_table);
+                self.rewrite_function_calls_in_block(body, type_table);
+            }
+            TirStmtKind::For {
+                condition,
+                body,
+                update,
+            } => {
+                if let Some(cond) = condition {
+                    self.rewrite_function_calls_in_expr(cond, type_table);
+                }
+                self.rewrite_function_calls_in_block(body, type_table);
+                if let Some(upd) = update {
+                    self.rewrite_function_calls_in_expr(upd, type_table);
+                }
+            }
+            TirStmtKind::Loop { body } => {
+                self.rewrite_function_calls_in_block(body, type_table);
+            }
+            TirStmtKind::ForOf { iterable, body, .. } => {
+                self.rewrite_function_calls_in_expr(iterable, type_table);
+                self.rewrite_function_calls_in_block(body, type_table);
+            }
+            TirStmtKind::Break | TirStmtKind::Continue | TirStmtKind::Assert { .. } => {}
+        }
+    }
+
+    fn rewrite_function_calls_in_expr(&self, expr: &mut TirExpr, type_table: &TypeTable) {
+        match &mut expr.kind {
+            TirExprKind::Call {
+                func_name,
+                type_args,
+                args,
+                ..
+            } => {
+                // If this is a generic call, rewrite to monomorphized name
+                if !type_args.is_empty() {
+                    let key = InstantiationKey {
+                        name: func_name.clone(),
+                        type_args: type_args.clone(),
+                    };
+                    if let Some(mangled) = self.function_instantiated.get(&key) {
+                        *func_name = mangled.clone();
+                        type_args.clear(); // Clear type args - now using concrete function
+                    }
+                }
+                for arg in args {
+                    self.rewrite_function_calls_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::MethodCall {
+                receiver,
+                method_name,
+                type_args,
+                args,
+            } => {
+                // If this is a generic method call, rewrite to monomorphized name
+                if !type_args.is_empty()
+                    && let Some(struct_name) =
+                        self.get_struct_name_from_type(receiver.type_id, type_table)
+                {
+                    let full_method_name = format!("{}::{}", struct_name, method_name);
+                    let key = InstantiationKey {
+                        name: full_method_name,
+                        type_args: type_args.clone(),
+                    };
+                    if let Some(mangled) = self.function_instantiated.get(&key) {
+                        // Update method_name to the monomorphized name
+                        // We need to extract just the method part from the mangled name
+                        // e.g., "Point::transform$2" -> we keep the full name for codegen
+                        // Actually, codegen constructs the full name, so we just need to update
+                        // the method_name part. The mangled name is "Struct::method$types",
+                        // so we extract the part after "::"
+                        if let Some(method_part) = mangled.split("::").nth(1) {
+                            *method_name = method_part.to_string();
+                        }
+                        type_args.clear(); // Clear type args - now using concrete method
+                    }
+                }
+                self.rewrite_function_calls_in_expr(receiver, type_table);
+                for arg in args {
+                    self.rewrite_function_calls_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::EffectCall { args, .. } => {
+                for arg in args {
+                    self.rewrite_function_calls_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::Binary { left, right, .. } => {
+                self.rewrite_function_calls_in_expr(left, type_table);
+                self.rewrite_function_calls_in_expr(right, type_table);
+            }
+            TirExprKind::Unary { expr: inner, .. } => {
+                self.rewrite_function_calls_in_expr(inner, type_table);
+            }
+            TirExprKind::Block(block) => {
+                self.rewrite_function_calls_in_block(block, type_table);
+            }
+            TirExprKind::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.rewrite_function_calls_in_expr(condition, type_table);
+                self.rewrite_function_calls_in_block(then_branch, type_table);
+                if let Some(else_blk) = else_branch {
+                    self.rewrite_function_calls_in_block(else_blk, type_table);
+                }
+            }
+            TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
+                for elem in elements {
+                    self.rewrite_function_calls_in_expr(elem, type_table);
+                }
+            }
+            TirExprKind::Assign { target, value } => {
+                self.rewrite_function_calls_in_expr(target, type_table);
+                self.rewrite_function_calls_in_expr(value, type_table);
+            }
+            TirExprKind::Cast { expr: inner, .. } => {
+                self.rewrite_function_calls_in_expr(inner, type_table);
+            }
+            TirExprKind::FieldAccess { expr: inner, .. } => {
+                self.rewrite_function_calls_in_expr(inner, type_table);
+            }
+            TirExprKind::Index { expr: array, index } => {
+                self.rewrite_function_calls_in_expr(array, type_table);
+                self.rewrite_function_calls_in_expr(index, type_table);
+            }
+            TirExprKind::Match {
+                expr: scrutinee,
+                arms,
+            } => {
+                self.rewrite_function_calls_in_expr(scrutinee, type_table);
+                for arm in arms {
+                    self.rewrite_function_calls_in_expr(&mut arm.body, type_table);
+                }
+            }
+            TirExprKind::Closure { body, .. } => {
+                self.rewrite_function_calls_in_expr(body, type_table);
+            }
+            TirExprKind::StructLiteral { fields, .. } => {
+                for field in fields {
+                    self.rewrite_function_calls_in_expr(&mut field.value, type_table);
+                }
+            }
+            // Literals and simple expressions
+            TirExprKind::IntLiteral { .. }
+            | TirExprKind::FloatLiteral { .. }
+            | TirExprKind::BoolLiteral(_)
+            | TirExprKind::CharLiteral(_)
+            | TirExprKind::StringLiteral(_)
+            | TirExprKind::Null
+            | TirExprKind::Unit
+            | TirExprKind::Local { .. }
+            | TirExprKind::Global { .. } => {}
+        }
+    }
 }
 
 // ============================================================================

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -9,7 +9,14 @@ use crate::tir::{
     PrimitiveType, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirModule,
     TirStmtKind, TypeId, TypeTable,
 };
+use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
+
+/// Call graph: function ID -> set of called function IDs
+type CallGraph = HashMap<FunctionId, HashSet<FunctionId>>;
+
+/// Effect usage: function ID -> set of (effect_name, operation_name) pairs
+type EffectUsageMap = HashMap<FunctionId, HashSet<(String, String)>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OptLevel {
@@ -103,7 +110,7 @@ struct FunctionAnalysis {
 
 /// Analyze all TIR modules and compute optimization hints including DCE
 pub fn analyze_all_modules(
-    modules: &HashMap<Vec<String>, TirModule>,
+    modules: &IndexMap<Vec<String>, TirModule>,
     entry_path: &[String],
 ) -> OptimizationHints {
     // Build call graph and effect usage from all modules
@@ -201,17 +208,10 @@ pub fn analyze_all_modules(
 }
 
 /// Build call graph and effect usage from all TIR modules
-/// Returns:
-/// - Call graph: map from function ID to set of called function IDs
-/// - Effect usage: map from function ID to set of (effect, operation) pairs
-fn build_analysis_graph(
-    modules: &HashMap<Vec<String>, TirModule>,
-) -> (
-    HashMap<FunctionId, HashSet<FunctionId>>,
-    HashMap<FunctionId, HashSet<(String, String)>>,
-) {
-    let mut call_graph: HashMap<FunctionId, HashSet<FunctionId>> = HashMap::new();
-    let mut effect_usage: HashMap<FunctionId, HashSet<(String, String)>> = HashMap::new();
+/// Returns (call_graph, effect_usage)
+fn build_analysis_graph(modules: &IndexMap<Vec<String>, TirModule>) -> (CallGraph, EffectUsageMap) {
+    let mut call_graph: CallGraph = HashMap::new();
+    let mut effect_usage: EffectUsageMap = HashMap::new();
 
     for (path, module) in modules {
         let type_table = &module.type_table;
@@ -379,6 +379,7 @@ fn analyze_expr(
             module_path,
             func_name,
             args,
+            ..
         } => {
             // Invariant: TirExprKind::Call should never have method names (containing "::")
             // Methods use TirExprKind::MethodCall instead. The only exception is "builtin::*".
@@ -425,6 +426,7 @@ fn analyze_expr(
             receiver,
             method_name,
             args,
+            ..
         } => {
             // Get receiver type to determine method target
             let receiver_type = type_table.get(receiver.type_id);

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -430,14 +430,8 @@ impl Parser {
 
         let name = self.consume_ident()?;
 
-        // Skip generic parameters like <T, E>
-        if self.check(&TokenKind::Lt) {
-            self.advance();
-            while !self.check(&TokenKind::Gt) && !self.is_at_end() {
-                self.advance();
-            }
-            self.expect(&TokenKind::Gt)?;
-        }
+        // Parse generic parameters like <T, U> or <T: Ord>
+        let type_params = self.parse_generic_params()?;
 
         self.expect(&TokenKind::LParen)?;
         let params = self.parse_param_list()?;
@@ -473,6 +467,7 @@ impl Parser {
         Ok(Function {
             name,
             is_pub,
+            type_params,
             attrs,
             params,
             return_type,
@@ -1321,9 +1316,37 @@ impl Parser {
                     let merged_span = callee_span.merge(&rparen_span);
                     expr = Expr::Call(Box::new(CallExpr {
                         callee: expr,
+                        type_args: vec![],
                         args,
                         span: merged_span,
                     }));
+                }
+                // Turbofish syntax for explicit type arguments: foo::<T>(x)
+                TokenKind::ColonColon => {
+                    // Check if this is turbofish (:: followed by <)
+                    // Peek at the token after ::
+                    let checkpoint = self.pos;
+                    self.advance(); // consume ::
+                    if self.check(&TokenKind::Lt) {
+                        // This is turbofish syntax: foo::<T>(x)
+                        let callee_span = expr.span();
+                        let type_args = self.parse_call_type_args()?;
+                        self.expect(&TokenKind::LParen)?;
+                        let args = self.parse_arg_list()?;
+                        let rparen_span = self.peek().span;
+                        self.expect(&TokenKind::RParen)?;
+                        let merged_span = callee_span.merge(&rparen_span);
+                        expr = Expr::Call(Box::new(CallExpr {
+                            callee: expr,
+                            type_args,
+                            args,
+                            span: merged_span,
+                        }));
+                    } else {
+                        // Not turbofish, backtrack
+                        self.pos = checkpoint;
+                        break;
+                    }
                 }
                 TokenKind::Dot => {
                     let receiver_span = expr.span();
@@ -1360,7 +1383,31 @@ impl Parser {
                         (self.consume_ident()?, None)
                     };
 
-                    if self.check(&TokenKind::LParen) {
+                    // Check for method call with turbofish: obj.method::<T>(x)
+                    if self.check(&TokenKind::ColonColon) {
+                        self.advance(); // consume ::
+                        if self.check(&TokenKind::Lt) {
+                            let type_args = self.parse_call_type_args()?;
+                            self.expect(&TokenKind::LParen)?;
+                            let args = self.parse_arg_list()?;
+                            let rparen_span = self.peek().span;
+                            self.expect(&TokenKind::RParen)?;
+                            let merged_span = receiver_span.merge(&rparen_span);
+                            expr = Expr::MethodCall(Box::new(MethodCallExpr {
+                                receiver: expr,
+                                method: field,
+                                type_args,
+                                args,
+                                span: merged_span,
+                            }));
+                        } else {
+                            // :: not followed by <, this is an error
+                            return Err(ParseError {
+                                message: "expected '<' after '::'".to_string(),
+                                span: self.peek().span,
+                            });
+                        }
+                    } else if self.check(&TokenKind::LParen) {
                         self.advance();
                         let args = self.parse_arg_list()?;
                         let rparen_span = self.peek().span;
@@ -1369,6 +1416,7 @@ impl Parser {
                         expr = Expr::MethodCall(Box::new(MethodCallExpr {
                             receiver: expr,
                             method: field,
+                            type_args: vec![],
                             args,
                             span: merged_span,
                         }));
@@ -1428,15 +1476,27 @@ impl Parser {
         match self.peek_kind().clone() {
             TokenKind::Ident(name) => {
                 self.advance();
-                // Check for qualified name (Effect::function)
+                // Check for qualified name (Effect::function) but not turbofish (foo::<T>)
                 if self.check(&TokenKind::ColonColon) {
-                    self.advance();
-                    let method = self.consume_ident()?;
-                    let qualified_name = format!("{}::{}", name, method);
-                    Ok(Expr::Ident(IdentExpr {
-                        name: qualified_name,
-                        span: start_span,
-                    }))
+                    // Peek ahead to check if this is turbofish (::< for type args)
+                    let checkpoint = self.pos;
+                    self.advance(); // consume ::
+                    if self.check(&TokenKind::Lt) {
+                        // This is turbofish, backtrack and let postfix expression handle it
+                        self.pos = checkpoint;
+                        Ok(Expr::Ident(IdentExpr {
+                            name,
+                            span: start_span,
+                        }))
+                    } else {
+                        // This is a qualified name like Effect::function
+                        let method = self.consume_ident()?;
+                        let qualified_name = format!("{}::{}", name, method);
+                        Ok(Expr::Ident(IdentExpr {
+                            name: qualified_name,
+                            span: start_span,
+                        }))
+                    }
                 } else if self.check(&TokenKind::LBrace)
                     && name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
                 {
@@ -1719,6 +1779,38 @@ impl Parser {
 
         let name = self.consume_ident()?;
 
+        // Check for namespaced type: namespace::type<T>
+        if self.check(&TokenKind::ColonColon) {
+            self.advance();
+            let type_name = self.consume_ident()?;
+
+            // Namespaced generic type: namespace::type<T>
+            if self.check(&TokenKind::Lt) {
+                self.advance();
+                let mut args = vec![self.parse_type()?];
+                while self.check(&TokenKind::Comma) {
+                    self.advance();
+                    args.push(self.parse_type()?);
+                }
+                self.expect_gt()?;
+
+                return Ok(Type::NamespacedGeneric(NamespacedGenericType {
+                    namespace: name,
+                    name: type_name,
+                    args,
+                    span: start_span,
+                }));
+            } else {
+                // Namespaced type without generics: namespace::type
+                return Ok(Type::NamespacedGeneric(NamespacedGenericType {
+                    namespace: name,
+                    name: type_name,
+                    args: Vec::new(),
+                    span: start_span,
+                }));
+            }
+        }
+
         if self.check(&TokenKind::Lt) {
             self.advance();
             let mut args = vec![self.parse_type()?];
@@ -1819,10 +1911,74 @@ impl Parser {
         })
     }
 
+    /// Parse generic type parameters: `<T>`, `<T, U>`, `<T: Ord>`, `<T: Ord + Clone>`
+    fn parse_generic_params(&mut self) -> ParseResult<Vec<crate::ast::GenericParam>> {
+        if !self.check(&TokenKind::Lt) {
+            return Ok(Vec::new());
+        }
+
+        self.advance(); // consume '<'
+
+        let mut params = Vec::new();
+
+        while !self.check(&TokenKind::Gt) && !self.is_at_end() {
+            let start_span = self.peek().span;
+            let name = self.consume_ident()?;
+
+            // Parse optional trait bounds: `T: Ord` or `T: Ord + Clone`
+            let bounds = if self.check(&TokenKind::Colon) {
+                self.advance();
+                let mut bounds = vec![self.consume_ident()?];
+                while self.check(&TokenKind::Plus) {
+                    self.advance();
+                    bounds.push(self.consume_ident()?);
+                }
+                bounds
+            } else {
+                Vec::new()
+            };
+
+            params.push(crate::ast::GenericParam {
+                name,
+                bounds,
+                span: start_span,
+            });
+
+            if self.check(&TokenKind::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        self.expect(&TokenKind::Gt)?;
+        Ok(params)
+    }
+
+    /// Parse type arguments for turbofish syntax: `<T1, T2, ...>`
+    /// Used in function calls like `identity::<i32>(x)`
+    fn parse_call_type_args(&mut self) -> ParseResult<Vec<Type>> {
+        // Must start with '<'
+        self.expect(&TokenKind::Lt)?;
+
+        let mut types = vec![self.parse_type()?];
+        while self.check(&TokenKind::Comma) {
+            self.advance();
+            types.push(self.parse_type()?);
+        }
+
+        self.expect_gt()?;
+        Ok(types)
+    }
+
     fn parse_struct_decl(&mut self, is_pub: bool) -> ParseResult<StructDecl> {
         let start_span = self.peek().span;
         self.expect(&TokenKind::Struct)?;
         let name = self.consume_ident()?;
+
+        // Parse generic parameters like <T, U>
+        let type_params = self.parse_generic_params()?;
+
         self.expect(&TokenKind::LBrace)?;
 
         let fields = self.parse_struct_fields()?;
@@ -1832,6 +1988,7 @@ impl Parser {
         Ok(StructDecl {
             name,
             is_pub,
+            type_params,
             fields,
             span: start_span.merge(&end_span),
         })
@@ -1864,6 +2021,10 @@ impl Parser {
         let start_span = self.peek().span;
         self.expect(&TokenKind::Enum)?;
         let name = self.consume_ident()?;
+
+        // Parse generic parameters like <T>
+        let type_params = self.parse_generic_params()?;
+
         self.expect(&TokenKind::LBrace)?;
 
         let mut variants = Vec::new();
@@ -1879,6 +2040,7 @@ impl Parser {
         Ok(EnumDecl {
             name,
             is_pub,
+            type_params,
             variants,
             span: start_span.merge(&end_span),
         })
@@ -1927,6 +2089,10 @@ impl Parser {
     fn parse_impl_block(&mut self) -> ParseResult<ImplBlock> {
         let start_span = self.peek().span;
         self.expect(&TokenKind::Impl)?;
+
+        // Parse generic parameters like <T>
+        let type_params = self.parse_generic_params()?;
+
         let ty = self.parse_type()?;
         self.expect(&TokenKind::LBrace)?;
 
@@ -1945,6 +2111,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(ImplBlock {
+            type_params,
             ty,
             methods,
             span: start_span.merge(&end_span),

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -8,7 +8,9 @@
 //! All type resolution happens in this phase. The output TIR has fully
 //! resolved types on every expression, making code generation mechanical.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use indexmap::IndexMap;
 
 use crate::ast::{
     self, AssertStmt, BinaryOp, Block, BreakStmt, ContinueStmt, Expr, ExprStmt, ForOfStmt, ForStmt,
@@ -22,6 +24,20 @@ use crate::tir::{
     TirUnaryOp, TypeId, TypeTable,
 };
 use crate::token::Span;
+
+/// Module path for the String struct in core/prelude
+const STRING_MODULE_PATH: &[&str] = &["core", "prelude"];
+
+/// Helper to convert STRING_MODULE_PATH to Vec<String>
+fn string_module_path() -> Vec<String> {
+    STRING_MODULE_PATH
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+}
+
+/// Struct field info: (module_path, fields) where fields is a list of (name, type_id) pairs
+type StructFieldInfo = (Vec<String>, Vec<(String, TypeId)>);
 
 /// Errors from the type resolution phase
 #[derive(Debug, Clone)]
@@ -210,8 +226,8 @@ pub struct Resolver<'a> {
     loaded_modules: &'a HashMap<Vec<String>, Module>,
     /// Type aliases (name -> resolved type)
     type_aliases: HashMap<String, TypeId>,
-    /// Struct field info (struct name -> fields)
-    struct_fields: HashMap<String, Vec<(String, TypeId)>>,
+    /// Struct field info (struct name -> (module_path, fields))
+    struct_fields: HashMap<String, StructFieldInfo>,
     /// Function return types (name -> return type)
     function_return_types: HashMap<String, TypeId>,
     /// Imported function names for the current module
@@ -224,6 +240,18 @@ pub struct Resolver<'a> {
     current_module_path: Vec<String>,
     /// Current module items (for local function parameter lookup)
     current_module_items: Vec<Item>,
+    /// Type parameters currently in scope (name -> (index, TypeId))
+    /// Set when resolving generic structs or functions
+    current_type_params: HashMap<String, (u32, TypeId)>,
+    /// Generic struct definitions (name -> type param count)
+    /// Used to determine if a struct is generic
+    generic_struct_names: HashSet<String>,
+    /// Generic function type parameters (func_name -> type_params)
+    /// Used for substituting type parameters in return types
+    generic_function_params: HashMap<String, Vec<(String, TypeId)>>,
+    /// Generic method type parameters (mangled_name -> type_params)
+    /// Used for substituting type parameters in method return types
+    generic_method_params: HashMap<String, Vec<(String, TypeId)>>,
 }
 
 impl<'a> Resolver<'a> {
@@ -245,6 +273,10 @@ impl<'a> Resolver<'a> {
             source_code,
             current_module_path: Vec::new(),
             current_module_items: Vec::new(),
+            current_type_params: HashMap::new(),
+            generic_struct_names: HashSet::new(),
+            generic_function_params: HashMap::new(),
+            generic_method_params: HashMap::new(),
         }
     }
 
@@ -292,7 +324,9 @@ impl<'a> Resolver<'a> {
                     // Resolve impl block methods with mangled names
                     let struct_name = self.get_type_name(&impl_block.ty);
                     for method in &impl_block.methods {
-                        if let Some(mut tir_func) = self.resolve_method(method, &struct_name) {
+                        if let Some(mut tir_func) =
+                            self.resolve_method(method, &struct_name, &impl_block.ty)
+                        {
                             // Mangle the method name: StructName::method_name
                             tir_func.name = format!("{}::{}", struct_name, method.name);
                             tir_module.add_function(tir_func);
@@ -323,13 +357,14 @@ impl<'a> Resolver<'a> {
     ///
     /// This resolves every module (entry and dependencies) to TIR,
     /// enabling TIR-only code generation.
+    /// Modules are returned in topological order based on struct field dependencies.
     pub fn resolve_all_modules(
         symbols: &'a SymbolTable,
         modules: &'a HashMap<Vec<String>, Module>,
         entry_path: &[String],
         entry_source: &'a str,
-    ) -> Result<HashMap<Vec<String>, TirModule>, Vec<TypeError>> {
-        let mut result = HashMap::new();
+    ) -> Result<IndexMap<Vec<String>, TirModule>, Vec<TypeError>> {
+        let mut result = IndexMap::new();
         let mut all_errors = Vec::new();
 
         // Create a shared type table
@@ -337,8 +372,18 @@ impl<'a> Resolver<'a> {
         let mut type_aliases = HashMap::new();
         let mut struct_fields = HashMap::new();
 
-        // First pass: collect types from all modules
-        for module in modules.values() {
+        // First pass: collect struct names from all modules (for forward references)
+        for (path, module) in modules {
+            for item in &module.items {
+                if let Item::Struct(struct_decl) = item {
+                    // Insert with empty fields first - will be populated in second sub-pass
+                    struct_fields.insert(struct_decl.name.clone(), (path.clone(), Vec::new()));
+                }
+            }
+        }
+
+        // Second sub-pass: resolve struct fields and type aliases
+        for (path, module) in modules {
             for item in &module.items {
                 match item {
                     Item::Struct(struct_decl) => {
@@ -348,16 +393,19 @@ impl<'a> Resolver<'a> {
                                 &field.ty,
                                 &mut type_table,
                                 &type_aliases,
+                                &struct_fields,
                             );
                             fields.push((field.name.clone(), type_id));
                         }
-                        struct_fields.insert(struct_decl.name.clone(), fields);
+                        // Update the struct_fields entry with actual fields
+                        struct_fields.insert(struct_decl.name.clone(), (path.clone(), fields));
                     }
                     Item::Type(type_alias) => {
                         let type_id = Self::resolve_type_static(
                             &type_alias.ty,
                             &mut type_table,
                             &type_aliases,
+                            &struct_fields,
                         );
                         type_aliases.insert(type_alias.name.clone(), type_id);
                     }
@@ -366,15 +414,25 @@ impl<'a> Resolver<'a> {
             }
         }
 
+        // Topologically sort modules based on struct field type dependencies
+        // A module depends on another if it has a struct with a field of a type defined there
+        let sorted_paths = Self::topological_sort_modules(modules, &struct_fields, &type_table);
+
         // Second pass: resolve each module with per-module function_return_types and imports
-        for (path, module) in modules {
+        for path in &sorted_paths {
+            let module = modules.get(path).expect("module should exist");
             // Build function_return_types for this module only
             // (functions defined in this module)
             let mut function_return_types = HashMap::new();
             for item in &module.items {
                 if let Item::Function(func) = item {
                     let return_type = if let Some(ret_ty) = &func.return_type {
-                        Self::resolve_type_static(ret_ty, &mut type_table, &type_aliases)
+                        Self::resolve_type_static(
+                            ret_ty,
+                            &mut type_table,
+                            &type_aliases,
+                            &struct_fields,
+                        )
                     } else {
                         TypeTable::UNIT
                     };
@@ -424,6 +482,10 @@ impl<'a> Resolver<'a> {
                 source_code: source,
                 current_module_path: Vec::new(), // Set in resolve_module
                 current_module_items: Vec::new(), // Set in resolve_module
+                current_type_params: HashMap::new(),
+                generic_struct_names: HashSet::new(),
+                generic_function_params: HashMap::new(),
+                generic_method_params: HashMap::new(),
             };
 
             match resolver.resolve_module(module, path.clone()) {
@@ -445,11 +507,100 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// Topologically sort modules based on struct field type dependencies.
+    ///
+    /// A module A depends on module B if A contains a struct with a field whose type
+    /// is a struct defined in B. This ensures that when we register struct types in
+    /// codegen, dependency structs are registered before the structs that reference them.
+    fn topological_sort_modules(
+        modules: &HashMap<Vec<String>, Module>,
+        struct_fields: &HashMap<String, StructFieldInfo>,
+        type_table: &TypeTable,
+    ) -> Vec<Vec<String>> {
+        // Collect and sort paths for deterministic ordering
+        let mut paths: Vec<&Vec<String>> = modules.keys().collect();
+        paths.sort();
+        let path_to_idx: HashMap<&Vec<String>, usize> =
+            paths.iter().enumerate().map(|(i, p)| (*p, i)).collect();
+
+        // Track dependency counts directly (no need for full dependency sets)
+        let mut dependency_count: Vec<usize> = vec![0; paths.len()];
+        // Track which edges we've already added to avoid duplicates
+        let mut seen_edges: HashSet<(usize, usize)> = HashSet::new();
+        // Build reverse graph: dependents[i] = modules that depend on module i
+        let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); paths.len()];
+
+        // Analyze struct fields to find cross-module dependencies
+        for (struct_name, (module_path, fields)) in struct_fields {
+            let Some(&from_idx) = path_to_idx.get(module_path) else {
+                continue;
+            };
+            for (_field_name, field_type_id) in fields {
+                if let ResolvedType::Struct {
+                    name: ref_struct_name,
+                    module_path: ref_module_path,
+                } = type_table.get(*field_type_id)
+                {
+                    // Skip self-references (same struct or same module)
+                    if ref_struct_name == struct_name || ref_module_path == module_path {
+                        continue;
+                    }
+                    if let Some(&to_idx) = path_to_idx.get(ref_module_path) {
+                        // from_idx depends on to_idx (dependency edge)
+                        if seen_edges.insert((from_idx, to_idx)) {
+                            dependency_count[from_idx] += 1;
+                            dependents[to_idx].push(from_idx);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Kahn's algorithm: start with modules that have no dependencies
+        let mut queue: VecDeque<usize> = dependency_count
+            .iter()
+            .enumerate()
+            .filter(|(_, count)| **count == 0)
+            .map(|(i, _)| i)
+            .collect();
+
+        let mut sorted_indices = Vec::with_capacity(paths.len());
+        while let Some(idx) = queue.pop_front() {
+            sorted_indices.push(idx);
+            // Update dependents using reverse graph (O(1) per edge)
+            for &dependent_idx in &dependents[idx] {
+                dependency_count[dependent_idx] -= 1;
+                if dependency_count[dependent_idx] == 0 {
+                    queue.push_back(dependent_idx);
+                }
+            }
+        }
+
+        // Cycle detection with warning (O(n) using HashSet)
+        if sorted_indices.len() < paths.len() {
+            let sorted_set: HashSet<usize> = sorted_indices.iter().copied().collect();
+            let in_cycle: Vec<usize> = (0..paths.len())
+                .filter(|i| !sorted_set.contains(i))
+                .collect();
+            let cycle_modules: Vec<_> = in_cycle.iter().map(|&i| paths[i].join("::")).collect();
+            eprintln!(
+                "Warning: circular struct dependencies detected among modules: {}",
+                cycle_modules.join(", ")
+            );
+            // Append remaining in deterministic order (already sorted by index)
+            sorted_indices.extend(in_cycle);
+        }
+
+        // Convert indices back to paths
+        sorted_indices.iter().map(|&i| paths[i].clone()).collect()
+    }
+
     /// Static version of resolve_type for use before the resolver is fully constructed
     fn resolve_type_static(
         ty: &Type,
         type_table: &mut TypeTable,
         type_aliases: &HashMap<String, TypeId>,
+        struct_fields: &HashMap<String, StructFieldInfo>,
     ) -> TypeId {
         match ty {
             Type::Named(named) => {
@@ -472,37 +623,102 @@ impl<'a> Resolver<'a> {
                     "u64" => TypeTable::U64,
                     "f32" => TypeTable::F32,
                     "f64" => TypeTable::F64,
-                    "String" => TypeTable::STRING,
                     "()" => TypeTable::UNIT,
                     "!" => TypeTable::NEVER,
-                    _ => TypeTable::UNKNOWN,
+                    _ => {
+                        // Check if it's a struct type
+                        if let Some((module_path, _)) = struct_fields.get(&named.name) {
+                            type_table.make_struct(named.name.clone(), module_path.clone())
+                        } else {
+                            TypeTable::UNKNOWN
+                        }
+                    }
                 }
             }
             Type::Generic(generic) => match generic.name.as_str() {
                 "Option" if !generic.args.is_empty() => {
-                    let inner =
-                        Self::resolve_type_static(&generic.args[0], type_table, type_aliases);
+                    let inner = Self::resolve_type_static(
+                        &generic.args[0],
+                        type_table,
+                        type_aliases,
+                        struct_fields,
+                    );
                     type_table.intern(ResolvedType::Option(inner))
                 }
                 "Result" if generic.args.len() >= 2 => {
-                    let ok = Self::resolve_type_static(&generic.args[0], type_table, type_aliases);
-                    let err = Self::resolve_type_static(&generic.args[1], type_table, type_aliases);
+                    let ok = Self::resolve_type_static(
+                        &generic.args[0],
+                        type_table,
+                        type_aliases,
+                        struct_fields,
+                    );
+                    let err = Self::resolve_type_static(
+                        &generic.args[1],
+                        type_table,
+                        type_aliases,
+                        struct_fields,
+                    );
                     type_table.intern(ResolvedType::Result { ok, err })
                 }
+                // Special case: Array<T> is defined as a struct in prelude, but we use
+                // ResolvedType::Array(elem) for codegen compatibility until proper
+                // generic struct monomorphization is implemented
                 "Array" if !generic.args.is_empty() => {
-                    let elem =
-                        Self::resolve_type_static(&generic.args[0], type_table, type_aliases);
+                    let elem = Self::resolve_type_static(
+                        &generic.args[0],
+                        type_table,
+                        type_aliases,
+                        struct_fields,
+                    );
                     type_table.intern(ResolvedType::Array(elem))
                 }
-                _ => TypeTable::UNKNOWN,
+                _ => {
+                    // Check if it's a generic struct type
+                    if let Some((module_path, _)) = struct_fields.get(&generic.name) {
+                        // Resolve type arguments
+                        let type_args: Vec<TypeId> = generic
+                            .args
+                            .iter()
+                            .map(|arg| {
+                                Self::resolve_type_static(
+                                    arg,
+                                    type_table,
+                                    type_aliases,
+                                    struct_fields,
+                                )
+                            })
+                            .collect();
+                        type_table.make_generic_instance(
+                            generic.name.clone(),
+                            module_path.clone(),
+                            type_args,
+                        )
+                    } else {
+                        TypeTable::UNKNOWN
+                    }
+                }
             },
             Type::Reference(inner) => {
-                let inner_type = Self::resolve_type_static(inner, type_table, type_aliases);
+                let inner_type =
+                    Self::resolve_type_static(inner, type_table, type_aliases, struct_fields);
                 type_table.make_ref(inner_type)
             }
             Type::MutReference(inner) => {
-                let inner_type = Self::resolve_type_static(inner, type_table, type_aliases);
+                let inner_type =
+                    Self::resolve_type_static(inner, type_table, type_aliases, struct_fields);
                 type_table.make_mut_ref(inner_type)
+            }
+            Type::NamespacedGeneric(namespaced) => {
+                // Handle builtin::array<T>
+                if namespaced.namespace == "builtin"
+                    && namespaced.name == "array"
+                    && let Some(elem_ty) = namespaced.args.first()
+                {
+                    let elem =
+                        Self::resolve_type_static(elem_ty, type_table, type_aliases, struct_fields);
+                    return type_table.make_builtin_array(elem);
+                }
+                TypeTable::UNKNOWN
             }
             _ => TypeTable::UNKNOWN,
         }
@@ -523,16 +739,52 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // Then collect from the main module
+        // First pass: collect generic struct names from loaded modules (needed for resolve_generic_type)
+        for loaded_module in self.loaded_modules.values() {
+            for item in &loaded_module.items {
+                if let Item::Struct(struct_decl) = item
+                    && !struct_decl.type_params.is_empty()
+                {
+                    self.generic_struct_names.insert(struct_decl.name.clone());
+                }
+            }
+        }
+
+        // Also collect generic struct names from the current module
+        for item in &module.items {
+            if let Item::Struct(struct_decl) = item
+                && !struct_decl.type_params.is_empty()
+            {
+                self.generic_struct_names.insert(struct_decl.name.clone());
+            }
+        }
+
+        // Then collect struct fields from the main module
         for item in &module.items {
             match item {
                 Item::Struct(struct_decl) => {
+                    // Set up type parameters in scope for resolving field types
+                    let old_type_params = std::mem::take(&mut self.current_type_params);
+                    for (index, param) in struct_decl.type_params.iter().enumerate() {
+                        let type_id = self
+                            .type_table
+                            .make_type_param(param.name.clone(), index as u32);
+                        self.current_type_params
+                            .insert(param.name.clone(), (index as u32, type_id));
+                    }
+
                     let mut fields = Vec::new();
                     for field in &struct_decl.fields {
                         let type_id = self.resolve_type(&field.ty);
                         fields.push((field.name.clone(), type_id));
                     }
-                    self.struct_fields.insert(struct_decl.name.clone(), fields);
+                    self.struct_fields.insert(
+                        struct_decl.name.clone(),
+                        (self.current_module_path.clone(), fields),
+                    );
+
+                    // Restore type params scope
+                    self.current_type_params = old_type_params;
                 }
                 Item::Type(type_alias) => {
                     let type_id = self.resolve_type(&type_alias.ty);
@@ -576,6 +828,16 @@ impl<'a> Resolver<'a> {
 
     /// Resolve a struct declaration
     fn resolve_struct(&mut self, struct_decl: &ast::StructDecl) -> TirStruct {
+        // Set up type parameters in scope before resolving fields
+        let old_type_params = std::mem::take(&mut self.current_type_params);
+        for (index, param) in struct_decl.type_params.iter().enumerate() {
+            let type_id = self
+                .type_table
+                .make_type_param(param.name.clone(), index as u32);
+            self.current_type_params
+                .insert(param.name.clone(), (index as u32, type_id));
+        }
+
         let mut fields = Vec::new();
         for (index, field) in struct_decl.fields.iter().enumerate() {
             let type_id = self.resolve_type(&field.ty);
@@ -587,9 +849,26 @@ impl<'a> Resolver<'a> {
             });
         }
 
+        // Restore previous type params scope
+        self.current_type_params = old_type_params;
+
+        // Convert AST type params to TIR type params
+        let type_params: Vec<crate::tir::TirTypeParam> = struct_decl
+            .type_params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| crate::tir::TirTypeParam {
+                name: p.name.clone(),
+                bounds: p.bounds.clone(),
+                index: i as u32,
+            })
+            .collect();
+
         TirStruct {
             name: struct_decl.name.clone(),
             is_pub: struct_decl.is_pub,
+            type_params,
+            monomorph_info: None, // Not from monomorphization
             fields,
             span: struct_decl.span,
         }
@@ -597,12 +876,35 @@ impl<'a> Resolver<'a> {
 
     /// Resolve a function
     fn resolve_function(&mut self, func: &Function) -> Option<TirFunction> {
+        // Set up type parameters in scope before resolving types
+        let old_type_params = std::mem::take(&mut self.current_type_params);
+        let mut type_param_list = Vec::new();
+        for (index, param) in func.type_params.iter().enumerate() {
+            let type_id = self
+                .type_table
+                .make_type_param(param.name.clone(), index as u32);
+            self.current_type_params
+                .insert(param.name.clone(), (index as u32, type_id));
+            type_param_list.push((param.name.clone(), type_id));
+        }
+
+        // Store type parameters for generic functions (for call site substitution)
+        if !func.type_params.is_empty() {
+            self.generic_function_params
+                .insert(func.name.clone(), type_param_list);
+        }
+
         // Resolve return type
         let return_type = func
             .return_type
             .as_ref()
             .map(|t| self.resolve_type(t))
             .unwrap_or(TypeTable::UNIT);
+
+        // Update the function_return_types with the resolved return type
+        // (This replaces the potentially incorrect type from static resolution)
+        self.function_return_types
+            .insert(func.name.clone(), return_type);
 
         let mut ctx = FunctionContext::new(return_type);
 
@@ -622,9 +924,26 @@ impl<'a> Resolver<'a> {
         // Resolve body
         let body = func.body.as_ref().map(|b| self.resolve_block(b, &mut ctx));
 
+        // Restore previous type params scope
+        self.current_type_params = old_type_params;
+
+        // Convert AST type params to TIR type params
+        let type_params: Vec<crate::tir::TirTypeParam> = func
+            .type_params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| crate::tir::TirTypeParam {
+                name: p.name.clone(),
+                bounds: p.bounds.clone(),
+                index: i as u32,
+            })
+            .collect();
+
         Some(TirFunction {
             name: func.name.clone(),
             is_pub: func.is_pub,
+            type_params,
+            monomorph_info: None, // Not from monomorphization
             params,
             return_type,
             effects: func.effects.clone(),
@@ -637,13 +956,36 @@ impl<'a> Resolver<'a> {
     }
 
     /// Resolve a method (function with &self parameter)
-    fn resolve_method(&mut self, func: &Function, struct_name: &str) -> Option<TirFunction> {
+    fn resolve_method(
+        &mut self,
+        func: &Function,
+        struct_name: &str,
+        impl_type: &Type,
+    ) -> Option<TirFunction> {
+        // Set up type parameters in scope before resolving types
+        let old_type_params = std::mem::take(&mut self.current_type_params);
+        let mut type_param_list = Vec::new();
+        for (index, param) in func.type_params.iter().enumerate() {
+            let type_id = self
+                .type_table
+                .make_type_param(param.name.clone(), index as u32);
+            self.current_type_params
+                .insert(param.name.clone(), (index as u32, type_id));
+            type_param_list.push((param.name.clone(), type_id));
+        }
+
         // Resolve return type
         let return_type = func
             .return_type
             .as_ref()
             .map(|t| self.resolve_type(t))
             .unwrap_or(TypeTable::UNIT);
+
+        // Update the function_return_types with the resolved return type
+        // (This replaces the potentially incorrect type from static resolution)
+        let mangled_name = format!("{}::{}", struct_name, func.name);
+        self.function_return_types
+            .insert(mangled_name.clone(), return_type);
 
         let mut ctx = FunctionContext::new(return_type);
 
@@ -652,10 +994,8 @@ impl<'a> Resolver<'a> {
         for param in &func.params {
             let is_self = !matches!(param.self_kind, ast::SelfKind::None);
             let type_id = if is_self {
-                // &self parameter is a reference to the struct type
-                // Use current_module_path so the type is correctly qualified
-                self.type_table
-                    .make_struct(struct_name.to_string(), self.current_module_path.clone())
+                // &self parameter type is the impl type (e.g., Box<i32> for `impl Box<i32>`)
+                self.resolve_type(impl_type)
             } else {
                 self.resolve_type(&param.ty)
             };
@@ -671,9 +1011,32 @@ impl<'a> Resolver<'a> {
         // Resolve body
         let body = func.body.as_ref().map(|b| self.resolve_block(b, &mut ctx));
 
+        // Restore previous type params scope
+        self.current_type_params = old_type_params;
+
+        // Store type parameters for generic methods (for call site substitution)
+        if !func.type_params.is_empty() {
+            self.generic_method_params
+                .insert(mangled_name, type_param_list);
+        }
+
+        // Convert AST type params to TIR type params
+        let type_params: Vec<crate::tir::TirTypeParam> = func
+            .type_params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| crate::tir::TirTypeParam {
+                name: p.name.clone(),
+                bounds: p.bounds.clone(),
+                index: i as u32,
+            })
+            .collect();
+
         Some(TirFunction {
             name: func.name.clone(), // Will be mangled by caller
             is_pub: func.is_pub,
+            type_params,
+            monomorph_info: None, // Not from monomorphization
             params,
             return_type,
             effects: func.effects.clone(),
@@ -689,6 +1052,7 @@ impl<'a> Resolver<'a> {
     fn get_type_name(&self, ty: &Type) -> String {
         match ty {
             Type::Named(named) => named.name.clone(),
+            Type::Generic(generic) => generic.name.clone(),
             Type::Reference(inner) => self.get_type_name(inner),
             Type::MutReference(inner) => self.get_type_name(inner),
             _ => "Unknown".to_string(),
@@ -1195,26 +1559,29 @@ impl<'a> Resolver<'a> {
         // Build panic call with message
         let message_expr = if let Some(msg) = &assert_stmt.message {
             // User provided message: "Assertion failed: {message}"
+            let string_type = self.get_string_struct_type();
             let user_msg = self.resolve_expr(msg, ctx);
             let prefix = TirExpr::new(
                 TirExprKind::StringLiteral("Assertion failed: ".to_string()),
-                TypeTable::STRING,
+                string_type,
                 assert_stmt.span,
             );
             TirExpr::new(
                 TirExprKind::Call {
                     module_path: vec!["core".to_string(), "internal".to_string()],
                     func_name: "string_concat".to_string(),
+                    type_args: vec![],
                     args: vec![prefix, user_msg],
                 },
-                TypeTable::STRING,
+                string_type,
                 assert_stmt.span,
             )
         } else {
             // No message: "Assertion failed:"
+            let string_type = self.get_string_struct_type();
             TirExpr::new(
                 TirExprKind::StringLiteral("Assertion failed:".to_string()),
-                TypeTable::STRING,
+                string_type,
                 assert_stmt.span,
             )
         };
@@ -1224,6 +1591,7 @@ impl<'a> Resolver<'a> {
             TirExprKind::Call {
                 module_path: vec!["core".to_string(), "prelude".to_string()],
                 func_name: "panic".to_string(),
+                type_args: vec![],
                 args: vec![message_expr],
             },
             TypeTable::NEVER,
@@ -1370,7 +1738,10 @@ impl<'a> Resolver<'a> {
             }
             Literal::Bool(b) => (TirExprKind::BoolLiteral(*b), TypeTable::BOOL),
             Literal::Char(c) => (TirExprKind::CharLiteral(*c), TypeTable::CHAR),
-            Literal::String(s) => (TirExprKind::StringLiteral(s.clone()), TypeTable::STRING),
+            Literal::String(s) => {
+                let string_type = self.get_string_struct_type();
+                (TirExprKind::StringLiteral(s.clone()), string_type)
+            }
             Literal::Null => {
                 // Null is Option<T> where T is unknown
                 let option_unknown = self.type_table.make_option(TypeTable::UNKNOWN);
@@ -1596,13 +1967,11 @@ impl<'a> Resolver<'a> {
                         (vec![prefix.to_string()], suffix.to_string(), true)
                     }
                 }
-                // First, check if it's a local function (defined in this module)
-                else if self.function_return_types.contains_key(&ident.name) {
-                    (Vec::new(), ident.name.clone(), true)
-                }
-                // Check for built-in type constructors (Ok, Err, Some, None)
-                // These are variant constructors, generated inline
-                else if matches!(ident.name.as_str(), "Ok" | "Err" | "Some" | "None") {
+                // Check if it's a local function (defined in this module) or
+                // a built-in type constructor (Ok, Err, Some, None)
+                else if self.function_return_types.contains_key(&ident.name)
+                    || matches!(ident.name.as_str(), "Ok" | "Err" | "Some" | "None")
+                {
                     (Vec::new(), ident.name.clone(), true)
                 }
                 // Check for prelude functions (panic, unreachable)
@@ -1648,13 +2017,26 @@ impl<'a> Resolver<'a> {
             });
         }
 
+        // Resolve explicit type arguments
+        let type_args: Vec<TypeId> = call
+            .type_args
+            .iter()
+            .map(|ty| self.resolve_type(ty))
+            .collect();
+
         // Look up function return type
-        let return_type = self.lookup_function_return_type(&module_path, &func_name);
+        let mut return_type = self.lookup_function_return_type(&module_path, &func_name);
+
+        // If we have explicit type args, substitute type parameters in the return type
+        if !type_args.is_empty() {
+            return_type = self.substitute_type_params(return_type, &type_args);
+        }
 
         TirExpr::new(
             TirExprKind::Call {
                 module_path,
                 func_name,
+                type_args,
                 args,
             },
             return_type,
@@ -1710,26 +2092,32 @@ impl<'a> Resolver<'a> {
 
     /// Get the return type of a WASI effect operation
     fn get_wasi_effect_return_type(&mut self, effect: &str, operation: &str) -> Option<TypeId> {
+        let string_type = self.get_string_struct_type();
         match (effect, operation) {
             // Environment effect operations
-            ("Environment", "get_arguments") => Some(
-                self.type_table
-                    .intern(ResolvedType::Array(TypeTable::STRING)),
-            ),
+            ("Environment", "get_arguments") => {
+                Some(self.type_table.intern(ResolvedType::Array(string_type)))
+            }
             ("Environment", "get_environment") => {
                 // Returns Array<[String, String]> - array of key-value tuple pairs
-                let tuple_type = self.type_table.intern(ResolvedType::Tuple(vec![
-                    TypeTable::STRING,
-                    TypeTable::STRING,
-                ]));
+                let tuple_type = self
+                    .type_table
+                    .intern(ResolvedType::Tuple(vec![string_type, string_type]));
                 Some(self.type_table.intern(ResolvedType::Array(tuple_type)))
             }
-            ("Environment", "get_initial_cwd") => Some(
-                self.type_table
-                    .intern(ResolvedType::Option(TypeTable::STRING)),
-            ),
+            ("Environment", "get_initial_cwd") => {
+                Some(self.type_table.intern(ResolvedType::Option(string_type)))
+            }
             _ => None,
         }
+    }
+
+    /// Get the String struct type (from prelude)
+    fn get_string_struct_type(&mut self) -> TypeId {
+        self.type_table.make_struct(
+            "String".to_string(),
+            vec!["core".to_string(), "prelude".to_string()],
+        )
     }
 
     /// Get the return type of a builtin function
@@ -1739,11 +2127,14 @@ impl<'a> Resolver<'a> {
             "array_len" => TypeTable::I32,
             "array_get_u8" => TypeTable::I32, // Returns u8 as i32
             "array_set_u8" => TypeTable::UNIT,
-            "string_new" => TypeTable::STRING,
-            "array_new_string" => self
-                .type_table
-                .intern(ResolvedType::Array(TypeTable::STRING)),
-            "array_get_string" => TypeTable::STRING,
+            "string_new" => self.get_string_struct_type(),
+            "array_new_string" => {
+                // Returns builtin::array<String>, not Array<String>
+                let string_type = self.get_string_struct_type();
+                self.type_table
+                    .intern(ResolvedType::BuiltinArray(string_type))
+            }
+            "array_get_string" => self.get_string_struct_type(),
             "array_set_string" => TypeTable::UNIT,
 
             // Memory operations
@@ -1892,7 +2283,6 @@ impl<'a> Resolver<'a> {
                 "f64" => TypeTable::F64,
                 "bool" => TypeTable::BOOL,
                 "char" => TypeTable::CHAR,
-                "String" => TypeTable::STRING,
                 "!" => TypeTable::NEVER,
                 "()" => TypeTable::UNIT,
                 _ => {
@@ -1921,13 +2311,26 @@ impl<'a> Resolver<'a> {
             .map(|a| self.resolve_expr(a, ctx))
             .collect();
 
+        // Resolve explicit type arguments
+        let type_args: Vec<TypeId> = method_call
+            .type_args
+            .iter()
+            .map(|ty| self.resolve_type(ty))
+            .collect();
+
         // Look up method return type based on receiver type
-        let return_type = self.lookup_method_return_type(receiver.type_id, &method_call.method);
+        let mut return_type = self.lookup_method_return_type(receiver.type_id, &method_call.method);
+
+        // If we have explicit type args, substitute type parameters in the return type
+        if !type_args.is_empty() {
+            return_type = self.substitute_type_params(return_type, &type_args);
+        }
 
         TirExpr::new(
             TirExprKind::MethodCall {
                 receiver: Box::new(receiver),
                 method_name: method_call.method.clone(),
+                type_args,
                 args,
             },
             return_type,
@@ -1940,17 +2343,29 @@ impl<'a> Resolver<'a> {
         // Get the struct name and module path from the receiver type
         let (struct_name, module_path) = match self.type_table.get(receiver_type) {
             ResolvedType::Struct { name, module_path } => (name.clone(), module_path.clone()),
+            // Generic instances like Box<i32> use the base name "Box" for method lookup
+            ResolvedType::GenericInstance {
+                name, module_path, ..
+            } => (name.clone(), module_path.clone()),
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                if let ResolvedType::Struct { name, module_path } = self.type_table.get(*inner) {
-                    (name.clone(), module_path.clone())
-                } else {
-                    return TypeTable::UNKNOWN;
+                match self.type_table.get(*inner) {
+                    ResolvedType::Struct { name, module_path } => {
+                        (name.clone(), module_path.clone())
+                    }
+                    ResolvedType::GenericInstance {
+                        name, module_path, ..
+                    } => (name.clone(), module_path.clone()),
+                    _ => return TypeTable::UNKNOWN,
                 }
             }
             // Primitive types have built-in methods like to_string()
             ResolvedType::Primitive(_) => {
                 if method_name == "to_string" {
-                    return TypeTable::STRING;
+                    // Return String struct type
+                    return self
+                        .type_table
+                        .find_struct_type("String", &string_module_path())
+                        .unwrap_or(TypeTable::UNKNOWN);
                 }
                 return TypeTable::UNKNOWN;
             }
@@ -1961,12 +2376,14 @@ impl<'a> Resolver<'a> {
                 }
                 return TypeTable::UNKNOWN;
             }
-            // String type has built-in methods like len()
+            // String type (legacy - String is now a struct, but handle for backwards compat)
             ResolvedType::String => {
-                if method_name == "len" {
-                    return TypeTable::I32;
+                match method_name {
+                    "len" => return TypeTable::I32,
+                    "get" => return TypeTable::I32, // returns u8 as i32
+                    "set" => return TypeTable::UNIT, // mutating method
+                    _ => return TypeTable::UNKNOWN,
                 }
-                return TypeTable::UNKNOWN;
             }
             _ => return TypeTable::UNKNOWN,
         };
@@ -1992,6 +2409,28 @@ impl<'a> Resolver<'a> {
                                     .as_ref()
                                     .map(|t| self.resolve_type_no_register(t))
                                     .unwrap_or(TypeTable::UNIT);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Search all loaded modules if module_path is empty (for prelude types)
+        if module_path.is_empty() {
+            for (_, module) in self.loaded_modules.iter() {
+                for item in &module.items {
+                    if let Item::Impl(impl_block) = item {
+                        let impl_struct_name = self.get_type_name(&impl_block.ty);
+                        if impl_struct_name == struct_name {
+                            for method in &impl_block.methods {
+                                if method.name == method_name {
+                                    return method
+                                        .return_type
+                                        .as_ref()
+                                        .map(|t| self.resolve_type_no_register(t))
+                                        .unwrap_or(TypeTable::UNIT);
+                                }
                             }
                         }
                     }
@@ -2027,15 +2466,17 @@ impl<'a> Resolver<'a> {
 
     /// Look up field type from a struct or tuple type
     fn lookup_field_type(
-        &self,
+        &mut self,
         struct_type: TypeId,
         field_name: &str,
-        span: Span,
+        _span: Span,
     ) -> (u32, TypeId) {
-        match self.type_table.get(struct_type) {
+        // Clone the type to avoid borrow issues
+        let resolved = self.type_table.get(struct_type).clone();
+        match resolved {
             // Struct field access
             ResolvedType::Struct { name, .. } => {
-                if let Some(fields) = self.struct_fields.get(name) {
+                if let Some((_, fields)) = self.struct_fields.get(&name) {
                     for (index, (fname, ftype)) in fields.iter().enumerate() {
                         if fname == field_name {
                             return (index as u32, *ftype);
@@ -2053,11 +2494,76 @@ impl<'a> Resolver<'a> {
             }
             // Reference types - look through to inner type
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                return self.lookup_field_type(*inner, field_name, span);
+                return self.lookup_field_type(inner, field_name, _span);
+            }
+            // Generic instance - look up field from generic struct definition
+            // and substitute type parameters with concrete type args
+            ResolvedType::GenericInstance {
+                name, type_args, ..
+            } => {
+                // Clone fields to avoid borrow issues
+                let fields_clone = self.struct_fields.get(&name).cloned();
+                if let Some((_, fields)) = fields_clone {
+                    for (index, (fname, ftype)) in fields.iter().enumerate() {
+                        if fname == field_name {
+                            // Substitute type parameters with concrete types
+                            let concrete_type = self.substitute_type_params(*ftype, &type_args);
+                            return (index as u32, concrete_type);
+                        }
+                    }
+                }
             }
             _ => {}
         }
         (0, TypeTable::UNKNOWN)
+    }
+
+    /// Substitute type parameters in a type with concrete type arguments
+    fn substitute_type_params(&mut self, type_id: TypeId, type_args: &[TypeId]) -> TypeId {
+        match self.type_table.get(type_id).clone() {
+            ResolvedType::TypeParam { index, .. } => {
+                // Direct substitution: T -> type_args[index]
+                type_args.get(index as usize).copied().unwrap_or(type_id)
+            }
+            ResolvedType::Array(elem) => {
+                let new_elem = self.substitute_type_params(elem, type_args);
+                self.type_table.make_array(new_elem)
+            }
+            ResolvedType::Option(inner) => {
+                let new_inner = self.substitute_type_params(inner, type_args);
+                self.type_table.make_option(new_inner)
+            }
+            ResolvedType::Ref(inner) => {
+                let new_inner = self.substitute_type_params(inner, type_args);
+                self.type_table.make_ref(new_inner)
+            }
+            ResolvedType::MutRef(inner) => {
+                let new_inner = self.substitute_type_params(inner, type_args);
+                self.type_table.make_mut_ref(new_inner)
+            }
+            ResolvedType::Tuple(elems) => {
+                let new_elems: Vec<TypeId> = elems
+                    .iter()
+                    .map(|&e| self.substitute_type_params(e, type_args))
+                    .collect();
+                self.type_table.make_tuple(new_elems)
+            }
+            ResolvedType::GenericInstance {
+                name,
+                module_path,
+                type_args: inner_args,
+            } => {
+                // Recursively substitute in nested generic instances
+                let new_args: Vec<TypeId> = inner_args
+                    .iter()
+                    .map(|&arg| self.substitute_type_params(arg, type_args))
+                    .collect();
+                self.type_table
+                    .make_generic_instance(name, module_path, new_args)
+            }
+            // Other types don't contain type parameters
+            _ => type_id,
+        }
     }
 
     /// Resolve an index expression
@@ -2298,6 +2804,9 @@ impl<'a> Resolver<'a> {
         template: &ast::TemplateStringExpr,
         ctx: &mut FunctionContext,
     ) -> TirExpr {
+        // Get the String struct type
+        let string_type = self.get_string_struct_type();
+
         // Collect all parts as expressions
         let mut parts: Vec<TirExpr> = Vec::new();
 
@@ -2307,7 +2816,7 @@ impl<'a> Resolver<'a> {
                     if !s.is_empty() {
                         parts.push(TirExpr::new(
                             TirExprKind::StringLiteral(s.clone()),
-                            TypeTable::STRING,
+                            string_type,
                             template.span,
                         ));
                     }
@@ -2317,7 +2826,7 @@ impl<'a> Resolver<'a> {
                     let resolved = self.resolve_expr(expr, ctx);
                     // TODO: handle format specifiers
                     // For now, wrap in to_string if not already a string
-                    let string_expr = if resolved.type_id == TypeTable::STRING {
+                    let string_expr = if resolved.type_id == string_type {
                         resolved
                     } else {
                         // Call to_string method
@@ -2325,9 +2834,10 @@ impl<'a> Resolver<'a> {
                             TirExprKind::MethodCall {
                                 receiver: Box::new(resolved.clone()),
                                 method_name: "to_string".to_string(),
+                                type_args: vec![],
                                 args: vec![],
                             },
-                            TypeTable::STRING,
+                            string_type,
                             expr.span(),
                         )
                     };
@@ -2345,7 +2855,7 @@ impl<'a> Resolver<'a> {
         if parts.is_empty() {
             return TirExpr::new(
                 TirExprKind::StringLiteral(String::new()),
-                TypeTable::STRING,
+                string_type,
                 template.span,
             );
         }
@@ -2358,9 +2868,10 @@ impl<'a> Resolver<'a> {
                 TirExprKind::Call {
                     module_path: vec!["core".to_string(), "internal".to_string()],
                     func_name: "string_concat".to_string(),
+                    type_args: vec![],
                     args: vec![result, part],
                 },
-                TypeTable::STRING,
+                string_type,
                 template.span,
             );
         }
@@ -2453,10 +2964,7 @@ impl<'a> Resolver<'a> {
             (name.clone(), Vec::new())
         };
 
-        let struct_type = self
-            .type_table
-            .make_struct(struct_name.clone(), module_path);
-
+        // Resolve field expressions first
         let fields: Vec<TirStructField> = struct_lit
             .fields
             .iter()
@@ -2471,6 +2979,17 @@ impl<'a> Resolver<'a> {
             })
             .collect();
 
+        // Check if this is a generic struct and infer type arguments
+        let struct_type = if self.generic_struct_names.contains(&struct_name) {
+            // This is a generic struct - infer type arguments from field values
+            let type_args = self.infer_type_args_from_fields(&struct_name, &fields);
+            self.type_table
+                .make_generic_instance(struct_name.clone(), module_path, type_args)
+        } else {
+            self.type_table
+                .make_struct(struct_name.clone(), module_path)
+        };
+
         TirExpr::new(
             TirExprKind::StructLiteral {
                 struct_type,
@@ -2480,6 +2999,46 @@ impl<'a> Resolver<'a> {
             struct_type,
             struct_lit.span,
         )
+    }
+
+    /// Infer type arguments for a generic struct from field values
+    fn infer_type_args_from_fields(
+        &self,
+        struct_name: &str,
+        fields: &[TirStructField],
+    ) -> Vec<TypeId> {
+        // Get the generic struct's field type information
+        let Some((_, field_types)) = self.struct_fields.get(struct_name) else {
+            return vec![];
+        };
+
+        // Build a map from type param TypeId to concrete TypeId
+        let mut type_param_map: HashMap<TypeId, TypeId> = HashMap::new();
+
+        for (struct_field, (_, expected_type_id)) in fields.iter().zip(field_types.iter()) {
+            let actual_type_id = struct_field.value.type_id;
+
+            // Check if expected type is a type parameter
+            if let ResolvedType::TypeParam { .. } = self.type_table.get(*expected_type_id) {
+                // Map this type param to the actual type
+                type_param_map.insert(*expected_type_id, actual_type_id);
+            }
+        }
+
+        // Collect type args in order (by TypeParam index)
+        let mut type_args: Vec<(u32, TypeId)> = type_param_map
+            .iter()
+            .filter_map(|(&param_id, &concrete_id)| {
+                if let ResolvedType::TypeParam { index, .. } = self.type_table.get(param_id) {
+                    Some((*index, concrete_id))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        type_args.sort_by_key(|(index, _)| *index);
+        type_args.into_iter().map(|(_, type_id)| type_id).collect()
     }
 
     /// Resolve a tuple literal expression: `[1, 2, 3]` or `[1, "hello", true]`
@@ -2534,11 +3093,54 @@ impl<'a> Resolver<'a> {
                 let inner_type = self.resolve_type(inner);
                 self.type_table.make_mut_ref(inner_type)
             }
+            Type::NamespacedGeneric(namespaced) => self.resolve_namespaced_generic_type(namespaced),
+        }
+    }
+
+    /// Resolve a namespaced generic type like `builtin::array<T>`
+    fn resolve_namespaced_generic_type(
+        &mut self,
+        namespaced: &crate::ast::NamespacedGenericType,
+    ) -> TypeId {
+        match namespaced.namespace.as_str() {
+            "builtin" => match namespaced.name.as_str() {
+                "array" => {
+                    if namespaced.args.len() != 1 {
+                        self.errors.push(TypeError::ArgumentCountMismatch {
+                            expected: 1,
+                            found: namespaced.args.len(),
+                            span: namespaced.span,
+                        });
+                        return TypeTable::ERROR;
+                    }
+                    let element_type = self.resolve_type(&namespaced.args[0]);
+                    self.type_table.make_builtin_array(element_type)
+                }
+                _ => {
+                    self.errors.push(TypeError::UnknownType {
+                        name: format!("builtin::{}", namespaced.name),
+                        span: namespaced.span,
+                    });
+                    TypeTable::ERROR
+                }
+            },
+            _ => {
+                self.errors.push(TypeError::UnknownType {
+                    name: format!("{}::{}", namespaced.namespace, namespaced.name),
+                    span: namespaced.span,
+                });
+                TypeTable::ERROR
+            }
         }
     }
 
     /// Resolve a named type
     fn resolve_named_type(&mut self, name: &str, _span: Span) -> TypeId {
+        // First check if it's a type parameter in scope
+        if let Some(&(_, type_id)) = self.current_type_params.get(name) {
+            return type_id;
+        }
+
         match name {
             // Primitives
             "i8" => TypeTable::I8,
@@ -2557,17 +3159,15 @@ impl<'a> Resolver<'a> {
             "char" => TypeTable::CHAR,
             "()" => TypeTable::UNIT,
             "!" => TypeTable::NEVER,
-            "String" => TypeTable::STRING,
 
-            // Check type aliases
+            // Check type aliases, then struct definitions
             _ => {
                 if let Some(&type_id) = self.type_aliases.get(name) {
                     type_id
-                } else if self.struct_fields.contains_key(name) {
-                    // It's a struct defined in the current module (or a previously collected module)
-                    // Use current_module_path to properly qualify the type
+                } else if let Some((module_path, _)) = self.struct_fields.get(name) {
+                    // It's a struct - use the module path where it was defined
                     self.type_table
-                        .make_struct(name.to_string(), self.current_module_path.clone())
+                        .make_struct(name.to_string(), module_path.clone())
                 } else {
                     // Unknown type
                     TypeTable::UNKNOWN
@@ -2579,13 +3179,6 @@ impl<'a> Resolver<'a> {
     /// Resolve a generic type
     fn resolve_generic_type(&mut self, name: &str, args: &[Type]) -> TypeId {
         match name {
-            "Array" | "Vec" => {
-                let elem_type = args
-                    .first()
-                    .map(|t| self.resolve_type(t))
-                    .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.make_array(elem_type)
-            }
             "Option" => {
                 let inner = args
                     .first()
@@ -2629,7 +3222,37 @@ impl<'a> Resolver<'a> {
                     .unwrap_or(TypeTable::UNKNOWN);
                 self.type_table.intern(ResolvedType::Dict { key, value })
             }
-            _ => TypeTable::UNKNOWN,
+            // Special case: Array<T> is defined as a struct in prelude, but we use
+            // ResolvedType::Array(elem) for codegen compatibility until proper
+            // generic struct monomorphization is implemented
+            "Array" => {
+                let elem = args
+                    .first()
+                    .map(|t| self.resolve_type(t))
+                    .unwrap_or(TypeTable::UNKNOWN);
+                self.type_table.intern(ResolvedType::Array(elem))
+            }
+            _ => {
+                // Check if it's a user-defined generic struct
+                if self.generic_struct_names.contains(name) {
+                    // Resolve type arguments
+                    let type_args: Vec<TypeId> =
+                        args.iter().map(|t| self.resolve_type(t)).collect();
+
+                    // Get the module path where the struct was defined
+                    let module_path = self
+                        .struct_fields
+                        .get(name)
+                        .map(|(path, _)| path.clone())
+                        .unwrap_or_else(|| self.current_module_path.clone());
+
+                    // Create a GenericInstance type
+                    self.type_table
+                        .make_generic_instance(name.to_string(), module_path, type_args)
+                } else {
+                    TypeTable::UNKNOWN
+                }
+            }
         }
     }
 

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -76,6 +76,25 @@ pub enum ResolvedType {
         value: TypeId,
     },
     Reactive(TypeId),
+    /// Type parameter (e.g., `T` in `struct Box<T>`)
+    /// Used before monomorphization; should be substituted with concrete types
+    TypeParam {
+        name: String,
+        /// Index of the type parameter in the generic definition (0 for first param)
+        index: u32,
+    },
+    /// Generic struct instantiation (e.g., `Box<i32>`)
+    /// Used to track instantiation sites before monomorphization
+    GenericInstance {
+        /// Base generic type name (e.g., "Box")
+        name: String,
+        module_path: Vec<String>,
+        /// Concrete type arguments (e.g., [i32])
+        type_args: Vec<TypeId>,
+    },
+    /// Raw GC array intrinsic (`builtin::array<T>`)
+    /// This is the underlying storage type for String and Array<T> structs
+    BuiltinArray(TypeId),
     Unknown,
     Error,
 }
@@ -109,9 +128,9 @@ impl TypeTable {
     pub const CHAR: TypeId = 13;
     pub const UNIT: TypeId = 14;
     pub const NEVER: TypeId = 15;
-    pub const STRING: TypeId = 16;
-    pub const UNKNOWN: TypeId = 17;
-    pub const ERROR: TypeId = 18;
+    // STRING removed - String is now a user-defined struct in core/prelude
+    pub const UNKNOWN: TypeId = 16;
+    pub const ERROR: TypeId = 17;
 
     pub fn new() -> Self {
         let mut table = Self {
@@ -136,7 +155,7 @@ impl TypeTable {
         table.intern(ResolvedType::Primitive(PrimitiveType::Char));
         table.intern(ResolvedType::Unit);
         table.intern(ResolvedType::Never);
-        table.intern(ResolvedType::String);
+        // ResolvedType::String removed - String is now a user-defined struct
         table.intern(ResolvedType::Unknown);
         table.intern(ResolvedType::Error);
 
@@ -198,6 +217,11 @@ impl TypeTable {
         self.intern(ResolvedType::Array(element))
     }
 
+    /// Create a raw GC array type (`builtin::array<T>`)
+    pub fn make_builtin_array(&mut self, element: TypeId) -> TypeId {
+        self.intern(ResolvedType::BuiltinArray(element))
+    }
+
     pub fn make_option(&mut self, inner: TypeId) -> TypeId {
         self.intern(ResolvedType::Option(inner))
     }
@@ -227,6 +251,16 @@ impl TypeTable {
         self.intern(ResolvedType::Struct { name, module_path })
     }
 
+    /// Find the type_id for a struct by name and module path (O(1) lookup via intern_map)
+    pub fn find_struct_type(&self, name: &str, module_path: &[String]) -> Option<TypeId> {
+        // Use the existing intern_map for O(1) lookup
+        let key = ResolvedType::Struct {
+            name: name.to_string(),
+            module_path: module_path.to_vec(),
+        };
+        self.intern_map.get(&key).copied()
+    }
+
     pub fn make_enum(&mut self, name: String, module_path: Vec<String>) -> TypeId {
         self.intern(ResolvedType::Enum { name, module_path })
     }
@@ -237,6 +271,58 @@ impl TypeTable {
 
     pub fn make_mut_ref(&mut self, inner: TypeId) -> TypeId {
         self.intern(ResolvedType::MutRef(inner))
+    }
+
+    /// Create a type parameter (e.g., `T` in `struct Box<T>`)
+    pub fn make_type_param(&mut self, name: String, index: u32) -> TypeId {
+        self.intern(ResolvedType::TypeParam { name, index })
+    }
+
+    /// Create a generic instance (e.g., `Box<i32>`)
+    pub fn make_generic_instance(
+        &mut self,
+        name: String,
+        module_path: Vec<String>,
+        type_args: Vec<TypeId>,
+    ) -> TypeId {
+        self.intern(ResolvedType::GenericInstance {
+            name,
+            module_path,
+            type_args,
+        })
+    }
+
+    /// Check if a type is or contains type parameters
+    pub fn contains_type_param(&self, id: TypeId) -> bool {
+        match self.get(id) {
+            ResolvedType::TypeParam { .. } => true,
+            ResolvedType::Array(inner)
+            | ResolvedType::BuiltinArray(inner)
+            | ResolvedType::Option(inner)
+            | ResolvedType::Ref(inner)
+            | ResolvedType::MutRef(inner)
+            | ResolvedType::Stream(inner)
+            | ResolvedType::Future(inner)
+            | ResolvedType::Reactive(inner) => self.contains_type_param(*inner),
+            ResolvedType::Result { ok, err }
+            | ResolvedType::Dict {
+                key: ok,
+                value: err,
+            } => self.contains_type_param(*ok) || self.contains_type_param(*err),
+            ResolvedType::Tuple(elems) => elems.iter().any(|e| self.contains_type_param(*e)),
+            ResolvedType::Function {
+                params,
+                return_type,
+                ..
+            } => {
+                params.iter().any(|p| self.contains_type_param(*p))
+                    || self.contains_type_param(*return_type)
+            }
+            ResolvedType::GenericInstance { type_args, .. } => {
+                type_args.iter().any(|t| self.contains_type_param(*t))
+            }
+            _ => false,
+        }
     }
 
     /// Get a human-readable name for a type
@@ -264,6 +350,9 @@ impl TypeTable {
             ResolvedType::Unknown => "unknown".to_string(),
             ResolvedType::Error => "error".to_string(),
             ResolvedType::Array(elem) => format!("Array<{}>", self.type_name(*elem)),
+            ResolvedType::BuiltinArray(elem) => {
+                format!("builtin::array<{}>", self.type_name(*elem))
+            }
             ResolvedType::Tuple(elems) => {
                 let elem_names: Vec<String> = elems.iter().map(|e| self.type_name(*e)).collect();
                 format!("[{}]", elem_names.join(", "))
@@ -295,6 +384,13 @@ impl TypeTable {
                 format!("Dict<{}, {}>", self.type_name(*key), self.type_name(*value))
             }
             ResolvedType::Reactive(inner) => format!("Reactive<{}>", self.type_name(*inner)),
+            ResolvedType::TypeParam { name, .. } => name.clone(),
+            ResolvedType::GenericInstance {
+                name, type_args, ..
+            } => {
+                let arg_names: Vec<String> = type_args.iter().map(|t| self.type_name(*t)).collect();
+                format!("{}<{}>", name, arg_names.join(", "))
+            }
         }
     }
 }
@@ -366,6 +462,8 @@ pub enum TirExprKind {
     Call {
         module_path: Vec<String>,
         func_name: String,
+        /// Explicit type arguments for generic functions: `identity::<i32>(x)`
+        type_args: Vec<TypeId>,
         args: Vec<TirExpr>,
     },
     EffectCall {
@@ -376,6 +474,8 @@ pub enum TirExprKind {
     MethodCall {
         receiver: Box<TirExpr>,
         method_name: String,
+        /// Explicit type arguments for generic methods: `obj.method::<i32>()`
+        type_args: Vec<TypeId>,
         args: Vec<TirExpr>,
     },
 
@@ -593,10 +693,31 @@ pub enum TirStmtKind {
 // Items (Top-level Declarations)
 // ============================================================================
 
+/// Generic type parameter in TIR (from AST GenericParam)
+#[derive(Debug, Clone)]
+pub struct TirTypeParam {
+    pub name: String,
+    pub bounds: Vec<String>,
+    pub index: u32,
+}
+
+/// Information about monomorphization origin for instantiated items
+#[derive(Debug, Clone)]
+pub struct MonomorphInfo {
+    /// Original generic name (e.g., "Box" for "Box$i32")
+    pub generic_name: String,
+    /// Concrete type arguments used for this instantiation
+    pub type_args: Vec<TypeId>,
+}
+
 #[derive(Debug, Clone)]
 pub struct TirFunction {
     pub name: String,
     pub is_pub: bool,
+    /// Generic type parameters (empty for non-generic functions)
+    pub type_params: Vec<TirTypeParam>,
+    /// If this function was created by monomorphization, contains the origin info
+    pub monomorph_info: Option<MonomorphInfo>,
     pub params: Vec<TirParam>,
     pub return_type: TypeId,
     pub effects: Vec<String>,
@@ -621,6 +742,10 @@ pub struct TirParam {
 pub struct TirStruct {
     pub name: String,
     pub is_pub: bool,
+    /// Generic type parameters (empty for non-generic structs)
+    pub type_params: Vec<TirTypeParam>,
+    /// If this struct was created by monomorphization, contains the origin info
+    pub monomorph_info: Option<MonomorphInfo>,
     pub fields: Vec<TirField>,
     pub span: Span,
 }
@@ -637,6 +762,10 @@ pub struct TirField {
 pub struct TirEnum {
     pub name: String,
     pub is_pub: bool,
+    /// Generic type parameters (empty for non-generic enums)
+    pub type_params: Vec<TirTypeParam>,
+    /// If this enum was created by monomorphization, contains the origin info
+    pub monomorph_info: Option<MonomorphInfo>,
     pub variants: Vec<TirVariant>,
     pub span: Span,
 }
@@ -675,6 +804,8 @@ pub struct TirEffectOp {
 
 #[derive(Debug, Clone)]
 pub struct TirImpl {
+    /// Generic type parameters for the impl block (e.g., `impl<T> Box<T>`)
+    pub type_params: Vec<TirTypeParam>,
     pub target_type: TypeId,
     pub methods: Vec<TirFunction>,
     pub span: Span,
@@ -683,6 +814,15 @@ pub struct TirImpl {
 // ============================================================================
 // Module
 // ============================================================================
+
+/// Tracks a requested instantiation of a generic item
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InstantiationKey {
+    /// Name of the generic item (struct, function, or enum)
+    pub name: String,
+    /// Concrete type arguments for instantiation
+    pub type_args: Vec<TypeId>,
+}
 
 #[derive(Debug, Clone)]
 pub struct TirModule {
@@ -696,6 +836,14 @@ pub struct TirModule {
     pub impls: Vec<TirImpl>,
     pub data_section: Option<String>,
     pub string_literals: Vec<String>,
+    /// Generic struct definitions (before monomorphization)
+    /// Key: struct name
+    pub generic_structs: HashMap<String, TirStruct>,
+    /// Generic function definitions (before monomorphization)
+    /// Key: function name
+    pub generic_functions: HashMap<String, TirFunction>,
+    /// Requested instantiations (populated during resolution, processed in lower)
+    pub instantiation_requests: std::collections::HashSet<InstantiationKey>,
 }
 
 impl TirModule {
@@ -711,6 +859,9 @@ impl TirModule {
             impls: Vec::new(),
             data_section: None,
             string_literals: Vec::new(),
+            generic_structs: HashMap::new(),
+            generic_functions: HashMap::new(),
+            instantiation_requests: std::collections::HashSet::new(),
         }
     }
 
@@ -726,6 +877,9 @@ impl TirModule {
             impls: Vec::new(),
             data_section: None,
             string_literals: Vec::new(),
+            generic_structs: HashMap::new(),
+            generic_functions: HashMap::new(),
+            instantiation_requests: std::collections::HashSet::new(),
         }
     }
 
@@ -811,7 +965,7 @@ mod tests {
             table.get(TypeTable::BOOL),
             ResolvedType::Primitive(PrimitiveType::Bool)
         ));
-        assert!(matches!(table.get(TypeTable::STRING), ResolvedType::String));
+        // Note: String is now a user-defined struct, not a builtin type
         assert!(matches!(table.get(TypeTable::UNIT), ResolvedType::Unit));
     }
 
@@ -827,15 +981,16 @@ mod tests {
     fn test_composite_types() {
         let mut table = TypeTable::new();
         let option_i32 = table.make_option(TypeTable::I32);
-        let result_i32_string = table.make_result(TypeTable::I32, TypeTable::STRING);
+        // Use I64 as error type since String is now a user-defined struct
+        let result_i32_i64 = table.make_result(TypeTable::I32, TypeTable::I64);
 
         assert!(matches!(
             table.get(option_i32),
             ResolvedType::Option(id) if *id == TypeTable::I32
         ));
         assert!(matches!(
-            table.get(result_i32_string),
-            ResolvedType::Result { ok, err } if *ok == TypeTable::I32 && *err == TypeTable::STRING
+            table.get(result_i32_i64),
+            ResolvedType::Result { ok, err } if *ok == TypeTable::I32 && *err == TypeTable::I64
         ));
     }
 }

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -191,6 +191,7 @@ impl<'a> Unparser<'a> {
 
         self.output.push_str("fn ");
         self.output.push_str(&f.name);
+        self.unparse_generic_params(&f.type_params);
         self.output.push('(');
 
         for (i, param) in f.params.iter().enumerate() {
@@ -267,6 +268,7 @@ impl<'a> Unparser<'a> {
 
         self.output.push_str("struct ");
         self.output.push_str(&s.name);
+        self.unparse_generic_params(&s.type_params);
         self.output.push_str(" {\n");
 
         self.indent_level += 1;
@@ -297,6 +299,30 @@ impl<'a> Unparser<'a> {
         self.output.push(',');
     }
 
+    /// Unparse generic type parameters: `<T, U: Ord>`
+    fn unparse_generic_params(&mut self, params: &[crate::ast::GenericParam]) {
+        if params.is_empty() {
+            return;
+        }
+        self.output.push('<');
+        for (i, param) in params.iter().enumerate() {
+            if i > 0 {
+                self.output.push_str(", ");
+            }
+            self.output.push_str(&param.name);
+            if !param.bounds.is_empty() {
+                self.output.push_str(": ");
+                for (j, bound) in param.bounds.iter().enumerate() {
+                    if j > 0 {
+                        self.output.push_str(" + ");
+                    }
+                    self.output.push_str(bound);
+                }
+            }
+        }
+        self.output.push('>');
+    }
+
     fn unparse_enum(&mut self, e: &EnumDecl) {
         self.write_indent();
 
@@ -306,6 +332,7 @@ impl<'a> Unparser<'a> {
 
         self.output.push_str("enum ");
         self.output.push_str(&e.name);
+        self.unparse_generic_params(&e.type_params);
         self.output.push_str(" {\n");
 
         self.indent_level += 1;
@@ -350,7 +377,9 @@ impl<'a> Unparser<'a> {
 
     fn unparse_impl(&mut self, i: &ImplBlock) {
         self.write_indent();
-        self.output.push_str("impl ");
+        self.output.push_str("impl");
+        self.unparse_generic_params(&i.type_params);
+        self.output.push(' ');
         self.unparse_type(&i.ty);
         self.output.push_str(" {\n");
 
@@ -529,6 +558,21 @@ impl<'a> Unparser<'a> {
             Type::MutReference(inner) => {
                 self.output.push_str("&mut ");
                 self.unparse_type(inner);
+            }
+            Type::NamespacedGeneric(ng) => {
+                self.output.push_str(&ng.namespace);
+                self.output.push_str("::");
+                self.output.push_str(&ng.name);
+                if !ng.args.is_empty() {
+                    self.output.push('<');
+                    for (i, arg) in ng.args.iter().enumerate() {
+                        if i > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.unparse_type(arg);
+                    }
+                    self.output.push('>');
+                }
             }
         }
     }
@@ -908,6 +952,17 @@ impl<'a> Unparser<'a> {
 
     fn unparse_call(&mut self, c: &CallExpr) {
         self.unparse_expr(&c.callee);
+        // Output turbofish syntax if there are type arguments
+        if !c.type_args.is_empty() {
+            self.output.push_str("::<");
+            for (i, ty) in c.type_args.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                self.unparse_type(ty);
+            }
+            self.output.push('>');
+        }
         self.output.push('(');
         for (i, arg) in c.args.iter().enumerate() {
             if i > 0 {
@@ -922,6 +977,17 @@ impl<'a> Unparser<'a> {
         self.unparse_expr(&m.receiver);
         self.output.push('.');
         self.output.push_str(&m.method);
+        // Output turbofish syntax if there are type arguments
+        if !m.type_args.is_empty() {
+            self.output.push_str("::<");
+            for (i, ty) in m.type_args.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                self.unparse_type(ty);
+            }
+            self.output.push('>');
+        }
         self.output.push('(');
         for (i, arg) in m.args.iter().enumerate() {
             if i > 0 {
@@ -1326,6 +1392,702 @@ fn escape_char(c: char) -> String {
         c if c.is_control() => format!("\\u{{{:04X}}}", c as u32),
         c => c.to_string(),
     }
+}
+
+// ============================================================================
+// TIR Unparser
+// ============================================================================
+
+use crate::tir::{
+    TirBinaryOp, TirBlock, TirEnum, TirExpr, TirExprKind, TirFunction, TirModule, TirParam,
+    TirPattern, TirStmt, TirStmtKind, TirStruct, TirUnaryOp, TypeTable,
+};
+
+/// Unparses TIR back to pseudo-Wado source code.
+/// The output shows the code after monomorphization and lowering.
+/// Note: The output may not be valid Wado (e.g., `Box$i32` isn't valid syntax).
+pub struct TirUnparser<'a> {
+    type_table: &'a TypeTable,
+    output: String,
+    indent_level: usize,
+}
+
+impl<'a> TirUnparser<'a> {
+    pub fn new(type_table: &'a TypeTable) -> Self {
+        Self {
+            type_table,
+            output: String::new(),
+            indent_level: 0,
+        }
+    }
+
+    pub fn unparse(mut self, module: &TirModule) -> String {
+        self.unparse_module(module);
+        self.output
+    }
+
+    fn unparse_module(&mut self, module: &TirModule) {
+        // Structs
+        for s in &module.structs {
+            self.unparse_struct(s);
+            self.output.push('\n');
+        }
+
+        // Enums
+        for e in &module.enums {
+            self.unparse_enum(e);
+            self.output.push('\n');
+        }
+
+        // Functions
+        for f in &module.functions {
+            self.unparse_function(f);
+            self.output.push('\n');
+        }
+
+        // Data section
+        if let Some(data) = &module.data_section {
+            self.output.push_str("__DATA__\n");
+            self.output.push_str(data);
+        }
+    }
+
+    fn unparse_struct(&mut self, s: &TirStruct) {
+        self.write_indent();
+        if s.is_pub {
+            self.output.push_str("pub ");
+        }
+        self.output.push_str("struct ");
+        self.output.push_str(&s.name);
+
+        // Show generic params if present (for unmonomorphized structs)
+        if !s.type_params.is_empty() {
+            self.output.push('<');
+            for (i, param) in s.type_params.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                self.output.push_str(&param.name);
+            }
+            self.output.push('>');
+        }
+
+        self.output.push_str(" {\n");
+        self.indent_level += 1;
+
+        for field in &s.fields {
+            self.write_indent();
+            self.output.push_str(&field.name);
+            self.output.push_str(": ");
+            self.output
+                .push_str(&self.type_table.type_name(field.type_id));
+            self.output.push_str(",\n");
+        }
+
+        self.indent_level -= 1;
+        self.write_indent();
+        self.output.push_str("}\n");
+    }
+
+    fn unparse_enum(&mut self, e: &TirEnum) {
+        self.write_indent();
+        if e.is_pub {
+            self.output.push_str("pub ");
+        }
+        self.output.push_str("enum ");
+        self.output.push_str(&e.name);
+        self.output.push_str(" {\n");
+        self.indent_level += 1;
+
+        for variant in &e.variants {
+            self.write_indent();
+            self.output.push_str(&variant.name);
+            if !variant.fields.is_empty() {
+                self.output.push('(');
+                for (i, field_ty) in variant.fields.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.output.push_str(&self.type_table.type_name(*field_ty));
+                }
+                self.output.push(')');
+            }
+            self.output.push_str(",\n");
+        }
+
+        self.indent_level -= 1;
+        self.write_indent();
+        self.output.push_str("}\n");
+    }
+
+    fn unparse_function(&mut self, f: &TirFunction) {
+        self.write_indent();
+        if f.is_pub {
+            self.output.push_str("pub ");
+        }
+        self.output.push_str("fn ");
+        self.output.push_str(&f.name);
+
+        // Generic params (for unmonomorphized functions)
+        if !f.type_params.is_empty() {
+            self.output.push('<');
+            for (i, param) in f.type_params.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                self.output.push_str(&param.name);
+            }
+            self.output.push('>');
+        }
+
+        self.output.push('(');
+        for (i, param) in f.params.iter().enumerate() {
+            if i > 0 {
+                self.output.push_str(", ");
+            }
+            self.unparse_param(param);
+        }
+        self.output.push(')');
+
+        // Return type
+        if f.return_type != TypeTable::UNIT {
+            self.output.push_str(" -> ");
+            self.output
+                .push_str(&self.type_table.type_name(f.return_type));
+        }
+
+        // Effects
+        if !f.effects.is_empty() {
+            self.output.push_str(" with ");
+            self.output.push_str(&f.effects.join(", "));
+        }
+
+        // Body
+        if let Some(body) = &f.body {
+            self.output.push_str(" {\n");
+            self.indent_level += 1;
+            self.unparse_block(body);
+            self.indent_level -= 1;
+            self.write_indent();
+            self.output.push_str("}\n");
+        } else {
+            self.output.push_str(";\n");
+        }
+    }
+
+    fn unparse_param(&mut self, param: &TirParam) {
+        self.output.push_str(&param.name);
+        self.output.push_str(": ");
+        self.output
+            .push_str(&self.type_table.type_name(param.type_id));
+    }
+
+    fn unparse_block(&mut self, block: &TirBlock) {
+        for stmt in &block.stmts {
+            self.unparse_stmt(stmt);
+        }
+    }
+
+    fn unparse_stmt(&mut self, stmt: &TirStmt) {
+        match &stmt.kind {
+            TirStmtKind::Let {
+                name,
+                is_mut,
+                is_reactive,
+                type_id,
+                value,
+                ..
+            } => {
+                self.write_indent();
+                self.output.push_str("let ");
+                if *is_reactive {
+                    self.output.push_str("reactive ");
+                }
+                if *is_mut {
+                    self.output.push_str("mut ");
+                }
+                self.output.push_str(name);
+                self.output.push_str(": ");
+                self.output.push_str(&self.type_table.type_name(*type_id));
+                self.output.push_str(" = ");
+                self.unparse_expr(value);
+                self.output.push_str(";\n");
+            }
+            TirStmtKind::Expr(expr) => {
+                self.write_indent();
+                self.unparse_expr(expr);
+                self.output.push_str(";\n");
+            }
+            TirStmtKind::Return { value } => {
+                self.write_indent();
+                self.output.push_str("return");
+                if let Some(v) = value {
+                    self.output.push(' ');
+                    self.unparse_expr(v);
+                }
+                self.output.push_str(";\n");
+            }
+            TirStmtKind::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.write_indent();
+                self.output.push_str("if ");
+                self.unparse_expr(condition);
+                self.output.push_str(" {\n");
+                self.indent_level += 1;
+                self.unparse_block(then_block);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push('}');
+                if let Some(else_blk) = else_block {
+                    self.output.push_str(" else {\n");
+                    self.indent_level += 1;
+                    self.unparse_block(else_blk);
+                    self.indent_level -= 1;
+                    self.write_indent();
+                    self.output.push('}');
+                }
+                self.output.push('\n');
+            }
+            TirStmtKind::While { condition, body } => {
+                self.write_indent();
+                self.output.push_str("while ");
+                self.unparse_expr(condition);
+                self.output.push_str(" {\n");
+                self.indent_level += 1;
+                self.unparse_block(body);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push_str("}\n");
+            }
+            TirStmtKind::For {
+                condition,
+                body,
+                update,
+            } => {
+                self.write_indent();
+                self.output.push_str("for ; ");
+                if let Some(cond) = condition {
+                    self.unparse_expr(cond);
+                }
+                self.output.push_str("; ");
+                if let Some(upd) = update {
+                    self.unparse_expr(upd);
+                }
+                self.output.push_str(" {\n");
+                self.indent_level += 1;
+                self.unparse_block(body);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push_str("}\n");
+            }
+            TirStmtKind::Loop { body } => {
+                self.write_indent();
+                self.output.push_str("loop {\n");
+                self.indent_level += 1;
+                self.unparse_block(body);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push_str("}\n");
+            }
+            TirStmtKind::ForOf { iterable, body, .. } => {
+                self.write_indent();
+                self.output.push_str("for let _item of ");
+                self.unparse_expr(iterable);
+                self.output.push_str(" {\n");
+                self.indent_level += 1;
+                self.unparse_block(body);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push_str("}\n");
+            }
+            TirStmtKind::Break => {
+                self.write_indent();
+                self.output.push_str("break;\n");
+            }
+            TirStmtKind::Continue => {
+                self.write_indent();
+                self.output.push_str("continue;\n");
+            }
+            TirStmtKind::Assert {
+                condition,
+                condition_source,
+                message,
+                ..
+            } => {
+                self.write_indent();
+                self.output.push_str("assert ");
+                // Use condition_source for readability
+                self.output.push_str(condition_source);
+                if let Some(msg) = message {
+                    self.output.push_str(", ");
+                    self.unparse_expr(msg);
+                }
+                // Show actual condition as comment
+                self.output.push_str(";  // ");
+                self.unparse_expr(condition);
+                self.output.push('\n');
+            }
+        }
+    }
+
+    fn unparse_expr(&mut self, expr: &TirExpr) {
+        match &expr.kind {
+            TirExprKind::IntLiteral { repr, .. } => {
+                self.output.push_str(repr);
+            }
+            TirExprKind::FloatLiteral { repr, .. } => {
+                self.output.push_str(repr);
+            }
+            TirExprKind::BoolLiteral(b) => {
+                self.output.push_str(if *b { "true" } else { "false" });
+            }
+            TirExprKind::CharLiteral(c) => {
+                self.output.push('\'');
+                self.output.push_str(&escape_char(*c));
+                self.output.push('\'');
+            }
+            TirExprKind::StringLiteral(s) => {
+                self.output.push('"');
+                self.output.push_str(&escape_string(s));
+                self.output.push('"');
+            }
+            TirExprKind::Null => {
+                self.output.push_str("null");
+            }
+            TirExprKind::Unit => {
+                self.output.push_str("()");
+            }
+            TirExprKind::Local { name, .. } => {
+                self.output.push_str(name);
+            }
+            TirExprKind::Global { name, module_path } => {
+                if !module_path.is_empty() {
+                    self.output.push_str(&module_path.join("::"));
+                    self.output.push_str("::");
+                }
+                self.output.push_str(name);
+            }
+            TirExprKind::Binary { left, op, right } => {
+                self.output.push('(');
+                self.unparse_expr(left);
+                self.output.push(' ');
+                self.output.push_str(tir_binary_op_str(*op));
+                self.output.push(' ');
+                self.unparse_expr(right);
+                self.output.push(')');
+            }
+            TirExprKind::Unary { op, expr: inner } => {
+                self.output.push_str(tir_unary_op_str(*op));
+                self.unparse_expr(inner);
+            }
+            TirExprKind::Assign { target, value } => {
+                self.unparse_expr(target);
+                self.output.push_str(" = ");
+                self.unparse_expr(value);
+            }
+            TirExprKind::Cast {
+                expr: inner,
+                target_type,
+            } => {
+                self.unparse_expr(inner);
+                self.output.push_str(" as ");
+                self.output
+                    .push_str(&self.type_table.type_name(*target_type));
+            }
+            TirExprKind::Call {
+                func_name,
+                type_args,
+                args,
+                module_path,
+            } => {
+                if !module_path.is_empty() {
+                    self.output.push_str(&module_path.join("::"));
+                    self.output.push_str("::");
+                }
+                self.output.push_str(func_name);
+                if !type_args.is_empty() {
+                    self.output.push_str("::<");
+                    for (i, type_arg) in type_args.iter().enumerate() {
+                        if i > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.output.push_str(&self.type_table.type_name(*type_arg));
+                    }
+                    self.output.push('>');
+                }
+                self.output.push('(');
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_expr(arg);
+                }
+                self.output.push(')');
+            }
+            TirExprKind::EffectCall {
+                effect_name,
+                op_name,
+                args,
+            } => {
+                self.output.push_str(effect_name);
+                self.output.push_str("::");
+                self.output.push_str(op_name);
+                self.output.push('(');
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_expr(arg);
+                }
+                self.output.push(')');
+            }
+            TirExprKind::MethodCall {
+                receiver,
+                method_name,
+                type_args,
+                args,
+            } => {
+                self.unparse_expr(receiver);
+                self.output.push('.');
+                self.output.push_str(method_name);
+                if !type_args.is_empty() {
+                    self.output.push_str("::<");
+                    for (i, type_arg) in type_args.iter().enumerate() {
+                        if i > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.output.push_str(&self.type_table.type_name(*type_arg));
+                    }
+                    self.output.push('>');
+                }
+                self.output.push('(');
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_expr(arg);
+                }
+                self.output.push(')');
+            }
+            TirExprKind::FieldAccess {
+                expr: inner,
+                field_name,
+                ..
+            } => {
+                self.unparse_expr(inner);
+                self.output.push('.');
+                self.output.push_str(field_name);
+            }
+            TirExprKind::Index { expr: array, index } => {
+                self.unparse_expr(array);
+                self.output.push('[');
+                self.unparse_expr(index);
+                self.output.push(']');
+            }
+            TirExprKind::Block(block) => {
+                self.output.push_str("{\n");
+                self.indent_level += 1;
+                self.unparse_block(block);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push('}');
+            }
+            TirExprKind::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.output.push_str("if ");
+                self.unparse_expr(condition);
+                self.output.push_str(" {\n");
+                self.indent_level += 1;
+                self.unparse_block(then_branch);
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push('}');
+                if let Some(else_blk) = else_branch {
+                    self.output.push_str(" else {\n");
+                    self.indent_level += 1;
+                    self.unparse_block(else_blk);
+                    self.indent_level -= 1;
+                    self.write_indent();
+                    self.output.push('}');
+                }
+            }
+            TirExprKind::Match {
+                expr: scrutinee,
+                arms,
+            } => {
+                self.output.push_str("match ");
+                self.unparse_expr(scrutinee);
+                self.output.push_str(" {\n");
+                self.indent_level += 1;
+                for arm in arms {
+                    self.write_indent();
+                    self.unparse_pattern(&arm.pattern);
+                    self.output.push_str(" => ");
+                    self.unparse_expr(&arm.body);
+                    self.output.push_str(",\n");
+                }
+                self.indent_level -= 1;
+                self.write_indent();
+                self.output.push('}');
+            }
+            TirExprKind::StructLiteral {
+                struct_name,
+                fields,
+                ..
+            } => {
+                self.output.push_str(struct_name);
+                self.output.push_str(" { ");
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.output.push_str(&field.name);
+                    self.output.push_str(": ");
+                    self.unparse_expr(&field.value);
+                }
+                self.output.push_str(" }");
+            }
+            TirExprKind::ArrayLiteral { elements } => {
+                self.output.push('[');
+                for (i, elem) in elements.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_expr(elem);
+                }
+                self.output.push(']');
+            }
+            TirExprKind::TupleLiteral { elements } => {
+                self.output.push('[');
+                for (i, elem) in elements.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_expr(elem);
+                }
+                self.output.push(']');
+            }
+            TirExprKind::Closure { params, body, .. } => {
+                self.output.push('|');
+                for (i, (name, type_id)) in params.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.output.push_str(name);
+                    self.output.push_str(": ");
+                    self.output.push_str(&self.type_table.type_name(*type_id));
+                }
+                self.output.push_str("| ");
+                self.unparse_expr(body);
+            }
+        }
+    }
+
+    fn unparse_pattern(&mut self, pattern: &TirPattern) {
+        match pattern {
+            TirPattern::Wildcard => self.output.push('_'),
+            TirPattern::Binding { name, .. } => self.output.push_str(name),
+            TirPattern::Literal(lit) => {
+                use crate::tir::TirLiteralPattern;
+                match lit {
+                    TirLiteralPattern::Int(v) => self.output.push_str(&v.to_string()),
+                    TirLiteralPattern::Bool(b) => {
+                        self.output.push_str(if *b { "true" } else { "false" })
+                    }
+                    TirLiteralPattern::Char(c) => {
+                        self.output.push('\'');
+                        self.output.push(*c);
+                        self.output.push('\'');
+                    }
+                    TirLiteralPattern::String(s) => {
+                        self.output.push('"');
+                        self.output.push_str(s);
+                        self.output.push('"');
+                    }
+                    TirLiteralPattern::Null => self.output.push_str("null"),
+                }
+            }
+            TirPattern::Tuple(patterns) => {
+                self.output.push('(');
+                for (i, p) in patterns.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_pattern(p);
+                }
+                self.output.push(')');
+            }
+            TirPattern::Variant {
+                variant_name,
+                bindings,
+                ..
+            } => {
+                self.output.push_str(variant_name);
+                if !bindings.is_empty() {
+                    self.output.push('(');
+                    for (i, b) in bindings.iter().enumerate() {
+                        if i > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.unparse_pattern(b);
+                    }
+                    self.output.push(')');
+                }
+            }
+        }
+    }
+
+    fn write_indent(&mut self) {
+        for _ in 0..self.indent_level {
+            self.output.push_str("    ");
+        }
+    }
+}
+
+fn tir_binary_op_str(op: TirBinaryOp) -> &'static str {
+    match op {
+        TirBinaryOp::Add => "+",
+        TirBinaryOp::Sub => "-",
+        TirBinaryOp::Mul => "*",
+        TirBinaryOp::Div => "/",
+        TirBinaryOp::Mod => "%",
+        TirBinaryOp::Eq => "==",
+        TirBinaryOp::NotEq => "!=",
+        TirBinaryOp::Lt => "<",
+        TirBinaryOp::LtEq => "<=",
+        TirBinaryOp::Gt => ">",
+        TirBinaryOp::GtEq => ">=",
+        TirBinaryOp::And => "&&",
+        TirBinaryOp::Or => "||",
+        TirBinaryOp::BitAnd => "&",
+        TirBinaryOp::BitOr => "|",
+        TirBinaryOp::BitXor => "^",
+        TirBinaryOp::Shl => "<<",
+        TirBinaryOp::Shr => ">>",
+    }
+}
+
+fn tir_unary_op_str(op: TirUnaryOp) -> &'static str {
+    match op {
+        TirUnaryOp::Neg => "-",
+        TirUnaryOp::Not => "!",
+        TirUnaryOp::BitNot => "~",
+        TirUnaryOp::Ref => "&",
+        TirUnaryOp::MutRef => "&mut ",
+        TirUnaryOp::Deref => "*",
+    }
+}
+
+/// Public function to unparse TIR module to pseudo-Wado source
+pub fn unparse_tir(module: &TirModule) -> String {
+    let unparser = TirUnparser::new(&module.type_table);
+    unparser.unparse(module)
 }
 
 #[cfg(test)]

--- a/wado-compiler/src/wasi_registry.rs
+++ b/wado-compiler/src/wasi_registry.rs
@@ -459,6 +459,17 @@ impl WasiRegistry {
                     effects: func_ty.effects.clone(),
                 }))
             }
+            // NamespacedGeneric types (like builtin::array<T>) are passed through
+            Type::NamespacedGeneric(ng) => {
+                let resolved_args: Vec<Type> =
+                    ng.args.iter().map(|arg| self.resolve_type(arg)).collect();
+                Type::NamespacedGeneric(crate::ast::NamespacedGenericType {
+                    namespace: ng.namespace.clone(),
+                    name: ng.name.clone(),
+                    args: resolved_args,
+                    span: ng.span,
+                })
+            }
         }
     }
 }

--- a/wado-compiler/src/wasm_builder.rs
+++ b/wado-compiler/src/wasm_builder.rs
@@ -111,11 +111,12 @@ impl CoreModuleBuilder {
     }
 
     /// Define a GC struct type and return its index
+    /// Uses is_final: false to allow more flexible subtyping with exact types
     pub fn define_gc_struct_type(&mut self, name: &str, fields: &[FieldType]) -> u32 {
         use wasm_encoder::StructType;
         let idx = self.next_type_idx;
         self.types.ty().subtype(&SubType {
-            is_final: true,
+            is_final: false, // Non-final allows (ref (exact $T)) to be subtype of (ref $T)
             supertype_idx: None,
             composite_type: CompositeType {
                 inner: CompositeInnerType::Struct(StructType {

--- a/wado-compiler/tests/fixtures/generic_array_of_generic.wado
+++ b/wado-compiler/tests/fixtures/generic_array_of_generic.wado
@@ -1,0 +1,19 @@
+// Test: Array of generic structs (nested generics)
+use { println, Stdout } from "core:cli";
+
+struct Pair<A, B> {
+    first: A,
+    second: B,
+}
+
+fn run() with Stdout {
+    // Array of generic struct
+    let pairs: Array<Pair<i32, String>> = [Pair { first: 1, second: "one" }, Pair { first: 2, second: "two" }];
+
+
+    println(`pairs[0]: ({pairs[0].first}, {pairs[0].second})`);
+    println(`pairs[1]: ({pairs[1].first}, {pairs[1].second})`);
+}
+
+__DATA__
+{"stdout": "pairs[0]: (1, one)\npairs[1]: (2, two)\n"}

--- a/wado-compiler/tests/fixtures/generic_array_of_struct.wado
+++ b/wado-compiler/tests/fixtures/generic_array_of_struct.wado
@@ -1,0 +1,19 @@
+// Test: Array of structs
+use { println, Stdout } from "core:cli";
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn run() with Stdout {
+    // Array of non-generic struct
+    let points: Array<Point> = [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
+
+
+    println(`points[0]: ({points[0].x}, {points[0].y})`);
+    println(`points[1]: ({points[1].x}, {points[1].y})`);
+}
+
+__DATA__
+{"stdout": "points[0]: (1, 2)\npoints[1]: (3, 4)\n"}

--- a/wado-compiler/tests/fixtures/generic_function_basic.wado
+++ b/wado-compiler/tests/fixtures/generic_function_basic.wado
@@ -1,0 +1,16 @@
+// Test: Basic generic function with turbofish syntax
+use { println, Stdout } from "core:cli";
+
+fn identity<T>(x: T) -> T {
+    return x;
+}
+
+fn run() with Stdout {
+    let a = identity::<i32>(42);
+    let b = identity::<i64>(100 as i64);
+    println(`a: {a}`);
+    println(`b: {b}`);
+}
+
+__DATA__
+{"stdout": "a: 42\nb: 100\n"}

--- a/wado-compiler/tests/fixtures/generic_function_calls_generic.wado
+++ b/wado-compiler/tests/fixtures/generic_function_calls_generic.wado
@@ -1,0 +1,23 @@
+// Test: Generic function that calls another generic function (with concrete type)
+use { println, Stdout } from "core:cli";
+
+fn identity<T>(x: T) -> T {
+    return x;
+}
+
+fn wrap_identity_i32(x: i32) -> i32 {
+    return identity::<i32>(x);
+}
+
+fn wrap_identity_i64(x: i64) -> i64 {
+    return identity::<i64>(x);
+}
+
+fn run() with Stdout {
+    let a = wrap_identity_i32(42);
+    let b = wrap_identity_i64(100 as i64);
+    println(`a: {a}, b: {b}`);
+}
+
+__DATA__
+{"stdout": "a: 42, b: 100\n"}

--- a/wado-compiler/tests/fixtures/generic_function_multi_instantiations.wado
+++ b/wado-compiler/tests/fixtures/generic_function_multi_instantiations.wado
@@ -1,0 +1,18 @@
+// Test: Same generic function instantiated with many different types
+use { println, Stdout } from "core:cli";
+
+fn identity<T>(x: T) -> T {
+    return x;
+}
+
+fn run() with Stdout {
+    let a = identity::<i32>(1);
+    let b = identity::<i64>(2 as i64);
+    let c = identity::<f32>(3.5 as f32);
+    let d = identity::<f64>(4.5);
+    let e = identity::<bool>(true);
+    println(`{a} {b} {c} {d} {e}`);
+}
+
+__DATA__
+{"stdout": "1 2 3.5 4.5 true\n"}

--- a/wado-compiler/tests/fixtures/generic_function_multi_params.wado
+++ b/wado-compiler/tests/fixtures/generic_function_multi_params.wado
@@ -1,0 +1,20 @@
+// Test: Generic function with multiple type parameters
+use { println, Stdout } from "core:cli";
+
+fn first<T, U>(x: T, y: U) -> T {
+    return x;
+}
+
+fn second<T, U>(x: T, y: U) -> U {
+    return y;
+}
+
+fn run() with Stdout {
+    let a = first::<i32, i64>(10, 20 as i64);
+    let b = second::<i32, i64>(30, 40 as i64);
+    println(`a: {a}`);
+    println(`b: {b}`);
+}
+
+__DATA__
+{"stdout": "a: 10\nb: 40\n"}

--- a/wado-compiler/tests/fixtures/generic_function_nested_calls.wado
+++ b/wado-compiler/tests/fixtures/generic_function_nested_calls.wado
@@ -1,0 +1,15 @@
+// Test: Nested generic function calls
+use { println, Stdout } from "core:cli";
+
+fn identity<T>(x: T) -> T {
+    return x;
+}
+
+fn run() with Stdout {
+    // Nested calls: identity(identity(identity(42)))
+    let result = identity::<i32>(identity::<i32>(identity::<i32>(42)));
+    println(`result: {result}`);
+}
+
+__DATA__
+{"stdout": "result: 42\n"}

--- a/wado-compiler/tests/fixtures/generic_function_returns_struct.wado
+++ b/wado-compiler/tests/fixtures/generic_function_returns_struct.wado
@@ -1,0 +1,24 @@
+// Test: Function that returns a generic struct (non-generic function)
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn make_box_i32(v: i32) -> Box<i32> {
+    return Box { value: v };
+}
+
+fn make_box_i64(v: i64) -> Box<i64> {
+    return Box { value: v };
+}
+
+fn run() with Stdout {
+    let b1 = make_box_i32(42);
+    let b2 = make_box_i64(100 as i64);
+    println(`b1: {b1.value}`);
+    println(`b2: {b2.value}`);
+}
+
+__DATA__
+{"stdout": "b1: 42\nb2: 100\n"}

--- a/wado-compiler/tests/fixtures/generic_function_two_params_swap.wado
+++ b/wado-compiler/tests/fixtures/generic_function_two_params_swap.wado
@@ -1,0 +1,20 @@
+// Test: Generic function with two type params doing different operations
+use { println, Stdout } from "core:cli";
+
+fn first<T, U>(a: T, b: U) -> T {
+    return a;
+}
+
+fn second<T, U>(a: T, b: U) -> U {
+    return b;
+}
+
+fn run() with Stdout {
+    let x = first::<i32, i64>(10, 20 as i64);
+    let y = second::<i32, i64>(10, 20 as i64);
+    let z = first::<String, i32>("hello", 42);
+    println(`x: {x}, y: {y}, z: {z}`);
+}
+
+__DATA__
+{"stdout": "x: 10, y: 20, z: hello\n"}

--- a/wado-compiler/tests/fixtures/generic_function_with_ref.wado
+++ b/wado-compiler/tests/fixtures/generic_function_with_ref.wado
@@ -1,0 +1,17 @@
+// Test: Generic function with reference parameter
+use { println, Stdout } from "core:cli";
+
+fn get_value<T>(r: &T) -> T {
+    return *r;
+}
+
+fn run() with Stdout {
+    let x = 42;
+    let y = 100 as i64;
+    let a = get_value::<i32>(&x);
+    let b = get_value::<i64>(&y);
+    println(`a: {a}, b: {b}`);
+}
+
+__DATA__
+{"stdout": "a: 42, b: 100\n"}

--- a/wado-compiler/tests/fixtures/generic_function_with_string.wado
+++ b/wado-compiler/tests/fixtures/generic_function_with_string.wado
@@ -1,0 +1,14 @@
+// Test: Generic function with String type
+use { println, Stdout } from "core:cli";
+
+fn identity<T>(x: T) -> T {
+    return x;
+}
+
+fn run() with Stdout {
+    let s = identity::<String>("hello");
+    println(`s: {s}`);
+}
+
+__DATA__
+{"stdout": "s: hello\n"}

--- a/wado-compiler/tests/fixtures/generic_method_basic.wado
+++ b/wado-compiler/tests/fixtures/generic_method_basic.wado
@@ -1,0 +1,21 @@
+// Test: Basic generic method with turbofish syntax
+use { println, Stdout } from "core:cli";
+
+struct Container {
+    value: i32,
+}
+
+impl Container {
+    fn transform<T>(&self, other: T) -> T {
+        return other;
+    }
+}
+
+fn run() with Stdout {
+    let c = Container { value: 42 };
+    let result = c.transform::<i64>(100 as i64);
+    println(`result: {result}`);
+}
+
+__DATA__
+{"stdout": "result: 100\n"}

--- a/wado-compiler/tests/fixtures/generic_method_multi_params.wado
+++ b/wado-compiler/tests/fixtures/generic_method_multi_params.wado
@@ -1,0 +1,28 @@
+// Test: Generic method with multiple type parameters
+use { println, Stdout } from "core:cli";
+
+struct Pair {
+    first: i32,
+    second: i32,
+}
+
+impl Pair {
+    fn combine<T, U>(&self, a: T, b: U) -> T {
+        return a;
+    }
+
+    fn swap<T, U>(&self, a: T, b: U) -> U {
+        return b;
+    }
+}
+
+fn run() with Stdout {
+    let p = Pair { first: 1, second: 2 };
+    let x = p.combine::<i32, i64>(10, 20 as i64);
+    let y = p.swap::<i32, i64>(30, 40 as i64);
+    println(`x: {x}`);
+    println(`y: {y}`);
+}
+
+__DATA__
+{"stdout": "x: 10\ny: 40\n"}

--- a/wado-compiler/tests/fixtures/generic_method_on_generic_struct.wado
+++ b/wado-compiler/tests/fixtures/generic_method_on_generic_struct.wado
@@ -1,0 +1,22 @@
+// Test: Generic method on a non-generic struct
+use { println, Stdout } from "core:cli";
+
+struct Wrapper {
+    value: i32,
+}
+
+impl Wrapper {
+    fn convert<U>(&self, other: U) -> U {
+        return other;
+    }
+}
+
+fn run() with Stdout {
+    let w = Wrapper { value: 42 };
+    let x = w.convert::<i64>(100 as i64);
+    let y = w.convert::<f64>(3.14);
+    println(`x: {x}, y: {y}`);
+}
+
+__DATA__
+{"stdout": "x: 100, y: 3.14\n"}

--- a/wado-compiler/tests/fixtures/generic_method_returns_self_field.wado
+++ b/wado-compiler/tests/fixtures/generic_method_returns_self_field.wado
@@ -1,0 +1,26 @@
+// Test: Generic method that uses self's field in computation
+use { println, Stdout } from "core:cli";
+
+struct Holder {
+    base: i32,
+}
+
+impl Holder {
+    fn add_to<T>(&self, x: T) -> T {
+        return x;
+    }
+
+    fn get_base(&self) -> i32 {
+        return self.base;
+    }
+}
+
+fn run() with Stdout {
+    let h = Holder { base: 10 };
+    let x = h.add_to::<i32>(5);
+    let b = h.get_base();
+    println(`x: {x}, base: {b}`);
+}
+
+__DATA__
+{"stdout": "x: 5, base: 10\n"}

--- a/wado-compiler/tests/fixtures/generic_struct.wado
+++ b/wado-compiler/tests/fixtures/generic_struct.wado
@@ -1,0 +1,14 @@
+// Test: generic struct basic usage
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn run() with Stdout {
+    let b = Box { value: 42 };
+    println(`value: {b.value}`);
+}
+
+__DATA__
+{"stdout": "value: 42\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_explicit.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_explicit.wado
@@ -1,0 +1,28 @@
+// Test: generic struct with explicit type annotations
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn run() with Stdout {
+    // Explicit type annotations
+    let i32_box: Box<i32> = Box { value: 42 };
+    let i64_box: Box<i64> = Box { value: 9999999999 as i64 };
+    let f32_box: Box<f32> = Box { value: 2.5 as f32 };
+    let f64_box: Box<f64> = Box { value: 3.14159 };
+    let bool_box: Box<bool> = Box { value: false };
+    let char_box: Box<char> = Box { value: 'Z' };
+    let str_box: Box<String> = Box { value: "world" };
+
+    println(`i32: {i32_box.value}`);
+    println(`i64: {i64_box.value}`);
+    println(`f32: {f32_box.value}`);
+    println(`f64: {f64_box.value}`);
+    println(`bool: {bool_box.value}`);
+    println(`char: {char_box.value}`);
+    println(`str: {str_box.value}`);
+}
+
+__DATA__
+{"stdout": "i32: 42\ni64: 9999999999\nf32: 2.5\nf64: 3.14159\nbool: false\nchar: Z\nstr: world\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_func.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_func.wado
@@ -1,0 +1,23 @@
+// Test: generic struct as function parameter and return value
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn make_box(v: i32) -> Box<i32> {
+    return Box { value: v };
+}
+
+fn get_value(b: Box<i32>) -> i32 {
+    return b.value;
+}
+
+fn run() with Stdout {
+    let b = make_box(42);
+    let v = get_value(b);
+    println(`value: {v}`);
+}
+
+__DATA__
+{"stdout": "value: 42\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_impl.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_impl.wado
@@ -1,0 +1,21 @@
+// Test: generic struct with impl block
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+impl Box<i32> {
+    fn get(&self) -> i32 {
+        return self.value;
+    }
+}
+
+fn run() with Stdout {
+    let b = Box { value: 42 };
+    let v = b.get();
+    println(`{v}`);
+}
+
+__DATA__
+{"stdout": "42\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_multi_params.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_multi_params.wado
@@ -1,0 +1,15 @@
+// Test: generic struct with multiple type parameters
+use { println, Stdout } from "core:cli";
+
+struct Pair<A, B> {
+    first: A,
+    second: B,
+}
+
+fn run() with Stdout {
+    let p = Pair { first: 42, second: "hello" };
+    println(`first: {p.first}, second: {p.second}`);
+}
+
+__DATA__
+{"stdout": "first: 42, second: hello\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_mut.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_mut.wado
@@ -1,0 +1,16 @@
+// Test: generic struct with mutable field access
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn run() with Stdout {
+    let mut b = Box { value: 10 };
+    println(`before: {b.value}`);
+    b.value = 42;
+    println(`after: {b.value}`);
+}
+
+__DATA__
+{"stdout": "before: 10\nafter: 42\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_nested.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_nested.wado
@@ -1,0 +1,15 @@
+// Test: nested generic types (Box containing Box)
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn run() with Stdout {
+    let inner = Box { value: 42 };
+    let outer = Box { value: inner };
+    println(`nested value: {outer.value.value}`);
+}
+
+__DATA__
+{"stdout": "nested value: 42\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_types.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_types.wado
@@ -1,0 +1,23 @@
+// Test: generic struct with different primitive types
+use { println, Stdout } from "core:cli";
+
+struct Box<T> {
+    value: T,
+}
+
+fn run() with Stdout {
+    let int_box = Box { value: 42 };
+    let float_box = Box { value: 3.14 };
+    let str_box = Box { value: "hello" };
+    let bool_box = Box { value: true };
+    let char_box = Box { value: 'A' };
+
+    println(`i32: {int_box.value}`);
+    println(`f64: {float_box.value}`);
+    println(`str: {str_box.value}`);
+    println(`bool: {bool_box.value}`);
+    println(`char: {char_box.value}`);
+}
+
+__DATA__
+{"stdout": "i32: 42\nf64: 3.14\nstr: hello\nbool: true\nchar: A\n"}

--- a/wado-compiler/tests/fixtures/generic_struct_with_struct.wado
+++ b/wado-compiler/tests/fixtures/generic_struct_with_struct.wado
@@ -1,0 +1,29 @@
+// Test: generic struct with struct type parameters
+use { println, Stdout } from "core:cli";
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+struct Pair<A, B> {
+    first: A,
+    second: B,
+}
+
+struct Box<T> {
+    value: T,
+}
+
+fn run() with Stdout {
+    // Box containing a non-generic struct
+    let point_box = Box { value: Point { x: 10, y: 20 } };
+    println(`point: ({point_box.value.x}, {point_box.value.y})`);
+
+    // Box containing a generic struct
+    let pair_box = Box { value: Pair { first: 1, second: "one" } };
+    println(`pair: ({pair_box.value.first}, {pair_box.value.second})`);
+}
+
+__DATA__
+{"stdout": "point: (10, 20)\npair: (1, one)\n"}


### PR DESCRIPTION
Add support for generic functions and methods with explicit type arguments using turbofish syntax (`::<T>`). This includes:

- Generic function parsing and resolution (`fn identity<T>(x: T) -> T`)
- Generic method parsing and resolution (`impl T { fn foo<U>(&self) }`)
- Monomorphization for both functions and methods in lower.rs
- TIR unparser for debugging (`wado dump --tir --unparse`)
- Test fixtures for generic structs, functions, and methods

The turbofish syntax was chosen over `foo<T>(...)` to avoid parsing ambiguity with comparison operators and future JSX support.