### PR TITLE
add `make install-deps`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,12 +206,27 @@ Format: `docs/adr-YYYY-MM-DD-feature-name.md`
 You can use `cargo` to manage the project, and also `Makefile` is provided for convenience:
 
 ```sh
+make install-deps  # install all dependency tools (wasm-tools, wasmtime, etc.)
+
 make build
 make test
 
 make hello     # generates example/hello.wat and example/hello.wasm
 make hello-run # simple smoke test
 ```
+
+### Dependencies
+
+Run `make install-deps` to install the required tools:
+
+- `wasm32-unknown-unknown` Rust target (for wado-bundled)
+- `wasm-tools` (for WAT generation)
+- `wasmtime-cli` (for running Wasm)
+
+Prerequisites (install manually):
+
+- `rustup` and `cargo` (Rust toolchain)
+- `npx` (Node.js package runner, for prettier in `make format`)
 
 ## On Your Task Done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,19 +215,6 @@ make hello     # generates example/hello.wat and example/hello.wasm
 make hello-run # simple smoke test
 ```
 
-### Dependencies
-
-Run `make install-deps` to install the required tools:
-
-- `wasm32-unknown-unknown` Rust target (for wado-bundled)
-- `wasm-tools` (for WAT generation)
-- `wasmtime-cli` (for running Wasm)
-
-Prerequisites (install manually):
-
-- `rustup` and `cargo` (Rust toolchain)
-- `npx` (Node.js package runner, for prettier in `make format`)
-
 ## On Your Task Done
 
 When you have completed a task, make sure everything is up-to-date and tested:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: install-deps
 install-deps:
+	@echo "Prerequisites (install manually if not present):"
+	@echo "  - rustup (Rust toolchain manager)"
+	@echo "  - cargo (Rust package manager)"
+	@echo "  - npx (Node.js package runner, for 'make format')"
+	@echo ""
 	@echo "Installing Rust wasm32-unknown-unknown target..."
 	rustup target add wasm32-unknown-unknown
 	@echo ""
@@ -10,16 +15,6 @@ install-deps:
 	cargo install wasmtime-cli
 	@echo ""
 	@echo "All dependencies installed successfully."
-	@echo ""
-	@echo "Required tools (install manually if not present):"
-	@echo "  - rustup (Rust toolchain manager)"
-	@echo "  - cargo (Rust package manager)"
-	@echo "  - npx (Node.js package runner, for prettier)"
-	@echo ""
-	@echo "Optional dependencies for benchmarks:"
-	@echo "  - cc (C compiler)"
-	@echo "  - node (Node.js)"
-	@echo "  - python3 (Python 3)"
 
 .PHONY: build
 build: wado-compiler/lib/builtins/wado-bundled.wat

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,26 @@
+.PHONY: install-deps
+install-deps:
+	@echo "Installing Rust wasm32-unknown-unknown target..."
+	rustup target add wasm32-unknown-unknown
+	@echo ""
+	@echo "Installing wasm-tools..."
+	cargo install wasm-tools
+	@echo ""
+	@echo "Installing wasmtime..."
+	cargo install wasmtime-cli
+	@echo ""
+	@echo "All dependencies installed successfully."
+	@echo ""
+	@echo "Required tools (install manually if not present):"
+	@echo "  - rustup (Rust toolchain manager)"
+	@echo "  - cargo (Rust package manager)"
+	@echo "  - npx (Node.js package runner, for prettier)"
+	@echo ""
+	@echo "Optional dependencies for benchmarks:"
+	@echo "  - cc (C compiler)"
+	@echo "  - node (Node.js)"
+	@echo "  - python3 (Python 3)"
+
 .PHONY: build
 build: wado-compiler/lib/builtins/wado-bundled.wat
 	cargo build

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,6 +28,14 @@ Counts prime numbers up to 10,000,000 using trial division.
 make benchmark-count-prime
 ```
 
+## Prerequisites
+
+To run all benchmarks, ensure you have the following tools installed:
+
+- `cc` (C compiler, e.g., clang or gcc)
+- `node` (Node.js)
+- `python3` (Python 3)
+
 ## Running Benchmarks
 
 ```bash


### PR DESCRIPTION
Installs wasm32-unknown-unknown Rust target, wasm-tools, and wasmtime-cli. Documents dependencies and prerequisites in AGENTS.md.