### PR TITLE
Speed up cargo test with linker and runtime optimizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,21 @@
+# Cargo configuration for faster builds and tests
+
+[build]
+# Use lld linker for faster linking (much faster than default ld)
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+# Parallel codegen units for faster compilation
+# Default is 16 for dev builds, but we can tune this
+# Lower values = better optimization but slower compile
+# Higher values = faster compile but less optimization
+# For tests, we want faster compile time
+[profile.dev]
+codegen-units = 256  # Maximum parallelism
+
+[profile.test]
+# Inherit from dev but we can override specific settings
+inherits = "dev"
+codegen-units = 256  # Maximum parallelism for test builds
+
+# Optional: uncomment for incremental compilation (enabled by default for dev/test)
+# incremental = true

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -4,7 +4,7 @@
 //! correct error types, messages, and source locations.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use wado_compiler::{CompileError, CompilerHost, Diagnostic, OptLevel, SourceError};
 
 // ============================================================================
@@ -71,18 +71,24 @@ impl CompilerHost for FilesystemTestHost {
     }
 }
 
-/// Create a tokio runtime for blocking on async code
-fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
+/// Shared tokio runtime for all tests (initialized once)
+static TOKIO_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Get or initialize the shared tokio runtime
+fn get_runtime() -> &'static tokio::runtime::Runtime {
+    TOKIO_RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime")
+    })
 }
 
 /// Compile source string using in-memory host
 fn compile(source: &str) -> Result<wado_compiler::CompileResult, CompileError> {
     let host = InMemoryTestHost;
-    runtime().block_on(wado_compiler::compile_with_host(
+    let rt = get_runtime();
+    rt.block_on(wado_compiler::compile_with_host(
         source,
         &host,
         None,
@@ -100,7 +106,8 @@ fn compile_file(path: &Path) -> Result<wado_compiler::CompileResult, CompileErro
     let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let host = FilesystemTestHost::new(base_path);
 
-    runtime().block_on(wado_compiler::compile_with_host(
+    let rt = get_runtime();
+    rt.block_on(wado_compiler::compile_with_host(
         &source,
         &host,
         Some(&path.to_string_lossy()),

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -77,17 +77,14 @@ fn compile_file_with_opts(
     let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let host = TestCompilerHost::new(base_path);
 
-    // Compile using async API (use tokio runtime)
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(wado_compiler::compile_with_host(
-            &source,
-            &host,
-            Some(&path.to_string_lossy()),
-            opt_level,
-        ))
+    // Compile using async API (use shared tokio runtime)
+    let rt = get_runtime();
+    rt.block_on(wado_compiler::compile_with_host(
+        &source,
+        &host,
+        Some(&path.to_string_lossy()),
+        opt_level,
+    ))
 }
 
 /// Shared wasmtime Engine for all tests (initialized once)


### PR DESCRIPTION
This commit implements several optimizations to significantly reduce
cargo test execution time:

1. Use lld linker for faster linking (via .cargo/config.toml)
2. Increase codegen-units to 256 for maximum parallelism
3. Share tokio runtime across all test compilations instead of
   creating a new runtime for each test

Changes:
- .cargo/config.toml: Configure lld linker and codegen-units
- wado-compiler/tests/e2e.rs: Use shared runtime for compilation
- wado-compiler/tests/compile_errors.rs: Use shared runtime

The E2E tests run 768 test cases (256 fixtures × 3 optimization levels),
each compiling Wado to Wasm and running it. These optimizations reduce
the overhead of test execution without reducing test coverage.