### PR TITLE
Implement Dict<K, V> as user-defined generic struct

### DIFF
--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -79,6 +79,106 @@ impl Array<T> {
     }
 }
 
+/// Dictionary type with insertion-order preservation
+/// Uses linear search - suitable for small dictionaries
+pub struct Dict<K, V> {
+    keys_repr: builtin::array<K>,
+    keys_used: i32,
+    values_repr: builtin::array<V>,
+    values_used: i32,
+}
+
+impl Dict<K, V> {
+    /// Create a new empty dictionary
+    pub fn new() -> Dict<K, V> {
+        return Dict {
+            keys_repr: builtin::array_new::<K>(4),
+            keys_used: 0,
+            values_repr: builtin::array_new::<V>(4),
+            values_used: 0,
+        };
+    }
+
+    /// Get the number of key-value pairs in the dictionary
+    pub fn len(&self) -> i32 {
+        return self.keys_used;
+    }
+
+    /// Check if a key exists in the dictionary
+    pub fn has(&self, key: K) -> bool {
+        let len = self.keys_used;
+        let mut i = 0;
+        while i < len {
+            let entry_key = builtin::array_get::<K>(self.keys_repr, i);
+            if entry_key == key {
+                return true;
+            }
+            i += 1;
+        }
+        return false;
+    }
+
+    /// Get the value associated with a key
+    /// Panics if the key is not found
+    pub fn get(&self, key: K) -> V {
+        let len = self.keys_used;
+        let mut i = 0;
+        while i < len {
+            let entry_key = builtin::array_get::<K>(self.keys_repr, i);
+            if entry_key == key {
+                return builtin::array_get::<V>(self.values_repr, i);
+            }
+            i += 1;
+        }
+        panic("Dict: key not found");
+    }
+
+    /// Set the value for a key
+    /// If the key already exists, updates the value
+    /// If the key doesn't exist, appends a new entry
+    pub fn set(&mut self, key: K, value: V) {
+        let len = self.keys_used;
+        let mut i = 0;
+        while i < len {
+            let entry_key = builtin::array_get::<K>(self.keys_repr, i);
+            if entry_key == key {
+                // Update existing value
+                builtin::array_set::<V>(self.values_repr, i, value);
+                return;
+            }
+            i += 1;
+        }
+
+        // Key not found, append new entry
+        let used = self.keys_used;
+        let capacity = builtin::array_len(self.keys_repr);
+
+        // Grow if needed
+        if builtin::unlikely(used >= capacity) {
+            // Calculate new capacity: 4 if empty, otherwise double
+            let mut new_capacity = capacity * 2;
+            if capacity == 0 {
+                new_capacity = 4;
+            }
+
+            // Create new arrays and copy elements
+            let new_keys = builtin::array_new::<K>(new_capacity);
+            let new_values = builtin::array_new::<V>(new_capacity);
+            builtin::array_copy::<K>(new_keys, 0, self.keys_repr, 0, used);
+            builtin::array_copy::<V>(new_values, 0, self.values_repr, 0, used);
+            self.keys_repr = new_keys;
+            self.values_repr = new_values;
+        }
+
+        // Append the new entry
+        builtin::array_set::<K>(self.keys_repr, used, key);
+        builtin::array_set::<V>(self.values_repr, used, value);
+        self.keys_used = used + 1;
+        self.values_used = used + 1;
+    }
+
+}
+
 /// Traps with a message
 /// Logs the message to stderr (ambient, no effect required) and traps.
 pub fn panic(message: String) -> ! {

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -517,11 +517,7 @@ impl Codegen {
             | ResolvedType::Stream(inner)
             | ResolvedType::Future(inner)
             | ResolvedType::Reactive(inner) => Self::get_struct_dependencies(type_table, *inner),
-            ResolvedType::Result { ok, err }
-            | ResolvedType::Dict {
-                key: ok,
-                value: err,
-            } => {
+            ResolvedType::Result { ok, err } => {
                 let mut deps = Self::get_struct_dependencies(type_table, *ok);
                 deps.extend(Self::get_struct_dependencies(type_table, *err));
                 deps
@@ -4171,9 +4167,6 @@ impl Codegen {
             }
             ResolvedType::Variant { .. } => {
                 panic!("Variant type codegen not yet implemented")
-            }
-            ResolvedType::Dict { .. } => {
-                panic!("Dict type codegen not yet implemented")
             }
 
             // Placeholder types (shouldn't appear in final TIR)

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -3918,17 +3918,6 @@ impl<'a> Resolver<'a> {
                     .unwrap_or(TypeTable::UNKNOWN);
                 self.type_table.intern(ResolvedType::Future(elem))
             }
-            "Dict" => {
-                let key = args
-                    .first()
-                    .map(|t| self.resolve_type(t))
-                    .unwrap_or(TypeTable::UNKNOWN);
-                let value = args
-                    .get(1)
-                    .map(|t| self.resolve_type(t))
-                    .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.intern(ResolvedType::Dict { key, value })
-            }
             _ => {
                 // Check if it's a user-defined generic struct
                 if self.generic_struct_names.contains(name) {

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -87,7 +87,7 @@ impl SyntaxDefinition {
             },
             builtin_types: vec![
                 "i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "f32", "f64",
-                "bool", "char", "String", "Array", "Option", "Result", "Dict", "Fn",
+                "bool", "char", "String", "Array", "Option", "Result", "Fn",
             ],
             constants: vec!["true", "false", "null", "self"],
             comments: CommentStyles {

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -168,14 +168,6 @@ impl SubstitutionContext {
                 let new_inner = self.substitute(inner, type_table);
                 type_table.intern(ResolvedType::Future(new_inner))
             }
-            ResolvedType::Dict { key, value } => {
-                let new_key = self.substitute(key, type_table);
-                let new_value = self.substitute(value, type_table);
-                type_table.intern(ResolvedType::Dict {
-                    key: new_key,
-                    value: new_value,
-                })
-            }
             ResolvedType::Reactive(inner) => {
                 let new_inner = self.substitute(inner, type_table);
                 type_table.intern(ResolvedType::Reactive(new_inner))
@@ -248,10 +240,6 @@ pub enum ResolvedType {
         effects: Vec<String>,
     },
     Tuple(Vec<TypeId>),
-    Dict {
-        key: TypeId,
-        value: TypeId,
-    },
     Reactive(TypeId),
     /// Type parameter (e.g., `T` in `struct Box<T>`)
     /// Used before monomorphization; should be substituted with concrete types
@@ -498,11 +486,9 @@ impl TypeTable {
             | ResolvedType::Stream(inner)
             | ResolvedType::Future(inner)
             | ResolvedType::Reactive(inner) => self.contains_type_param(*inner),
-            ResolvedType::Result { ok, err }
-            | ResolvedType::Dict {
-                key: ok,
-                value: err,
-            } => self.contains_type_param(*ok) || self.contains_type_param(*err),
+            ResolvedType::Result { ok, err } => {
+                self.contains_type_param(*ok) || self.contains_type_param(*err)
+            }
             ResolvedType::Tuple(elems) => elems.iter().any(|e| self.contains_type_param(*e)),
             ResolvedType::Function {
                 params,
@@ -573,9 +559,6 @@ impl TypeTable {
             ResolvedType::Variant { name, .. } => name.clone(),
             ResolvedType::Stream(inner) => format!("Stream<{}>", self.type_name(*inner)),
             ResolvedType::Future(inner) => format!("Future<{}>", self.type_name(*inner)),
-            ResolvedType::Dict { key, value } => {
-                format!("Dict<{}, {}>", self.type_name(*key), self.type_name(*value))
-            }
             ResolvedType::Reactive(inner) => format!("Reactive<{}>", self.type_name(*inner)),
             ResolvedType::TypeParam { name, .. } => name.clone(),
             ResolvedType::GenericInstance {

--- a/wado-compiler/tests/fixtures/dict-basic.wado
+++ b/wado-compiler/tests/fixtures/dict-basic.wado
@@ -1,0 +1,44 @@
+use {println, Stdout} from "core:cli";
+
+fn run() with Stdout {
+    // Create a new dict
+    let mut d = Dict::<String, i32>::new();
+
+    // Check empty dict
+    assert d.len() == 0;
+    assert !d.has("key1");
+
+    // Set some values
+    d.set("key1", 10);
+    d.set("key2", 20);
+    d.set("key3", 30);
+
+    // Check length
+    assert d.len() == 3;
+
+    // Check has
+    assert d.has("key1");
+    assert d.has("key2");
+    assert d.has("key3");
+    assert !d.has("key4");
+
+    // Check get
+    assert d.get("key1") == 10;
+    assert d.get("key2") == 20;
+    assert d.get("key3") == 30;
+
+    // Update existing key
+    d.set("key2", 200);
+    assert d.len() == 3;
+    assert d.get("key2") == 200;
+
+    // Print values to verify
+    println(`key1: {d.get("key1")}`);
+    println(`key2: {d.get("key2")}`);
+    println(`key3: {d.get("key3")}`);
+
+    println("All tests passed!");
+}
+
+__DATA__
+{"stdout": "key1: 10\nkey2: 200\nkey3: 30\nAll tests passed!\n"}

--- a/wado-compiler/tests/fixtures/dict-panic.wado
+++ b/wado-compiler/tests/fixtures/dict-panic.wado
@@ -1,0 +1,13 @@
+use {println, Stdout} from "core:cli";
+
+fn run() with Stdout {
+    let mut d = Dict::<String, i32>::new();
+    d.set("key1", 10);
+
+    // This should panic because "key2" doesn't exist
+    let value = d.get("key2");
+    println(`Value: {value}`);
+}
+
+__DATA__
+{"trapped": true, "stderr_contains": ["Dict: key not found"]}

--- a/wado-compiler/tests/fixtures/dict-simple.wado
+++ b/wado-compiler/tests/fixtures/dict-simple.wado
@@ -1,0 +1,10 @@
+use {println, Stdout} from "core:cli";
+
+fn run() with Stdout {
+    let mut d = Dict::<String, i32>::new();
+    let len = d.len();
+    println(`Length: {len}`);
+}
+
+__DATA__
+{"stdout": "Length: 0\n"}


### PR DESCRIPTION
- Remove built-in Dict type from compiler (syntax.rs, resolver.rs, tir.rs, codegen.rs)
- Implement Dict<K, V> in prelude.wado using linear search
- Methods: new(), len(), has(), get(), set()
- Uses separate builtin::array<K> and builtin::array<V> for storage
- Preserves insertion order

Note: Tests currently fail due to compiler limitation - codegen doesn't
support method calls on GenericInstance types. This is a broader issue
affecting all user-defined generic structs with methods.