### PR TITLE
Fix parser bug with nested generic types (e.g., Array<Foo<T>>)

### DIFF
--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -1898,7 +1898,8 @@ impl Parser {
             if self.check(&TokenKind::Lt) {
                 self.advance();
                 let mut args = vec![self.parse_type()?];
-                while self.check(&TokenKind::Comma) {
+                // Continue parsing args only if we see a comma AND we don't have a pending >
+                while !self.pending_gt && self.check(&TokenKind::Comma) {
                     self.advance();
                     args.push(self.parse_type()?);
                 }
@@ -1924,7 +1925,9 @@ impl Parser {
         if self.check(&TokenKind::Lt) {
             self.advance();
             let mut args = vec![self.parse_type()?];
-            while self.check(&TokenKind::Comma) {
+            // Continue parsing args only if we see a comma AND we don't have a pending >
+            // (pending_gt means we split >> and the outer > closes this type arg list)
+            while !self.pending_gt && self.check(&TokenKind::Comma) {
                 self.advance();
                 args.push(self.parse_type()?);
             }


### PR DESCRIPTION
This fixes a critical parser bug where nested generic types like
`Array<Pair<K, V>>` or `Array<Foo<i32>>` would fail to parse with
"expected identifier, found RBrace" error.

Root cause: When parsing type arguments, the comma-checking while loop
didn't account for the `pending_gt` flag that's set when >> is split
into two > tokens. This caused the parser to mistake the comma AFTER
the >> for a type argument separator.

Fix: Added `!self.pending_gt &&` condition to the while loops at:
- Line 1929 (regular generic types)
- Line 1902 (namespaced generic types)

This ensures that when we've virtually split >> into two >, we stop
parsing type arguments after consuming the first > (via pending_gt),
and don't mistakenly continue parsing when we see a comma that belongs
to outer syntax (like struct field separators).

Impact: Enables parsing of arbitrary nested generic types throughout
the language, not just for specific use cases.

Related investigation: This fix was discovered while attempting to
implement MiniDict<K, V>. While MiniDict cannot be fully implemented
yet due to codegen limitations with generic struct monomorphization,
this parser fix is valuable for other nested generic use cases.