### PR TITLE
Update WEP: Refine WebAssembly Module Import Strategy

### DIFF
--- a/docs/wep-2026-01-10-wasm-import.md
+++ b/docs/wep-2026-01-10-wasm-import.md
@@ -39,7 +39,8 @@ The compiler determines linking strategy based on component origin, not file ext
 use {helper} from "./lib.wado";
 
 // Wado-compiled component (detected via metadata)
-use {utils} from "./precompiled.wasm";  // If compiled by Wado compiler
+use {utils} from "./precompiled.wasm" with { type: "wasm" };
+// Has @custom "wado-compiler" marker → Zero overhead
 ```
 
 **Implementation**:
@@ -54,7 +55,8 @@ use {utils} from "./precompiled.wasm";  // If compiled by Wado compiler
 
 ```wado
 // External component (from Rust, C, AssemblyScript, etc.)
-use {compress} from "./zlib.wasm";  // No wado-compiler marker
+use {compress} from "./zlib.wasm" with { type: "wasm" };
+// No wado-compiler marker → Component Model boundary
 ```
 
 **Implementation**:
@@ -71,40 +73,38 @@ use {compress} from "./zlib.wasm";  // No wado-compiler marker
 // Wado source file (IR-level integration)
 use {helper} from "./lib.wado";
 
-// Wado-compiled component (auto-detected via metadata, core linking)
-use {utils} from "./precompiled.wasm";
-// Has @custom "wado-compiler" → Zero overhead, no annotation needed
+// Wado-compiled component (core linking via marker detection)
+use {utils} from "./precompiled.wasm" with { type: "wasm" };
+// Has @custom "wado-compiler" → Zero overhead
 
-// External Wasm component (Component Model boundary, annotation REQUIRED)
+// External Wasm component (Component Model boundary)
 use {sin, cos} from "./libm.wasm" with { type: "wasm" };
 // No "wado-compiler" marker → Type-safe interop
 
-// JSON import (for comparison)
+// JSON import
 use config from "./config.json" with { type: "json" };
 ```
 
-**Type annotation requirement**:
-- **Wado-compiled `.wasm`**: No annotation needed (detected via `@custom "wado-compiler"`)
-- **External `.wasm`**: `with { type: "wasm" }` **required**
+**Type annotation requirement (for security)**:
 - **`.wado` source**: No annotation needed (Wado source)
+- **All `.wasm` files**: `with { type: "wasm" }` **required**
+- **`.json` files**: `with { type: "json" }` **required**
+- **Rationale**: Explicit type declaration prevents accidental execution of untrusted code
 
 ### Type Annotation Rules
 
-| Import Source                 | `type` Attribute        | Format                  | Linking Strategy     |
-| ----------------------------- | ----------------------- | ----------------------- | -------------------- |
-| `.wado` files                 | Not applicable          | Wado source             | IR-level integration |
-| `.wasm` (Wado-compiled)       | Not required (optional) | Component + metadata    | Core Wasm linking    |
-| `.wasm` (External)            | **Required**            | `type: "wasm"`          | Component boundary   |
-| `.json` files                 | **Required**            | `type: "json"`          | Compile-time embed   |
-| `core:*`, `wasi:*` namespaces | Not applicable          | Special namespace       | IR-level integration |
-| `https:` URLs                 | **Required**            | Must specify content    | Depends on type      |
-| Future: `.wit` files          | **Required**            | `type: "wit"`           | Interface-only (TBD) |
+| Import Source                 | `type` Attribute | Format            | Linking Strategy     |
+| ----------------------------- | ---------------- | ----------------- | -------------------- |
+| `.wado` files                 | Not applicable   | Wado source       | IR-level integration |
+| `.wasm` files (any origin)    | **Required**     | `type: "wasm"`    | See detection logic  |
+| `.json` files                 | **Required**     | `type: "json"`    | Compile-time embed   |
+| `core:*`, `wasi:*` namespaces | Not applicable   | Special namespace | IR-level integration |
+| `https:` URLs                 | **Required**     | Must specify type | Depends on type      |
 
-**Detection logic**:
-1. If `with { type: "wasm" }` is present → External component (Component Model boundary)
-2. If no type annotation → Check for `@custom "wado-compiler"` marker:
-   - Has marker → Wado-compiled (Core Wasm linking)
-   - No marker → Error: External `.wasm` requires `with { type: "wasm" }`
+**Detection logic for `.wasm` imports** (after `type: "wasm"` validation):
+1. Check for `@custom "wado-compiler"` marker in component binary:
+   - Has marker → Wado-origin (Core Wasm linking, zero overhead)
+   - No marker → External (Component Model boundary, type-safe)
 
 ### WIT Requirements
 
@@ -117,11 +117,11 @@ use config from "./config.json" with { type: "json" };
 
 ### Implementation Requirements
 
-1. **Component Origin Detection**
-   - If `with { type: "wasm" }` is present → External component (skip marker check)
-   - If no type annotation → Check for `@custom "wado-compiler"` in component binary:
+1. **Import Validation and Origin Detection**
+   - Validate `.wasm` imports have `with { type: "wasm" }` (security requirement)
+   - Parse component binary and check for `@custom "wado-compiler"` marker:
      - If present: Wado-origin → Use core linking strategy
-     - If absent: Error - external `.wasm` requires `with { type: "wasm" }`
+     - If absent: External → Use Component Model boundary
    - Custom section format: `(custom "wado-compiler" "version=X.Y.Z")`
 
 2. **Component Model Binary Parsing**
@@ -148,34 +148,33 @@ use config from "./config.json" with { type: "json" };
 5. **Dual Linking Strategy**
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│ Wado Compiler                                               │
-├─────────────────────────────────────────────────────────────┤
-│ 1. Import resolution                                        │
-│    .wado → Parse as Wado source (IR integration)            │
-│    .wasm → Check type annotation:                           │
-│            ├─ with { type: "wasm" }? → External component   │
-│            └─ No annotation?                                │
-│                ├─ Has "wado-compiler" marker? → Wado-origin │
-│                └─ No marker? → Error (annotation required)  │
-│                                                             │
-│ 2. Type checking                                            │
-│    .wado / Wado-origin .wasm → Wado type system (internal)  │
-│    External .wasm → WIT type extraction + mapping           │
-│                                                             │
-│ 3. Code generation                                          │
-│    .wado → IR-level integration (no Wasm intermediate)      │
-│    Wado-origin .wasm → Core Wasm linking (shared memory)    │
-│    External .wasm → Component boundary (canonical ABI)      │
-│                                                             │
-│ 4. Linking                                                  │
-│    .wado / Wado-origin → Core Wasm linking (zero overhead)  │
-│    External .wasm → Component composition (type-safe)       │
-│                                                             │
-│ 5. Optimization (future)                                    │
-│    .wado / Wado-origin → wasm-opt inline, DCE, LTO          │
-│    External → Limited (ABI boundary)                        │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│ Wado Compiler                                                │
+├──────────────────────────────────────────────────────────────┤
+│ 1. Import resolution                                         │
+│    .wado → Parse as Wado source (IR integration)             │
+│    .wasm → Validate `with { type: "wasm" }` (required)       │
+│            Check "wado-compiler" marker:                     │
+│            ├─ Has marker? → Wado-origin                      │
+│            └─ No marker? → External component                │
+│                                                              │
+│ 2. Type checking                                             │
+│    .wado / Wado-origin .wasm → Wado type system (internal)   │
+│    External .wasm → WIT type extraction + mapping            │
+│                                                              │
+│ 3. Code generation                                           │
+│    .wado → IR-level integration (no Wasm intermediate)       │
+│    Wado-origin .wasm → Core Wasm linking (shared memory)     │
+│    External .wasm → Component boundary (canonical ABI)       │
+│                                                              │
+│ 4. Linking                                                   │
+│    .wado / Wado-origin → Core Wasm linking (zero overhead)   │
+│    External .wasm → Component composition (type-safe)        │
+│                                                              │
+│ 5. Optimization (future)                                     │
+│    .wado / Wado-origin → wasm-opt inline, DCE, LTO           │
+│    External → Limited (ABI boundary)                         │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ### Tooling Dependencies
@@ -202,7 +201,7 @@ wasm-tools (CLI)            # Component composition (`wasm-tools compose`)
 ✅ **Automatic optimization**: Compiler auto-detects origin and chooses best strategy
 ✅ **Future-proof**: Supports emerging Wasm ecosystem standards
 ✅ **Type safety**: Component Model enforces type correctness at external boundaries
-✅ **Simplicity**: No manual type annotations needed (auto-detected via metadata)
+✅ **Security**: Explicit type annotations prevent accidental execution of untrusted code
 
 ### Negative
 
@@ -264,67 +263,11 @@ Current `wado-bundled.wat` is **Core Wasm** (MVP format) for zero overhead:
 
 ## Implementation Plan
 
-### Phase 0: Wado-origin Detection
-
-- [ ] Add custom section generator: `@custom "wado-compiler" "version=X.Y.Z"`
-- [ ] Emit custom section in all Wado-compiled components
-- [ ] Implement detection logic in component parser
-- [ ] Test: Verify Wado-compiled `.wasm` uses core linking
-
-### Phase 1: Component Model Parsing
-
-- [ ] Parse `use {...} from "*.wasm"` syntax
-- [ ] Parse `with { type: "wasm" }` annotation
-- [ ] Integrate `wasmparser` for Component Model binary parsing
-- [ ] Implement detection logic:
-  - If `type: "wasm"` → External (skip marker check)
-  - If no annotation → Check `wado-compiler` marker
-- [ ] Extract type information from component binary sections (external only)
-- [ ] Error handling for:
-  - Missing/invalid `.wasm` files
-  - `.wasm` without annotation and without `wado-compiler` marker
-  - Non-component binaries (must be Component Model format)
-  - Unsupported WIT types
-
-### Phase 2: WIT Type Mapping (External components)
-
-- [ ] Map WIT primitives to Wado types (bool, integers, floats)
-- [ ] Map WIT `string` to Wado `String`
-- [ ] Map WIT `list<T>` to Wado `Array<T>`
-- [ ] Map WIT `option<T>` to Wado `Option<T>`
-- [ ] Map WIT `record` to Wado `struct`
-- [ ] Generate Wado type definitions for imported interfaces
-- [ ] Type check imported functions against usage
-
-### Phase 3: Component Boundary Codegen (External components)
-
-- [ ] Generate Canonical ABI adapters for imported functions
-- [ ] Handle lowering: Wado types → WIT types
-- [ ] Handle lifting: WIT types → Wado types
-- [ ] Integrate with existing codegen pipeline
-
-### Phase 4: Dual Linking Implementation
-
-- [ ] **Wado-origin path**: Extract core module and link directly (zero overhead)
-- [ ] **External path**: Use `wasm-tools compose` to combine components
-- [ ] Handle import/export resolution for both strategies
-- [ ] Generate appropriate output (core module or component)
-- [ ] Ensure Wado-origin core linking maintains LTO capability
-
-### Phase 5: Optimization and Tooling
-
-- [ ] Tree-shaking unused imports (both strategies)
-- [ ] Cache parsed component metadata
-- [ ] **Wado-origin LTO**: Cross-module inlining and DCE
-- [ ] wasm-opt integration for core modules
-- [ ] Benchmark: Verify zero overhead for Wado-origin imports
-
-### Future: wado-bundled Component Wrapper (Optional)
-
-- [ ] Add WIT definitions for `wado-bundled` functions
-- [ ] Create Component Model wrapper (for external projects)
-- [ ] Keep core linking internally (Wado compiler)
-- [ ] Document usage for non-Wado projects
+1. **Wado-origin Detection**: Add `@custom "wado-compiler"` marker to all Wado-compiled components
+2. **Component Model Parsing**: Parse `.wasm` imports with `type: "wasm"` validation and marker detection
+3. **WIT Type Mapping**: Map WIT types to Wado types for external components
+4. **Dual Linking**: Implement core linking for Wado-origin, Component Model boundary for external
+5. **Optimization**: Enable LTO for Wado-origin modules
 
 ## References
 

--- a/docs/wep-2026-01-10-wasm-import.md
+++ b/docs/wep-2026-01-10-wasm-import.md
@@ -30,30 +30,36 @@ Introduce **WebAssembly Component Model** import support with a **two-tier strat
 
 ### Two-Tier Strategy
 
-#### Tier 1: Wado-to-Wado (Zero-overhead linking)
+The compiler determines linking strategy based on component origin, not file extension.
+
+#### Tier 1: Wado-origin (Zero-overhead linking)
 
 ```wado
-// Same project, Wado source files
+// Wado source file
 use {helper} from "./lib.wado";
+
+// Wado-compiled component (detected via metadata)
+use {utils} from "./precompiled.wasm";  // If compiled by Wado compiler
 ```
 
 **Implementation**:
+- Detect Wado origin via custom section marker: `@custom "wado-compiler"`
 - Compile as core Wasm modules (not components)
 - Link with shared memory (current `wado-bundled.wat` approach)
-- Enable cross-module optimizations (inlining, DCE)
+- Enable cross-module optimizations (inlining, DCE, LTO)
 - **Zero Component Model overhead**
 
-**Use case**: Internal project modules, standard library
+**Use case**: Internal project modules, standard library, pre-compiled Wado modules
 
 #### Tier 2: External Wasm Components (Type-safe interop)
 
 ```wado
-// External component (possibly from other language)
-use {compress} from "./zlib.wasm";
+// External component (from Rust, C, AssemblyScript, etc.)
+use {compress} from "./zlib.wasm";  // No wado-compiler marker
 ```
 
 **Implementation**:
-- Must be Component Model format (with embedded WIT)
+- Component Model format (with embedded WIT)
 - Type information extracted from component binary
 - Canonical ABI for lowering/lifting
 - **Component Model overhead** (necessary for type safety)
@@ -63,26 +69,36 @@ use {compress} from "./zlib.wasm";
 ### Syntax
 
 ```wado
-// External Wasm component (Component Model format)
-use {sin, cos} from "./libm.wasm";
+// Wado source file (core linking)
+use {helper} from "./lib.wado";
 
-// No `type: "wasm"` needed - .wasm extension implies component
-// WIT is extracted from component binary (embedded)
+// Wado-compiled component (auto-detected, core linking)
+use {utils} from "./precompiled.wasm";
+// Has @custom "wado-compiler" → Zero overhead
+
+// External Wasm component (Component Model boundary)
+use {sin, cos} from "./libm.wasm";
+// No "wado-compiler" marker → Type-safe interop
 
 // JSON import (for comparison)
 use config from "./config.json" with { type: "json" };
 ```
 
+**Auto-detection**: Compiler checks for `@custom "wado-compiler"` section to determine linking strategy.
+
 ### Type Annotation Rules
 
-| Import Source        | `type` Attribute | Format                  | Linking Strategy     |
-| -------------------- | ---------------- | ----------------------- | -------------------- |
-| `.wado` files        | Not applicable   | Wado source             | Core Wasm linking    |
-| `.wasm` files        | Not applicable   | Component Model (+ WIT) | Component boundary   |
-| `.json` files        | **Required**     | `type: "json"`          | Compile-time embed   |
-| `core:*`, `wasi:*`   | Not applicable   | Special namespace       | Core Wasm linking    |
-| `https:` URLs        | **Required**     | Must specify content    | Depends on type      |
-| Future: `.wit` files | **Required**     | `type: "wit"`           | Interface-only (TBD) |
+| Import Source                 | `type` Attribute | Format                  | Linking Strategy     |
+| ----------------------------- | ---------------- | ----------------------- | -------------------- |
+| `.wado` files                 | Not applicable   | Wado source             | Core Wasm linking    |
+| `.wasm` (Wado-compiled)       | Not applicable   | Component + metadata    | Core Wasm linking    |
+| `.wasm` (External)            | Not applicable   | Component Model (+ WIT) | Component boundary   |
+| `.json` files                 | **Required**     | `type: "json"`          | Compile-time embed   |
+| `core:*`, `wasi:*` namespaces | Not applicable   | Special namespace       | Core Wasm linking    |
+| `https:` URLs                 | **Required**     | Must specify content    | Depends on type      |
+| Future: `.wit` files          | **Required**     | `type: "wit"`           | Interface-only (TBD) |
+
+**Note**: `.wasm` files are auto-detected as Wado-compiled or external via custom section metadata.
 
 ### WIT Requirements
 
@@ -95,12 +111,18 @@ use config from "./config.json" with { type: "json" };
 
 ### Implementation Requirements
 
-1. **Component Model Binary Parsing**
+1. **Component Origin Detection**
+   - Check for custom section `@custom "wado-compiler"` in component binary
+   - If present: Wado-origin → Use core linking strategy
+   - If absent: External → Use Component Model boundary
+   - Custom section format: `(custom "wado-compiler" "version=X.Y.Z")`
+
+2. **Component Model Binary Parsing**
    - Parse Component Model format using `wasmparser`
    - Extract embedded type information from component binary
    - No need to parse WIT text format (types are in binary)
 
-2. **WIT Type Extraction and Mapping**
+3. **WIT Type Extraction and Mapping** (External components only)
    - Extract type information from component binary type sections
    - Map WIT types to Wado types:
      - `bool`, `s32`, `u32`, `f32`, `f64` → Wado primitives
@@ -110,37 +132,40 @@ use config from "./config.json" with { type: "json" };
      - `record { ... }` → `struct { ... }`
    - Generate Wado type definitions for imported interfaces
 
-3. **Type Checking**
-   - Validate imported function signatures against usage
-   - Ensure type compatibility at Component Model boundary
+4. **Type Checking**
+   - **Wado-origin**: Use internal Wado type system (same as `.wado` imports)
+   - **External**: Validate via WIT type mapping
+   - Ensure type compatibility at boundaries
    - Reject imports with unsupported WIT types (early error)
 
-4. **Dual Linking Strategy**
+5. **Dual Linking Strategy**
 
 ```
-┌───────────────────────────────────────────────────────┐
-│ Wado Compiler                                         │
-├───────────────────────────────────────────────────────┤
-│ 1. Import resolution                                  │
-│    .wado → Parse as Wado source                       │
-│    .wasm → Parse as Component Model binary            │
-│                                                       │
-│ 2. Type checking                                      │
-│    .wado → Wado type system (internal)                │
-│    .wasm → WIT type extraction + mapping              │
-│                                                       │
-│ 3. Code generation                                    │
-│    .wado → Core Wasm module (shared memory)           │
-│    .wasm → Component boundary (canonical ABI)         │
-│                                                       │
-│ 4. Linking                                            │
-│    Wado-to-Wado → Core Wasm linking (zero overhead)   │
-│    External .wasm → Component composition             │
-│                                                       │
-│ 5. Optimization (future)                              │
-│    Core modules → wasm-opt inline, DCE                │
-│    Components → Limited (ABI boundary)                │
-└───────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────┐
+│ Wado Compiler                                              │
+├────────────────────────────────────────────────────────────┤
+│ 1. Import resolution                                       │
+│    .wado → Parse as Wado source                            │
+│    .wasm → Parse as Component Model binary                 │
+│            ├─ Has "wado-compiler" marker? → Wado-origin    │
+│            └─ No marker? → External component              │
+│                                                            │
+│ 2. Type checking                                           │
+│    .wado / Wado-origin .wasm → Wado type system (internal) │
+│    External .wasm → WIT type extraction + mapping          │
+│                                                            │
+│ 3. Code generation                                         │
+│    .wado / Wado-origin .wasm → Core Wasm linking           │
+│    External .wasm → Component boundary (canonical ABI)     │
+│                                                            │
+│ 4. Linking                                                 │
+│    Wado-origin → Core Wasm linking (zero overhead, LTO)    │
+│    External .wasm → Component composition (type-safe)      │
+│                                                            │
+│ 5. Optimization (future)                                   │
+│    Wado-origin → wasm-opt inline, DCE, LTO                 │
+│    External → Limited (ABI boundary)                       │
+└────────────────────────────────────────────────────────────┘
 ```
 
 ### Tooling Dependencies
@@ -161,11 +186,13 @@ wasm-tools (CLI)            # Component composition (`wasm-tools compose`)
 
 ✅ **Ecosystem interoperability**: Can use any Component Model library, regardless of source language
 ✅ **Component Model alignment**: Fully leverages embedded type information for type safety
-✅ **Zero-overhead internal modules**: Wado-to-Wado linking maintains performance
+✅ **Zero-overhead Wado modules**: Both `.wado` and Wado-compiled `.wasm` use core linking
+✅ **Distributed compilation**: Pre-compiled Wado modules maintain full LTO capability
 ✅ **Standard library flexibility**: Enables bundling optimized libraries (Rust libm, etc.)
+✅ **Automatic optimization**: Compiler auto-detects origin and chooses best strategy
 ✅ **Future-proof**: Supports emerging Wasm ecosystem standards
-✅ **Type safety**: Component Model enforces type correctness at boundaries
-✅ **Simplicity**: No manual type annotations needed (types are in component binary)
+✅ **Type safety**: Component Model enforces type correctness at external boundaries
+✅ **Simplicity**: No manual type annotations needed (auto-detected via metadata)
 
 ### Negative
 
@@ -187,9 +214,11 @@ wasm-tools (CLI)            # Component composition (`wasm-tools compose`)
 - **Future optimization**: Component Model may add inline hints
 
 **Benchmark expectations**:
-- Wado-to-Wado function call: ~0 overhead (same as internal call)
+- Wado-origin function call: ~0 overhead (same as internal call, LTO enabled)
 - Component boundary call: ~10-50ns overhead (ABI translation)
 - For most use cases (crypto, parsing, I/O), ABI overhead is negligible
+
+**Key advantage**: Pre-compiled Wado modules (`.wasm`) get same zero-overhead treatment as `.wado` source files, enabling distributed compilation without performance penalty.
 
 #### Component Model Dependency
 
@@ -225,17 +254,25 @@ Current `wado-bundled.wat` is **Core Wasm** (MVP format) for zero overhead:
 
 ## Implementation Plan
 
+### Phase 0: Wado-origin Detection
+
+- [ ] Add custom section generator: `@custom "wado-compiler" "version=X.Y.Z"`
+- [ ] Emit custom section in all Wado-compiled components
+- [ ] Implement detection logic in component parser
+- [ ] Test: Verify Wado-compiled `.wasm` uses core linking
+
 ### Phase 1: Component Model Parsing
 
 - [ ] Parse `use {...} from "*.wasm"` syntax (no type annotation needed)
 - [ ] Integrate `wasmparser` for Component Model binary parsing
-- [ ] Extract type information from component binary sections
+- [ ] Check for `wado-compiler` custom section (origin detection)
+- [ ] Extract type information from component binary sections (external only)
 - [ ] Error handling for:
   - Missing/invalid `.wasm` files
   - Non-component binaries (must be Component Model format)
   - Unsupported WIT types
 
-### Phase 2: WIT Type Mapping
+### Phase 2: WIT Type Mapping (External components)
 
 - [ ] Map WIT primitives to Wado types (bool, integers, floats)
 - [ ] Map WIT `string` to Wado `String`
@@ -245,26 +282,28 @@ Current `wado-bundled.wat` is **Core Wasm** (MVP format) for zero overhead:
 - [ ] Generate Wado type definitions for imported interfaces
 - [ ] Type check imported functions against usage
 
-### Phase 3: Component Boundary Codegen
+### Phase 3: Component Boundary Codegen (External components)
 
 - [ ] Generate Canonical ABI adapters for imported functions
 - [ ] Handle lowering: Wado types → WIT types
 - [ ] Handle lifting: WIT types → Wado types
 - [ ] Integrate with existing codegen pipeline
 
-### Phase 4: Component Composition
+### Phase 4: Dual Linking Implementation
 
-- [ ] Use `wasm-tools compose` to combine components
-- [ ] Handle import/export resolution
-- [ ] Generate final Component Model output
-- [ ] Ensure Wado-to-Wado core linking still works
+- [ ] **Wado-origin path**: Extract core module and link directly (zero overhead)
+- [ ] **External path**: Use `wasm-tools compose` to combine components
+- [ ] Handle import/export resolution for both strategies
+- [ ] Generate appropriate output (core module or component)
+- [ ] Ensure Wado-origin core linking maintains LTO capability
 
 ### Phase 5: Optimization and Tooling
 
-- [ ] Tree-shaking unused imports
+- [ ] Tree-shaking unused imports (both strategies)
 - [ ] Cache parsed component metadata
-- [ ] Cross-module optimization for Wado-to-Wado
+- [ ] **Wado-origin LTO**: Cross-module inlining and DCE
 - [ ] wasm-opt integration for core modules
+- [ ] Benchmark: Verify zero overhead for Wado-origin imports
 
 ### Future: wado-bundled Component Wrapper (Optional)
 

--- a/docs/wep-2026-01-10-wasm-import.md
+++ b/docs/wep-2026-01-10-wasm-import.md
@@ -14,7 +14,7 @@ This capability is essential for:
 
 Wado currently supports imports only from:
 
-- `.wado` modules (local files, compiled as core Wasm and linked with shared memory)
+- `.wado` modules (local files, integrated at IR level during compilation)
 - `core:*` namespace (core library, written in Wado)
 - `wasi:*` namespace (WASI interfaces, mapped to WIT)
 - `https:` URLs (remote modules)
@@ -43,9 +43,8 @@ use {utils} from "./precompiled.wasm";  // If compiled by Wado compiler
 ```
 
 **Implementation**:
-- Detect Wado origin via custom section marker: `@custom "wado-compiler"`
-- Compile as core Wasm modules (not components)
-- Link with shared memory (current `wado-bundled.wat` approach)
+- **`.wado` source**: Integrate at IR (TIR) level during compilation (no Wasm intermediate)
+- **`.wasm` (Wado-origin)**: Detect via custom section marker `@custom "wado-compiler"`, link as core module with shared memory
 - Enable cross-module optimizations (inlining, DCE, LTO)
 - **Zero Component Model overhead**
 

--- a/docs/wep-2026-01-10-wasm-import.md
+++ b/docs/wep-2026-01-10-wasm-import.md
@@ -1,4 +1,4 @@
-# ARD: WebAssembly Module Import Support
+# WEP: WebAssembly Module Import Support
 
 ## Context
 
@@ -6,7 +6,7 @@ Wado aims to be a "Wasm only" language, maintaining zero abstraction over WebAss
 
 This capability is essential for:
 
-1. **Standard library implementation**: Integrating deterministic math functions (see ARD-2026-01-10-deterministic-libm)
+1. **Standard library implementation**: Integrating deterministic math functions (see WEP-2026-01-10-deterministic-libm)
 2. **Ecosystem integration**: Using existing Wasm libraries (cryptography, parsers, etc.)
 3. **Multi-language projects**: Composing modules written in different languages (Rust, C, AssemblyScript, etc.)
 
@@ -14,28 +14,60 @@ This capability is essential for:
 
 Wado currently supports imports only from:
 
-- `.wado` modules (local files)
+- `.wado` modules (local files, compiled as core Wasm and linked with shared memory)
 - `core:*` namespace (core library, written in Wado)
 - `wasi:*` namespace (WASI interfaces, mapped to WIT)
 - `https:` URLs (remote modules)
 
-There is no support for importing compiled `.wasm` files.
+There is no support for importing external compiled `.wasm` files (Component Model format).
 
 ## Decision
 
-Introduce `.wasm` file import support with **mandatory type annotation** to ensure type safety and clarity.
+Introduce **WebAssembly Component Model** import support with a **two-tier strategy** to balance type safety and performance:
+
+1. **Wado-to-Wado**: Core Wasm linking with zero overhead (current mechanism)
+2. **External Components**: Component Model boundary with full type safety
+
+### Two-Tier Strategy
+
+#### Tier 1: Wado-to-Wado (Zero-overhead linking)
+
+```wado
+// Same project, Wado source files
+use {helper} from "./lib.wado";
+```
+
+**Implementation**:
+- Compile as core Wasm modules (not components)
+- Link with shared memory (current `wado-bundled.wat` approach)
+- Enable cross-module optimizations (inlining, DCE)
+- **Zero Component Model overhead**
+
+**Use case**: Internal project modules, standard library
+
+#### Tier 2: External Wasm Components (Type-safe interop)
+
+```wado
+// External component (possibly from other language)
+use {compress} from "./zlib.wasm";
+```
+
+**Implementation**:
+- Must be Component Model format (with embedded WIT)
+- Type information extracted from component binary
+- Canonical ABI for lowering/lifting
+- **Component Model overhead** (necessary for type safety)
+
+**Use case**: Third-party libraries, cross-language modules
 
 ### Syntax
 
 ```wado
-// Explicit type annotation required for non-.wado imports
-use {sin, cos} from "./libm.wasm" with { type: "wasm" };
+// External Wasm component (Component Model format)
+use {sin, cos} from "./libm.wasm";
 
-// Optional: specify WIT file for type information
-use {foo} from "./external.wasm" with {
-    type: "wasm",
-    wit: "./external.wit",  // Override/supplement embedded WIT
-};
+// No `type: "wasm"` needed - .wasm extension implies component
+// WIT is extracted from component binary (embedded)
 
 // JSON import (for comparison)
 use config from "./config.json" with { type: "json" };
@@ -43,127 +75,208 @@ use config from "./config.json" with { type: "json" };
 
 ### Type Annotation Rules
 
-| Import Source        | `type` Attribute | Notes                          |
-| -------------------- | ---------------- | ------------------------------ |
-| `.wado` files        | Optional         | Type inferred from Wado source |
-| `.wasm` files        | **Required**     | `type: "wasm"`                 |
-| `.json` files        | **Required**     | `type: "json"`                 |
-| `core:*`, `wasi:*`   | Not applicable   | Special namespace handling     |
-| `https:` URLs        | **Required**     | Must specify content type      |
-| Future: `.wit` files | **Required**     | `type: "wit"` (interface-only) |
+| Import Source        | `type` Attribute | Format                  | Linking Strategy     |
+| -------------------- | ---------------- | ----------------------- | -------------------- |
+| `.wado` files        | Not applicable   | Wado source             | Core Wasm linking    |
+| `.wasm` files        | Not applicable   | Component Model (+ WIT) | Component boundary   |
+| `.json` files        | **Required**     | `type: "json"`          | Compile-time embed   |
+| `core:*`, `wasi:*`   | Not applicable   | Special namespace       | Core Wasm linking    |
+| `https:` URLs        | **Required**     | Must specify content    | Depends on type      |
+| Future: `.wit` files | **Required**     | `type: "wit"`           | Interface-only (TBD) |
+
+### WIT Requirements
+
+**Component Model format mandates embedded type information** in the binary:
+
+- Component binaries include type sections (binary format)
+- WIT text format can be extracted via `wasm-tools component wit`
+- **External WIT files are NOT required** - types are in the component binary
+- Optional: External `.wit` files for development convenience (future enhancement)
 
 ### Implementation Requirements
 
-1. **Wasm Component Model Support**
-   - Parse Component Model format (`.wasm` with embedded WIT)
-   - Parse Core Wasm with external WIT (`.wit` file)
-   - Extract type information from embedded WIT metadata
+1. **Component Model Binary Parsing**
+   - Parse Component Model format using `wasmparser`
+   - Extract embedded type information from component binary
+   - No need to parse WIT text format (types are in binary)
 
-2. **Type Checking**
-   - Use WIT definitions for type checking imported functions
-   - Validate import/export signature matching
-   - Generate Wado type definitions from WIT interfaces
+2. **WIT Type Extraction and Mapping**
+   - Extract type information from component binary type sections
+   - Map WIT types to Wado types:
+     - `bool`, `s32`, `u32`, `f32`, `f64` → Wado primitives
+     - `string` → `String`
+     - `list<T>` → `Array<T>`
+     - `option<T>` → `Option<T>`
+     - `record { ... }` → `struct { ... }`
+   - Generate Wado type definitions for imported interfaces
 
-3. **Linking and Composition**
-   - Integrate imported Wasm modules into final component
-   - Resolve cross-module references
-   - Handle component composition (similar to `wasm-tools compose`)
+3. **Type Checking**
+   - Validate imported function signatures against usage
+   - Ensure type compatibility at Component Model boundary
+   - Reject imports with unsupported WIT types (early error)
 
-4. **Compiler Pipeline**
+4. **Dual Linking Strategy**
 
 ```
-┌─────────────────────────────────────────────┐
-│ Wado Compiler                               │
-├─────────────────────────────────────────────┤
-│ 1. Parse import declarations                │
-│    - .wado → Wado parser                    │
-│    - .wasm → wasmparser + wit-parser        │
-│    - .json → JSON parser                    │
-│                                             │
-│ 2. Type checking                            │
-│    - .wado → Wado type system               │
-│    - .wasm → WIT-based type checking        │
-│                                             │
-│ 3. Code generation                          │
-│    - Generate Wasm for Wado modules         │
-│    - Link imported Wasm modules             │
-│                                             │
-│ 4. Component composition                    │
-│    - Combine all modules into final .wasm   │
-└─────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────┐
+│ Wado Compiler                                         │
+├───────────────────────────────────────────────────────┤
+│ 1. Import resolution                                  │
+│    .wado → Parse as Wado source                       │
+│    .wasm → Parse as Component Model binary            │
+│                                                       │
+│ 2. Type checking                                      │
+│    .wado → Wado type system (internal)                │
+│    .wasm → WIT type extraction + mapping              │
+│                                                       │
+│ 3. Code generation                                    │
+│    .wado → Core Wasm module (shared memory)           │
+│    .wasm → Component boundary (canonical ABI)         │
+│                                                       │
+│ 4. Linking                                            │
+│    Wado-to-Wado → Core Wasm linking (zero overhead)   │
+│    External .wasm → Component composition             │
+│                                                       │
+│ 5. Optimization (future)                              │
+│    Core modules → wasm-opt inline, DCE                │
+│    Components → Limited (ABI boundary)                │
+└───────────────────────────────────────────────────────┘
 ```
 
 ### Tooling Dependencies
 
 ```toml
 [dependencies]
-wasmparser = "0.121"        # Parse Wasm binary
-wit-parser = "0.15"         # Parse WIT definitions
-wit-component = "0.18"      # Component Model support
+wasmparser = "0.121"        # Parse Wasm and Component Model binaries
+wit-component = "0.18"      # Component Model type extraction
 wasm-encoder = "0.38"       # Generate Wasm
-wasm-compose = "0.5"        # Compose components
+wasm-tools (CLI)            # Component composition (`wasm-tools compose`)
 ```
+
+**Note**: `wit-parser` is NOT needed - type information is extracted from component binaries, not parsed from WIT text files.
 
 ## Consequences
 
 ### Positive
 
-✅ **Ecosystem interoperability**: Can use any Wasm library, regardless of source language
-✅ **Component Model alignment**: Fully leverages WIT for type safety
+✅ **Ecosystem interoperability**: Can use any Component Model library, regardless of source language
+✅ **Component Model alignment**: Fully leverages embedded type information for type safety
+✅ **Zero-overhead internal modules**: Wado-to-Wado linking maintains performance
 ✅ **Standard library flexibility**: Enables bundling optimized libraries (Rust libm, etc.)
 ✅ **Future-proof**: Supports emerging Wasm ecosystem standards
-✅ **Type safety**: Mandatory `type` annotation prevents ambiguity
-✅ **Consistency**: Same `use ... with { type: "..." }` pattern for all non-Wado imports
+✅ **Type safety**: Component Model enforces type correctness at boundaries
+✅ **Simplicity**: No manual type annotations needed (types are in component binary)
 
 ### Negative
 
-⚠️ **Complexity**: Requires implementing Component Model composition
-⚠️ **Build time**: Parsing and linking Wasm modules adds compilation overhead
+⚠️ **Component Model overhead**: External imports have Canonical ABI lifting/lowering cost
+⚠️ **Limited cross-component optimization**: Cannot inline across Component Model boundaries
+⚠️ **Build time**: Parsing component binaries adds compilation overhead
 ⚠️ **Debugging**: Multi-language debugging can be challenging
-⚠️ **Versioning**: Need to handle compatibility between Wasm modules
-⚠️ **Mandatory annotation**: More verbose than extension-based inference
+⚠️ **Versioning**: Need to handle compatibility between Wasm components
 
 ### Trade-offs
 
-- **Type annotation requirement**: Prioritizes explicitness over brevity
-  - **Rationale**: Wado's design philosophy emphasizes clarity and explicit dependencies
-  - **Mitigation**: IDE/editor tooling can auto-suggest `with { type: "wasm" }`
+#### Performance: Component Model Overhead
 
-- **Component Model dependency**: Ties Wado to Component Model evolution
-  - **Rationale**: Component Model is the standard for Wasm interoperability
-  - **Mitigation**: Abstract WIT parsing behind internal API for future flexibility
+**Problem**: Canonical ABI (lowering/lifting) has runtime cost
+
+**Mitigation**:
+- **Two-tier strategy**: Wado-to-Wado uses core linking (zero overhead)
+- **Strategic bundling**: Keep performance-critical code in Wado
+- **Future optimization**: Component Model may add inline hints
+
+**Benchmark expectations**:
+- Wado-to-Wado function call: ~0 overhead (same as internal call)
+- Component boundary call: ~10-50ns overhead (ABI translation)
+- For most use cases (crypto, parsing, I/O), ABI overhead is negligible
+
+#### Component Model Dependency
+
+**Trade-off**: Ties Wado to Component Model evolution
+
+**Rationale**:
+- Component Model is the **only** standard for type-safe Wasm interop
+- Core Wasm MVP lacks type information (`i32` ambiguity)
+- Alternative (Core Wasm + manual bindings) is unsafe and unmaintainable
+
+**Mitigation**:
+- Component Model is stable (1.0 released)
+- Wado can evolve independently within Component Model constraints
+
+### Performance Considerations
+
+#### wado-bundled Migration
+
+Current `wado-bundled.wat` is **Core Wasm** (MVP format) for zero overhead:
+
+```wat
+;; Current: Core Wasm
+(func $f64_to_buffer (param f64 i32) (result i32))
+```
+
+**Migration plan**:
+1. **Keep core linking internally**: `wado-bundled` stays as core module
+2. **Add WIT documentation**: Define types for external projects
+3. **Optional component wrapper**: For external use only
+4. **Wado compiler**: Continue using core linking (zero overhead)
+
+**Rationale**: `wado-bundled` is internal to Wado stdlib - no need for Component Model overhead.
 
 ## Implementation Plan
 
-### Phase 1: Foundation (Minimal Viable Feature)
+### Phase 1: Component Model Parsing
 
-- [ ] Parse `use {...} from "*.wasm" with { type: "wasm" }` syntax
-- [ ] Integrate `wasmparser` for basic Wasm validation
-- [ ] Extract exports from Wasm module
-- [ ] Error handling for missing/invalid `.wasm` files
+- [ ] Parse `use {...} from "*.wasm"` syntax (no type annotation needed)
+- [ ] Integrate `wasmparser` for Component Model binary parsing
+- [ ] Extract type information from component binary sections
+- [ ] Error handling for:
+  - Missing/invalid `.wasm` files
+  - Non-component binaries (must be Component Model format)
+  - Unsupported WIT types
 
-### Phase 2: WIT Integration
+### Phase 2: WIT Type Mapping
 
-- [ ] Parse embedded WIT from Component Model format
-- [ ] Support external WIT with `with { wit: "..." }` attribute
-- [ ] Generate Wado type definitions from WIT interfaces
+- [ ] Map WIT primitives to Wado types (bool, integers, floats)
+- [ ] Map WIT `string` to Wado `String`
+- [ ] Map WIT `list<T>` to Wado `Array<T>`
+- [ ] Map WIT `option<T>` to Wado `Option<T>`
+- [ ] Map WIT `record` to Wado `struct`
+- [ ] Generate Wado type definitions for imported interfaces
 - [ ] Type check imported functions against usage
 
-### Phase 3: Linking
+### Phase 3: Component Boundary Codegen
 
-- [ ] Compose Wado-generated Wasm with imported modules
+- [ ] Generate Canonical ABI adapters for imported functions
+- [ ] Handle lowering: Wado types → WIT types
+- [ ] Handle lifting: WIT types → Wado types
+- [ ] Integrate with existing codegen pipeline
+
+### Phase 4: Component Composition
+
+- [ ] Use `wasm-tools compose` to combine components
 - [ ] Handle import/export resolution
 - [ ] Generate final Component Model output
+- [ ] Ensure Wado-to-Wado core linking still works
 
-### Phase 4: Optimization
+### Phase 5: Optimization and Tooling
 
 - [ ] Tree-shaking unused imports
-- [ ] Optimize module composition
-- [ ] Cache parsed WIT definitions
+- [ ] Cache parsed component metadata
+- [ ] Cross-module optimization for Wado-to-Wado
+- [ ] wasm-opt integration for core modules
+
+### Future: wado-bundled Component Wrapper (Optional)
+
+- [ ] Add WIT definitions for `wado-bundled` functions
+- [ ] Create Component Model wrapper (for external projects)
+- [ ] Keep core linking internally (Wado compiler)
+- [ ] Document usage for non-Wado projects
 
 ## References
 
 - [WebAssembly Component Model](https://github.com/WebAssembly/component-model)
 - [WIT (Wasm Interface Types) Format](https://component-model.bytecodealliance.org/design/wit.html)
+- [Canonical ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md)
 - [wasm-tools Documentation](https://github.com/bytecodealliance/wasm-tools)
-- Related ARD: [ARD-2026-01-10-deterministic-libm](./ard-2026-01-10-deterministic-libm.md)
+- Related WEP: [WEP-2026-01-10-deterministic-libm](./wep-2026-01-10-deterministic-libm.md)

--- a/docs/wep-2026-01-10-wasm-import.md
+++ b/docs/wep-2026-01-10-wasm-import.md
@@ -68,36 +68,43 @@ use {compress} from "./zlib.wasm";  // No wado-compiler marker
 ### Syntax
 
 ```wado
-// Wado source file (core linking)
+// Wado source file (IR-level integration)
 use {helper} from "./lib.wado";
 
-// Wado-compiled component (auto-detected, core linking)
+// Wado-compiled component (auto-detected via metadata, core linking)
 use {utils} from "./precompiled.wasm";
-// Has @custom "wado-compiler" → Zero overhead
+// Has @custom "wado-compiler" → Zero overhead, no annotation needed
 
-// External Wasm component (Component Model boundary)
-use {sin, cos} from "./libm.wasm";
+// External Wasm component (Component Model boundary, annotation REQUIRED)
+use {sin, cos} from "./libm.wasm" with { type: "wasm" };
 // No "wado-compiler" marker → Type-safe interop
 
 // JSON import (for comparison)
 use config from "./config.json" with { type: "json" };
 ```
 
-**Auto-detection**: Compiler checks for `@custom "wado-compiler"` section to determine linking strategy.
+**Type annotation requirement**:
+- **Wado-compiled `.wasm`**: No annotation needed (detected via `@custom "wado-compiler"`)
+- **External `.wasm`**: `with { type: "wasm" }` **required**
+- **`.wado` source**: No annotation needed (Wado source)
 
 ### Type Annotation Rules
 
-| Import Source                 | `type` Attribute | Format                  | Linking Strategy     |
-| ----------------------------- | ---------------- | ----------------------- | -------------------- |
-| `.wado` files                 | Not applicable   | Wado source             | Core Wasm linking    |
-| `.wasm` (Wado-compiled)       | Not applicable   | Component + metadata    | Core Wasm linking    |
-| `.wasm` (External)            | Not applicable   | Component Model (+ WIT) | Component boundary   |
-| `.json` files                 | **Required**     | `type: "json"`          | Compile-time embed   |
-| `core:*`, `wasi:*` namespaces | Not applicable   | Special namespace       | Core Wasm linking    |
-| `https:` URLs                 | **Required**     | Must specify content    | Depends on type      |
-| Future: `.wit` files          | **Required**     | `type: "wit"`           | Interface-only (TBD) |
+| Import Source                 | `type` Attribute        | Format                  | Linking Strategy     |
+| ----------------------------- | ----------------------- | ----------------------- | -------------------- |
+| `.wado` files                 | Not applicable          | Wado source             | IR-level integration |
+| `.wasm` (Wado-compiled)       | Not required (optional) | Component + metadata    | Core Wasm linking    |
+| `.wasm` (External)            | **Required**            | `type: "wasm"`          | Component boundary   |
+| `.json` files                 | **Required**            | `type: "json"`          | Compile-time embed   |
+| `core:*`, `wasi:*` namespaces | Not applicable          | Special namespace       | IR-level integration |
+| `https:` URLs                 | **Required**            | Must specify content    | Depends on type      |
+| Future: `.wit` files          | **Required**            | `type: "wit"`           | Interface-only (TBD) |
 
-**Note**: `.wasm` files are auto-detected as Wado-compiled or external via custom section metadata.
+**Detection logic**:
+1. If `with { type: "wasm" }` is present → External component (Component Model boundary)
+2. If no type annotation → Check for `@custom "wado-compiler"` marker:
+   - Has marker → Wado-compiled (Core Wasm linking)
+   - No marker → Error: External `.wasm` requires `with { type: "wasm" }`
 
 ### WIT Requirements
 
@@ -111,9 +118,10 @@ use config from "./config.json" with { type: "json" };
 ### Implementation Requirements
 
 1. **Component Origin Detection**
-   - Check for custom section `@custom "wado-compiler"` in component binary
-   - If present: Wado-origin → Use core linking strategy
-   - If absent: External → Use Component Model boundary
+   - If `with { type: "wasm" }` is present → External component (skip marker check)
+   - If no type annotation → Check for `@custom "wado-compiler"` in component binary:
+     - If present: Wado-origin → Use core linking strategy
+     - If absent: Error - external `.wasm` requires `with { type: "wasm" }`
    - Custom section format: `(custom "wado-compiler" "version=X.Y.Z")`
 
 2. **Component Model Binary Parsing**
@@ -140,31 +148,34 @@ use config from "./config.json" with { type: "json" };
 5. **Dual Linking Strategy**
 
 ```
-┌────────────────────────────────────────────────────────────┐
-│ Wado Compiler                                              │
-├────────────────────────────────────────────────────────────┤
-│ 1. Import resolution                                       │
-│    .wado → Parse as Wado source                            │
-│    .wasm → Parse as Component Model binary                 │
-│            ├─ Has "wado-compiler" marker? → Wado-origin    │
-│            └─ No marker? → External component              │
-│                                                            │
-│ 2. Type checking                                           │
-│    .wado / Wado-origin .wasm → Wado type system (internal) │
-│    External .wasm → WIT type extraction + mapping          │
-│                                                            │
-│ 3. Code generation                                         │
-│    .wado / Wado-origin .wasm → Core Wasm linking           │
-│    External .wasm → Component boundary (canonical ABI)     │
-│                                                            │
-│ 4. Linking                                                 │
-│    Wado-origin → Core Wasm linking (zero overhead, LTO)    │
-│    External .wasm → Component composition (type-safe)      │
-│                                                            │
-│ 5. Optimization (future)                                   │
-│    Wado-origin → wasm-opt inline, DCE, LTO                 │
-│    External → Limited (ABI boundary)                       │
-└────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│ Wado Compiler                                               │
+├─────────────────────────────────────────────────────────────┤
+│ 1. Import resolution                                        │
+│    .wado → Parse as Wado source (IR integration)            │
+│    .wasm → Check type annotation:                           │
+│            ├─ with { type: "wasm" }? → External component   │
+│            └─ No annotation?                                │
+│                ├─ Has "wado-compiler" marker? → Wado-origin │
+│                └─ No marker? → Error (annotation required)  │
+│                                                             │
+│ 2. Type checking                                            │
+│    .wado / Wado-origin .wasm → Wado type system (internal)  │
+│    External .wasm → WIT type extraction + mapping           │
+│                                                             │
+│ 3. Code generation                                          │
+│    .wado → IR-level integration (no Wasm intermediate)      │
+│    Wado-origin .wasm → Core Wasm linking (shared memory)    │
+│    External .wasm → Component boundary (canonical ABI)      │
+│                                                             │
+│ 4. Linking                                                  │
+│    .wado / Wado-origin → Core Wasm linking (zero overhead)  │
+│    External .wasm → Component composition (type-safe)       │
+│                                                             │
+│ 5. Optimization (future)                                    │
+│    .wado / Wado-origin → wasm-opt inline, DCE, LTO          │
+│    External → Limited (ABI boundary)                        │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ### Tooling Dependencies
@@ -262,12 +273,16 @@ Current `wado-bundled.wat` is **Core Wasm** (MVP format) for zero overhead:
 
 ### Phase 1: Component Model Parsing
 
-- [ ] Parse `use {...} from "*.wasm"` syntax (no type annotation needed)
+- [ ] Parse `use {...} from "*.wasm"` syntax
+- [ ] Parse `with { type: "wasm" }` annotation
 - [ ] Integrate `wasmparser` for Component Model binary parsing
-- [ ] Check for `wado-compiler` custom section (origin detection)
+- [ ] Implement detection logic:
+  - If `type: "wasm"` → External (skip marker check)
+  - If no annotation → Check `wado-compiler` marker
 - [ ] Extract type information from component binary sections (external only)
 - [ ] Error handling for:
   - Missing/invalid `.wasm` files
+  - `.wasm` without annotation and without `wado-compiler` marker
   - Non-component binaries (must be Component Model format)
   - Unsupported WIT types
 


### PR DESCRIPTION
- Adopt Component Model only (drop Core Wasm MVP support)
- Introduce two-tier linking strategy:
  * Wado-to-Wado: Core Wasm linking (zero overhead)
  * External .wasm: Component Model boundary (type-safe)
- WIT embedded in component binary (no external .wit files needed)
- Keep wado-bundled as Core Wasm internally (no CM overhead)
- Simplify syntax: no `type: "wasm"` annotation needed
- Document performance trade-offs and optimization strategy