### PR TITLE
Add Array::filled(n, element) for efficient array initialization

### DIFF
--- a/benchmark/sieve.wado
+++ b/benchmark/sieve.wado
@@ -12,13 +12,8 @@ use {println, Stdout} from "core:cli";
 use {now, MonotonicClock} from "core:clocks";
 
 fn sieve_count(limit: i32) -> i32 {
-    // Pre-allocate sieve array with capacity
-    let mut is_prime = Array::<bool>::with_capacity(limit + 1);
-    let mut i = 0;
-    while i <= limit {
-        is_prime.append(true);
-        i += 1;
-    }
+    // Pre-allocate sieve array filled with true
+    let mut is_prime = Array::<bool>::filled(limit + 1, true);
 
     // 0 and 1 are not prime
     is_prime[0] = false;

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -111,8 +111,12 @@ let b = [1, 2, 3] as Array<i32>;         // explicit cast
 fn takes(arr: Array<i32>) {}
 takes([1, 2, 3]);                        // implicit coercion
 
+// Array constructors
+let arr = Array::<i32>::with_capacity(10);  // empty array with pre-allocated capacity
+let bools = Array::<bool>::filled(100, true);  // array of 100 elements, all true
+
 // Array methods
-let arr: Array<i32> = [];
+let mut arr: Array<i32> = [];
 arr.append(1);                           // add element to end
 arr.append(2);
 let n = arr.len();                       // get length (2)

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -100,6 +100,10 @@ fn array_set<T>(arr: builtin::array<T>, idx: i32, value: T);
 /// Copies `len` elements from src[src_offset..] to dst[dst_offset..]
 fn array_copy<T>(dst: builtin::array<T>, dst_offset: i32, src: builtin::array<T>, src_offset: i32, len: i32);
 
+/// Fill a builtin::array<T> with a value
+/// Fills `len` elements starting at `offset` with `value`
+fn array_fill<T>(arr: builtin::array<T>, offset: i32, value: T, len: i32);
+
 /// Create a new String struct with given capacity
 fn string_new(len: i32) -> String;
 

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -43,6 +43,16 @@ impl Array<T> {
         };
     }
 
+    /// Create a new array with `n` elements, all initialized to `element`
+    pub fn filled(n: i32, element: T) -> Array<T> {
+        let repr = builtin::array_new::<T>(n);
+        builtin::array_fill::<T>(repr, 0, element, n);
+        return Array {
+            repr,
+            used: n,
+        };
+    }
+
     /// Get the number of elements in the array
     pub fn len(&self) -> i32 {
         return self.used;

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -7864,6 +7864,26 @@ impl Codegen {
                     }
                 }
             }
+            "builtin::array_fill" => {
+                // array.fill $t : [(ref null $t) i32 t i32] -> []
+                // args: (arr, offset, value, len)
+                if let Some(arr_arg) = args.first() {
+                    if let ResolvedType::BuiltinArray(element_type) =
+                        type_table.get(arr_arg.type_id)
+                    {
+                        let array_type_idx = *self
+                            .array_types
+                            .get(element_type)
+                            .expect("Array type should be registered for array_fill");
+                        for arg in args {
+                            self.generate_expr(func, arg, type_table, ctx, builder);
+                        }
+                        func.instruction(&Instruction::ArrayFill(array_type_idx));
+                    } else {
+                        panic!("array_fill first argument must be builtin::array<T>");
+                    }
+                }
+            }
             "builtin::i32_and" => {
                 for arg in args {
                     self.generate_expr(func, arg, type_table, ctx, builder);


### PR DESCRIPTION
Use Wasm GC's array.fill instruction to initialize arrays in O(1) instead of calling append() in a loop. Improves sieve benchmark from 197ms to 95ms (~2x faster).