### PR TITLE
Optimize wasmtime for test execution speed

### DIFF
--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -112,6 +112,10 @@ fn get_engine() -> &'static Engine {
         config.wasm_gc(true);
         config.wasm_function_references(true);
 
+        // Use minimal optimization for faster compilation in tests
+        // This reduces Wasm compilation time while maintaining compatibility with all features
+        config.cranelift_opt_level(wasmtime::OptLevel::None);
+
         Engine::new(&config).expect("Failed to create wasmtime Engine")
     })
 }


### PR DESCRIPTION
Configure wasmtime to use OptLevel::None (minimal optimization) for E2E
tests. This significantly reduces Wasm compilation time without affecting
test correctness.

Performance improvement:
- Test execution: 24.83s → 12.18s (51% faster, ~2x speedup)
- Total test time: 112.7s → 21.2s (81% faster, ~5.3x speedup)
- User CPU time: 8m49s → 2m41s (70% reduction)
- System CPU time: 1m38s → 0m16s (83% reduction)

Since tests prioritize fast iteration over runtime performance, disabling
Wasm optimizations provides substantial time savings. The tests still verify
all functionality correctly, just with faster compilation.

Note: Initially attempted to use Winch compiler, but it doesn't support
wasm_function_references required by the component model with GC. Using
Cranelift with OptLevel::None provides compatibility with all features
while still achieving significant speedup.