### PR TITLE
Extract WASI function names from stdlib registry

### DIFF
--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -409,6 +409,16 @@ impl WasiRegistry {
         self.effect_to_func.get("Stderr::write_via_stream")
     }
 
+    /// Get all registered WASI function names
+    ///
+    /// Returns an iterator over function names in `Effect::method` format
+    /// (e.g., "Stdout::write_via_stream", "MonotonicClock::now").
+    ///
+    /// Used by the optimizer to populate used_wasi_functions in O0 mode.
+    pub fn all_function_names(&self) -> impl Iterator<Item = &str> {
+        self.effect_to_func.keys().map(|s| s.as_str())
+    }
+
     // ============================================================================
     // Type Conversion (AST types to Wasm types)
     // ============================================================================

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -4,6 +4,7 @@
 //! - Dead Code Elimination (DCE) at function level
 //! - Usage analysis for conditional feature inclusion
 
+use crate::component_model::WasiRegistry;
 use crate::name::{FreeFunctionName, FunctionId, MethodName};
 use crate::project::Project;
 use crate::tir::{
@@ -1827,19 +1828,6 @@ fn inline_calls_in_expr(
 // - `base + counter * step` where counter increments by 1
 // - Nested loops with induction variables
 
-/// Standard WASI functions for each effect (for O0 mode)
-pub const STANDARD_WASI_FUNCTIONS: &[&str] = &[
-    "Stdout::write_via_stream",
-    "Stderr::write_via_stream",
-    "Environment::get_arguments",
-    "Environment::get_environment",
-    "Environment::get_initial_cwd",
-    "MonotonicClock::now",
-    "MonotonicClock::get_resolution",
-    "MonotonicClock::wait_until",
-    "MonotonicClock::wait_for",
-];
-
 // =============================================================================
 // Dead Code Elimination (DCE)
 // =============================================================================
@@ -2095,9 +2083,10 @@ fn populate_all_features(project: &mut Project) {
     project.all_reachable = true;
     // Standard effects (all except Exit which requires explicit usage)
     project.used_effects = WasiEffect::STANDARD.iter().copied().collect();
-    // Standard WASI functions for the above effects
-    project.used_wasi_functions = STANDARD_WASI_FUNCTIONS
-        .iter()
+    // Standard WASI functions from the stdlib registry
+    let (wasi_registry, _world_registry) = WasiRegistry::build_from_stdlib();
+    project.used_wasi_functions = wasi_registry
+        .all_function_names()
         .map(|s| s.to_string())
         .collect();
     // All importable builtins when DCE is disabled


### PR DESCRIPTION
Remove hardcoded STANDARD_WASI_FUNCTIONS constant and instead derive the list dynamically from WasiRegistry::build_from_stdlib(). This ensures new WASI functions added to lib/wasi/*.wado are automatically included in O0 mode.