### PR TITLE
drpint for markdown formatter

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -5,6 +5,9 @@
 [tools]
 # Rust toolchain - mise respects rust-toolchain.toml automatically
 
+# dprint - fast code formatter
+dprint = "latest"
+
 # WebAssembly toolchain for parsing, printing, and validating Wasm
 "github:bytecodealliance/wasm-tools" = "latest"
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -14,7 +14,7 @@ dprint = "latest"
 # WebAssembly runtime with WASI P3 support
 wasmtime = "latest"
 
-# Node.js - required for VS Code extension development and prettier
+# Node.js - required for VS Code extension development
 node = "24"
 
 [settings]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "rust-lang.rust-analyzer",
-    "esbenp.prettier-vscode"
+    "rust-lang.rust-analyzer"
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ on-task-done: clippy-fix update-bundled update-golden-fixtures test format
 .PHONY: format
 format:
 	cargo fmt --verbose --all
-	npx prettier --write spec.md AGENTS.md README.md docs/*.md benchmark/*.md
+	dprint fmt
 
 .PHONY: format-wado
 format-wado:

--- a/docs/wep-2026-01-10-deterministic-libm.md
+++ b/docs/wep-2026-01-10-deterministic-libm.md
@@ -52,16 +52,16 @@ Wado's core principles demand determinism:
 
 **Rationale**:
 
-| Criterion             | Rust `libm`                                         | musl libm               | fdlibm                     |
-| --------------------- | --------------------------------------------------- | ----------------------- | -------------------------- |
+| Criterion             | Rust `libm`                                         | musl libm               | fdlibm                    |
+| --------------------- | --------------------------------------------------- | ----------------------- | ------------------------- |
 | **License**           | ✅ MIT/Apache-2.0                                   | ✅ MIT                  | ⚠️ Permissive (verify)     |
-| **Language**          | ✅ Pure Rust                                        | ❌ C (requires clang)   | ❌ C                       |
-| **Wasm compilation**  | ✅ Native (cargo → wasm32-unknown-unknown)          | ⚠️ Requires wasi-sdk    | ⚠️ Requires wasi-sdk       |
-| **no_std support**    | ✅ Yes (no libc/WASI dependencies)                  | ❌ No                   | ❌ No                      |
+| **Language**          | ✅ Pure Rust                                        | ❌ C (requires clang)   | ❌ C                      |
+| **Wasm compilation**  | ✅ Native (cargo → wasm32-unknown-unknown)          | ⚠️ Requires wasi-sdk     | ⚠️ Requires wasi-sdk       |
+| **no_std support**    | ✅ Yes (no libc/WASI dependencies)                  | ❌ No                   | ❌ No                     |
 | **Upstream**          | ✅ Based on musl, actively maintained               | ✅ High quality         | ⚠️ Less active maintenance |
-| **Rust integration**  | ✅ Native Cargo dependency                          | ⚠️ FFI required         | ⚠️ FFI required            |
-| **Production usage**  | ✅ Used in Rust `no_std` ecosystem (embedded, Wasm) | ✅ Alpine Linux default | ✅ Java StrictMath, V8     |
-| **Compiler affinity** | ✅ Wado compiler is Rust-based                      | ⚠️ Neutral              | ⚠️ Neutral                 |
+| **Rust integration**  | ✅ Native Cargo dependency                          | ⚠️ FFI required          | ⚠️ FFI required            |
+| **Production usage**  | ✅ Used in Rust `no_std` ecosystem (embedded, Wasm) | ✅ Alpine Linux default | ✅ Java StrictMath, V8    |
+| **Compiler affinity** | ✅ Wado compiler is Rust-based                      | ⚠️ Neutral               | ⚠️ Neutral                 |
 
 ### Integration Architecture
 

--- a/docs/wep-2026-01-12-data-section.md
+++ b/docs/wep-2026-01-12-data-section.md
@@ -16,7 +16,7 @@ Several languages provide similar mechanisms:
 
 Other testing approaches include:
 
-- **Cram tests**: Shell session format with `$ ` prefixed commands
+- **Cram tests**: Shell session format with `$` prefixed commands
 - **LLVM lit/FileCheck**: `RUN:` and `CHECK:` directives in comments
 - **OCaml ppx_expect**: `[%expect {...}]` blocks with auto-promotion
 - **Snapshot testing**: External golden files in `testdata/` or `__snapshots__/`

--- a/docs/wep-2026-01-12-literal-type-conversion.md
+++ b/docs/wep-2026-01-12-literal-type-conversion.md
@@ -25,11 +25,11 @@ We investigated how modern statically-typed languages (Rust, Go, Swift, Zig) han
 
 ### Conversion Patterns
 
-| Case                         | Example                            | Rust | Go  | Zig | Swift |
-| ---------------------------- | ---------------------------------- | ---- | --- | --- | ----- |
-| Literal → variable           | `let x: i64 = 32;`                 | ✅   | ✅  | ✅  | ✅    |
-| Untyped literal → variable   | Go: `const C = 32; var x i64 = C`  | N/A  | ✅  | ✅  | ✅    |
-| Typed value → different type | `let x: i64 = 32; let z: i32 = x;` | ❌   | ❌  | ❌  | ❌    |
+| Case                         | Example                            | Rust | Go | Zig | Swift |
+| ---------------------------- | ---------------------------------- | ---- | -- | --- | ----- |
+| Literal → variable           | `let x: i64 = 32;`                 | ✅   | ✅ | ✅  | ✅    |
+| Untyped literal → variable   | Go: `const C = 32; var x i64 = C`  | N/A  | ✅ | ✅  | ✅    |
+| Typed value → different type | `let x: i64 = 32; let z: i32 = x;` | ❌   | ❌ | ❌  | ❌    |
 
 **Key finding**: All languages allow flexibility at the "untyped" stage only. Once a value has a concrete type, implicit conversions are disallowed.
 

--- a/docs/wep-2026-01-15-dict-naming.md
+++ b/docs/wep-2026-01-15-dict-naming.md
@@ -207,7 +207,7 @@ None needed - this is the initial naming decision. No existing code uses a diffe
 
 ## References
 
-- [Comparison of programming languages (associative array) - Wikipedia](<https://en.wikipedia.org/wiki/Comparison_of_programming_languages_(associative_array)>)
+- [Comparison of programming languages (associative array) - Wikipedia](https://en.wikipedia.org/wiki/Comparison_of_programming_languages_(associative_array))
 - [Python dict documentation](https://docs.python.org/3/library/stdtypes.html#dict)
 - [Julia Dict documentation](https://docs.julialang.org/en/v1/base/collections/#Dictionaries)
 - Component Model specification: list<tuple<K, V>> mapping

--- a/docs/wep-2026-01-18-iterator-based-literal-coercion.md
+++ b/docs/wep-2026-01-18-iterator-based-literal-coercion.md
@@ -421,9 +421,9 @@ This requires `Dict` to implement `FromIterator<[K, V]>`, which is natural.
 | **Compiler complexity** | High (special cases)       | Low (general rule)           |
 | **Extensibility**       | ❌ Compiler changes needed | ✅ Trait implementation only |
 | **User-defined types**  | ❌ Not supported           | ✅ Fully supported           |
-| **Performance**         | ✅ Direct codegen          | ⚠️ Requires optimization     |
+| **Performance**         | ✅ Direct codegen          | ⚠️ Requires optimization      |
 | **Consistency**         | ❌ Array is special        | ✅ All collections equal     |
-| **Error messages**      | ⚠️ "Type mismatch"         | ✅ "Missing trait impl"      |
+| **Error messages**      | ⚠️ "Type mismatch"          | ✅ "Missing trait impl"      |
 | **Maintenance**         | ❌ High                    | ✅ Low                       |
 
 ## Examples

--- a/docs/wep-2026-01-18-operator-overloading.md
+++ b/docs/wep-2026-01-18-operator-overloading.md
@@ -678,11 +678,11 @@ let scaled = v * 2.0;  // Vec3
 
 | Aspect              | Rust/Wado (Traits)         | C++/Kotlin (operator keyword) | Zig (No overloading) |
 | ------------------- | -------------------------- | ----------------------------- | -------------------- |
-| Discoverability     | ✅ High (via traits)       | ⚠️ Medium (special syntax)    | ✅ N/A               |
-| Type safety         | ✅ High (associated types) | ⚠️ Medium                     | ✅ N/A               |
-| Generic programming | ✅ Yes (trait bounds)      | ⚠️ Limited (templates)        | ❌ No                |
-| Verbosity           | ⚠️ Verbose                 | ✅ Concise                    | ✅ Explicit calls    |
-| Consistency         | ✅ Part of trait system    | ⚠️ Special case               | ✅ No special cases  |
+| Discoverability     | ✅ High (via traits)       | ⚠️ Medium (special syntax)     | ✅ N/A               |
+| Type safety         | ✅ High (associated types) | ⚠️ Medium                      | ✅ N/A               |
+| Generic programming | ✅ Yes (trait bounds)      | ⚠️ Limited (templates)         | ❌ No                |
+| Verbosity           | ⚠️ Verbose                  | ✅ Concise                    | ✅ Explicit calls    |
+| Consistency         | ✅ Part of trait system    | ⚠️ Special case                | ✅ No special cases  |
 | Ergonomics (math)   | ✅ Good                    | ✅ Good                       | ❌ Poor              |
 
 ## Examples

--- a/dprint.json
+++ b/dprint.json
@@ -4,6 +4,6 @@
   "includes": ["**/*.md"],
   "excludes": ["vendor/**", "target/**", "node_modules/**"],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.17.8.wasm"
+    "https://plugins.dprint.dev/markdown-0.20.0.wasm"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://dprint.dev/schemas/v0.json",
+  "markdown": {},
+  "includes": ["**/*.md"],
+  "excludes": ["vendor/**", "target/**", "node_modules/**"],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.17.8.wasm"
+  ]
+}

--- a/spec.md
+++ b/spec.md
@@ -2140,7 +2140,6 @@ world WorldName {
     export async fn exported_function(arg: Type) -> ReturnType;
     export fn synchronous_function() -> i32;
 }
-
 ```
 
 > **TBD: Component/Module Structure**


### PR DESCRIPTION
Replace prettier with dprint for markdown formatting. Add dprint to mise.toml and create dprint.json configuration. Format existing markdown files to normalize table column widths and URL escaping.