### PR TITLE
fix: preserve formatting for else-if, trailing commas, and comments

### DIFF
--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -558,6 +558,9 @@ pub struct StructLiteralExpr {
     /// which require type context (e.g., `let p: Point = { x: 1, y: 2 }`).
     pub name: Option<String>,
     pub fields: Vec<StructLiteralField>,
+    /// Whether the original source had a trailing comma (for formatting purposes).
+    /// Multiline formatting is used when this is true.
+    pub has_trailing_comma: bool,
     pub span: Span,
 }
 
@@ -713,6 +716,8 @@ pub struct CallExpr {
     /// Explicit type arguments for generic functions: `foo::<i32>(x)`
     pub type_args: Vec<Type>,
     pub args: Vec<Expr>,
+    /// Whether the original source had a trailing comma (for formatting purposes).
+    pub has_trailing_comma: bool,
     pub span: Span,
 }
 
@@ -723,6 +728,8 @@ pub struct MethodCallExpr {
     /// Explicit type arguments for generic methods: `obj.foo::<i32>(x)`
     pub type_args: Vec<Type>,
     pub args: Vec<Expr>,
+    /// Whether the original source had a trailing comma (for formatting purposes).
+    pub has_trailing_comma: bool,
     pub span: Span,
 }
 
@@ -735,6 +742,8 @@ pub struct StaticMethodCallExpr {
     pub method: String,
     /// Arguments to the method
     pub args: Vec<Expr>,
+    /// Whether the original source had a trailing comma (for formatting purposes).
+    pub has_trailing_comma: bool,
     pub span: Span,
 }
 

--- a/wado-compiler/src/desugar.rs
+++ b/wado-compiler/src/desugar.rs
@@ -241,6 +241,7 @@ fn desugar_expr_impl(expr: &Expr, ctx: Option<&mut DesugarContext>) -> Expr {
             callee: desugar_expr(&c.callee),
             type_args: c.type_args.clone(),
             args: c.args.iter().map(desugar_expr).collect(),
+            has_trailing_comma: c.has_trailing_comma,
             span: c.span,
         })),
         Expr::MethodCall(m) => Expr::MethodCall(Box::new(MethodCallExpr {
@@ -248,12 +249,14 @@ fn desugar_expr_impl(expr: &Expr, ctx: Option<&mut DesugarContext>) -> Expr {
             method: m.method.clone(),
             type_args: m.type_args.clone(),
             args: m.args.iter().map(desugar_expr).collect(),
+            has_trailing_comma: m.has_trailing_comma,
             span: m.span,
         })),
         Expr::StaticMethodCall(s) => Expr::StaticMethodCall(Box::new(StaticMethodCallExpr {
             target_type: s.target_type.clone(),
             method: s.method.clone(),
             args: s.args.iter().map(desugar_expr).collect(),
+            has_trailing_comma: s.has_trailing_comma,
             span: s.span,
         })),
         Expr::FieldAccess(f) => Expr::FieldAccess(Box::new(FieldAccessExpr {
@@ -335,6 +338,7 @@ fn desugar_expr_impl(expr: &Expr, ctx: Option<&mut DesugarContext>) -> Expr {
                     span: f.span,
                 })
                 .collect(),
+            has_trailing_comma: s.has_trailing_comma,
             span: s.span,
         })),
         Expr::TupleLiteral(t) => Expr::TupleLiteral(Box::new(TupleLiteralExpr {
@@ -548,6 +552,7 @@ fn desugar_assert(assert_stmt: &AssertStmt, ctx: &mut DesugarContext) -> Stmt {
         }),
         type_args: vec![],
         args: vec![error_message],
+        has_trailing_comma: false,
         span,
     }));
 

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -1877,7 +1877,7 @@ impl Parser {
         })))
     }
 
-    /// Parse argument list. Returns (args, has_trailing_comma).
+    /// Parse argument list. Returns (args, `has_trailing_comma`).
     fn parse_arg_list(&mut self) -> ParseResult<(Vec<Expr>, bool)> {
         let mut args = Vec::new();
         let mut has_trailing_comma = false;

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -1487,7 +1487,7 @@ impl Parser {
                 TokenKind::LParen => {
                     let callee_span = expr.span();
                     self.advance();
-                    let args = self.parse_arg_list()?;
+                    let (args, has_trailing_comma) = self.parse_arg_list()?;
                     let rparen_span = self.peek().span;
                     self.expect(&TokenKind::RParen)?;
                     let merged_span = callee_span.merge(&rparen_span);
@@ -1495,6 +1495,7 @@ impl Parser {
                         callee: expr,
                         type_args: vec![],
                         args,
+                        has_trailing_comma,
                         span: merged_span,
                     }));
                 }
@@ -1509,7 +1510,7 @@ impl Parser {
                         let callee_span = expr.span();
                         let type_args = self.parse_call_type_args()?;
                         self.expect(&TokenKind::LParen)?;
-                        let args = self.parse_arg_list()?;
+                        let (args, has_trailing_comma) = self.parse_arg_list()?;
                         let rparen_span = self.peek().span;
                         self.expect(&TokenKind::RParen)?;
                         let merged_span = callee_span.merge(&rparen_span);
@@ -1517,6 +1518,7 @@ impl Parser {
                             callee: expr,
                             type_args,
                             args,
+                            has_trailing_comma,
                             span: merged_span,
                         }));
                     } else {
@@ -1566,7 +1568,7 @@ impl Parser {
                         if self.check(&TokenKind::Lt) {
                             let type_args = self.parse_call_type_args()?;
                             self.expect(&TokenKind::LParen)?;
-                            let args = self.parse_arg_list()?;
+                            let (args, has_trailing_comma) = self.parse_arg_list()?;
                             let rparen_span = self.peek().span;
                             self.expect(&TokenKind::RParen)?;
                             let merged_span = receiver_span.merge(&rparen_span);
@@ -1575,6 +1577,7 @@ impl Parser {
                                 method: field,
                                 type_args,
                                 args,
+                                has_trailing_comma,
                                 span: merged_span,
                             }));
                         } else {
@@ -1586,7 +1589,7 @@ impl Parser {
                         }
                     } else if self.check(&TokenKind::LParen) {
                         self.advance();
-                        let args = self.parse_arg_list()?;
+                        let (args, has_trailing_comma) = self.parse_arg_list()?;
                         let rparen_span = self.peek().span;
                         self.expect(&TokenKind::RParen)?;
                         let merged_span = receiver_span.merge(&rparen_span);
@@ -1595,6 +1598,7 @@ impl Parser {
                             method: field,
                             type_args: vec![],
                             args,
+                            has_trailing_comma,
                             span: merged_span,
                         }));
                     } else {
@@ -1677,7 +1681,7 @@ impl Parser {
                             self.advance(); // consume ::
                             let method = self.consume_ident()?;
                             self.expect(&TokenKind::LParen)?;
-                            let args = self.parse_arg_list()?;
+                            let (args, has_trailing_comma) = self.parse_arg_list()?;
                             let end_span = self.expect(&TokenKind::RParen)?.span;
 
                             Ok(Expr::StaticMethodCall(Box::new(StaticMethodCallExpr {
@@ -1688,6 +1692,7 @@ impl Parser {
                                 }),
                                 method,
                                 args,
+                                has_trailing_comma,
                                 span: start_span.merge(&end_span),
                             })))
                         } else {
@@ -1872,8 +1877,10 @@ impl Parser {
         })))
     }
 
-    fn parse_arg_list(&mut self) -> ParseResult<Vec<Expr>> {
+    /// Parse argument list. Returns (args, has_trailing_comma).
+    fn parse_arg_list(&mut self) -> ParseResult<(Vec<Expr>, bool)> {
         let mut args = Vec::new();
+        let mut has_trailing_comma = false;
 
         if !self.check(&TokenKind::RParen) {
             args.push(self.parse_expr()?);
@@ -1881,13 +1888,14 @@ impl Parser {
             while self.check(&TokenKind::Comma) {
                 self.advance();
                 if self.check(&TokenKind::RParen) {
+                    has_trailing_comma = true;
                     break;
                 }
                 args.push(self.parse_expr()?);
             }
         }
 
-        Ok(args)
+        Ok((args, has_trailing_comma))
     }
 
     fn parse_closure(&mut self) -> ParseResult<Expr> {
@@ -2862,6 +2870,7 @@ impl Parser {
         }
 
         let mut fields = Vec::new();
+        let mut has_trailing_comma = false;
 
         if !self.check(&TokenKind::RBrace) {
             loop {
@@ -2894,6 +2903,7 @@ impl Parser {
                 }
                 self.advance(); // consume comma
                 if self.check(&TokenKind::RBrace) {
+                    has_trailing_comma = true;
                     break; // trailing comma allowed
                 }
             }
@@ -2905,6 +2915,7 @@ impl Parser {
         Ok(Expr::StructLiteral(Box::new(StructLiteralExpr {
             name,
             fields,
+            has_trailing_comma,
             span: start_span.merge(&end_span),
         })))
     }

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -459,12 +459,44 @@ impl<'a> Unparser<'a> {
             self.output.push('\n');
         }
 
+        // Save last_source_line for method context
+        let saved_line = self.last_source_line;
+        // Initialize to the opening brace line for proper blank line tracking
+        self.last_source_line = i.span.line;
+
         for (idx, method) in i.methods.iter().enumerate() {
+            // Get the effective start line (considering leading comments)
+            let leading_comments = self.comments.leading_comments(&method.span);
+            let effective_start = leading_comments
+                .first()
+                .map_or(method.span.line, |c| c.span.line);
+
+            // Emit blank lines before the method (or its leading comments)
+            // but ensure at least one blank line between methods
             if idx > 0 {
-                self.output.push('\n');
+                let blank_lines = self
+                    .comments
+                    .blank_lines_between(self.last_source_line, effective_start)
+                    .max(1);
+                for _ in 0..blank_lines {
+                    self.output.push('\n');
+                }
             }
+
+            // Now emit leading comments (without additional blank lines)
+            for comment in leading_comments {
+                if self.emitted_comments.insert(comment.span.start) {
+                    self.write_indent();
+                    self.emit_comment(comment);
+                    self.output.push('\n');
+                }
+            }
+
             self.unparse_function(method);
+            self.last_source_line = method.span.end_line();
         }
+
+        self.last_source_line = saved_line.max(i.span.end_line());
         self.indent_level -= 1;
 
         self.write_indent();
@@ -498,10 +530,8 @@ impl<'a> Unparser<'a> {
             self.output.push('\n');
         }
 
-        for (idx, method) in t.methods.iter().enumerate() {
-            if idx > 0 {
-                self.output.push('\n');
-            }
+        // For trait declarations, don't add extra blank lines between method signatures
+        for method in &t.methods {
             self.unparse_function(method);
         }
         self.indent_level -= 1;
@@ -834,6 +864,65 @@ impl<'a> Unparser<'a> {
         self.output.push('}');
 
         if let Some(else_block) = &i.else_block {
+            // Check if this is an `else if` (else block contains only an if statement)
+            if else_block.stmts.len() == 1 {
+                if let Stmt::If(nested_if) = &else_block.stmts[0] {
+                    self.output.push_str(" else ");
+                    self.unparse_if_stmt_continuation(nested_if);
+                    return;
+                }
+            }
+            self.output.push_str(" else {\n");
+            self.indent_level += 1;
+            self.unparse_block(else_block);
+            self.indent_level -= 1;
+            self.write_indent();
+            self.output.push('}');
+        }
+
+        self.output.push('\n');
+    }
+
+    /// Unparse an if statement continuation (for else-if chains).
+    /// This skips the initial indent and final newline since they're handled by the parent.
+    fn unparse_if_stmt_continuation(&mut self, i: &IfStmt) {
+        self.output.push_str("if ");
+
+        // Handle optional init binding
+        if let Some(init) = &i.init {
+            self.output.push_str("let ");
+            if init.is_mut {
+                self.output.push_str("mut ");
+            }
+            self.output.push_str(&init.name);
+            if let Some(ty) = &init.ty {
+                self.output.push_str(": ");
+                self.unparse_type(ty);
+            }
+            self.output.push_str(" = ");
+            self.unparse_expr(&init.value);
+            self.output.push_str("; ");
+        }
+
+        self.unparse_if_condition(&i.condition);
+        self.output.push_str(" {\n");
+
+        self.indent_level += 1;
+        self.unparse_block(&i.then_block);
+        self.indent_level -= 1;
+
+        self.write_indent();
+        self.output.push('}');
+
+        if let Some(else_block) = &i.else_block {
+            // Check if this is an `else if` (else block contains only an if statement)
+            if else_block.stmts.len() == 1 {
+                if let Stmt::If(nested_if) = &else_block.stmts[0] {
+                    self.output.push_str(" else ");
+                    self.unparse_if_stmt_continuation(nested_if);
+                    return;
+                }
+            }
             self.output.push_str(" else {\n");
             self.indent_level += 1;
             self.unparse_block(else_block);
@@ -1123,14 +1212,7 @@ impl<'a> Unparser<'a> {
             }
             self.output.push('>');
         }
-        self.output.push('(');
-        for (i, arg) in c.args.iter().enumerate() {
-            if i > 0 {
-                self.output.push_str(", ");
-            }
-            self.unparse_expr(arg);
-        }
-        self.output.push(')');
+        self.unparse_call_args(&c.args, c.has_trailing_comma);
     }
 
     fn unparse_method_call(&mut self, m: &MethodCallExpr) {
@@ -1148,14 +1230,7 @@ impl<'a> Unparser<'a> {
             }
             self.output.push('>');
         }
-        self.output.push('(');
-        for (i, arg) in m.args.iter().enumerate() {
-            if i > 0 {
-                self.output.push_str(", ");
-            }
-            self.unparse_expr(arg);
-        }
-        self.output.push(')');
+        self.unparse_call_args(&m.args, m.has_trailing_comma);
     }
 
     fn unparse_static_method_call(&mut self, s: &StaticMethodCallExpr) {
@@ -1176,14 +1251,33 @@ impl<'a> Unparser<'a> {
         }
         self.output.push_str("::");
         self.output.push_str(&s.method);
-        self.output.push('(');
-        for (i, arg) in s.args.iter().enumerate() {
-            if i > 0 {
-                self.output.push_str(", ");
+        self.unparse_call_args(&s.args, s.has_trailing_comma);
+    }
+
+    fn unparse_call_args(&mut self, args: &[Expr], has_trailing_comma: bool) {
+        if has_trailing_comma && !args.is_empty() {
+            // Multiline format with trailing comma
+            self.output.push_str("(\n");
+            self.indent_level += 1;
+            for arg in args {
+                self.write_indent();
+                self.unparse_expr(arg);
+                self.output.push_str(",\n");
             }
-            self.unparse_expr(arg);
+            self.indent_level -= 1;
+            self.write_indent();
+            self.output.push(')');
+        } else {
+            // Single-line format
+            self.output.push('(');
+            for (i, arg) in args.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                self.unparse_expr(arg);
+            }
+            self.output.push(')');
         }
-        self.output.push(')');
     }
 
     fn unparse_field_access(&mut self, f: &FieldAccessExpr) {
@@ -1374,20 +1468,38 @@ impl<'a> Unparser<'a> {
             self.output.push_str(name);
             self.output.push(' ');
         }
-        self.output.push_str("{ ");
 
-        for (i, field) in s.fields.iter().enumerate() {
-            if i > 0 {
-                self.output.push_str(", ");
+        if s.has_trailing_comma && !s.fields.is_empty() {
+            // Multiline format with trailing comma
+            self.output.push_str("{\n");
+            self.indent_level += 1;
+            for field in &s.fields {
+                self.write_indent();
+                self.output.push_str(&field.name);
+                if !field.is_shorthand {
+                    self.output.push_str(": ");
+                    self.unparse_expr(&field.value);
+                }
+                self.output.push_str(",\n");
             }
-            self.output.push_str(&field.name);
-            if !field.is_shorthand {
-                self.output.push_str(": ");
-                self.unparse_expr(&field.value);
+            self.indent_level -= 1;
+            self.write_indent();
+            self.output.push('}');
+        } else {
+            // Single-line format without trailing comma
+            self.output.push_str("{ ");
+            for (i, field) in s.fields.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                self.output.push_str(&field.name);
+                if !field.is_shorthand {
+                    self.output.push_str(": ");
+                    self.unparse_expr(&field.value);
+                }
             }
+            self.output.push_str(" }");
         }
-
-        self.output.push_str(" }");
     }
 
     // Helper methods

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -865,12 +865,12 @@ impl<'a> Unparser<'a> {
 
         if let Some(else_block) = &i.else_block {
             // Check if this is an `else if` (else block contains only an if statement)
-            if else_block.stmts.len() == 1 {
-                if let Stmt::If(nested_if) = &else_block.stmts[0] {
-                    self.output.push_str(" else ");
-                    self.unparse_if_stmt_continuation(nested_if);
-                    return;
-                }
+            if else_block.stmts.len() == 1
+                && let Stmt::If(nested_if) = &else_block.stmts[0]
+            {
+                self.output.push_str(" else ");
+                self.unparse_if_stmt_continuation(nested_if);
+                return;
             }
             self.output.push_str(" else {\n");
             self.indent_level += 1;
@@ -916,12 +916,12 @@ impl<'a> Unparser<'a> {
 
         if let Some(else_block) = &i.else_block {
             // Check if this is an `else if` (else block contains only an if statement)
-            if else_block.stmts.len() == 1 {
-                if let Stmt::If(nested_if) = &else_block.stmts[0] {
-                    self.output.push_str(" else ");
-                    self.unparse_if_stmt_continuation(nested_if);
-                    return;
-                }
+            if else_block.stmts.len() == 1
+                && let Stmt::If(nested_if) = &else_block.stmts[0]
+            {
+                self.output.push_str(" else ");
+                self.unparse_if_stmt_continuation(nested_if);
+                return;
             }
             self.output.push_str(" else {\n");
             self.indent_level += 1;

--- a/wado-compiler/tests/fixtures/index_trait_full_struct.wado
+++ b/wado-compiler/tests/fixtures/index_trait_full_struct.wado
@@ -140,6 +140,7 @@ fn run() with Stdout {
         Value::new(30, "c"),
     );
 
+
     // Index read (uses Index trait)
     let v0 = c[0];
     println(`v0: {v0.describe()}`);
@@ -148,8 +149,8 @@ fn run() with Stdout {
 
     // IndexMut (uses IndexMut trait) - call mutable methods on different indices
     c[0].increment();  // write_count = 1
-    c[1].add(100);     // write_count = 2
-    c[2].add(200);     // write_count = 3
+    c[1].add(100);  // write_count = 2
+    c[2].add(200);  // write_count = 3
 
     println(`After mutations:`);
     println(`v0: {c.v0.describe()}`);

--- a/wado-compiler/tests/fixtures/index_value_generic.wado
+++ b/wado-compiler/tests/fixtures/index_value_generic.wado
@@ -1,7 +1,7 @@
 // Test IndexValue trait with generic type parameter binding
 // This tests that `impl IndexValue<i32> for Container<T>` correctly binds T
 // when indexing into Container<i32>, Container<String>, etc.
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 // A simple generic container with three slots
 struct Triple<T> {

--- a/wado-compiler/tests/fixtures/index_value_trait.wado
+++ b/wado-compiler/tests/fixtures/index_value_trait.wado
@@ -1,5 +1,5 @@
 // Test IndexValue trait for value-returning indexing
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 // Simple container that stores values and returns them by copy
 struct IntStore {

--- a/wado-compiler/tests/fixtures/opt_inline_array.wado
+++ b/wado-compiler/tests/fixtures/opt_inline_array.wado
@@ -2,7 +2,7 @@
 // This tests that local_types are pushed in the correct order during inlining
 // (params first, then non-params) to match index assignment order.
 
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn test(n: i32) -> i32 {
     let arr = Array::<i32>::with_capacity(n);

--- a/wado-compiler/tests/fixtures/short_circuit.wado
+++ b/wado-compiler/tests/fixtures/short_circuit.wado
@@ -1,5 +1,5 @@
 // Test short-circuit evaluation for && and ||
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn side_effect(msg: String, result: bool) -> bool with Stdout {
     println(`side_effect called: {msg}`);
@@ -51,7 +51,7 @@ fn run() with Stdout {
     let b = false;
 
     // (a && b) is false, so right side of || should be evaluated
-    if (a && b) || side_effect("nested: should print", true) {
+    if a && b || side_effect("nested: should print", true) {
         println("nested branch taken (correct)");
     }
 

--- a/wado-compiler/tests/fixtures/treemap_btree.wado
+++ b/wado-compiler/tests/fixtures/treemap_btree.wado
@@ -1,7 +1,7 @@
 // TreeMap B-tree implementation test
 // Tests basic operations: insert, get, delete, iter, compact
 
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 // B-tree node
 struct BTreeNode<K, V> {
@@ -291,8 +291,7 @@ impl TreeMap<K, V> {
     }
 
     fn needs_compaction(&self) -> bool {
-        return self.deleted_count > 0 &&
-               self.deleted_count * 4 > self.size + self.deleted_count;
+        return self.deleted_count > 0 && self.deleted_count * 4 > self.size + self.deleted_count;
     }
 
     fn len(&self) -> i32 {

--- a/wado-compiler/tests/fixtures/treemap_btree2.wado
+++ b/wado-compiler/tests/fixtures/treemap_btree2.wado
@@ -1,7 +1,7 @@
 // TreeMap B-tree implementation test with Index traits
 // Tests basic operations with index syntax: map["key"], map["key"] = value
 
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 // B-tree node
 struct BTreeNode<K, V> {
@@ -291,8 +291,7 @@ impl TreeMap<K, V> {
     }
 
     fn needs_compaction(&self) -> bool {
-        return self.deleted_count > 0 &&
-               self.deleted_count * 4 > self.size + self.deleted_count;
+        return self.deleted_count > 0 && self.deleted_count * 4 > self.size + self.deleted_count;
     }
 
     fn len(&self) -> i32 {


### PR DESCRIPTION
- Fix else-if being expanded to nested else { if { } } blocks
- Add has_trailing_comma field to struct literals, call expressions
- Multiline format when trailing comma present for structs and calls
- Fix comments before methods in impl blocks being moved inside
- Remove extra blank lines between trait method declarations