### PR TITLE
feat(compiler): add sync diagnostics and structured logging

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::process;
 
 use lexopt::Arg::{Long, Short, Value};
+use wado_compiler::LogLevel;
 
 use crate::args::{
     next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
@@ -57,6 +58,7 @@ pub struct CompileOptions {
     pub format: Option<OutputFormat>,
     pub opt_level: OptLevel,
     pub wat_to_stdout: bool,
+    pub log_level: LogLevel,
 }
 
 pub fn print_usage() {
@@ -69,7 +71,20 @@ pub fn print_usage() {
         "  --wat-to-stdout  Output WAT to stdout (shorthand for --format wat -o /dev/stdout)"
     );
     eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
+    eprintln!("  --log-level <l>  Log level: debug, info, warn, error, off (default: info)");
     eprintln!("  --help           Show this help message");
+}
+
+/// Parse log level from string
+fn parse_log_level(s: &str) -> Option<LogLevel> {
+    match s.to_lowercase().as_str() {
+        "debug" => Some(LogLevel::Debug),
+        "info" => Some(LogLevel::Info),
+        "warn" | "warning" => Some(LogLevel::Warn),
+        "error" => Some(LogLevel::Error),
+        "off" | "none" => Some(LogLevel::Off),
+        _ => None,
+    }
 }
 
 pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
@@ -78,6 +93,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
     let mut wat_to_stdout = false;
+    let mut log_level = LogLevel::default();
 
     while let Some(arg) = next_arg(&mut parser) {
         match arg {
@@ -120,6 +136,17 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
                     process::exit(1);
                 }
             }
+            Long("log-level") => {
+                let level_str = require_string(&mut parser);
+                if let Some(level) = parse_log_level(&level_str) {
+                    log_level = level;
+                } else {
+                    eprintln!(
+                        "Error: unknown log level '{level_str}'. Use debug, info, warn, error, or off"
+                    );
+                    process::exit(1);
+                }
+            }
             Value(val) => {
                 reject_multiple_inputs(&input);
                 input = Some(val.to_string_lossy().into_owned());
@@ -134,6 +161,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
         format,
         opt_level,
         wat_to_stdout,
+        log_level,
     }
 }
 
@@ -149,11 +177,11 @@ fn to_compiler_opt_level(level: OptLevel) -> wado_compiler::OptLevel {
 
 /// Compile a Wado source file and return the Wasm binary
 pub async fn compile(filename: &str) -> Vec<u8> {
-    compile_with_opts(filename, OptLevel::default()).await
+    compile_with_opts(filename, OptLevel::default(), LogLevel::default()).await
 }
 
 /// Compile a Wado source file with optimization options
-pub async fn compile_with_opts(filename: &str, opt_level: OptLevel) -> Vec<u8> {
+pub async fn compile_with_opts(filename: &str, opt_level: OptLevel, log_level: LogLevel) -> Vec<u8> {
     let path = Path::new(filename);
 
     // Read source file
@@ -170,7 +198,7 @@ pub async fn compile_with_opts(filename: &str, opt_level: OptLevel) -> Vec<u8> {
         .parent()
         .map(std::path::Path::to_path_buf)
         .unwrap_or_default();
-    let host = FilesystemCompilerHost::new(base_path);
+    let host = FilesystemCompilerHost::with_log_level(base_path, log_level);
 
     // Compile using async API
     let compiler_opt_level = to_compiler_opt_level(opt_level);
@@ -201,7 +229,7 @@ fn wasm_to_wat(wasm: &[u8]) -> String {
 }
 
 pub async fn run(opts: CompileOptions) {
-    let wasm = compile_with_opts(&opts.input, opts.opt_level).await;
+    let wasm = compile_with_opts(&opts.input, opts.opt_level, opts.log_level).await;
 
     // Handle --wat-to-stdout: output WAT to stdout and return
     if opts.wat_to_stdout {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -181,7 +181,11 @@ pub async fn compile(filename: &str) -> Vec<u8> {
 }
 
 /// Compile a Wado source file with optimization options
-pub async fn compile_with_opts(filename: &str, opt_level: OptLevel, log_level: LogLevel) -> Vec<u8> {
+pub async fn compile_with_opts(
+    filename: &str,
+    opt_level: OptLevel,
+    log_level: LogLevel,
+) -> Vec<u8> {
     let path = Path::new(filename);
 
     // Read source file

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -96,16 +96,18 @@ impl FilesystemCompilerHost {
         }
     }
 
-    /// Format diagnostic with optional timestamp for phase tracking
+    /// Format diagnostic with timestamp for span tracking
+    ///
+    /// Time tracking is done here in the CLI to keep the compiler syscall-free.
     fn format_diagnostic(&self, diagnostic: &Diagnostic) -> String {
         let elapsed = self.start_time.elapsed();
         let timestamp = format!("[{:>6.3}s]", elapsed.as_secs_f64());
 
         match diagnostic.code {
-            Code::PhaseStart => {
+            Code::SpanStart => {
                 format!("{timestamp} >> {}", diagnostic.message)
             }
-            Code::PhaseEnd => {
+            Code::SpanEnd => {
                 format!("{timestamp} << {}", diagnostic.message)
             }
             _ => {

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -5,13 +5,14 @@
 
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::time::Instant;
 
-use wado_compiler::{CompilerHost, Diagnostic, Severity, SourceError};
+use wado_compiler::{Code, CompilerHost, Diagnostic, LogLevel, Severity, SourceError};
 
 /// Filesystem-based compiler host
 ///
 /// This is the standard host used by the CLI. It loads sources from the filesystem
-/// and prints diagnostics to stderr.
+/// and prints diagnostics to stderr with optional timestamps for phase tracking.
 #[derive(Debug)]
 pub struct FilesystemCompilerHost {
     /// Base path for resolving relative imports
@@ -20,6 +21,10 @@ pub struct FilesystemCompilerHost {
     diagnostics: Mutex<Vec<Diagnostic>>,
     /// Whether to print diagnostics to stderr
     print_diagnostics: bool,
+    /// Log level for filtering output
+    log_level: LogLevel,
+    /// Start time for timestamp calculation
+    start_time: Instant,
 }
 
 impl FilesystemCompilerHost {
@@ -30,6 +35,8 @@ impl FilesystemCompilerHost {
             base_path,
             diagnostics: Mutex::new(Vec::new()),
             print_diagnostics: true,
+            log_level: LogLevel::Info,
+            start_time: Instant::now(),
         }
     }
 
@@ -40,6 +47,20 @@ impl FilesystemCompilerHost {
             base_path,
             diagnostics: Mutex::new(Vec::new()),
             print_diagnostics: false,
+            log_level: LogLevel::Off,
+            start_time: Instant::now(),
+        }
+    }
+
+    /// Create a host with a specific log level
+    #[must_use]
+    pub fn with_log_level(base_path: PathBuf, log_level: LogLevel) -> Self {
+        Self {
+            base_path,
+            diagnostics: Mutex::new(Vec::new()),
+            print_diagnostics: true,
+            log_level,
+            start_time: Instant::now(),
         }
     }
 
@@ -61,6 +82,44 @@ impl FilesystemCompilerHost {
     pub fn base_path(&self) -> &PathBuf {
         &self.base_path
     }
+
+    /// Check if the given severity should be logged at the current level
+    fn should_log(&self, severity: Severity) -> bool {
+        match self.log_level {
+            LogLevel::Off => false,
+            LogLevel::Error => severity == Severity::Error,
+            LogLevel::Warn => matches!(severity, Severity::Error | Severity::Warning),
+            LogLevel::Info => {
+                matches!(severity, Severity::Error | Severity::Warning | Severity::Info)
+            }
+            LogLevel::Debug => true,
+        }
+    }
+
+    /// Format diagnostic with optional timestamp for phase tracking
+    fn format_diagnostic(&self, diagnostic: &Diagnostic) -> String {
+        let elapsed = self.start_time.elapsed();
+        let timestamp = format!("[{:>6.3}s]", elapsed.as_secs_f64());
+
+        match diagnostic.code {
+            Code::PhaseStart => {
+                format!("{timestamp} >> {}", diagnostic.message)
+            }
+            Code::PhaseEnd => {
+                format!("{timestamp} << {}", diagnostic.message)
+            }
+            _ => {
+                if let Some(span) = &diagnostic.span {
+                    format!(
+                        "{timestamp} {}:{}:{}: {}: {}",
+                        span.file, span.line, span.column, diagnostic.severity, diagnostic.message
+                    )
+                } else {
+                    format!("{timestamp} {}: {}", diagnostic.severity, diagnostic.message)
+                }
+            }
+        }
+    }
 }
 
 impl CompilerHost for FilesystemCompilerHost {
@@ -72,10 +131,14 @@ impl CompilerHost for FilesystemCompilerHost {
         })
     }
 
-    async fn emit_diagnostic(&self, diagnostic: Diagnostic) {
-        if self.print_diagnostics {
-            eprintln!("{diagnostic}");
+    fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+        // Always collect diagnostics (for errors check)
+        self.diagnostics.lock().unwrap().push(diagnostic.clone());
+
+        // Print if enabled and severity passes the log level filter
+        if self.print_diagnostics && self.should_log(diagnostic.severity) {
+            let formatted = self.format_diagnostic(&diagnostic);
+            eprintln!("{formatted}");
         }
-        self.diagnostics.lock().unwrap().push(diagnostic);
     }
 }

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -90,7 +90,10 @@ impl FilesystemCompilerHost {
             LogLevel::Error => severity == Severity::Error,
             LogLevel::Warn => matches!(severity, Severity::Error | Severity::Warning),
             LogLevel::Info => {
-                matches!(severity, Severity::Error | Severity::Warning | Severity::Info)
+                matches!(
+                    severity,
+                    Severity::Error | Severity::Warning | Severity::Info
+                )
             }
             LogLevel::Debug => true,
         }
@@ -117,7 +120,10 @@ impl FilesystemCompilerHost {
                         span.file, span.line, span.column, diagnostic.severity, diagnostic.message
                     )
                 } else {
-                    format!("{timestamp} {}: {}", diagnostic.severity, diagnostic.message)
+                    format!(
+                        "{timestamp} {}: {}",
+                        diagnostic.severity, diagnostic.message
+                    )
                 }
             }
         }

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -115,6 +115,10 @@ pub enum Code {
     SpanStart,
     /// End of a span (phase, operation, etc.)
     SpanEnd,
+
+    // General logging
+    /// Generic log message (info, debug, etc.)
+    Log,
 }
 
 impl std::fmt::Display for Code {
@@ -141,6 +145,7 @@ impl std::fmt::Display for Code {
             Code::UnsupportedFeature => "UNSUPPORTED_FEATURE",
             Code::SpanStart => "SPAN_START",
             Code::SpanEnd => "SPAN_END",
+            Code::Log => "LOG",
         };
         write!(f, "{name}")
     }

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -110,11 +110,11 @@ pub enum Code {
     /// Unsupported feature
     UnsupportedFeature,
 
-    // Phase tracking codes (for logging/profiling)
-    /// Start of a compilation phase
-    PhaseStart,
-    /// End of a compilation phase
-    PhaseEnd,
+    // Span tracking codes (for logging/profiling)
+    /// Start of a span (phase, operation, etc.)
+    SpanStart,
+    /// End of a span (phase, operation, etc.)
+    SpanEnd,
 }
 
 impl std::fmt::Display for Code {
@@ -139,8 +139,8 @@ impl std::fmt::Display for Code {
             Code::NetworkError => "NETWORK_ERROR",
             Code::CodegenError => "CODEGEN_ERROR",
             Code::UnsupportedFeature => "UNSUPPORTED_FEATURE",
-            Code::PhaseStart => "PHASE_START",
-            Code::PhaseEnd => "PHASE_END",
+            Code::SpanStart => "SPAN_START",
+            Code::SpanEnd => "SPAN_END",
         };
         write!(f, "{name}")
     }

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -12,6 +12,22 @@ use std::future::Future;
 
 use crate::token::Span;
 
+/// Log level for filtering diagnostics and log messages
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum LogLevel {
+    /// Show all messages including debug
+    Debug,
+    /// Show info, warnings, and errors
+    #[default]
+    Info,
+    /// Show only warnings and errors
+    Warn,
+    /// Show only errors
+    Error,
+    /// Show nothing
+    Off,
+}
+
 /// Severity level for diagnostics
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
@@ -36,12 +52,12 @@ impl std::fmt::Display for Severity {
     }
 }
 
-/// Error code for diagnostics
+/// Diagnostic code for categorizing messages
 ///
-/// Named error codes without payloads for clear categorization.
-/// The actual error details go in the `Diagnostic::message` field.
+/// Named codes without payloads for clear categorization.
+/// The actual details go in the `Diagnostic::message` field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ErrorCode {
+pub enum Code {
     // Lexer errors
     /// Invalid character in source
     InvalidCharacter,
@@ -93,30 +109,38 @@ pub enum ErrorCode {
     CodegenError,
     /// Unsupported feature
     UnsupportedFeature,
+
+    // Phase tracking codes (for logging/profiling)
+    /// Start of a compilation phase
+    PhaseStart,
+    /// End of a compilation phase
+    PhaseEnd,
 }
 
-impl std::fmt::Display for ErrorCode {
+impl std::fmt::Display for Code {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
-            ErrorCode::InvalidCharacter => "INVALID_CHARACTER",
-            ErrorCode::UnterminatedString => "UNTERMINATED_STRING",
-            ErrorCode::InvalidEscape => "INVALID_ESCAPE",
-            ErrorCode::UnexpectedToken => "UNEXPECTED_TOKEN",
-            ErrorCode::ExpectedToken => "EXPECTED_TOKEN",
-            ErrorCode::InvalidSyntax => "INVALID_SYNTAX",
-            ErrorCode::UndefinedVariable => "UNDEFINED_VARIABLE",
-            ErrorCode::DuplicateDefinition => "DUPLICATE_DEFINITION",
-            ErrorCode::ImmutableAssignment => "IMMUTABLE_ASSIGNMENT",
-            ErrorCode::TypeMismatch => "TYPE_MISMATCH",
-            ErrorCode::UnknownType => "UNKNOWN_TYPE",
-            ErrorCode::InvalidCast => "INVALID_CAST",
-            ErrorCode::ModuleNotFound => "MODULE_NOT_FOUND",
-            ErrorCode::CircularDependency => "CIRCULAR_DEPENDENCY",
-            ErrorCode::ModuleParseError => "MODULE_PARSE_ERROR",
-            ErrorCode::FileReadError => "FILE_READ_ERROR",
-            ErrorCode::NetworkError => "NETWORK_ERROR",
-            ErrorCode::CodegenError => "CODEGEN_ERROR",
-            ErrorCode::UnsupportedFeature => "UNSUPPORTED_FEATURE",
+            Code::InvalidCharacter => "INVALID_CHARACTER",
+            Code::UnterminatedString => "UNTERMINATED_STRING",
+            Code::InvalidEscape => "INVALID_ESCAPE",
+            Code::UnexpectedToken => "UNEXPECTED_TOKEN",
+            Code::ExpectedToken => "EXPECTED_TOKEN",
+            Code::InvalidSyntax => "INVALID_SYNTAX",
+            Code::UndefinedVariable => "UNDEFINED_VARIABLE",
+            Code::DuplicateDefinition => "DUPLICATE_DEFINITION",
+            Code::ImmutableAssignment => "IMMUTABLE_ASSIGNMENT",
+            Code::TypeMismatch => "TYPE_MISMATCH",
+            Code::UnknownType => "UNKNOWN_TYPE",
+            Code::InvalidCast => "INVALID_CAST",
+            Code::ModuleNotFound => "MODULE_NOT_FOUND",
+            Code::CircularDependency => "CIRCULAR_DEPENDENCY",
+            Code::ModuleParseError => "MODULE_PARSE_ERROR",
+            Code::FileReadError => "FILE_READ_ERROR",
+            Code::NetworkError => "NETWORK_ERROR",
+            Code::CodegenError => "CODEGEN_ERROR",
+            Code::UnsupportedFeature => "UNSUPPORTED_FEATURE",
+            Code::PhaseStart => "PHASE_START",
+            Code::PhaseEnd => "PHASE_END",
         };
         write!(f, "{name}")
     }
@@ -127,8 +151,8 @@ impl std::fmt::Display for ErrorCode {
 pub struct Diagnostic {
     /// Severity level
     pub severity: Severity,
-    /// Error code categorizing the diagnostic
-    pub code: ErrorCode,
+    /// Code categorizing the diagnostic
+    pub code: Code,
     /// Human-readable message
     pub message: String,
     /// Source location (if available)
@@ -226,7 +250,7 @@ impl std::error::Error for SourceError {}
 ///         // Load source from custom storage
 ///     }
 ///
-///     async fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+///     fn emit_diagnostic(&self, diagnostic: Diagnostic) {
 ///         // Handle diagnostic (print, collect, send to UI, etc.)
 ///     }
 /// }
@@ -248,9 +272,10 @@ pub trait CompilerHost: Send + Sync {
 
     /// Emit a diagnostic (error, warning, etc.)
     ///
-    /// This method is called by the compiler whenever a diagnostic needs to be reported.
-    /// Implementations can print to stderr, collect into a list, send to an LSP client, etc.
-    fn emit_diagnostic(&self, diagnostic: Diagnostic) -> impl Future<Output = ()> + Send;
+    /// This method is called synchronously by the compiler whenever a diagnostic
+    /// needs to be reported. Implementations can print to stderr, collect into
+    /// a list, send to an LSP client, etc.
+    fn emit_diagnostic(&self, diagnostic: Diagnostic);
 }
 
 /// A simple in-memory compiler host for testing
@@ -305,7 +330,7 @@ impl CompilerHost for InMemoryCompilerHost {
             })
     }
 
-    async fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+    fn emit_diagnostic(&self, diagnostic: Diagnostic) {
         self.diagnostics.lock().unwrap().push(diagnostic);
     }
 }
@@ -333,7 +358,7 @@ mod tests {
     fn test_diagnostic_display() {
         let diag = Diagnostic {
             severity: Severity::Error,
-            code: ErrorCode::UnexpectedToken,
+            code: Code::UnexpectedToken,
             message: "expected ';' but found '}'".to_string(),
             span: Some(DiagnosticSpan {
                 file: "test.wado".to_string(),

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -80,6 +80,7 @@ pub mod component_model;
 pub mod desugar;
 pub mod lexer;
 pub mod loader;
+pub mod logger;
 pub mod lower;
 pub mod name;
 pub mod optimize;
@@ -106,8 +107,9 @@ pub use analyze::Analyzer;
 pub use bind::{BindError, Binder};
 pub use codegen::Codegen;
 pub use compiler_host::{
-    CompilerHost, Diagnostic, DiagnosticSpan, ErrorCode, Severity, SourceError,
+    Code, CompilerHost, Diagnostic, DiagnosticSpan, LogLevel, Severity, SourceError,
 };
+pub use logger::Logger;
 
 #[cfg(test)]
 pub use compiler_host::InMemoryCompilerHost;

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -222,8 +222,7 @@ pub async fn compile_with_host<H: CompilerHost>(
 
     // === Phase 4: Load all modules upfront ===
     let load_result = {
-        let module_loader =
-            loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
+        let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
             .load_all(source, filename.as_deref())
             .await
@@ -380,8 +379,7 @@ pub async fn dump_with_host<H: CompilerHost>(
 
     // === Phase 5: Load all modules ===
     let load_result = {
-        let module_loader =
-            loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
+        let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
             .load_all(source, filename.as_deref())
             .await

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -222,9 +222,10 @@ pub async fn compile_with_host<H: CompilerHost>(
 
     // === Phase 4: Load all modules upfront ===
     let load_result = {
+        let logger = logger::Logger::new(host, compiler_host::LogLevel::default());
         let module_loader = loader::ModuleLoader::new();
         module_loader
-            .load_all(source, filename.as_deref(), host)
+            .load_all(source, filename.as_deref(), &logger)
             .await
             .map_err(|e| CompileError::Analyzer {
                 message: e.to_string(),
@@ -379,9 +380,10 @@ pub async fn dump_with_host<H: CompilerHost>(
 
     // === Phase 5: Load all modules ===
     let load_result = {
+        let logger = logger::Logger::new(host, compiler_host::LogLevel::default());
         let module_loader = loader::ModuleLoader::new();
         module_loader
-            .load_all(source, filename.as_deref(), host)
+            .load_all(source, filename.as_deref(), &logger)
             .await
             .map_err(|e| CompileError::Analyzer {
                 message: e.to_string(),

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -222,10 +222,10 @@ pub async fn compile_with_host<H: CompilerHost>(
 
     // === Phase 4: Load all modules upfront ===
     let load_result = {
-        let logger = logger::Logger::new(host, compiler_host::LogLevel::default());
-        let module_loader = loader::ModuleLoader::new();
+        let module_loader =
+            loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
-            .load_all(source, filename.as_deref(), &logger)
+            .load_all(source, filename.as_deref())
             .await
             .map_err(|e| CompileError::Analyzer {
                 message: e.to_string(),
@@ -380,10 +380,10 @@ pub async fn dump_with_host<H: CompilerHost>(
 
     // === Phase 5: Load all modules ===
     let load_result = {
-        let logger = logger::Logger::new(host, compiler_host::LogLevel::default());
-        let module_loader = loader::ModuleLoader::new();
+        let module_loader =
+            loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
-            .load_all(source, filename.as_deref(), &logger)
+            .load_all(source, filename.as_deref())
             .await
             .map_err(|e| CompileError::Analyzer {
                 message: e.to_string(),

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -182,9 +182,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             self.loading.insert(module_source.clone());
 
             // Load and parse the module
-            let source = self
-                .get_source(&module_source, &from_module_source)
-                .await?;
+            let source = self.get_source(&module_source, &from_module_source).await?;
             let module = self.parse_source(&source, &module_source)?;
 
             // Collect its imports
@@ -259,9 +257,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                             {
                                 self.logger().warn(
                                     Code::ModuleParseError,
-                                    format!(
-                                        "failed to collect imports from implicit module: {e}"
-                                    ),
+                                    format!("failed to collect imports from implicit module: {e}"),
                                 );
                                 continue;
                             }
@@ -445,4 +441,3 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         })
     }
 }
-

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -98,11 +98,17 @@ pub struct LoadResult {
     pub implicit_modules: HashSet<ModuleSource>,
 }
 
+use crate::compiler_host::LogLevel;
+
 /// Module loader
 ///
 /// Loads all modules upfront before analysis and codegen.
 /// Uses a `CompilerHost` for I/O operations.
-pub struct ModuleLoader {
+pub struct ModuleLoader<'a, H: CompilerHost> {
+    /// Host for I/O operations
+    host: &'a H,
+    /// Log level for filtering messages
+    log_level: LogLevel,
     /// Cache of already parsed modules
     loaded: HashMap<ModuleSource, Module>,
     /// Set of modules currently being loaded (for cycle detection during collection)
@@ -111,17 +117,24 @@ pub struct ModuleLoader {
     implicit_modules: HashSet<ModuleSource>,
 }
 
-impl ModuleLoader {
-    /// Create a new module loader
-    pub fn new() -> Self {
+impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
+    /// Create a new module loader with the given host and log level
+    pub fn new(host: &'a H, log_level: LogLevel) -> Self {
         Self {
+            host,
+            log_level,
             loaded: HashMap::new(),
             loading: HashSet::new(),
             implicit_modules: HashSet::new(),
         }
     }
 
-    /// Load all modules starting from the entry source using a `Logger`
+    /// Create a logger for emitting diagnostics
+    fn logger(&self) -> Logger<'_, H> {
+        Logger::new(self.host, self.log_level)
+    }
+
+    /// Load all modules starting from the entry source
     ///
     /// This loads the entry module and all its transitive dependencies.
     /// It also loads implicit modules (core:prelude, core:internal, core:builtin).
@@ -129,12 +142,10 @@ impl ModuleLoader {
     /// # Arguments
     /// * `entry_source` - Source code of the entry module
     /// * `entry_filename` - Optional filename of the entry module (for error messages)
-    /// * `logger` - `Logger` for loading user modules and emitting diagnostics
-    pub async fn load_all<H: CompilerHost>(
+    pub async fn load_all(
         mut self,
         entry_source: &str,
         entry_filename: Option<&str>,
-        logger: &Logger<'_, H>,
     ) -> Result<LoadResult, LoadError> {
         // Parse entry module
         let entry_module_source = if let Some(filename) = entry_filename {
@@ -170,7 +181,7 @@ impl ModuleLoader {
 
             // Load and parse the module
             let source = self
-                .get_source_with_host(&module_source, &from_module_source, logger.host())
+                .get_source(&module_source, &from_module_source)
                 .await?;
             let module = self.parse_source(&source, &module_source)?;
 
@@ -184,7 +195,7 @@ impl ModuleLoader {
         }
 
         // Load implicit modules (for compiler-generated code)
-        self.load_implicit_modules(logger).await?;
+        self.load_implicit_modules().await?;
 
         Ok(LoadResult {
             modules: self.loaded,
@@ -210,10 +221,7 @@ impl ModuleLoader {
     }
 
     /// Load implicit modules required by the compiler
-    async fn load_implicit_modules<H: CompilerHost>(
-        &mut self,
-        logger: &Logger<'_, H>,
-    ) -> Result<(), LoadError> {
+    async fn load_implicit_modules(&mut self) -> Result<(), LoadError> {
         let implicit_module_sources = [
             ModuleSource::Core {
                 name: "prelude".to_string(),
@@ -233,7 +241,7 @@ impl ModuleLoader {
 
             // Try to load - errors are warnings for implicit modules
             match self
-                .get_source_with_host(&module_source, &ModuleSource::entry_point(), logger.host())
+                .get_source(&module_source, &ModuleSource::entry_point())
                 .await
             {
                 Ok(source) => {
@@ -245,7 +253,7 @@ impl ModuleLoader {
                             if let Err(e) =
                                 self.collect_imports(&module, &module_source, &mut pending)
                             {
-                                logger.warn(
+                                self.logger().warn(
                                     Code::ModuleParseError,
                                     format!(
                                         "failed to collect imports from implicit module: {e}"
@@ -262,11 +270,7 @@ impl ModuleLoader {
                                     continue;
                                 }
                                 if let Ok(dep_source) = self
-                                    .get_source_with_host(
-                                        &dep_module_source,
-                                        &from_module_source,
-                                        logger.host(),
-                                    )
+                                    .get_source(&dep_module_source, &from_module_source)
                                     .await
                                     && let Ok(dep_module) =
                                         self.parse_source(&dep_source, &dep_module_source)
@@ -288,7 +292,7 @@ impl ModuleLoader {
                             self.implicit_modules.insert(module_source);
                         }
                         Err(e) => {
-                            logger.warn(
+                            self.logger().warn(
                                 Code::ModuleParseError,
                                 format!("failed to parse implicit module: {e}"),
                             );
@@ -296,7 +300,7 @@ impl ModuleLoader {
                     }
                 }
                 Err(e) => {
-                    logger.warn(
+                    self.logger().warn(
                         Code::ModuleNotFound,
                         format!("failed to load implicit module: {e}"),
                     );
@@ -369,16 +373,19 @@ impl ModuleLoader {
         })
     }
 
-    /// Get source code for a module using `CompilerHost`
-    async fn get_source_with_host<H: CompilerHost>(
+    /// Get source code for a module
+    async fn get_source(
         &self,
         module_source: &ModuleSource,
         _from_module_source: &ModuleSource,
-        host: &H,
     ) -> Result<String, LoadError> {
         match module_source {
-            ModuleSource::Local { path } => host.load_source(path).await.map_err(LoadError::from),
-            ModuleSource::Remote { url } => host.load_source(url).await.map_err(LoadError::from),
+            ModuleSource::Local { path } => {
+                self.host.load_source(path).await.map_err(LoadError::from)
+            }
+            ModuleSource::Remote { url } => {
+                self.host.load_source(url).await.map_err(LoadError::from)
+            }
             ModuleSource::Core { name } => {
                 let import_path = format!("core:{name}");
                 if let Some(source) = stdlib::get_stdlib_module(&import_path) {
@@ -435,8 +442,3 @@ impl ModuleLoader {
     }
 }
 
-impl Default for ModuleLoader {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -6,9 +6,10 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{Item, Module};
-use crate::compiler_host::{Code, CompilerHost, Diagnostic, Severity, SourceError};
+use crate::compiler_host::{Code, CompilerHost, SourceError};
 use crate::desugar::desugar_module;
 use crate::lexer::Lexer;
+use crate::logger::Logger;
 use crate::name::{ModuleSource, normalize_module_path, resolve_module_path};
 use crate::parser::Parser;
 use crate::stdlib;
@@ -120,7 +121,7 @@ impl ModuleLoader {
         }
     }
 
-    /// Load all modules starting from the entry source using a `CompilerHost`
+    /// Load all modules starting from the entry source using a `Logger`
     ///
     /// This loads the entry module and all its transitive dependencies.
     /// It also loads implicit modules (core:prelude, core:internal, core:builtin).
@@ -128,12 +129,12 @@ impl ModuleLoader {
     /// # Arguments
     /// * `entry_source` - Source code of the entry module
     /// * `entry_filename` - Optional filename of the entry module (for error messages)
-    /// * `host` - `CompilerHost` for loading user modules and emitting diagnostics
+    /// * `logger` - `Logger` for loading user modules and emitting diagnostics
     pub async fn load_all<H: CompilerHost>(
         mut self,
         entry_source: &str,
         entry_filename: Option<&str>,
-        host: &H,
+        logger: &Logger<'_, H>,
     ) -> Result<LoadResult, LoadError> {
         // Parse entry module
         let entry_module_source = if let Some(filename) = entry_filename {
@@ -169,7 +170,7 @@ impl ModuleLoader {
 
             // Load and parse the module
             let source = self
-                .get_source_with_host(&module_source, &from_module_source, host)
+                .get_source_with_host(&module_source, &from_module_source, logger.host())
                 .await?;
             let module = self.parse_source(&source, &module_source)?;
 
@@ -183,7 +184,7 @@ impl ModuleLoader {
         }
 
         // Load implicit modules (for compiler-generated code)
-        self.load_implicit_modules(host).await?;
+        self.load_implicit_modules(logger).await?;
 
         Ok(LoadResult {
             modules: self.loaded,
@@ -209,7 +210,10 @@ impl ModuleLoader {
     }
 
     /// Load implicit modules required by the compiler
-    async fn load_implicit_modules<H: CompilerHost>(&mut self, host: &H) -> Result<(), LoadError> {
+    async fn load_implicit_modules<H: CompilerHost>(
+        &mut self,
+        logger: &Logger<'_, H>,
+    ) -> Result<(), LoadError> {
         let implicit_module_sources = [
             ModuleSource::Core {
                 name: "prelude".to_string(),
@@ -229,7 +233,7 @@ impl ModuleLoader {
 
             // Try to load - errors are warnings for implicit modules
             match self
-                .get_source_with_host(&module_source, &ModuleSource::entry_point(), host)
+                .get_source_with_host(&module_source, &ModuleSource::entry_point(), logger.host())
                 .await
             {
                 Ok(source) => {
@@ -241,14 +245,12 @@ impl ModuleLoader {
                             if let Err(e) =
                                 self.collect_imports(&module, &module_source, &mut pending)
                             {
-                                host.emit_diagnostic(Diagnostic {
-                                    severity: Severity::Warning,
-                                    code: Code::ModuleParseError,
-                                    message: format!(
+                                logger.warn(
+                                    Code::ModuleParseError,
+                                    format!(
                                         "failed to collect imports from implicit module: {e}"
                                     ),
-                                    span: None,
-                                });
+                                );
                                 continue;
                             }
 
@@ -263,7 +265,7 @@ impl ModuleLoader {
                                     .get_source_with_host(
                                         &dep_module_source,
                                         &from_module_source,
-                                        host,
+                                        logger.host(),
                                     )
                                     .await
                                     && let Ok(dep_module) =
@@ -286,22 +288,18 @@ impl ModuleLoader {
                             self.implicit_modules.insert(module_source);
                         }
                         Err(e) => {
-                            host.emit_diagnostic(Diagnostic {
-                                severity: Severity::Warning,
-                                code: Code::ModuleParseError,
-                                message: format!("failed to parse implicit module: {e}"),
-                                span: None,
-                            });
+                            logger.warn(
+                                Code::ModuleParseError,
+                                format!("failed to parse implicit module: {e}"),
+                            );
                         }
                     }
                 }
                 Err(e) => {
-                    host.emit_diagnostic(Diagnostic {
-                        severity: Severity::Warning,
-                        code: Code::ModuleNotFound,
-                        message: format!("failed to load implicit module: {e}"),
-                        span: None,
-                    });
+                    logger.warn(
+                        Code::ModuleNotFound,
+                        format!("failed to load implicit module: {e}"),
+                    );
                 }
             }
         }

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -147,6 +147,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         entry_source: &str,
         entry_filename: Option<&str>,
     ) -> Result<LoadResult, LoadError> {
+        self.logger().span_start("load");
+
         // Parse entry module
         let entry_module_source = if let Some(filename) = entry_filename {
             ModuleSource::entry_point_with_filename(filename)
@@ -196,6 +198,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
 
         // Load implicit modules (for compiler-generated code)
         self.load_implicit_modules().await?;
+
+        self.logger().span_end("load");
 
         Ok(LoadResult {
             modules: self.loaded,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{Item, Module};
-use crate::compiler_host::{CompilerHost, Diagnostic, ErrorCode, Severity, SourceError};
+use crate::compiler_host::{Code, CompilerHost, Diagnostic, Severity, SourceError};
 use crate::desugar::desugar_module;
 use crate::lexer::Lexer;
 use crate::name::{ModuleSource, normalize_module_path, resolve_module_path};
@@ -243,13 +243,12 @@ impl ModuleLoader {
                             {
                                 host.emit_diagnostic(Diagnostic {
                                     severity: Severity::Warning,
-                                    code: ErrorCode::ModuleParseError,
+                                    code: Code::ModuleParseError,
                                     message: format!(
                                         "failed to collect imports from implicit module: {e}"
                                     ),
                                     span: None,
-                                })
-                                .await;
+                                });
                                 continue;
                             }
 
@@ -289,22 +288,20 @@ impl ModuleLoader {
                         Err(e) => {
                             host.emit_diagnostic(Diagnostic {
                                 severity: Severity::Warning,
-                                code: ErrorCode::ModuleParseError,
+                                code: Code::ModuleParseError,
                                 message: format!("failed to parse implicit module: {e}"),
                                 span: None,
-                            })
-                            .await;
+                            });
                         }
                     }
                 }
                 Err(e) => {
                     host.emit_diagnostic(Diagnostic {
                         severity: Severity::Warning,
-                        code: ErrorCode::ModuleNotFound,
+                        code: Code::ModuleNotFound,
                         message: format!("failed to load implicit module: {e}"),
                         span: None,
-                    })
-                    .await;
+                    });
                 }
             }
         }

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -80,14 +80,11 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     }
 
     /// Log an info message
-    ///
-    /// Uses `Code::SpanStart` as a generic info code since info messages
-    /// don't typically have specific error codes.
     pub fn info(&self, message: impl Into<String>) {
         if self.should_log(Severity::Info) {
             self.host.emit_diagnostic(Diagnostic {
                 severity: Severity::Info,
-                code: Code::SpanStart, // Generic code for info
+                code: Code::Log,
                 message: message.into(),
                 span: None,
             });
@@ -95,14 +92,11 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     }
 
     /// Log a debug message
-    ///
-    /// Uses `Code::SpanStart` as a generic debug code since debug messages
-    /// don't typically have specific error codes.
     pub fn debug(&self, message: impl Into<String>) {
         if self.should_log(Severity::Hint) {
             self.host.emit_diagnostic(Diagnostic {
                 severity: Severity::Hint, // Use Hint for debug level
-                code: Code::SpanStart,    // Generic code for debug
+                code: Code::Log,
                 message: message.into(),
                 span: None,
             });

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -131,6 +131,32 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         }
     }
 
+    /// Emit a span start marker
+    ///
+    /// Use this when RAII pattern (`span()`) doesn't work due to borrow conflicts.
+    /// Must be paired with a corresponding `span_end()` call.
+    pub fn span_start(&self, name: &str) {
+        self.host.emit_diagnostic(Diagnostic {
+            severity: Severity::Info,
+            code: Code::SpanStart,
+            message: name.to_string(),
+            span: None,
+        });
+    }
+
+    /// Emit a span end marker
+    ///
+    /// Use this when RAII pattern (`span()`) doesn't work due to borrow conflicts.
+    /// Must be paired with a corresponding `span_start()` call.
+    pub fn span_end(&self, name: &str) {
+        self.host.emit_diagnostic(Diagnostic {
+            severity: Severity::Info,
+            code: Code::SpanEnd,
+            message: name.to_string(),
+            span: None,
+        });
+    }
+
     /// Get a reference to the underlying host
     pub fn host(&self) -> &'a H {
         self.host

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -1,9 +1,10 @@
 //! Logger module for structured compiler logging
 //!
 //! Provides a `Logger` wrapper around `CompilerHost` for convenient logging
-//! with severity levels and phase span tracking.
-
-use std::time::Instant;
+//! with severity levels and span tracking.
+//!
+//! Note: Time tracking is intentionally omitted from the compiler to keep it
+//! syscall-free. The CLI or host implementation should add timestamps if needed.
 
 use crate::compiler_host::{Code, CompilerHost, Diagnostic, LogLevel, Severity};
 
@@ -80,13 +81,13 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
 
     /// Log an info message
     ///
-    /// Uses `Code::PhaseStart` as a generic info code since info messages
+    /// Uses `Code::SpanStart` as a generic info code since info messages
     /// don't typically have specific error codes.
     pub fn info(&self, message: impl Into<String>) {
         if self.should_log(Severity::Info) {
             self.host.emit_diagnostic(Diagnostic {
                 severity: Severity::Info,
-                code: Code::PhaseStart, // Generic code for info
+                code: Code::SpanStart, // Generic code for info
                 message: message.into(),
                 span: None,
             });
@@ -95,23 +96,23 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
 
     /// Log a debug message
     ///
-    /// Uses `Code::PhaseStart` as a generic debug code since debug messages
+    /// Uses `Code::SpanStart` as a generic debug code since debug messages
     /// don't typically have specific error codes.
     pub fn debug(&self, message: impl Into<String>) {
         if self.should_log(Severity::Hint) {
             self.host.emit_diagnostic(Diagnostic {
                 severity: Severity::Hint, // Use Hint for debug level
-                code: Code::PhaseStart,   // Generic code for debug
+                code: Code::SpanStart,    // Generic code for debug
                 message: message.into(),
                 span: None,
             });
         }
     }
 
-    /// Start a phase span for timing
+    /// Start a span for tracking
     ///
-    /// Returns a `SpanGuard` that emits `PhaseEnd` when dropped.
-    /// The CLI can add timestamps to track compilation phase timing.
+    /// Returns a `SpanGuard` that emits `SpanEnd` when dropped.
+    /// The CLI or host implementation can add timestamps to track timing.
     ///
     /// # Example
     ///
@@ -119,13 +120,13 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     /// {
     ///     let _span = logger.span("parse");
     ///     // ... parsing ...
-    /// } // PhaseEnd emitted here
+    /// } // SpanEnd emitted here
     /// ```
     pub fn span(&self, name: &str) -> SpanGuard<'_, 'a, H> {
-        // Emit PhaseStart
+        // Emit SpanStart
         self.host.emit_diagnostic(Diagnostic {
             severity: Severity::Info,
-            code: Code::PhaseStart,
+            code: Code::SpanStart,
             message: name.to_string(),
             span: None,
         });
@@ -133,7 +134,6 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         SpanGuard {
             logger: self,
             name: name.to_string(),
-            start: Instant::now(),
         }
     }
 
@@ -143,22 +143,20 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     }
 }
 
-/// RAII guard for phase span tracking
+/// RAII guard for span tracking
 ///
-/// When dropped, emits a `PhaseEnd` diagnostic with the phase name.
-/// The CLI can use timestamps to measure phase duration.
+/// When dropped, emits a `SpanEnd` diagnostic with the span name.
+/// The CLI or host implementation can use timestamps to measure duration.
 pub struct SpanGuard<'l, 'a, H: CompilerHost> {
     logger: &'l Logger<'a, H>,
     name: String,
-    #[allow(dead_code)]
-    start: Instant,
 }
 
 impl<H: CompilerHost> Drop for SpanGuard<'_, '_, H> {
     fn drop(&mut self) {
         self.logger.host.emit_diagnostic(Diagnostic {
             severity: Severity::Info,
-            code: Code::PhaseEnd,
+            code: Code::SpanEnd,
             message: self.name.clone(),
             span: None,
         });
@@ -200,9 +198,9 @@ mod tests {
 
         let diags = host.diagnostics();
         assert_eq!(diags.len(), 2);
-        assert_eq!(diags[0].code, Code::PhaseStart);
+        assert_eq!(diags[0].code, Code::SpanStart);
         assert_eq!(diags[0].message, "test_phase");
-        assert_eq!(diags[1].code, Code::PhaseEnd);
+        assert_eq!(diags[1].code, Code::SpanEnd);
         assert_eq!(diags[1].message, "test_phase");
     }
 

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -49,7 +49,10 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
             LogLevel::Error => severity == Severity::Error,
             LogLevel::Warn => matches!(severity, Severity::Error | Severity::Warning),
             LogLevel::Info => {
-                matches!(severity, Severity::Error | Severity::Warning | Severity::Info)
+                matches!(
+                    severity,
+                    Severity::Error | Severity::Warning | Severity::Info
+                )
             }
             LogLevel::Debug => true,
         }

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -1,0 +1,222 @@
+//! Logger module for structured compiler logging
+//!
+//! Provides a `Logger` wrapper around `CompilerHost` for convenient logging
+//! with severity levels and phase span tracking.
+
+use std::time::Instant;
+
+use crate::compiler_host::{Code, CompilerHost, Diagnostic, LogLevel, Severity};
+
+/// Logger for compiler phases
+///
+/// Wraps a `CompilerHost` and provides convenience methods for logging
+/// at different severity levels. Also supports phase span tracking with
+/// RAII guards.
+///
+/// # Example
+///
+/// ```ignore
+/// let logger = Logger::new(&host, LogLevel::Debug);
+///
+/// // Log messages at different levels
+/// logger.debug("entering function");
+/// logger.info("processing 10 items");
+/// logger.warn("deprecated feature used");
+/// logger.error(Code::TypeMismatch, "expected i32, found String", None);
+///
+/// // Track phase timing with RAII guard
+/// {
+///     let _span = logger.span("parse");
+///     // ... parsing happens here ...
+/// } // PhaseEnd is emitted when _span is dropped
+/// ```
+pub struct Logger<'a, H: CompilerHost> {
+    host: &'a H,
+    level: LogLevel,
+}
+
+impl<'a, H: CompilerHost> Logger<'a, H> {
+    /// Create a new logger with the given host and log level
+    pub fn new(host: &'a H, level: LogLevel) -> Self {
+        Self { host, level }
+    }
+
+    /// Check if the given severity should be logged at the current level
+    fn should_log(&self, severity: Severity) -> bool {
+        match self.level {
+            LogLevel::Off => false,
+            LogLevel::Error => severity == Severity::Error,
+            LogLevel::Warn => matches!(severity, Severity::Error | Severity::Warning),
+            LogLevel::Info => {
+                matches!(severity, Severity::Error | Severity::Warning | Severity::Info)
+            }
+            LogLevel::Debug => true,
+        }
+    }
+
+    /// Log an error with a diagnostic code
+    pub fn error(&self, code: Code, message: impl Into<String>) {
+        if self.should_log(Severity::Error) {
+            self.host.emit_diagnostic(Diagnostic {
+                severity: Severity::Error,
+                code,
+                message: message.into(),
+                span: None,
+            });
+        }
+    }
+
+    /// Log a warning with a diagnostic code
+    pub fn warn(&self, code: Code, message: impl Into<String>) {
+        if self.should_log(Severity::Warning) {
+            self.host.emit_diagnostic(Diagnostic {
+                severity: Severity::Warning,
+                code,
+                message: message.into(),
+                span: None,
+            });
+        }
+    }
+
+    /// Log an info message
+    ///
+    /// Uses `Code::PhaseStart` as a generic info code since info messages
+    /// don't typically have specific error codes.
+    pub fn info(&self, message: impl Into<String>) {
+        if self.should_log(Severity::Info) {
+            self.host.emit_diagnostic(Diagnostic {
+                severity: Severity::Info,
+                code: Code::PhaseStart, // Generic code for info
+                message: message.into(),
+                span: None,
+            });
+        }
+    }
+
+    /// Log a debug message
+    ///
+    /// Uses `Code::PhaseStart` as a generic debug code since debug messages
+    /// don't typically have specific error codes.
+    pub fn debug(&self, message: impl Into<String>) {
+        if self.should_log(Severity::Hint) {
+            self.host.emit_diagnostic(Diagnostic {
+                severity: Severity::Hint, // Use Hint for debug level
+                code: Code::PhaseStart,   // Generic code for debug
+                message: message.into(),
+                span: None,
+            });
+        }
+    }
+
+    /// Start a phase span for timing
+    ///
+    /// Returns a `SpanGuard` that emits `PhaseEnd` when dropped.
+    /// The CLI can add timestamps to track compilation phase timing.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// {
+    ///     let _span = logger.span("parse");
+    ///     // ... parsing ...
+    /// } // PhaseEnd emitted here
+    /// ```
+    pub fn span(&self, name: &str) -> SpanGuard<'_, 'a, H> {
+        // Emit PhaseStart
+        self.host.emit_diagnostic(Diagnostic {
+            severity: Severity::Info,
+            code: Code::PhaseStart,
+            message: name.to_string(),
+            span: None,
+        });
+
+        SpanGuard {
+            logger: self,
+            name: name.to_string(),
+            start: Instant::now(),
+        }
+    }
+
+    /// Get a reference to the underlying host
+    pub fn host(&self) -> &'a H {
+        self.host
+    }
+}
+
+/// RAII guard for phase span tracking
+///
+/// When dropped, emits a `PhaseEnd` diagnostic with the phase name.
+/// The CLI can use timestamps to measure phase duration.
+pub struct SpanGuard<'l, 'a, H: CompilerHost> {
+    logger: &'l Logger<'a, H>,
+    name: String,
+    #[allow(dead_code)]
+    start: Instant,
+}
+
+impl<H: CompilerHost> Drop for SpanGuard<'_, '_, H> {
+    fn drop(&mut self) {
+        self.logger.host.emit_diagnostic(Diagnostic {
+            severity: Severity::Info,
+            code: Code::PhaseEnd,
+            message: self.name.clone(),
+            span: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler_host::InMemoryCompilerHost;
+
+    #[test]
+    fn test_logger_levels() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Warn);
+
+        // Debug and info should be filtered out
+        logger.debug("debug message");
+        logger.info("info message");
+        logger.warn(Code::UnsupportedFeature, "warning message");
+        logger.error(Code::TypeMismatch, "error message");
+
+        let diags = host.diagnostics();
+        assert_eq!(diags.len(), 2);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[1].severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_span_guard() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Debug);
+
+        {
+            let _span = logger.span("test_phase");
+            // Span is active
+        }
+        // Span should be closed
+
+        let diags = host.diagnostics();
+        assert_eq!(diags.len(), 2);
+        assert_eq!(diags[0].code, Code::PhaseStart);
+        assert_eq!(diags[0].message, "test_phase");
+        assert_eq!(diags[1].code, Code::PhaseEnd);
+        assert_eq!(diags[1].message, "test_phase");
+    }
+
+    #[test]
+    fn test_log_level_off() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Off);
+
+        logger.error(Code::TypeMismatch, "error");
+        logger.warn(Code::UnsupportedFeature, "warning");
+        logger.info("info");
+        logger.debug("debug");
+
+        let diags = host.diagnostics();
+        assert!(diags.is_empty());
+    }
+}

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -23,12 +23,7 @@ impl CompilerHost for InMemoryTestHost {
         async move { Err(SourceError::NotFound { path }) }
     }
 
-    fn emit_diagnostic(
-        &self,
-        _diagnostic: Diagnostic,
-    ) -> impl std::future::Future<Output = ()> + Send {
-        async {}
-    }
+    fn emit_diagnostic(&self, _diagnostic: Diagnostic) {}
 }
 
 /// Filesystem compiler host for file-based tests
@@ -60,14 +55,8 @@ impl CompilerHost for FilesystemTestHost {
         }
     }
 
-    fn emit_diagnostic(
-        &self,
-        diagnostic: Diagnostic,
-    ) -> impl std::future::Future<Output = ()> + Send {
-        let diagnostics = &self.diagnostics;
-        async move {
-            diagnostics.lock().unwrap().push(diagnostic);
-        }
+    fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
     }
 }
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -51,14 +51,8 @@ impl CompilerHost for TestCompilerHost {
         }
     }
 
-    fn emit_diagnostic(
-        &self,
-        diagnostic: wado_compiler::Diagnostic,
-    ) -> impl std::future::Future<Output = ()> + Send {
-        let diagnostics = &self.diagnostics;
-        async move {
-            diagnostics.lock().unwrap().push(diagnostic);
-        }
+    fn emit_diagnostic(&self, diagnostic: wado_compiler::Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
     }
 }
 

--- a/wado-compiler/tests/lowered.rs
+++ b/wado-compiler/tests/lowered.rs
@@ -45,14 +45,8 @@ impl CompilerHost for TestCompilerHost {
         }
     }
 
-    fn emit_diagnostic(
-        &self,
-        diagnostic: wado_compiler::Diagnostic,
-    ) -> impl std::future::Future<Output = ()> + Send {
-        let diagnostics = &self.diagnostics;
-        async move {
-            diagnostics.lock().unwrap().push(diagnostic);
-        }
+    fn emit_diagnostic(&self, diagnostic: wado_compiler::Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
     }
 }
 

--- a/wado-compiler/tests/wat.rs
+++ b/wado-compiler/tests/wat.rs
@@ -40,14 +40,8 @@ impl CompilerHost for TestCompilerHost {
         }
     }
 
-    fn emit_diagnostic(
-        &self,
-        diagnostic: wado_compiler::Diagnostic,
-    ) -> impl std::future::Future<Output = ()> + Send {
-        let diagnostics = &self.diagnostics;
-        async move {
-            diagnostics.lock().unwrap().push(diagnostic);
-        }
+    fn emit_diagnostic(&self, diagnostic: wado_compiler::Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
     }
 }
 


### PR DESCRIPTION
- Rename ErrorCode to Code for broader usage (warnings, info, hints)
- Add PhaseStart/PhaseEnd codes for compilation phase tracking
- Make emit_diagnostic sync instead of async for performance
- Add Logger module with RAII SpanGuard for phase timing
- Add LogLevel enum (Debug, Info, Warn, Error, Off)
- Add --log-level CLI option to compile command
- Update FilesystemCompilerHost to support log levels and timestamps
- Update all test files to use sync emit_diagnostic