### PR TITLE
Refactor ModuleLoader to use Logger for host access

### DIFF
--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -144,7 +144,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         entry_source: &str,
         entry_filename: Option<&str>,
     ) -> Result<LoadResult, LoadError> {
-        self.logger().span_start("load");
+        let _span = self.logger.span("load");
 
         // Parse entry module
         let entry_module_source = if let Some(filename) = entry_filename {
@@ -192,9 +192,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         }
 
         // Load implicit modules (for compiler-generated code)
+        // Drop span before calling method that needs &mut self
+        drop(_span);
         self.load_implicit_modules().await?;
-
-        self.logger().span_end("load");
 
         Ok(LoadResult {
             modules: self.loaded,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -105,10 +105,8 @@ use crate::compiler_host::LogLevel;
 /// Loads all modules upfront before analysis and codegen.
 /// Uses a `CompilerHost` for I/O operations.
 pub struct ModuleLoader<'a, H: CompilerHost> {
-    /// Host for I/O operations
-    host: &'a H,
-    /// Log level for filtering messages
-    log_level: LogLevel,
+    /// Logger for diagnostics (also provides access to host)
+    logger: Logger<'a, H>,
     /// Cache of already parsed modules
     loaded: HashMap<ModuleSource, Module>,
     /// Set of modules currently being loaded (for cycle detection during collection)
@@ -121,17 +119,16 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     /// Create a new module loader with the given host and log level
     pub fn new(host: &'a H, log_level: LogLevel) -> Self {
         Self {
-            host,
-            log_level,
+            logger: Logger::new(host, log_level),
             loaded: HashMap::new(),
             loading: HashSet::new(),
             implicit_modules: HashSet::new(),
         }
     }
 
-    /// Create a logger for emitting diagnostics
-    fn logger(&self) -> Logger<'_, H> {
-        Logger::new(self.host, self.log_level)
+    /// Get the logger for emitting diagnostics
+    pub fn logger(&self) -> &Logger<'a, H> {
+        &self.logger
     }
 
     /// Load all modules starting from the entry source
@@ -380,12 +377,18 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         _from_module_source: &ModuleSource,
     ) -> Result<String, LoadError> {
         match module_source {
-            ModuleSource::Local { path } => {
-                self.host.load_source(path).await.map_err(LoadError::from)
-            }
-            ModuleSource::Remote { url } => {
-                self.host.load_source(url).await.map_err(LoadError::from)
-            }
+            ModuleSource::Local { path } => self
+                .logger
+                .host()
+                .load_source(path)
+                .await
+                .map_err(LoadError::from),
+            ModuleSource::Remote { url } => self
+                .logger
+                .host()
+                .load_source(url)
+                .await
+                .map_err(LoadError::from),
             ModuleSource::Core { name } => {
                 let import_path = format!("core:{name}");
                 if let Some(source) = stdlib::get_stdlib_module(&import_path) {


### PR DESCRIPTION
## Summary
Refactored `ModuleLoader` to store a `Logger` instance instead of separate `host` and `log_level` fields, simplifying the API and improving encapsulation of host access.

## Key Changes
- Replaced `host: &'a H` and `log_level: LogLevel` fields with a single `logger: Logger<'a, H>` field
- Changed `logger()` method from private to public and updated it to return a reference to the stored logger instead of creating a new instance
- Updated all host access to go through `self.logger.host()` instead of direct `self.host` references
- Improved span management by using RAII pattern with `span()` method instead of separate `span_start()` and `span_end()` calls
- Explicitly dropped the span guard before calling `load_implicit_modules()` to avoid holding the span across an `&mut self` method call

## Implementation Details
- The `Logger` now serves as the single point of access for both logging and host I/O operations
- This change reduces redundant logger instantiation and centralizes host access patterns
- The span guard is properly managed to ensure it's dropped before methods requiring mutable self access