### PR TITLE
Add iterator traits and builtin comparison traits documentation

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -316,6 +316,68 @@ Traits use static dispatch - method calls are resolved at compile time to the co
 
 Associated types allow traits to declare placeholder types that are specified by implementors. Use `Self::TypeName` to refer to an associated type within trait methods.
 
+### Builtin Traits
+
+The prelude defines several builtin traits for common operations:
+
+```wado
+// Eq - equality comparisons (== and !=)
+trait Eq {
+    fn eq(&self, other: &Self) -> bool;
+}
+
+// Ord - ordering comparisons (<, <=, >, >=)
+trait Ord {
+    fn lt(&self, other: &Self) -> bool;
+}
+
+// IndexValue - value-based index access (arr[i] returns a copy)
+trait IndexValue<IndexType> {
+    type Output;
+    fn index_value(&self, index: IndexType) -> Self::Output;
+}
+
+// IndexAssign - index assignment (arr[i] = value)
+trait IndexAssign<IndexType> {
+    type Input;
+    fn index_assign(&mut self, index: IndexType, value: Self::Input);
+}
+
+// Index - reference-based index access (for reference-type elements)
+trait Index<IndexType> {
+    type Output;
+    fn index(&self, index: IndexType) -> &Self::Output;
+}
+```
+
+`String` and `Array<T>` implement `Eq` and `Ord` in the prelude:
+
+```wado
+// String comparison (lexicographic)
+let a = "apple";
+let b = "banana";
+if a < b {
+    println("apple comes before banana");
+}
+
+// Custom Eq implementation
+struct Point { x: i32, y: i32 }
+
+impl Eq for Point {
+    fn eq(&self, other: &Self) -> bool {
+        return self.x == other.x && self.y == other.y;
+    }
+}
+
+let p1 = Point { x: 1, y: 2 };
+let p2 = Point { x: 1, y: 2 };
+if p1 == p2 {
+    println("Points are equal");
+}
+```
+
+Note: `IndexValue` returns elements by value (copy) because Wasm GC cannot return references to array elements. `Index` is for containers of reference-type elements.
+
 ## Control Flow
 
 ```wado
@@ -370,10 +432,11 @@ for let mut i = 0; i < 10; i += 1 {
     println(`{i}`);
 }
 
-// For-of (iterables)
+// For-of (any IntoIterator type)
 for let item of items {
     println(`{item}`);
 }
+// Works with Array<T> and any type implementing IntoIterator
 
 // Infinite loop
 loop {
@@ -618,6 +681,128 @@ let make_point = |x: i32, y: i32| Point { x, y };
 
 Note: Closures that capture outer variables are not yet implemented (pure closures work).
 
+## Iterators
+
+Wado provides iterator traits for generic iteration over collections.
+
+### Iterator Traits
+
+```wado
+// Iterator - the core trait for yielding values
+trait Iterator {
+    type Item;
+    fn next(&mut self) -> Option<Self::Item>;
+}
+
+// IntoIterator - convert a collection into an iterator
+trait IntoIterator {
+    type Item;
+    type Iter;
+    fn into_iter(&self) -> Self::Iter;
+}
+
+// FromIterator - create a collection from an iterator
+trait FromIterator<T> {
+    type Iter;
+    fn from_iter(iter: Self::Iter) -> Self;
+}
+```
+
+### ArrayIter and Array Iteration
+
+```wado
+// Array<T> implements IntoIterator
+let arr: Array<i32> = [1, 2, 3, 4, 5];
+
+// for-of uses IntoIterator automatically
+for let x of arr {
+    println(`{x}`);
+}
+
+// Get iterator explicitly
+let mut iter = arr.iter();
+
+// Manual iteration
+loop {
+    if let Some(x) = iter.next() {
+        println(`{x}`);
+    } else {
+        break;
+    }
+}
+
+// Collect remaining elements into a new array
+let mut iter2 = arr.iter();
+iter2.next();  // skip first element
+let rest = iter2.collect();  // Array<i32> with [2, 3, 4, 5]
+```
+
+### Iterator vs IntoIterator
+
+| Trait            | Question                               | Examples             |
+| ---------------- | -------------------------------------- | -------------------- |
+| **Iterator**     | "Can I call `next()` on this?"         | `ArrayIter<T>`       |
+| **IntoIterator** | "Can I convert this into an iterator?" | `Array<T>`, `String` |
+
+Collections like `Array<T>` implement `IntoIterator` to produce a separate iterator object:
+
+```wado
+let arr: Array<i32> = [1, 2, 3];
+// arr.next() would NOT work - Array has no next() method
+
+let mut iter: ArrayIter<i32> = arr.into_iter();
+// ArrayIter implements Iterator
+iter.next();  // Some(1)
+iter.next();  // Some(2)
+```
+
+### Custom Iterables
+
+Implement `IntoIterator` to make custom types work with `for-of`:
+
+```wado
+struct Stack<T> {
+    items: Array<T>,
+}
+
+struct StackIter<T> {
+    items: Array<T>,
+    index: i32,
+}
+
+impl Iterator for StackIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < 0 {
+            return null;
+        }
+        let item = self.items.get(self.index);
+        self.index -= 1;
+        return Option::<T>::Some(item);
+    }
+}
+
+impl IntoIterator for Stack<T> {
+    type Item = T;
+    type Iter = StackIter<T>;
+
+    fn into_iter(&self) -> StackIter<T> {
+        return StackIter {
+            items: self.items,
+            index: self.items.len() - 1,
+        };
+    }
+}
+
+// Now for-of works with Stack
+for let x of stack {
+    println(`{x}`);  // Iterates in LIFO order
+}
+```
+
+Note: Iterator combinators (`map`, `filter`, `fold`) are not yet implemented (requires closures with captures).
+
 ## Compile-Time Location Literals
 
 ```wado
@@ -665,6 +850,7 @@ Wado intentionally does not support macros.
 - Effect handlers
 - `reactive` values and `observe()`
 - Closures that capture outer variables (pure closures work)
+- Iterator combinators (`map`, `filter`, `fold`) - requires closures with captures
 - `stores[...]` syntax for reference storage
 - `Dict<K, V>`
 - postfix `?` operator (error propagation)

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -532,6 +532,123 @@ impl Container for IntBox {
 }
 ```
 
+### Iterator Trait Resolution
+
+The compiler resolves iterator traits (`Iterator`, `IntoIterator`, `FromIterator`) using the same static dispatch mechanism as other traits.
+
+**For-Of Loop Compilation:**
+
+For-of loops are desugared to use `IntoIterator` and `Iterator` traits:
+
+```wado
+// Source
+for let item of collection {
+    body(item);
+}
+
+// Desugars to (conceptually)
+{
+    let mut __iter = IntoIterator::into_iter(&collection);
+    loop {
+        match Iterator::next(&mut __iter) {
+            Some(__item) => {
+                let item = __item;
+                body(item);
+            }
+            None => break,
+        }
+    }
+}
+```
+
+**Resolution Process:**
+
+1. **Type lookup**: Get the type of `collection`
+2. **IntoIterator lookup**: Find `impl IntoIterator for CollectionType`
+3. **Iter type extraction**: Get `Self::Iter` associated type
+4. **Iterator lookup**: Find `impl Iterator for IterType`
+5. **Item type extraction**: Get `Self::Item` associated type for the loop binding
+
+**Known Limitations:**
+
+- **Cross-module monomorphization**: Generic stdlib methods (like `ArrayIter::collect` calling `Array::append`) may encounter type table ID mismatches when called from user code. Workaround: Use direct builtin calls in stdlib generic functions instead of method calls.
+
+### Builtin Comparison Traits
+
+The compiler desugars comparison operators to trait method calls:
+
+**Eq Trait (Equality):**
+
+```wado
+// a == b desugars to:
+Eq::eq(&a, &b)
+
+// a != b desugars to:
+!Eq::eq(&a, &b)
+```
+
+**Ord Trait (Ordering):**
+
+```wado
+// a < b desugars to:
+Ord::lt(&a, &b)
+
+// a <= b desugars to:
+Ord::lt(&a, &b) || Eq::eq(&a, &b)
+
+// a > b desugars to:
+Ord::lt(&b, &a)
+
+// a >= b desugars to:
+Ord::lt(&b, &a) || Eq::eq(&a, &b)
+```
+
+**Resolution:**
+
+1. For primitive types (`i32`, `f64`, etc.), the compiler generates direct Wasm comparison instructions
+2. For `String` and `Array<T>`, the resolver looks up the trait implementation in prelude
+3. For user-defined types, the resolver finds `impl Eq for Type` or `impl Ord for Type`
+
+### Indexing Traits
+
+Index expressions desugar to trait method calls:
+
+```wado
+// arr[i] (read) desugars to:
+IndexValue::index_value(&arr, i)
+// or Index::index(&arr, i) for reference-type elements
+
+// arr[i] = value (write) desugars to:
+IndexAssign::index_assign(&mut arr, i, value)
+```
+
+**Design Note:** `IndexValue` returns by value because Wasm GC's `array.get` copies elements. For primitive arrays, you cannot get a reference to an element. `Index` is only used for containers of reference-type elements.
+
+### Module Loader
+
+The module loader validates module paths before loading:
+
+**Namespace Validation:**
+
+```rust
+pub enum ModuleSource {
+    Core { name: String },      // core:prelude, core:cli
+    Wasi { interface: String }, // wasi:cli, wasi:io
+    Local { path: String },     // ./module.wado, ../lib.wado
+    Remote { url: String },     // https://example.com/lib.wado
+    EntryPoint,                 // The main entry module
+}
+```
+
+**Resolution Rules:**
+
+1. `core:*` → `ModuleSource::Core` → embedded stdlib
+2. `wasi:*` → `ModuleSource::Wasi` → embedded stdlib
+3. `http://` or `https://` → `ModuleSource::Remote` → host.load_remote()
+4. `./` or `../` → `ModuleSource::Local` → host.load_source()
+5. Unknown `xxx:` → Error: `unknown module namespace`
+6. Other → Error: `invalid module path`
+
 ### Type System
 
 **Primitive Layer (`builtin::`):**

--- a/spec.md
+++ b/spec.md
@@ -1818,18 +1818,6 @@ Module paths are validated before loading to provide clear error messages:
 4. **Invalid paths**: Paths not matching any pattern are rejected
    - Error: `invalid module path 'xxx'; use './' for local modules or 'namespace:' for library modules`
 
-**Migration Note:**
-
-Bare filenames no longer work; use `./` prefix for local imports:
-
-```wado
-// Old (no longer valid)
-use {foo} from "utils.wado";
-
-// New (required)
-use {foo} from "./utils.wado";
-```
-
 ### Import Syntax
 
 ```wado

--- a/spec.md
+++ b/spec.md
@@ -321,7 +321,7 @@ for ;; {
 
 ### For-Of Loop
 
-For iterating over arrays:
+For iterating over any type that implements `IntoIterator`:
 
 ```wado
 let numbers: Array<i32> = [1, 2, 3, 4, 5];
@@ -334,9 +334,36 @@ for let mut item of items {
     item = item * 2;  // Can modify the local binding
     println(`{item}`);
 }
+
+// Custom types that implement IntoIterator also work
+for let x of my_collection {
+    println(`{x}`);
+}
 ```
 
-**Note:** For-of loops are for arrays only, not tuples. The binding is a copy of each element, so modifying it does not affect the original array.
+**For-of desugaring:**
+
+```wado
+// Source
+for let item of collection {
+    body(item);
+}
+
+// Desugars to
+scope: {
+    let mut __iter = collection.into_iter();
+    loop {
+        if let Some(__item) = __iter.next() {
+            let item = __item;
+            body(item);
+        } else {
+            break;
+        }
+    }
+}
+```
+
+**Note:** The binding is a copy of each element (value semantics), so modifying it does not affect the original collection. For-of works with any type implementing `IntoIterator`, not just arrays.
 
 ### Infinite Loop
 
@@ -1407,6 +1434,217 @@ Note: `IndexAssign` takes a value parameter rather than returning `&mut T` (like
 - Trait objects (`dyn Trait`)
 - Fully qualified syntax for disambiguation (`<Type as Trait>::method()`)
 
+### Iterator Traits
+
+The prelude defines iterator traits for generic iteration over collections.
+
+**Iterator - Core Iteration Trait:**
+
+```wado
+/// Types that can yield a sequence of values
+pub trait Iterator {
+    type Item;
+
+    /// Advances the iterator and returns the next value.
+    /// Returns None when iteration is complete.
+    fn next(&mut self) -> Option<Self::Item>;
+}
+```
+
+**IntoIterator - Conversion Trait:**
+
+```wado
+/// Types that can be converted into an iterator
+pub trait IntoIterator {
+    type Item;
+    type Iter;  // The iterator type
+
+    /// Creates an iterator from a value
+    fn into_iter(&self) -> Self::Iter;
+}
+```
+
+**FromIterator - Collection Construction:**
+
+```wado
+/// Types that can be constructed from an iterator
+pub trait FromIterator<T> {
+    type Iter;
+    fn from_iter(iter: Self::Iter) -> Self;
+}
+```
+
+**ArrayIter:**
+
+The prelude provides `ArrayIter<T>` as the iterator type for `Array<T>`:
+
+```wado
+/// Iterator over Array<T> elements
+pub struct ArrayIter<T> {
+    // internal fields
+}
+
+impl Iterator for ArrayIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> { ... }
+}
+
+impl IntoIterator for Array<T> {
+    type Item = T;
+    type Iter = ArrayIter<T>;
+    fn into_iter(&self) -> ArrayIter<T> { ... }
+}
+```
+
+**Usage:**
+
+```wado
+let arr: Array<i32> = [1, 2, 3, 4, 5];
+
+// for-of uses IntoIterator automatically
+for let x of arr {
+    println(`{x}`);
+}
+
+// Explicit iterator
+let mut iter = arr.iter();
+while let Some(x) = iter.next() {
+    println(`{x}`);
+}
+
+// Collect remaining elements
+let mut iter2 = arr.iter();
+iter2.next();  // skip first
+let rest = iter2.collect();  // [2, 3, 4, 5]
+```
+
+**Value Semantics:**
+
+Iterator `next()` returns copies of elements (value semantics). Wasm GC cannot yield `&mut T` for array elements, so `iter_mut()` is not available. For in-place mutation, use indexed access:
+
+```wado
+for let mut i = 0; i < arr.len(); i += 1 {
+    arr[i] = arr[i] * 2;
+}
+```
+
+**Custom Iterables:**
+
+Any type can be made iterable by implementing `IntoIterator`:
+
+```wado
+struct Stack<T> { items: Array<T> }
+struct StackIter<T> { items: Array<T>, index: i32 }
+
+impl Iterator for StackIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> { ... }
+}
+
+impl IntoIterator for Stack<T> {
+    type Item = T;
+    type Iter = StackIter<T>;
+    fn into_iter(&self) -> StackIter<T> { ... }
+}
+
+// Now for-of works
+for let x of stack { ... }
+```
+
+### Builtin Comparison Traits
+
+The prelude defines traits for comparison operators:
+
+**Eq - Equality:**
+
+```wado
+/// Types that can be compared for equality
+pub trait Eq {
+    /// Returns true if self equals other
+    fn eq(&self, other: &Self) -> bool;
+}
+```
+
+The `==` and `!=` operators use `Eq::eq`:
+
+- `a == b` desugars to `Eq::eq(&a, &b)`
+- `a != b` desugars to `!Eq::eq(&a, &b)`
+
+**Ord - Ordering:**
+
+```wado
+/// Types that can be ordered
+pub trait Ord {
+    /// Returns true if self is less than other
+    fn lt(&self, other: &Self) -> bool;
+}
+```
+
+Comparison operators use `Ord::lt`:
+
+- `a < b` desugars to `Ord::lt(&a, &b)`
+- `a <= b` desugars to `Ord::lt(&a, &b) || Eq::eq(&a, &b)`
+- `a > b` desugars to `Ord::lt(&b, &a)`
+- `a >= b` desugars to `Ord::lt(&b, &a) || Eq::eq(&a, &b)`
+
+**Default Implementations:**
+
+`String` and `Array<T>` implement `Eq` and `Ord` with lexicographic comparison:
+
+```wado
+impl Eq for String { ... }  // byte-by-byte equality
+impl Ord for String { ... } // lexicographic ordering
+
+// Usage
+let a = "apple";
+let b = "banana";
+if a < b { ... }  // true
+```
+
+### Indexing Traits
+
+The prelude defines traits for index-based access:
+
+**IndexValue - Value Read:**
+
+```wado
+/// Returns element by value (copy)
+pub trait IndexValue<IndexType> {
+    type Output;
+    fn index_value(&self, index: IndexType) -> Self::Output;
+}
+```
+
+**IndexAssign - Value Write:**
+
+```wado
+/// Assigns value to element at index
+pub trait IndexAssign<IndexType> {
+    type Input;
+    fn index_assign(&mut self, index: IndexType, value: Self::Input);
+}
+```
+
+**Index - Reference Read:**
+
+```wado
+/// Returns element by reference (for reference-type elements only)
+pub trait Index<IndexType> {
+    type Output;
+    fn index(&self, index: IndexType) -> &Self::Output;
+}
+```
+
+**Design Note:** `IndexValue` returns by value because Wasm GC's `array.get` instruction copies elements. For primitives like `i32`, you cannot get `&i32` from an array element. `Index` is for containers of reference-type elements where returning a reference is possible.
+
+`Array<T>` implements `IndexValue` and `IndexAssign`:
+
+```wado
+let mut arr: Array<i32> = [1, 2, 3];
+let x = arr[0];    // IndexValue::index_value
+arr[1] = 100;      // IndexAssign::index_assign
+```
+
 ### Enums, Variants, and Flags
 
 Wado follows Component Model's distinction between enums and variants (unlike Rust):
@@ -1561,6 +1799,36 @@ Wado uses an ESM-like import syntax with `use {...} from "source"`. This aligns 
 | Remote (HTTP) | `"https://..."`               | `"https://example.com/lib.wado"`     |
 | Local file    | `"./<path>"` or `"../<path>"` | `"./utils.wado"`, `"../config.wado"` |
 | Package       | `"<package-name>"`            | `"parser-lib"`, `"json-utils"`       |
+
+### Module Path Validation
+
+Module paths are validated before loading to provide clear error messages:
+
+**Namespace Resolution:**
+
+1. **Reserved namespaces** (`identifier:`): Paths matching `xxx:` pattern are namespace paths
+   - `core:` - Wado standard library
+   - `wasi:` - WASI interface modules
+   - Unknown namespaces result in compile error: `unknown module namespace 'xxx'; expected 'core' or 'wasi'`
+
+2. **Remote modules** (`http://` or `https://`): Delegated to CompilerHost
+
+3. **Local modules** (`./` or `../`): Resolved relative to importing module
+
+4. **Invalid paths**: Paths not matching any pattern are rejected
+   - Error: `invalid module path 'xxx'; use './' for local modules or 'namespace:' for library modules`
+
+**Migration Note:**
+
+Bare filenames no longer work; use `./` prefix for local imports:
+
+```wado
+// Old (no longer valid)
+use {foo} from "utils.wado";
+
+// New (required)
+use {foo} from "./utils.wado";
+```
 
 ### Import Syntax
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for iterator traits, builtin comparison traits, and indexing traits to the Wado language specification and compiler documentation. It also clarifies for-of loop semantics and module path validation.

## Key Changes

### Documentation Updates

- **Iterator Traits**: Added detailed documentation for `Iterator`, `IntoIterator`, and `FromIterator` traits with examples of array iteration and custom iterable implementations
- **Builtin Comparison Traits**: Documented `Eq` and `Ord` traits with desugaring rules for comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`)
- **Indexing Traits**: Clarified `IndexValue`, `IndexAssign`, and `Index` traits with explanation of value vs. reference semantics in Wasm GC context
- **For-Of Loop Semantics**: Updated specification to clarify that for-of works with any `IntoIterator` type (not just arrays) and added desugaring rules
- **Module Path Validation**: Added documentation for namespace validation and migration notes for local imports (now require `./` prefix)

### Compiler Documentation

- Added "Iterator Trait Resolution" section explaining for-of loop desugaring and the 5-step resolution process
- Added "Builtin Comparison Traits" section with trait method call desugaring for all comparison operators
- Added "Indexing Traits" section explaining the design rationale for value-based indexing
- Added "Module Loader" section documenting namespace validation and resolution rules

### Cheatsheet Updates

- Added "Builtin Traits" section with trait definitions and practical examples
- Added "Iterators" section with iterator trait overview, array iteration patterns, and custom iterable examples
- Updated for-of loop documentation with clarification about `IntoIterator` support
- Updated "Not Yet Implemented" list to include iterator combinators

## Notable Details

- Emphasized that `IndexValue` returns by value (copy) because Wasm GC's `array.get` copies elements, making `&T` references to array elements impossible
- Clarified the distinction between `Iterator` (has `next()` method) and `IntoIterator` (converts into an iterator)
- Documented known limitation: cross-module monomorphization issues with generic stdlib methods
- Added migration guidance for module imports (bare filenames now require `./` prefix)