### PR TITLE
Refine world conformance and export design with implicit conformance

### DIFF
--- a/docs/wep-2026-01-16-world-conformance-and-export.md
+++ b/docs/wep-2026-01-16-world-conformance-and-export.md
@@ -15,77 +15,140 @@ To properly support Component Model worlds, we need:
 1. **Explicit world conformance declaration**: Verify that a module satisfies a world's requirements (similar to interface implementation in other languages)
 2. **CM boundary export**: Generate ABI glue code to expose functions across the Component Model boundary (like `extern "C"` in C/Rust)
 3. **Multiple world support**: Allow a single module to conform to multiple worlds
-4. **Conflict resolution**: Handle cases where multiple worlds export functions with the same name but different signatures or semantics
+4. **Conflict resolution**: Handle cases where multiple worlds export functions with the same name
 
 ### Design Goals
 
 - **No attribute syntax**: Avoid Rust-style `#[...]` attributes which can become chaotic
 - **Clear separation of concerns**: Distinguish between Wado module visibility (`pub`), world conformance declaration, and CM boundary export
-- **Explicit over implicit**: Make world conformance explicit rather than relying solely on duck typing (unlike Go)
+- **Implicit conformance**: Allow world conformance to be inferred from exports (like Go's interfaces)
 - **Align with WIT**: Use `export` keyword consistent with WIT syntax
 
 ## Decision
 
-We introduce two new language constructs:
+### Visibility and Export
 
-### 1. `contract` Keyword - World Conformance Declaration
+Two orthogonal concepts control accessibility:
+
+| Declaration | From Wado modules | From CM boundary |
+|-------------|-------------------|------------------|
+| `fn foo()` | ❌ | ❌ |
+| `pub fn foo()` | ✅ | ❌ |
+| `export fn foo()` | ❌ | ✅ |
+| `pub export fn foo()` | ✅ | ✅ |
+
+- **`pub`**: Makes a declaration visible to other Wado modules
+- **`export`**: Generates Component Model ABI glue code, making it accessible across CM boundary
+
+### World as First-Class Entity
+
+Worlds are imported like other Wado entities:
 
 ```wado
-contract World;
+use { Command } from "wasi:cli";
 ```
 
-- Declares that this module conforms to the specified world
+### `contract` Declaration
+
+Declares that this module conforms to a specified world:
+
+```wado
+use { Command } from "wasi:cli";
+
+contract Command;
+```
+
 - One world per line; multiple worlds supported via multiple declarations
 - Triggers compile-time verification that all world requirements are satisfied
-- Does NOT generate code by itself; purely declarative/verification
+- **Optional**: If omitted, the runtime environment determines the expected world (e.g., `wado run` expects `wasi:cli/Command`)
 
-**Multiple worlds example:**
+### Explicit Export Mapping
 
-```wado
-contract Command;
-contract HttpHandler;
-```
-
-### 2. `export` Keyword - CM Boundary Export
+When function names don't match world export names, or when exporting to multiple worlds:
 
 ```wado
-export pub fn function_name() { ... }
-```
-
-- `export`: Generates Component Model ABI glue code
-- `pub`: Controls Wado module visibility (both required)
-- Automatically maps to world export if function name matches
-
-**Explicit mapping for name conflicts:**
-
-```wado
-export(World::export_name) pub fn wado_function_name() { ... }
-```
-
-### Complete Examples
-
-#### Simple Case: Single World
-
-```wado
-use {println} from "core:cli";
+use { Command, HttpServer } from "wasi:cli";
 
 contract Command;
+contract HttpServer;
 
-export pub fn run() -> Result<(), ()> {
+// Explicit mapping to a single world
+export(Command::run) pub fn run_cli() { ... }
+
+// Export to multiple worlds
+export(Command::run, HttpServer::run) pub fn shared_run() { ... }
+```
+
+If signature matches, a single `export fn` can satisfy multiple worlds without explicit mapping.
+
+### Type Export
+
+Types can be exported with the same syntax:
+
+```wado
+export struct MyRecord { x: i32 }
+export(SomeWorld::MyType) struct AliasedRecord { x: i32 }
+```
+
+### World Imports and Effect System
+
+World imports (dependencies the component needs from its host) are not explicitly declared. Instead:
+
+- Use `use` to import capabilities from WASI modules
+- Effect system tracks which capabilities a function requires
+- **Compile-time check**: Using an effect not provided by the world's imports is a compile error
+
+```wado
+use { Command } from "wasi:cli";
+use { Stdout } from "wasi:cli";  // Required for println
+
+contract Command;
+
+export fn run() with Stdout {
+    println("Hello!");  // OK: Command world imports Stdout
+}
+```
+
+## Examples
+
+### Simple Case: CLI Application
+
+```wado
+use { Command } from "wasi:cli";
+use { println, Stdout } from "core:cli";
+
+contract Command;
+
+export fn run() with Stdout {
     println("Hello, World!");
 }
 ```
 
-#### Complex Case: Multiple Worlds with Name Conflicts
+### Implicit World Conformance
+
+For simple scripts, `contract` can be omitted:
 
 ```wado
+use { println, Stdout } from "core:cli";
+
+// No contract declaration - runtime determines expected world
+// `wado run` expects Command world
+
+export fn run() with Stdout {
+    println("Hello!");
+}
+```
+
+### Multiple Worlds with Name Conflicts
+
+```wado
+use { Command, Daemon } from "my:worlds";
+
 contract Command;
 contract Daemon;
 
-// Same function name, different worlds
-export(Command::run) pub fn run_cli() -> Result<(), ()> {
+export(Command::run) pub fn run_cli() {
     println("CLI mode");
-    return Ok(());
 }
 
 export(Daemon::run) pub fn run_daemon() {
@@ -95,89 +158,57 @@ export(Daemon::run) pub fn run_daemon() {
 }
 ```
 
-#### Library with Multiple Exports
+### Shared Implementation Across Worlds
 
 ```wado
-contract MathService;
+use { Command, HttpServer } from "my:worlds";
 
-export pub fn add(a: i32, b: i32) -> i32 {
-    return a + b;
-}
+contract Command;
+contract HttpServer;
 
-export pub fn multiply(a: i32, b: i32) -> i32 {
-    return a * b;
+// Both worlds have compatible `run` - export to both
+export(Command::run, HttpServer::run) pub fn run() {
+    initialize();
+    serve();
 }
 ```
 
 ## Keyword Selection Rationale
 
-We evaluated multiple keyword options:
-
 | Keyword      | Pros                                   | Cons                           | Decision     |
 | ------------ | -------------------------------------- | ------------------------------ | ------------ |
-| `implements` | Most common in OOP languages           | Strong class-level connotation | Rejected     |
+| `implements` | Common in OOP languages                | Strong class-level connotation | Rejected     |
 | `conforms`   | Clear protocol conformance meaning     | Slightly verbose               | Considered   |
-| `satisfies`  | TypeScript-like, emphasizes validation | Value-level connotation        | Rejected     |
-| `entrypoint` | Emphasizes CM connection point         | Implies singularity            | Rejected     |
+| `confirms`   | Declarative reading                    | Unusual verb form              | Considered   |
 | `contract`   | Clear boundary contract semantics      | N/A                            | **Accepted** |
 
 **Why `contract`:**
 
-- Emphasizes the contract between component and runtime
+- "This module satisfies the specified world contract"
 - Natural for multiple declarations: `contract A; contract B;`
 - Aligns with Component Model terminology
-- Distinct from class-based `implements`
+- Works as both noun and verb in singular form
 
 ## Consequences
 
 ### Positive
 
 - **Explicit world conformance**: Developers can verify their module satisfies world requirements
+- **Implicit conformance option**: Simple scripts work without boilerplate (like Go interfaces)
 - **Multiple world support**: Natural syntax for conforming to multiple worlds
-- **Conflict resolution**: Explicit mapping syntax resolves name/signature conflicts
-- **Three-layer separation**:
+- **Conflict resolution**: Explicit mapping syntax resolves name conflicts
+- **Clear separation**:
   - `pub`: Wado module visibility
-  - `contract`: World conformance verification
-  - `export`: CM boundary ABI generation
-- **No attribute chaos**: Clean keyword-based syntax instead of attributes
-- **Gradual complexity**: Simple cases remain simple; complex cases have escape hatches
+  - `export`: CM boundary accessibility
+  - `contract`: World conformance verification (optional)
+- **Effect system integration**: World import requirements checked at compile time
 
 ### Negative
 
 - **More keywords**: Introduces `contract` and extends `export` syntax
-- **Verbosity**: Requires both `export` and `pub` for exported public functions
-- **Learning curve**: Developers must understand three visibility concepts
-
-### Migration Path
-
-- **Current code**: `pub fn run()` continues to work with implicit Command world mapping
-- **New code**: Should use `contract Command; export pub fn run()` for clarity
-- **Future**: Consider deprecating implicit world mapping in favor of explicit `contract`
-
-### Implementation Requirements
-
-1. **Parser**: Support `contract World;` declarations and `export(World::fn)` syntax
-2. **AST**: Add `ContractDecl` and extend `Function` with optional world mapping
-3. **Semantic analysis**: Verify world requirements are satisfied by exported functions
-4. **Code generation**: Generate CM ABI glue code for `export` functions with correct world bindings
-5. **Error messages**: Clear diagnostics for missing exports, signature mismatches, and name conflicts
-
-### Open Questions
-
-1. **Default world**: Should there be a default world if no `contract` is declared? (Propose: error, require explicit `contract`)
-2. **Library components**: How to handle components with no exports? (Propose: allow, but warn)
-3. **World import syntax**: Should worlds themselves be importable? (Future work)
-4. **Wildcard exports**: Should `export *` syntax be supported for forwarding? (TBD)
-
-## Related ADRs
-
-- [Target WASI P3 Only](./wep-2026-01-11-wasi-p3-only.md) - WASI world context
-- [Value Semantics and Reference Captures](./wep-2026-01-12-value-semantics-and-captures.md) - Related to export semantics
+- **Three concepts**: Developers must understand `pub`, `export`, and `contract`
 
 ## References
 
 - [WIT Reference - Component Model](https://component-model.bytecodealliance.org/design/wit.html)
 - [Worlds - Component Model](https://component-model.bytecodealliance.org/design/worlds.html)
-- [TypeScript satisfies operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html)
-- [Swift Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)
-- [Elixir Protocols and Behaviours](https://elixir-lang.org/getting-started/protocols.html)

--- a/docs/wep-2026-01-16-world-conformance-and-export.md
+++ b/docs/wep-2026-01-16-world-conformance-and-export.md
@@ -30,12 +30,12 @@ To properly support Component Model worlds, we need:
 
 Two orthogonal concepts control accessibility:
 
-| Declaration | From Wado modules | From CM boundary |
-|-------------|-------------------|------------------|
-| `fn foo()` | ❌ | ❌ |
-| `pub fn foo()` | ✅ | ❌ |
-| `export fn foo()` | ❌ | ✅ |
-| `pub export fn foo()` | ✅ | ✅ |
+| Declaration           | From Wado modules | From CM boundary |
+| --------------------- | ----------------- | ---------------- |
+| `fn foo()`            | ❌                | ❌               |
+| `pub fn foo()`        | ✅                | ❌               |
+| `export fn foo()`     | ❌                | ✅               |
+| `pub export fn foo()` | ✅                | ✅               |
 
 - **`pub`**: Makes a declaration visible to other Wado modules
 - **`export`**: Generates Component Model ABI glue code, making it accessible across CM boundary
@@ -175,12 +175,12 @@ export(Command::run, HttpServer::run) pub fn run() {
 
 ## Keyword Selection Rationale
 
-| Keyword      | Pros                                   | Cons                           | Decision     |
-| ------------ | -------------------------------------- | ------------------------------ | ------------ |
-| `implements` | Common in OOP languages                | Strong class-level connotation | Rejected     |
-| `conforms`   | Clear protocol conformance meaning     | Slightly verbose               | Considered   |
-| `confirms`   | Declarative reading                    | Unusual verb form              | Considered   |
-| `contract`   | Clear boundary contract semantics      | N/A                            | **Accepted** |
+| Keyword      | Pros                               | Cons                           | Decision     |
+| ------------ | ---------------------------------- | ------------------------------ | ------------ |
+| `implements` | Common in OOP languages            | Strong class-level connotation | Rejected     |
+| `conforms`   | Clear protocol conformance meaning | Slightly verbose               | Considered   |
+| `confirms`   | Declarative reading                | Unusual verb form              | Considered   |
+| `contract`   | Clear boundary contract semantics  | N/A                            | **Accepted** |
 
 **Why `contract`:**
 


### PR DESCRIPTION
## Summary

This PR significantly refines the world conformance and export design for Component Model support in Wado. The key change is shifting from requiring explicit `contract` declarations to supporting implicit world conformance (like Go interfaces), while maintaining explicit options for complex scenarios.

## Key Changes

- **Implicit conformance support**: `contract` declarations are now optional; world conformance can be inferred from exports when the runtime environment specifies the expected world
- **Clearer visibility model**: Introduced a table distinguishing between `pub` (Wado module visibility) and `export` (Component Model boundary accessibility)
- **Worlds as first-class entities**: Worlds are now imported via `use` statements, making them proper language constructs
- **Simplified export mapping**: Explicit mapping syntax `export(World::name)` is only needed for name conflicts or multiple-world exports
- **Type exports**: Extended export syntax to support exporting types with optional world mapping
- **Effect system integration**: World imports are tracked through the effect system rather than explicit declarations
- **Reduced keyword complexity**: Removed `pub` requirement from exports; `export` alone is sufficient for CM boundary exposure
- **Simplified examples**: Updated all examples to reflect the new design, including implicit conformance cases

## Notable Design Decisions

- **Optional `contract` declarations**: Enables simple scripts to work without boilerplate while allowing explicit verification in complex modules
- **Orthogonal `pub` and `export`**: These are now clearly independent concerns rather than requiring both together
- **Effect system for world imports**: Leverages existing effect tracking to verify that used capabilities are provided by the world
- **Simplified keyword rationale**: Focused the keyword selection table on the most relevant alternatives

## Removed Content

- Migration path and implementation requirements sections (moved to future work)
- Open questions about default worlds and library components
- References to TypeScript, Swift, and Elixir (language-specific examples)
- Verbosity concerns about requiring both `export` and `pub` (resolved by making `pub` optional)