### PR TITLE
WEP update: Replace iterator-based with builder-pattern for tuple coercion

### DIFF
--- a/docs/wep-2026-01-18-iterator-based-literal-coercion.md
+++ b/docs/wep-2026-01-18-iterator-based-literal-coercion.md
@@ -41,6 +41,14 @@ let obj = { name: "Alice", age: 30 };
 
 Default type is an anonymous struct. The parser already supports this as "implicit struct".
 
+#### Null Literal
+
+```wado
+let n = null;  // Type: Null
+```
+
+`null` has the special type `Null`. By default, `Null` coerces to `Option::None`. Custom coercion can be provided via `impl Into<T> for Null`.
+
 ### 2. TupleBuilder Trait
 
 ```wado
@@ -56,7 +64,7 @@ pub trait TupleBuilder {
     fn append(&mut self, element: Self::Element);
 
     /// Finalize and return the built collection
-    fn into(self) -> Self::Output;
+    fn build(self) -> Self::Output;
 }
 ```
 
@@ -85,7 +93,7 @@ pub trait ObjectBuilder {
     fn insert(&mut self, key: String, value: Self::Value);
 
     /// Finalize and return the built collection
-    fn into(self) -> Self::Output;
+    fn build(self) -> Self::Output;
 }
 ```
 
@@ -120,7 +128,8 @@ impl Into<T> for T {
 When the compiler encounters a tuple literal `[e0, e1, ..., en]` with target type `C` where `C: FromTuple<Element = E>`:
 
 1. **Check each element**: Verify `Ti: Into<E>` for each element type `Ti`
-2. **Expand at compile time**:
+2. **Recursively coerce nested literals**: If `ei` is itself a literal (tuple or object), coerce it to `E` first
+3. **Expand at compile time**:
 
 ```wado
 // Source
@@ -132,8 +141,16 @@ let container: C = {
     __builder.append(Into::<E>::into(e0));
     __builder.append(Into::<E>::into(e1));
     __builder.append(Into::<E>::into(e2));
-    __builder.into()
+    __builder.build()
 };
+```
+
+**Important**: Coercion only applies to **literals**, not variables:
+
+```wado
+let t = [1, 2, 3];           // t is a tuple [i32, i32, i32]
+let arr: Array<i32> = t;     // ERROR: t is not a literal, no coercion
+let arr: Array<i32> = [1, 2, 3];  // OK: literal coercion
 ```
 
 ### 8. Object Literal Coercion Rules
@@ -141,7 +158,8 @@ let container: C = {
 When the compiler encounters an object literal `{ k0: v0, k1: v1, ... }` with target type `C` where `C: FromObject<Value = V>`:
 
 1. **Check each value**: Verify `Vi: Into<V>` for each value type `Vi`
-2. **Expand at compile time**:
+2. **Recursively coerce nested literals**: If `vi` is itself a literal (tuple or object), coerce it to `V` first
+3. **Expand at compile time**:
 
 ```wado
 // Source
@@ -152,17 +170,34 @@ let container: C = {
     let mut __builder = C::Builder::with_capacity(2);
     __builder.insert("name", Into::<V>::into("Alice"));
     __builder.insert("age", Into::<V>::into(30));
-    __builder.into()
+    __builder.build()
 };
+```
+
+**Struct literal priority**: If the target type is a struct with matching fields, it is interpreted as a struct literal, not an object literal coercion:
+
+```wado
+struct Config { width: i32, height: i32 }
+
+let c: Config = { width: 1920, height: 1080 };  // Struct literal, NOT FromObject coercion
 ```
 
 ### 9. Coercion Contexts
 
-Coercion applies in three contexts:
+Coercion applies in the following contexts where the target type is known:
 
 1. **Variable initialization**: `let arr: Array<i32> = [1, 2, 3];`
 2. **Function argument**: `process([1, 2, 3]);`
 3. **Explicit cast**: `[1, 2, 3] as Array<i32>`
+4. **Return statement**: `fn f() -> Array<i32> { return [1, 2, 3]; }`
+5. **Conditional branches**: `let x: Array<i32> = if cond { [1, 2] } else { [3, 4, 5] };`
+
+**Not a coercion context** (requires explicit cast):
+
+```wado
+[1, 2, 3].iter()  // ERROR: tuple has no iter() method
+([1, 2, 3] as Array<i32>).iter()  // OK: explicit cast
+```
 
 ### 10. Array Implementation
 
@@ -181,7 +216,7 @@ impl TupleBuilder for Array<T> {
         self.append(element);  // Existing method
     }
 
-    fn into(self) -> Array<T> {
+    fn build(self) -> Array<T> {
         return self;  // Identity
     }
 }
@@ -203,7 +238,7 @@ let arr: Array<i32> = [1, 2, 3];
     __builder.append(1);
     __builder.append(2);
     __builder.append(3);
-    __builder.into()
+    __builder.build()
 }
 ```
 
@@ -224,7 +259,7 @@ impl ObjectBuilder for Dict<String, V> {
         self.insert(key, value);  // Existing method
     }
 
-    fn into(self) -> Dict<String, V> {
+    fn build(self) -> Dict<String, V> {
         return self;  // Identity
     }
 }
@@ -245,11 +280,13 @@ let config: Dict<String, i32> = { "width": 1920, "height": 1080 };
     let mut __builder = Dict::<String, i32>::with_capacity(2);
     __builder.insert("width", 1920);
     __builder.insert("height", 1080);
-    __builder.into()
+    __builder.build()
 }
 ```
 
-### 12. JSONArray Example (Heterogeneous Tuple)
+### 12. JSONValue Example (Both FromTuple and FromObject)
+
+JSONValue can accept both tuple and object literals by implementing both traits:
 
 ```wado
 pub variant JSONValue {
@@ -257,8 +294,8 @@ pub variant JSONValue {
     Bool(bool),
     Number(f64),
     String(String),
-    Array(JSONArray),
-    Object(JSONObject),
+    Array(Array<JSONValue>),
+    Object(Dict<String, JSONValue>),
 }
 
 // Into implementations for JSONValue
@@ -280,102 +317,100 @@ impl Into<JSONValue> for bool {
     }
 }
 
-// JSONArray can use Array<JSONValue> as its builder
-pub struct JSONArray {
+// Null type coerces to JSONValue::Null
+impl Into<JSONValue> for Null {
+    fn into(self) -> JSONValue {
+        return JSONValue::Null;
+    }
+}
+```
+
+### 13. JSONValue FromTuple Implementation
+
+```wado
+// Builder for tuple literals → JSONValue::Array
+pub struct JSONValueArrayBuilder {
     items: Array<JSONValue>,
 }
 
-impl TupleBuilder for JSONArray {
+impl TupleBuilder for JSONValueArrayBuilder {
     type Element = JSONValue;
-    type Output = JSONArray;
+    type Output = JSONValue;
 
     fn with_capacity(n: i32) -> Self {
-        return JSONArray { items: Array::<JSONValue>::with_capacity(n) };
+        return JSONValueArrayBuilder { items: Array::<JSONValue>::with_capacity(n) };
     }
 
     fn append(&mut self, element: JSONValue) {
         self.items.append(element);
     }
 
-    fn into(self) -> JSONArray {
-        return self;
+    fn build(self) -> JSONValue {
+        return JSONValue::Array(self.items);
     }
 }
 
-impl FromTuple for JSONArray {
+impl FromTuple for JSONValue {
     type Element = JSONValue;
-    type Builder = JSONArray;
+    type Builder = JSONValueArrayBuilder;
 }
 ```
 
-Usage:
+### 14. JSONValue FromObject Implementation
 
 ```wado
-// Heterogeneous tuple → JSONArray
-let json: JSONArray = [1, "hello", true, null];
-
-// Expands to:
-{
-    let mut __builder = JSONArray::with_capacity(4);
-    __builder.append(Into::<JSONValue>::into(1));        // i32 → JSONValue::Number
-    __builder.append(Into::<JSONValue>::into("hello"));  // String → JSONValue::String
-    __builder.append(Into::<JSONValue>::into(true));     // bool → JSONValue::Bool
-    __builder.append(Into::<JSONValue>::into(null));     // null → JSONValue::Null
-    __builder.into()
-}
-```
-
-### 13. JSONObject Example (Heterogeneous Object)
-
-```wado
-pub struct JSONObject {
+// Builder for object literals → JSONValue::Object
+pub struct JSONValueObjectBuilder {
     entries: Dict<String, JSONValue>,
 }
 
-impl ObjectBuilder for JSONObject {
+impl ObjectBuilder for JSONValueObjectBuilder {
     type Value = JSONValue;
-    type Output = JSONObject;
+    type Output = JSONValue;
 
     fn with_capacity(n: i32) -> Self {
-        return JSONObject { entries: Dict::<String, JSONValue>::with_capacity(n) };
+        return JSONValueObjectBuilder { entries: Dict::<String, JSONValue>::with_capacity(n) };
     }
 
     fn insert(&mut self, key: String, value: JSONValue) {
         self.entries.insert(key, value);
     }
 
-    fn into(self) -> JSONObject {
-        return self;
+    fn build(self) -> JSONValue {
+        return JSONValue::Object(self.entries);
     }
 }
 
-impl FromObject for JSONObject {
+impl FromObject for JSONValue {
     type Value = JSONValue;
-    type Builder = JSONObject;
+    type Builder = JSONValueObjectBuilder;
 }
 ```
 
-Usage:
+### 15. Nested JSON Literals
+
+With both traits implemented, JSONValue supports nested structures:
 
 ```wado
-// Heterogeneous object → JSONObject
-let obj: JSONObject = {
+let data: JSONValue = {
     "name": "Alice",
     "age": 30,
-    "active": true
+    "tags": [1, 2, 3],           // Nested tuple → JSONValue::Array
+    "metadata": {                 // Nested object → JSONValue::Object
+        "created": "2024-01-01",
+        "active": true,
+    },
+    "nullable": null,            // Null → JSONValue::Null
 };
 
-// Expands to:
-{
-    let mut __builder = JSONObject::with_capacity(3);
-    __builder.insert("name", Into::<JSONValue>::into("Alice"));
-    __builder.insert("age", Into::<JSONValue>::into(30));
-    __builder.insert("active", Into::<JSONValue>::into(true));
-    __builder.into()
-}
+// Compiler recursively coerces each nested literal:
+// 1. Outer { ... } → FromObject → JSONValue::Object
+// 2. Inner [1, 2, 3] → FromTuple → JSONValue::Array
+// 3. Inner { ... } → FromObject → JSONValue::Object
+// 4. null → Into<JSONValue> → JSONValue::Null
 ```
 
-### 14. Immutable Collection Example
+### 16. Immutable Collection Example
 
 ```wado
 // Completely immutable - no mutation methods exposed
@@ -407,7 +442,7 @@ impl TupleBuilder for ImmutableListBuilder<T> {
         self.buffer.append(element);
     }
 
-    fn into(self) -> ImmutableList<T> {
+    fn build(self) -> ImmutableList<T> {
         return ImmutableList::from_array(self.buffer);
     }
 }
@@ -422,7 +457,7 @@ let list: ImmutableList<i32> = [1, 2, 3, 4, 5];
 // list has no mutation methods, but was constructed via Builder
 ```
 
-### 15. Empty Literals
+### 17. Empty Literals
 
 Empty literals coerce to empty collections:
 
@@ -431,10 +466,10 @@ let empty_arr: Array<i32> = [];
 let empty_dict: Dict<String, i32> = {};
 
 // Expand to:
-// C::Builder::with_capacity(0).into()
+// C::Builder::with_capacity(0).build()
 ```
 
-### 16. Relationship with Iterator Traits
+### 18. Relationship with Iterator Traits
 
 Builder-based coercion and Iterator traits serve different purposes:
 
@@ -470,7 +505,7 @@ impl FromIterator<T> for Array<T> {
 }
 ```
 
-### 17. Type Error Messages
+### 19. Type Error Messages
 
 Clear error messages guide users:
 
@@ -497,7 +532,7 @@ let m: MyType = [1, 2, 3];
 //    = help: implement FromTuple for MyType to enable tuple coercion
 ```
 
-### 18. Implementation Strategy
+### 20. Implementation Strategy
 
 #### Phase 1: Core Traits
 
@@ -546,7 +581,7 @@ fn try_tuple_coercion(elements: &[Expr], target_type: &Type) -> Option<Expr> {
         let converted = call_into(elem, element_type);
         stmts.push(call_method_stmt("__builder", "append", [converted]));
     }
-    stmts.push(call_method("__builder", "into", []));
+    stmts.push(call_method("__builder", "build", []));
 
     return Some(block_expr(stmts));
 }
@@ -644,7 +679,7 @@ impl TupleBuilder for SortedSetBuilder<T: Ord> {
         // ...
     }
 
-    fn into(self) -> SortedSet<T> {
+    fn build(self) -> SortedSet<T> {
         return SortedSet { items: self.items };
     }
 }

--- a/docs/wep-2026-01-18-iterator-based-literal-coercion.md
+++ b/docs/wep-2026-01-18-iterator-based-literal-coercion.md
@@ -1,8 +1,8 @@
-# WEP: Iterator-Based Literal Coercion
+# WEP: Tuple-to-Collection Coercion
 
 ## Context
 
-Wado allows tuple literals to be coerced to `Array<T>` in certain contexts:
+Wado allows tuple literals to be coerced to collection types in certain contexts:
 
 ```wado
 let a: Array<i32> = [1, 2, 3];  // Tuple literal → Array<i32>
@@ -13,605 +13,551 @@ let b = [1, 2, 3] as Array<i32>; // Explicit cast
 
 This coercion is currently **hardcoded** in the compiler. When the compiler encounters a tuple literal with a target type of `Array<T>`, it performs special conversion logic.
 
-### Current Implementation
+### Requirements
 
-The resolver has three specific coercion points:
+The coercion mechanism must support:
 
-1. **Variable initialization with type annotation**
+1. **Homogeneous tuples**: `[1, 2, 3]` → `Array<i32>`
+2. **Heterogeneous tuples**: `[1, "hello", true]` → `JSONArray` (when each element converts to `JSONValue`)
+3. **Immutable containers**: Target container may not expose mutation methods
+4. **User-defined collections**: Any collection implementing the right traits
 
-   ```rust
-   // In resolver.rs
-   if let ResolvedType::Array { element_type } = target_type {
-       // Special case: convert TupleLiteral to ArrayLiteral
-       return coerce_tuple_to_array(...);
-   }
-   ```
+### Approaches Considered
 
-2. **Function argument passing**
-
-   ```rust
-   // Check if parameter type is Array and argument is tuple
-   if is_array_type(param_type) && is_tuple_literal(arg) {
-       coerce_tuple_to_array(...);
-   }
-   ```
-
-3. **Explicit `as` cast**
-   ```rust
-   // Handle tuple-to-array cast specially
-   if cast_to_array && expr_is_tuple {
-       convert_to_array_literal(...);
-   }
-   ```
-
-### Problems with Current Approach
-
-1. **Compiler complexity**: Each new collection type (Set, Dict, Vec, etc.) requires adding more special cases to the compiler
-2. **Limited extensibility**: Users cannot define their own collection types with literal coercion
-3. **Inconsistency**: Array gets special treatment, but other collection types don't
-4. **Maintenance burden**: Coercion logic is scattered across multiple compiler phases
-
-### The Opportunity
-
-Wado already has iterator traits defined in the spec (WEP: Struct and Trait System):
+#### Approach A: Iterator-Based (FromIterator)
 
 ```wado
-trait Iterator {
-    type Item;
-    fn next(&mut self) -> Option<Self::Item>;
-}
-
-trait IntoIterator {
-    type Item;
-    type Iter: Iterator<Item = Self::Item>;
-    fn into_iter(self) -> Self::Iter;
-}
-
-trait FromIterator<T> {
-    fn from_iter<I: Iterator<Item = T>>(iter: I) -> Self;
-}
+let a: Array<i32> = [1, 2, 3];
+// Desugars to: Array::from_iter([1, 2, 3].into_iter())
 ```
 
-These traits provide a **general mechanism** for converting between iterable types and collections. If we leverage them for literal coercion, we can:
+Limitations:
+- **Cannot handle heterogeneous tuples**: `IntoIterator::Item` must be a single type
+- Requires `IntoIterator` impl for each tuple arity
 
-- Remove hardcoded Array coercion from the compiler
-- Enable coercion for any type implementing `FromIterator<T>`
-- Allow users to define custom collection types with literal syntax
-- Align with Rust's `.collect()` pattern
-
-### Language Survey
-
-#### Rust
-
-Rust uses explicit `.collect()` with type inference:
-
-```rust
-let v: Vec<i32> = vec![1, 2, 3].into_iter().collect();
-let set: HashSet<i32> = vec![1, 2, 2, 3].into_iter().collect();
-```
-
-Wado's proposal is similar but allows implicit coercion in type contexts:
+#### Approach B: Builder Pattern
 
 ```wado
-let a: Array<i32> = [1, 2, 3];  // Implicit
-let s: Set<i32> = [1, 2, 2, 3]; // Implicit
+let a: Array<i32> = [1, 2, 3];
+// Desugars to:
+// ArrayBuilder::new().add(1).add(2).add(3).build()
 ```
 
-This is more concise while maintaining type safety.
+Advantages:
+- **Handles heterogeneous tuples**: Each `add()` call can use `Into<E>` conversion
+- **Works with immutable containers**: Only Builder exposes mutation
+- **Compile-time expansion**: Known tuple size allows direct code generation
 
-#### TypeScript
+### Decision: Builder Pattern
 
-TypeScript has structural typing and doesn't have explicit iterator-based coercion. Arrays and tuples are distinguished by type annotations only.
-
-#### Python
-
-Python has distinct syntax for lists `[1, 2, 3]` and tuples `(1, 2, 3)`, and uses comprehensions or explicit constructors:
-
-```python
-my_set = set([1, 2, 2, 3])  # Explicit constructor
-```
-
-Wado's approach is more elegant with implicit coercion based on type context.
+We adopt the Builder pattern as the primary mechanism for tuple-to-collection coercion.
 
 ## Decision
 
-### 1. Generalize Literal Coercion via Iterator Traits
-
-When the compiler encounters an expression `expr` that doesn't match the target type `T`, it applies the following coercion rule:
-
-**Automatic Iterator Coercion**:
-
-- If `expr`'s type `E` implements `IntoIterator`
-- And target type `T` implements `FromIterator<E::Item>`
-- Then desugar to: `T::from_iter(expr.into_iter())`
-
-This replaces all hardcoded tuple-to-array coercion logic.
-
-### 2. Tuple Types Implement IntoIterator
-
-All tuple types implement `IntoIterator`:
+### 1. Builder Trait
 
 ```wado
-// For homogeneous tuples (same element type)
-impl<T> IntoIterator for [T, T] {
-    type Item = T;
-    type Iter = TupleIter<T>;
+/// Trait for building collections element by element
+pub trait Builder {
+    type Element;
+    type Output;
 
-    fn into_iter(self) -> TupleIter<T> {
-        return TupleIter::new_2(self.0, self.1);
-    }
+    /// Create a new empty builder
+    fn new() -> Self;
+
+    /// Add an element and return the builder
+    fn add(self, element: Self::Element) -> Self;
+
+    /// Finalize and return the built collection
+    fn build(self) -> Self::Output;
 }
-
-impl<T> IntoIterator for [T, T, T] {
-    type Item = T;
-    type Iter = TupleIter<T>;
-
-    fn into_iter(self) -> TupleIter<T> {
-        return TupleIter::new_3(self.0, self.1, self.2);
-    }
-}
-
-// ... and so on for various tuple sizes
 ```
 
-**Note**: Only homogeneous tuples (all elements same type) can implement `IntoIterator`. Heterogeneous tuples like `[i32, String, bool]` cannot be iterated uniformly.
+The `add` method takes `self` by value (consuming) to enable fluent chaining. Implementations may internally use mutation.
 
-### 3. Collection Types Implement FromIterator
-
-Standard collection types implement `FromIterator<T>`:
+### 2. Collectable Trait
 
 ```wado
-// Array
-impl<T> FromIterator<T> for Array<T> {
-    fn from_iter<I: Iterator<Item = T>>(iter: I) -> Array<T> {
-        let mut arr: Array<T> = [];
-        for let item of iter {
-            arr.append(item);
-        }
-        return arr;
-    }
+/// Trait for collection types that can be built from elements
+pub trait Collectable {
+    type Element;
+    type Builder: Builder<Element = Self::Element, Output = Self>;
+}
+```
+
+This associates a collection type with its builder.
+
+### 3. Into Trait for Element Conversion
+
+```wado
+/// Trait for type conversions
+pub trait Into<T> {
+    fn into(self) -> T;
 }
 
-// Set (hypothetical)
-impl<T: Eq + Hash> FromIterator<T> for Set<T> {
-    fn from_iter<I: Iterator<Item = T>>(iter: I) -> Set<T> {
-        let mut set = Set::new();
-        for let item of iter {
-            set.insert(item);
-        }
-        return set;
-    }
-}
-
-// Dict (from key-value pair tuples)
-impl<K: Eq + Hash, V> FromIterator<[K, V]> for Dict<K, V> {
-    fn from_iter<I: Iterator<Item = [K, V]>>(iter: I) -> Dict<K, V> {
-        let mut dict = Dict::new();
-        for let [k, v] of iter {
-            dict.insert(k, v);
-        }
-        return dict;
+// Identity implementation
+impl Into<T> for T {
+    fn into(self) -> T {
+        return self;
     }
 }
 ```
 
-### 4. Compiler Desugaring Rules
+### 4. Coercion Rules
 
-The compiler applies iterator coercion in three contexts (same as current hardcoded coercion):
+When the compiler encounters a tuple literal `[e0, e1, ..., en]` with target type `C` where `C: Collectable<Element = E>`:
+
+1. **Check each element**: Verify `Ti: Into<E>` for each element type `Ti`
+2. **Expand at compile time**: Generate builder chain
+
+```wado
+// Source
+let container: C = [e0, e1, e2];
+
+// Compiler expansion
+let container: C = {
+    C::Builder::new()
+        .add(Into::<E>::into(e0))
+        .add(Into::<E>::into(e1))
+        .add(Into::<E>::into(e2))
+        .build()
+};
+```
+
+### 5. Coercion Contexts
+
+Coercion applies in three contexts:
 
 #### Context 1: Variable Initialization with Type Annotation
 
 ```wado
-// Source
-let a: Array<i32> = [1, 2, 3];
-
-// Desugared to
-let a: Array<i32> = Array::from_iter([1, 2, 3].into_iter());
+let arr: Array<i32> = [1, 2, 3];
 ```
 
 #### Context 2: Function Argument Passing
 
 ```wado
-// Source
 fn process(items: Array<i32>) { ... }
 process([1, 2, 3]);
-
-// Desugared to
-fn process(items: Array<i32>) { ... }
-process(Array::from_iter([1, 2, 3].into_iter()));
 ```
 
 #### Context 3: Explicit Cast with `as`
 
 ```wado
-// Source
-let a = [1, 2, 3] as Array<i32>;
-
-// Desugared to
-let a = Array::from_iter([1, 2, 3].into_iter()) as Array<i32>;
+let arr = [1, 2, 3] as Array<i32>;
 ```
 
-### 5. Type Checking Requirements
-
-For coercion to succeed, the compiler verifies:
-
-1. **Source implements IntoIterator**: `E: IntoIterator`
-2. **Target implements FromIterator**: `T: FromIterator<E::Item>`
-3. **Element type matches**: The `Item` type from `IntoIterator` matches the type parameter of `FromIterator`
-
-If any condition fails, coercion is not applied and a type error is reported.
-
-### 6. Heterogeneous Tuple Handling
-
-Heterogeneous tuples (mixed element types) cannot be coerced to collections:
+### 6. Array Implementation
 
 ```wado
-let mixed = [1, "hello", true];  // Type: [i32, String, bool]
-
-// ERROR: Cannot coerce to Array<?>
-let a: Array<i32> = mixed;  // ❌ Heterogeneous tuple doesn't implement IntoIterator
-```
-
-This is a compile-time error with a clear message:
-
-```
-error: cannot coerce heterogeneous tuple to Array
-  --> example.wado:2:21
-   |
-2  | let a: Array<i32> = mixed;
-   |                     ^^^^^ type [i32, String, bool] does not implement IntoIterator
-   |
-   = note: only homogeneous tuples (all elements same type) can be iterated
-```
-
-### 7. Empty Tuple Special Case
-
-The empty tuple `[]` has type `[]` (0-tuple). It implements `IntoIterator`:
-
-```wado
-impl IntoIterator for [] {
-    type Item = !;  // Never type (no elements)
-    type Iter = EmptyIter;
-
-    fn into_iter(self) -> EmptyIter {
-        return EmptyIter::new();
-    }
-}
-```
-
-This allows:
-
-```wado
-let empty: Array<i32> = [];  // OK: creates empty array
-let empty_set: Set<String> = [];  // OK: creates empty set
-```
-
-**Type parameter inference**: When coercing `[]`, the element type is inferred from the target collection's type parameter.
-
-### 8. User-Defined Collection Types
-
-Users can define their own collection types with literal coercion by implementing `FromIterator`:
-
-```wado
-// User-defined immutable vector
-struct Vec<T> {
+pub struct ArrayBuilder<T> {
     items: Array<T>,
 }
 
-impl<T> Vec<T> {
-    fn new() -> Vec<T> {
-        return Vec { items: [] };
+impl Builder for ArrayBuilder<T> {
+    type Element = T;
+    type Output = Array<T>;
+
+    fn new() -> Self {
+        return ArrayBuilder { items: [] };
+    }
+
+    fn add(self, element: T) -> Self {
+        self.items.append(element);
+        return self;
+    }
+
+    fn build(self) -> Array<T> {
+        return self.items;
     }
 }
 
-impl<T> FromIterator<T> for Vec<T> {
-    fn from_iter<I: Iterator<Item = T>>(iter: I) -> Vec<T> {
-        let mut vec = Vec::new();
-        for let item of iter {
-            vec.items.append(item);
+impl Collectable for Array<T> {
+    type Element = T;
+    type Builder = ArrayBuilder<T>;
+}
+```
+
+### 7. JSONArray Example (Heterogeneous)
+
+```wado
+pub variant JSONValue {
+    Null,
+    Bool(bool),
+    Number(f64),
+    String(String),
+    Array(JSONArray),
+    Object(JSONObject),
+}
+
+pub struct JSONArray {
+    items: Array<JSONValue>,
+}
+
+// Into implementations for JSONValue
+impl Into<JSONValue> for i32 {
+    fn into(self) -> JSONValue {
+        return JSONValue::Number(self as f64);
+    }
+}
+
+impl Into<JSONValue> for String {
+    fn into(self) -> JSONValue {
+        return JSONValue::String(self);
+    }
+}
+
+impl Into<JSONValue> for bool {
+    fn into(self) -> JSONValue {
+        return JSONValue::Bool(self);
+    }
+}
+
+// Builder for JSONArray
+pub struct JSONArrayBuilder {
+    items: Array<JSONValue>,
+}
+
+impl Builder for JSONArrayBuilder {
+    type Element = JSONValue;
+    type Output = JSONArray;
+
+    fn new() -> Self {
+        return JSONArrayBuilder { items: [] };
+    }
+
+    fn add(self, element: JSONValue) -> Self {
+        self.items.append(element);
+        return self;
+    }
+
+    fn build(self) -> JSONArray {
+        return JSONArray { items: self.items };
+    }
+}
+
+impl Collectable for JSONArray {
+    type Element = JSONValue;
+    type Builder = JSONArrayBuilder;
+}
+```
+
+Usage:
+
+```wado
+// Heterogeneous tuple → JSONArray
+let json: JSONArray = [1, "hello", true, null];
+
+// Expands to:
+let json: JSONArray = {
+    JSONArrayBuilder::new()
+        .add(Into::<JSONValue>::into(1))        // i32 → JSONValue::Number
+        .add(Into::<JSONValue>::into("hello"))  // String → JSONValue::String
+        .add(Into::<JSONValue>::into(true))     // bool → JSONValue::Bool
+        .add(Into::<JSONValue>::into(null))     // null → JSONValue::Null
+        .build()
+};
+```
+
+### 8. Immutable Collection Example
+
+```wado
+// Completely immutable - no mutation methods exposed
+pub struct ImmutableList<T> {
+    // Internal representation (e.g., cons list, rope, etc.)
+    #[hidden]
+    repr: InternalRepr<T>,
+}
+
+impl ImmutableList<T> {
+    fn len(&self) -> i32 { ... }
+    fn get(&self, index: i32) -> Option<T> { ... }
+    // No append, push, or any mutation methods!
+}
+
+// Builder handles construction internally
+pub struct ImmutableListBuilder<T> {
+    buffer: Array<T>,
+}
+
+impl Builder for ImmutableListBuilder<T> {
+    type Element = T;
+    type Output = ImmutableList<T>;
+
+    fn new() -> Self {
+        return ImmutableListBuilder { buffer: [] };
+    }
+
+    fn add(self, element: T) -> Self {
+        self.buffer.append(element);
+        return self;
+    }
+
+    fn build(self) -> ImmutableList<T> {
+        // Convert buffer to immutable internal representation
+        return ImmutableList::from_array(self.buffer);
+    }
+}
+
+impl Collectable for ImmutableList<T> {
+    type Element = T;
+    type Builder = ImmutableListBuilder<T>;
+}
+
+// Now this works!
+let list: ImmutableList<i32> = [1, 2, 3, 4, 5];
+// list has no mutation methods, but was constructed via Builder
+```
+
+### 9. Empty Tuple
+
+The empty tuple `[]` coerces to empty collections:
+
+```wado
+let empty_arr: Array<i32> = [];
+let empty_json: JSONArray = [];
+let empty_list: ImmutableList<String> = [];
+
+// All expand to: C::Builder::new().build()
+```
+
+### 10. Relationship with Iterator Traits
+
+Builder-based coercion and Iterator traits serve different purposes:
+
+| Mechanism | Purpose | Tuple Support |
+|-----------|---------|---------------|
+| **Builder** | Literal → Collection coercion | Homo + Hetero |
+| **FromIterator** | Iterator → Collection | Homo only |
+| **IntoIterator** | Collection → Iterator | N/A |
+
+They can coexist:
+
+```wado
+// Builder-based (compile-time, supports hetero)
+let json: JSONArray = [1, "hello", true];
+
+// Iterator-based (runtime, homo only)
+let arr: Array<i32> = some_iterator.collect();
+
+// FromIterator can use Builder internally
+impl FromIterator<T> for Array<T> {
+    fn from_iter(iter: impl Iterator<Item = T>) -> Array<T> {
+        let mut builder = ArrayBuilder::new();
+        loop {
+            if let Some(item) = iter.next() {
+                builder = builder.add(item);
+            } else {
+                break;
+            }
         }
-        return vec;
-    }
-}
-
-// Now tuple literals work automatically!
-let v: Vec<i32> = [1, 2, 3];  // ✅ Coercion via FromIterator
-```
-
-No compiler changes needed - the trait implementation is sufficient.
-
-### 9. Chaining with Iterator Methods
-
-Iterator coercion composes with iterator methods:
-
-```wado
-// Explicit iterator chain
-let even_doubles: Array<i32> = [1, 2, 3, 4, 5]
-    .into_iter()
-    .filter(|x| x % 2 == 0)
-    .map(|x| x * 2)
-    .collect();
-
-// With type inference
-let result: Set<String> = [1, 2, 2, 3]
-    .into_iter()
-    .map(|n| `num_{n}`)
-    .collect();
-```
-
-**Note**: `.collect()` is a method on `Iterator` that calls `FromIterator::from_iter(self)`. It provides the same functionality as implicit coercion but can be used mid-chain.
-
-### 10. Remove Hardcoded Array Coercion
-
-The compiler's special-case logic for tuple-to-array coercion (in `resolver.rs`) is **removed** and replaced with the general iterator coercion mechanism.
-
-**Before** (hardcoded):
-
-```rust
-// resolver.rs - REMOVED
-if let ResolvedType::Array { element_type } = target_type {
-    if let TirExprKind::TupleLiteral { elements } = &expr.kind {
-        // Special case: convert to ArrayLiteral
-        return coerce_tuple_to_array(elements, element_type);
+        return builder.build();
     }
 }
 ```
 
-**After** (general):
+### 11. Type Error Messages
+
+Clear error messages guide users:
+
+```wado
+// ERROR: No Into<E> implementation
+let arr: Array<i32> = [1, "hello", 3];
+// error: cannot coerce String to i32
+//   --> example.wado:1:27
+//    |
+// 1  | let arr: Array<i32> = [1, "hello", 3];
+//    |                           ^^^^^^^ String does not implement Into<i32>
+```
+
+```wado
+// ERROR: Collection not Collectable
+struct MyType { ... }
+let m: MyType = [1, 2, 3];
+// error: MyType does not implement Collectable
+//   --> example.wado:2:5
+//    |
+// 2  | let m: MyType = [1, 2, 3];
+//    |     ^ cannot coerce tuple literal to MyType
+//    |
+//    = help: implement Collectable for MyType to enable tuple coercion
+```
+
+### 12. Implementation Strategy
+
+#### Phase 1: Core Traits
+
+Define `Builder`, `Collectable`, and `Into` traits in prelude.
+
+#### Phase 2: Array Implementation
+
+Implement `ArrayBuilder` and `Collectable for Array<T>`.
+
+#### Phase 3: Compiler Coercion Logic
+
+Replace hardcoded tuple-to-array coercion with trait-based expansion:
 
 ```rust
-// resolver.rs - NEW
-if let Some(coercion) = try_iterator_coercion(expr_type, target_type) {
-    // General case: E: IntoIterator, T: FromIterator<E::Item>
-    return desugar_to_from_iter_call(expr, target_type, coercion);
+// In resolver.rs
+fn try_tuple_coercion(tuple_expr: &Expr, target_type: &Type) -> Option<Expr> {
+    // 1. Check target implements Collectable
+    let element_type = get_collectable_element(target_type)?;
+    let builder_type = get_collectable_builder(target_type)?;
+
+    // 2. Check each tuple element has Into<Element>
+    for elem in tuple_elements {
+        check_into_impl(elem.type, element_type)?;
+    }
+
+    // 3. Generate builder chain
+    let mut expr = call_static(builder_type, "new", []);
+    for elem in tuple_elements {
+        let converted = call_into(elem, element_type);
+        expr = call_method(expr, "add", [converted]);
+    }
+    expr = call_method(expr, "build", []);
+
+    return Some(expr);
 }
 ```
 
-### 11. Dict Literal Syntax (Future Extension)
+#### Phase 4: Standard Library
 
-While not part of this WEP, the iterator-based coercion enables future Dict literal syntax:
-
-```wado
-// Tuple of 2-tuples coerces to Dict
-let config: Dict<String, i32> = [
-    ["width", 800],
-    ["height", 600],
-    ["fps", 60],
-];
-
-// Desugars to
-let config: Dict<String, i32> = Dict::from_iter(
-    [["width", 800], ["height", 600], ["fps", 60]].into_iter()
-);
-```
-
-This requires `Dict` to implement `FromIterator<[K, V]>`, which is natural.
+Implement `Collectable` for standard collections (Set, Dict, etc.).
 
 ## Consequences
 
 ### Positive
 
-1. **Simplicity**: Removes ~200 lines of special-case coercion logic from the compiler
-2. **Generality**: Any type implementing `FromIterator<T>` gets literal coercion for free
-3. **Extensibility**: Users can define custom collection types with literal syntax
-4. **Consistency**: All collections are treated uniformly, not just `Array<T>`
-5. **Composability**: Works seamlessly with iterator methods (`.filter()`, `.map()`, etc.)
-6. **Rust alignment**: Matches Rust's `.collect()` pattern, reducing learning curve
-7. **Type safety**: Compiler verifies trait bounds at compile time
-8. **Clear errors**: Type errors point to missing trait implementations, not mysterious coercion failures
-9. **Future-proof**: New collection types (Set, Dict, Vec, etc.) work automatically
+1. **Heterogeneous tuple support**: `[1, "hello", true]` → `JSONArray` works
+2. **Immutable containers**: Collections need not expose mutation
+3. **User extensibility**: Any type can implement `Collectable`
+4. **Compile-time expansion**: No runtime iterator overhead for literals
+5. **Type safety**: Each element conversion is checked at compile time
+6. **Clear semantics**: Builder pattern is well-understood
 
 ### Negative
 
-1. **Requires trait system**: This feature depends on full trait implementation (not yet complete)
-   - **Mitigation**: Trait system is high priority and already designed (WEP: Struct and Trait System)
-2. **Potential performance**: Iterator creation and `from_iter` calls may have overhead
-   - **Mitigation**: Compiler can inline and optimize away iterator abstractions in most cases
-   - **Mitigation**: For literals, the compiler can directly generate optimized code (constant folding)
-3. **Heterogeneous tuples don't coerce**: Mixed-type tuples like `[1, "hello"]` cannot be iterated
-   - **Mitigation**: This is expected behavior - heterogeneous collections don't make sense
-   - **Mitigation**: Clear error messages guide users
-4. **Breaking change**: If any code relies on current coercion behavior, it may break
-   - **Mitigation**: Current behavior is preserved - this is a drop-in replacement
+1. **Requires Builder per collection**: Each collection needs a Builder type
+   - **Mitigation**: Can be derived or generated
+2. **More traits to implement**: `Builder`, `Collectable`, `Into`
+   - **Mitigation**: `Into` is useful beyond coercion; Builder is optional
+3. **Trait bounds complexity**: `Builder<Element = E, Output = C>`
+   - **Mitigation**: Users rarely write these directly
 
 ### Trade-offs
 
-| Aspect                  | Hardcoded Coercion         | Iterator-Based Coercion      |
-| ----------------------- | -------------------------- | ---------------------------- |
-| **Compiler complexity** | High (special cases)       | Low (general rule)           |
-| **Extensibility**       | ❌ Compiler changes needed | ✅ Trait implementation only |
-| **User-defined types**  | ❌ Not supported           | ✅ Fully supported           |
-| **Performance**         | ✅ Direct codegen          | ⚠️ Requires optimization      |
-| **Consistency**         | ❌ Array is special        | ✅ All collections equal     |
-| **Error messages**      | ⚠️ "Type mismatch"          | ✅ "Missing trait impl"      |
-| **Maintenance**         | ❌ High                    | ✅ Low                       |
+| Aspect | Iterator-Based | Builder-Based |
+|--------|---------------|---------------|
+| Heterogeneous tuples | ❌ Not supported | ✅ Supported |
+| Immutable containers | ⚠️ Needs internal mutation | ✅ Fully supported |
+| Runtime overhead | ⚠️ Iterator creation | ✅ None (compile-time) |
+| Implementation effort | Low (one trait) | Medium (two traits + Builder type) |
+| Generality | High | High |
 
 ## Examples
 
-### Basic Array Coercion
+### Basic Array
 
 ```wado
-use {println} from "core:cli";
-
 fn run() with Stdout {
-    // Tuple literal coerces to Array
+    // Homogeneous tuple → Array
     let numbers: Array<i32> = [1, 2, 3, 4, 5];
 
-    // Works in function arguments
-    fn sum(items: Array<i32>) -> i32 {
-        let mut total = 0;
-        for let n of items {
-            total += n;
-        }
-        return total;
+    for let n of numbers {
+        println(`{n}`);
     }
-
-    let result = sum([10, 20, 30]);  // Implicit coercion
-    println(`Sum: {result}`);  // Sum: 60
-
-    // Explicit cast
-    let explicit = [1, 2, 3] as Array<i32>;
 }
 ```
 
-### User-Defined Collection
+### JSON Construction
 
 ```wado
-// User-defined immutable vector
-struct ImmutableVec<T> {
+fn run() with Stdout {
+    // Heterogeneous tuple → JSONArray
+    let data: JSONArray = [
+        42,
+        "hello",
+        true,
+        null,
+        [1, 2, 3],  // Nested array
+    ];
+
+    println(data.stringify());
+    // [42, "hello", true, null, [1, 2, 3]]
+}
+```
+
+### Custom Collection
+
+```wado
+// User-defined sorted set
+struct SortedSet<T: Ord> {
     items: Array<T>,
 }
 
-impl<T> ImmutableVec<T> {
-    fn len(&self) -> i32 {
-        return self.items.len();
-    }
-
-    fn get(&self, idx: i32) -> &T {
-        return &self.items[idx];
-    }
-}
-
-// Implement FromIterator to enable literal coercion
-impl<T> FromIterator<T> for ImmutableVec<T> {
-    fn from_iter<I: Iterator<Item = T>>(iter: I) -> ImmutableVec<T> {
-        let items = Array::from_iter(iter);
-        return ImmutableVec { items };
-    }
-}
-
-fn run() {
-    // Now tuple literals work automatically!
-    let vec: ImmutableVec<i32> = [1, 2, 3, 4, 5];
-
-    assert vec.len() == 5;
-    assert *vec.get(0) == 1;
-}
-```
-
-### Iterator Method Chaining
-
-```wado
-fn run() {
-    // Filter and map with automatic coercion
-    let squares: Array<i32> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        .into_iter()
-        .filter(|x| x % 2 == 0)
-        .map(|x| x * x)
-        .collect();
-
-    // squares = [4, 16, 36, 64, 100]
-    assert squares.len() == 5;
-}
-```
-
-### Set with Deduplication
-
-```wado
-// Hypothetical Set implementation
-struct Set<T> {
+struct SortedSetBuilder<T: Ord> {
     items: Array<T>,
 }
 
-impl<T: Eq + Hash> FromIterator<T> for Set<T> {
-    fn from_iter<I: Iterator<Item = T>>(iter: I) -> Set<T> {
-        let mut set = Set { items: [] };
-        for let item of iter {
-            if !set.contains(&item) {
-                set.items.append(item);
-            }
-        }
-        return set;
+impl Builder for SortedSetBuilder<T: Ord> {
+    type Element = T;
+    type Output = SortedSet<T>;
+
+    fn new() -> Self {
+        return SortedSetBuilder { items: [] };
+    }
+
+    fn add(self, element: T) -> Self {
+        // Insert in sorted order, skip duplicates
+        // ... implementation ...
+        return self;
+    }
+
+    fn build(self) -> SortedSet<T> {
+        return SortedSet { items: self.items };
     }
 }
 
+impl Collectable for SortedSet<T: Ord> {
+    type Element = T;
+    type Builder = SortedSetBuilder<T>;
+}
+
 fn run() {
-    // Duplicates automatically removed
-    let unique: Set<i32> = [1, 2, 2, 3, 3, 3, 4];
-    assert unique.len() == 4;  // [1, 2, 3, 4]
+    // Automatically sorted and deduplicated!
+    let set: SortedSet<i32> = [3, 1, 4, 1, 5, 9, 2, 6];
+    // set.items = [1, 2, 3, 4, 5, 6, 9]
 }
 ```
 
-### Dict from Tuple Pairs
+### Dict from Pairs
 
 ```wado
-// Hypothetical Dict implementation
-impl<K: Eq + Hash, V> FromIterator<[K, V]> for Dict<K, V> {
-    fn from_iter<I: Iterator<Item = [K, V]>>(iter: I) -> Dict<K, V> {
-        let mut dict = Dict::new();
-        for let [k, v] of iter {
-            dict.insert(k, v);
-        }
-        return dict;
-    }
+impl Collectable for Dict<K, V> {
+    type Element = [K, V];  // Key-value tuple
+    type Builder = DictBuilder<K, V>;
 }
 
 fn run() {
-    // Config dict from tuple of tuples
+    // Tuple of pairs → Dict
     let config: Dict<String, i32> = [
         ["width", 1920],
         ["height", 1080],
         ["fps", 60],
     ];
-
-    assert config.get("width") == Some(1920);
 }
 ```
-
-### Empty Collection
-
-```wado
-fn run() {
-    // Empty tuple coerces to empty collections
-    let empty_array: Array<i32> = [];
-    let empty_set: Set<String> = [];
-    let empty_dict: Dict<i32, String> = [];
-
-    assert empty_array.len() == 0;
-    assert empty_set.len() == 0;
-    assert empty_dict.len() == 0;
-}
-```
-
-### Error Cases
-
-```wado
-fn run() {
-    // ERROR: Heterogeneous tuple cannot be coerced
-    let mixed = [1, "hello", true];  // [i32, String, bool]
-    let arr: Array<i32> = mixed;
-    // error: type [i32, String, bool] does not implement IntoIterator
-
-    // ERROR: Element type mismatch
-    let numbers = [1, 2, 3];  // [i32, i32, i32]
-    let strings: Array<String> = numbers;
-    // error: cannot coerce [i32, i32, i32] to Array<String>
-    //        element types do not match (i32 vs String)
-}
-```
-
-## Comparison with Other Languages
-
-| Language   | Literal Syntax  | Default Type            | Coercion Mechanism              |
-| ---------- | --------------- | ----------------------- | ------------------------------- |
-| **Wado**   | `[1, 2, 3]`     | Tuple `[i32, i32, i32]` | `IntoIterator` + `FromIterator` |
-| Rust       | `vec![1, 2, 3]` | `Vec<i32>` (macro)      | Explicit `.collect()`           |
-| TypeScript | `[1, 2, 3]`     | `number[]`              | Type annotation for tuples      |
-| Python     | `[1, 2, 3]`     | `list`                  | Constructor: `set([1, 2, 3])`   |
-| Swift      | `[1, 2, 3]`     | `[Int]`                 | No coercion to Set/Dict         |
-
-Wado's approach is unique in providing **implicit coercion via traits** while maintaining **type safety** and **extensibility**.
 
 ## Related WEPs
 
-- [WEP: Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md) - Defines tuple literal syntax
-- [WEP: Struct and Trait System](./wep-2026-01-13-struct-and-trait.md) - Foundation for trait-based coercion
-- [WEP: Literal Type Conversion Rules](./wep-2026-01-12-literal-type-conversion.md) - General type conversion philosophy
+- [Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md) - Defines tuple literal syntax
+- [Iterator Traits Design](./wep-2026-01-24-iterator-traits.md) - Iterator traits (orthogonal to Builder)
+- [Struct and Trait System](./wep-2026-01-13-struct-and-trait.md) - Foundation for traits
 
 ## References
 
-- [Rust Iterator trait](https://doc.rust-lang.org/std/iter/trait.Iterator.html)
-- [Rust IntoIterator trait](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)
-- [Rust FromIterator trait](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)
-- [Rust collect() method](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect)
-- [TypeScript Tuple Types](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types)
+- [Rust std::iter::FromIterator](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)
+- [Swift ExpressibleByArrayLiteral](https://developer.apple.com/documentation/swift/expressiblebyarrayliteral)
+- [C# Collection Initializers](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers)
+- [Kotlin buildList](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/build-list.html)

--- a/docs/wep-2026-01-18-iterator-based-literal-coercion.md
+++ b/docs/wep-2026-01-18-iterator-based-literal-coercion.md
@@ -1,93 +1,105 @@
-# WEP: Tuple-to-Collection Coercion
+# WEP: Literal-to-Collection Coercion
 
 ## Context
 
-Wado allows tuple literals to be coerced to collection types in certain contexts:
+Wado allows literals to be coerced to collection types in certain contexts:
 
 ```wado
-let a: Array<i32> = [1, 2, 3];  // Tuple literal → Array<i32>
-fn takes(arr: Array<i32>) {}
-takes([1, 2, 3]);                // Implicit coercion
-let b = [1, 2, 3] as Array<i32>; // Explicit cast
-```
-
-This coercion is currently **hardcoded** in the compiler. When the compiler encounters a tuple literal with a target type of `Array<T>`, it performs special conversion logic.
-
-### Requirements
-
-The coercion mechanism must support:
-
-1. **Homogeneous tuples**: `[1, 2, 3]` → `Array<i32>`
-2. **Heterogeneous tuples**: `[1, "hello", true]` → `JSONArray` (when each element converts to `JSONValue`)
-3. **Immutable containers**: Target container may not expose mutation methods
-4. **User-defined collections**: Any collection implementing the right traits
-
-### Approaches Considered
-
-#### Approach A: Iterator-Based (FromIterator)
-
-```wado
+// Tuple literal → Array
 let a: Array<i32> = [1, 2, 3];
-// Desugars to: Array::from_iter([1, 2, 3].into_iter())
+
+// Object literal → Dict
+let d: Dict<String, i32> = { "width": 1920, "height": 1080 };
 ```
 
-Limitations:
-- **Cannot handle heterogeneous tuples**: `IntoIterator::Item` must be a single type
-- Requires `IntoIterator` impl for each tuple arity
+This coercion is currently **hardcoded** in the compiler. We need a trait-based mechanism that:
 
-#### Approach B: Builder Pattern
-
-```wado
-let a: Array<i32> = [1, 2, 3];
-// Desugars to:
-// ArrayBuilder::new().add(1).add(2).add(3).build()
-```
-
-Advantages:
-- **Handles heterogeneous tuples**: Each `add()` call can use `Into<E>` conversion
-- **Works with immutable containers**: Only Builder exposes mutation
-- **Compile-time expansion**: Known tuple size allows direct code generation
-
-### Decision: Builder Pattern
-
-We adopt the Builder pattern as the primary mechanism for tuple-to-collection coercion.
+1. Supports both tuple literals and object literals
+2. Handles heterogeneous elements (e.g., `[1, "hello", true]` → `JSONArray`)
+3. Works with immutable containers
+4. Is extensible to user-defined collections
 
 ## Decision
 
-### 1. Builder Trait
+### 1. Literal Types
+
+#### Tuple Literal
 
 ```wado
-/// Trait for building collections element by element
-pub trait Builder {
+let t = [1, 2, 3];       // Type: [i32, i32, i32]
+let mixed = [1, "hi"];   // Type: [i32, String]
+```
+
+Default type is a tuple with the inferred element types.
+
+#### Object Literal
+
+```wado
+let obj = { name: "Alice", age: 30 };
+// Type: { name: String, age: i32 } (anonymous struct)
+```
+
+Default type is an anonymous struct. The parser already supports this as "implicit struct".
+
+### 2. TupleBuilder Trait
+
+```wado
+/// Trait for building collections from tuple literals
+pub trait TupleBuilder {
     type Element;
     type Output;
 
-    /// Create a new empty builder
-    fn new() -> Self;
+    /// Create a builder with pre-allocated capacity
+    fn with_capacity(n: i32) -> Self;
 
-    /// Add an element and return the builder
-    fn add(self, element: Self::Element) -> Self;
+    /// Append an element to the builder
+    fn append(&mut self, element: Self::Element);
 
     /// Finalize and return the built collection
-    fn build(self) -> Self::Output;
+    fn into(self) -> Self::Output;
 }
 ```
 
-The `add` method takes `self` by value (consuming) to enable fluent chaining. Implementations may internally use mutation.
-
-### 2. Collectable Trait
+### 3. FromTuple Trait
 
 ```wado
-/// Trait for collection types that can be built from elements
-pub trait Collectable {
+/// Trait for collection types that can be built from tuple literals
+pub trait FromTuple {
     type Element;
-    type Builder: Builder<Element = Self::Element, Output = Self>;
+    type Builder: TupleBuilder<Element = Self::Element, Output = Self>;
 }
 ```
 
-This associates a collection type with its builder.
+### 4. ObjectBuilder Trait
 
-### 3. Into Trait for Element Conversion
+```wado
+/// Trait for building collections from object literals
+pub trait ObjectBuilder {
+    type Value;
+    type Output;
+
+    /// Create a builder with pre-allocated capacity
+    fn with_capacity(n: i32) -> Self;
+
+    /// Insert a key-value pair
+    fn insert(&mut self, key: String, value: Self::Value);
+
+    /// Finalize and return the built collection
+    fn into(self) -> Self::Output;
+}
+```
+
+### 5. FromObject Trait
+
+```wado
+/// Trait for collection types that can be built from object literals
+pub trait FromObject {
+    type Value;
+    type Builder: ObjectBuilder<Value = Self::Value, Output = Self>;
+}
+```
+
+### 6. Into Trait for Element Conversion
 
 ```wado
 /// Trait for type conversions
@@ -103,12 +115,12 @@ impl Into<T> for T {
 }
 ```
 
-### 4. Coercion Rules
+### 7. Tuple Literal Coercion Rules
 
-When the compiler encounters a tuple literal `[e0, e1, ..., en]` with target type `C` where `C: Collectable<Element = E>`:
+When the compiler encounters a tuple literal `[e0, e1, ..., en]` with target type `C` where `C: FromTuple<Element = E>`:
 
 1. **Check each element**: Verify `Ti: Into<E>` for each element type `Ti`
-2. **Expand at compile time**: Generate builder chain
+2. **Expand at compile time**:
 
 ```wado
 // Source
@@ -116,69 +128,128 @@ let container: C = [e0, e1, e2];
 
 // Compiler expansion
 let container: C = {
-    C::Builder::new()
-        .add(Into::<E>::into(e0))
-        .add(Into::<E>::into(e1))
-        .add(Into::<E>::into(e2))
-        .build()
+    let mut __builder = C::Builder::with_capacity(3);
+    __builder.append(Into::<E>::into(e0));
+    __builder.append(Into::<E>::into(e1));
+    __builder.append(Into::<E>::into(e2));
+    __builder.into()
 };
 ```
 
-### 5. Coercion Contexts
+### 8. Object Literal Coercion Rules
+
+When the compiler encounters an object literal `{ k0: v0, k1: v1, ... }` with target type `C` where `C: FromObject<Value = V>`:
+
+1. **Check each value**: Verify `Vi: Into<V>` for each value type `Vi`
+2. **Expand at compile time**:
+
+```wado
+// Source
+let container: C = { "name": "Alice", "age": 30 };
+
+// Compiler expansion
+let container: C = {
+    let mut __builder = C::Builder::with_capacity(2);
+    __builder.insert("name", Into::<V>::into("Alice"));
+    __builder.insert("age", Into::<V>::into(30));
+    __builder.into()
+};
+```
+
+### 9. Coercion Contexts
 
 Coercion applies in three contexts:
 
-#### Context 1: Variable Initialization with Type Annotation
+1. **Variable initialization**: `let arr: Array<i32> = [1, 2, 3];`
+2. **Function argument**: `process([1, 2, 3]);`
+3. **Explicit cast**: `[1, 2, 3] as Array<i32>`
+
+### 10. Array Implementation
+
+Array serves as its own builder (no separate builder type needed):
 
 ```wado
-let arr: Array<i32> = [1, 2, 3];
-```
-
-#### Context 2: Function Argument Passing
-
-```wado
-fn process(items: Array<i32>) { ... }
-process([1, 2, 3]);
-```
-
-#### Context 3: Explicit Cast with `as`
-
-```wado
-let arr = [1, 2, 3] as Array<i32>;
-```
-
-### 6. Array Implementation
-
-```wado
-pub struct ArrayBuilder<T> {
-    items: Array<T>,
-}
-
-impl Builder for ArrayBuilder<T> {
+impl TupleBuilder for Array<T> {
     type Element = T;
     type Output = Array<T>;
 
-    fn new() -> Self {
-        return ArrayBuilder { items: [] };
+    fn with_capacity(n: i32) -> Self {
+        return Array::<T>::with_capacity(n);
     }
 
-    fn add(self, element: T) -> Self {
-        self.items.append(element);
-        return self;
+    fn append(&mut self, element: T) {
+        self.append(element);  // Existing method
     }
 
-    fn build(self) -> Array<T> {
-        return self.items;
+    fn into(self) -> Array<T> {
+        return self;  // Identity
     }
 }
 
-impl Collectable for Array<T> {
+impl FromTuple for Array<T> {
     type Element = T;
-    type Builder = ArrayBuilder<T>;
+    type Builder = Array<T>;  // Array is its own builder!
 }
 ```
 
-### 7. JSONArray Example (Heterogeneous)
+Expansion for Array:
+
+```wado
+let arr: Array<i32> = [1, 2, 3];
+
+// →
+{
+    let mut __builder = Array::<i32>::with_capacity(3);
+    __builder.append(1);
+    __builder.append(2);
+    __builder.append(3);
+    __builder.into()
+}
+```
+
+### 11. Dict Implementation
+
+Dict also serves as its own builder:
+
+```wado
+impl ObjectBuilder for Dict<String, V> {
+    type Value = V;
+    type Output = Dict<String, V>;
+
+    fn with_capacity(n: i32) -> Self {
+        return Dict::<String, V>::with_capacity(n);
+    }
+
+    fn insert(&mut self, key: String, value: V) {
+        self.insert(key, value);  // Existing method
+    }
+
+    fn into(self) -> Dict<String, V> {
+        return self;  // Identity
+    }
+}
+
+impl FromObject for Dict<String, V> {
+    type Value = V;
+    type Builder = Dict<String, V>;
+}
+```
+
+Expansion for Dict:
+
+```wado
+let config: Dict<String, i32> = { "width": 1920, "height": 1080 };
+
+// →
+{
+    let mut __builder = Dict::<String, i32>::with_capacity(2);
+    __builder.insert("width", 1920);
+    __builder.insert("height", 1080);
+    __builder.into()
+}
+```
+
+### 12. JSONArray Example (Heterogeneous Tuple)
 
 ```wado
 pub variant JSONValue {
@@ -188,10 +259,6 @@ pub variant JSONValue {
     String(String),
     Array(JSONArray),
     Object(JSONObject),
-}
-
-pub struct JSONArray {
-    items: Array<JSONValue>,
 }
 
 // Into implementations for JSONValue
@@ -213,32 +280,31 @@ impl Into<JSONValue> for bool {
     }
 }
 
-// Builder for JSONArray
-pub struct JSONArrayBuilder {
+// JSONArray can use Array<JSONValue> as its builder
+pub struct JSONArray {
     items: Array<JSONValue>,
 }
 
-impl Builder for JSONArrayBuilder {
+impl TupleBuilder for JSONArray {
     type Element = JSONValue;
     type Output = JSONArray;
 
-    fn new() -> Self {
-        return JSONArrayBuilder { items: [] };
+    fn with_capacity(n: i32) -> Self {
+        return JSONArray { items: Array::<JSONValue>::with_capacity(n) };
     }
 
-    fn add(self, element: JSONValue) -> Self {
+    fn append(&mut self, element: JSONValue) {
         self.items.append(element);
-        return self;
     }
 
-    fn build(self) -> JSONArray {
-        return JSONArray { items: self.items };
+    fn into(self) -> JSONArray {
+        return self;
     }
 }
 
-impl Collectable for JSONArray {
+impl FromTuple for JSONArray {
     type Element = JSONValue;
-    type Builder = JSONArrayBuilder;
+    type Builder = JSONArray;
 }
 ```
 
@@ -249,22 +315,71 @@ Usage:
 let json: JSONArray = [1, "hello", true, null];
 
 // Expands to:
-let json: JSONArray = {
-    JSONArrayBuilder::new()
-        .add(Into::<JSONValue>::into(1))        // i32 → JSONValue::Number
-        .add(Into::<JSONValue>::into("hello"))  // String → JSONValue::String
-        .add(Into::<JSONValue>::into(true))     // bool → JSONValue::Bool
-        .add(Into::<JSONValue>::into(null))     // null → JSONValue::Null
-        .build()
-};
+{
+    let mut __builder = JSONArray::with_capacity(4);
+    __builder.append(Into::<JSONValue>::into(1));        // i32 → JSONValue::Number
+    __builder.append(Into::<JSONValue>::into("hello"));  // String → JSONValue::String
+    __builder.append(Into::<JSONValue>::into(true));     // bool → JSONValue::Bool
+    __builder.append(Into::<JSONValue>::into(null));     // null → JSONValue::Null
+    __builder.into()
+}
 ```
 
-### 8. Immutable Collection Example
+### 13. JSONObject Example (Heterogeneous Object)
+
+```wado
+pub struct JSONObject {
+    entries: Dict<String, JSONValue>,
+}
+
+impl ObjectBuilder for JSONObject {
+    type Value = JSONValue;
+    type Output = JSONObject;
+
+    fn with_capacity(n: i32) -> Self {
+        return JSONObject { entries: Dict::<String, JSONValue>::with_capacity(n) };
+    }
+
+    fn insert(&mut self, key: String, value: JSONValue) {
+        self.entries.insert(key, value);
+    }
+
+    fn into(self) -> JSONObject {
+        return self;
+    }
+}
+
+impl FromObject for JSONObject {
+    type Value = JSONValue;
+    type Builder = JSONObject;
+}
+```
+
+Usage:
+
+```wado
+// Heterogeneous object → JSONObject
+let obj: JSONObject = {
+    "name": "Alice",
+    "age": 30,
+    "active": true
+};
+
+// Expands to:
+{
+    let mut __builder = JSONObject::with_capacity(3);
+    __builder.insert("name", Into::<JSONValue>::into("Alice"));
+    __builder.insert("age", Into::<JSONValue>::into(30));
+    __builder.insert("active", Into::<JSONValue>::into(true));
+    __builder.into()
+}
+```
+
+### 14. Immutable Collection Example
 
 ```wado
 // Completely immutable - no mutation methods exposed
 pub struct ImmutableList<T> {
-    // Internal representation (e.g., cons list, rope, etc.)
     #[hidden]
     repr: InternalRepr<T>,
 }
@@ -275,31 +390,29 @@ impl ImmutableList<T> {
     // No append, push, or any mutation methods!
 }
 
-// Builder handles construction internally
+// Separate builder for immutable list
 pub struct ImmutableListBuilder<T> {
     buffer: Array<T>,
 }
 
-impl Builder for ImmutableListBuilder<T> {
+impl TupleBuilder for ImmutableListBuilder<T> {
     type Element = T;
     type Output = ImmutableList<T>;
 
-    fn new() -> Self {
-        return ImmutableListBuilder { buffer: [] };
+    fn with_capacity(n: i32) -> Self {
+        return ImmutableListBuilder { buffer: Array::<T>::with_capacity(n) };
     }
 
-    fn add(self, element: T) -> Self {
+    fn append(&mut self, element: T) {
         self.buffer.append(element);
-        return self;
     }
 
-    fn build(self) -> ImmutableList<T> {
-        // Convert buffer to immutable internal representation
+    fn into(self) -> ImmutableList<T> {
         return ImmutableList::from_array(self.buffer);
     }
 }
 
-impl Collectable for ImmutableList<T> {
+impl FromTuple for ImmutableList<T> {
     type Element = T;
     type Builder = ImmutableListBuilder<T>;
 }
@@ -309,54 +422,55 @@ let list: ImmutableList<i32> = [1, 2, 3, 4, 5];
 // list has no mutation methods, but was constructed via Builder
 ```
 
-### 9. Empty Tuple
+### 15. Empty Literals
 
-The empty tuple `[]` coerces to empty collections:
+Empty literals coerce to empty collections:
 
 ```wado
 let empty_arr: Array<i32> = [];
-let empty_json: JSONArray = [];
-let empty_list: ImmutableList<String> = [];
+let empty_dict: Dict<String, i32> = {};
 
-// All expand to: C::Builder::new().build()
+// Expand to:
+// C::Builder::with_capacity(0).into()
 ```
 
-### 10. Relationship with Iterator Traits
+### 16. Relationship with Iterator Traits
 
 Builder-based coercion and Iterator traits serve different purposes:
 
-| Mechanism | Purpose | Tuple Support |
-|-----------|---------|---------------|
-| **Builder** | Literal → Collection coercion | Homo + Hetero |
-| **FromIterator** | Iterator → Collection | Homo only |
+| Mechanism | Purpose | Hetero Support |
+|-----------|---------|----------------|
+| **TupleBuilder** | Tuple literal → Collection | ✅ Yes |
+| **ObjectBuilder** | Object literal → Collection | ✅ Yes |
+| **FromIterator** | Iterator → Collection | ❌ Homo only |
 | **IntoIterator** | Collection → Iterator | N/A |
 
-They can coexist:
+They coexist and can be combined:
 
 ```wado
-// Builder-based (compile-time, supports hetero)
+// Literal-based (compile-time, supports hetero)
 let json: JSONArray = [1, "hello", true];
 
 // Iterator-based (runtime, homo only)
 let arr: Array<i32> = some_iterator.collect();
 
-// FromIterator can use Builder internally
+// FromIterator can use TupleBuilder internally
 impl FromIterator<T> for Array<T> {
     fn from_iter(iter: impl Iterator<Item = T>) -> Array<T> {
-        let mut builder = ArrayBuilder::new();
+        let mut arr = Array::<T>::with_capacity(0);
         loop {
             if let Some(item) = iter.next() {
-                builder = builder.add(item);
+                arr.append(item);
             } else {
                 break;
             }
         }
-        return builder.build();
+        return arr;
     }
 }
 ```
 
-### 11. Type Error Messages
+### 17. Type Error Messages
 
 Clear error messages guide users:
 
@@ -371,98 +485,115 @@ let arr: Array<i32> = [1, "hello", 3];
 ```
 
 ```wado
-// ERROR: Collection not Collectable
+// ERROR: Type not FromTuple
 struct MyType { ... }
 let m: MyType = [1, 2, 3];
-// error: MyType does not implement Collectable
+// error: MyType does not implement FromTuple
 //   --> example.wado:2:5
 //    |
 // 2  | let m: MyType = [1, 2, 3];
 //    |     ^ cannot coerce tuple literal to MyType
 //    |
-//    = help: implement Collectable for MyType to enable tuple coercion
+//    = help: implement FromTuple for MyType to enable tuple coercion
 ```
 
-### 12. Implementation Strategy
+### 18. Implementation Strategy
 
 #### Phase 1: Core Traits
 
-Define `Builder`, `Collectable`, and `Into` traits in prelude.
+Define traits in prelude:
+- `Into<T>`
+- `TupleBuilder` / `FromTuple`
+- `ObjectBuilder` / `FromObject`
 
-#### Phase 2: Array Implementation
+#### Phase 2: Standard Implementations
 
-Implement `ArrayBuilder` and `Collectable for Array<T>`.
+- `impl TupleBuilder for Array<T>`
+- `impl FromTuple for Array<T>`
+- `impl ObjectBuilder for Dict<String, V>`
+- `impl FromObject for Dict<String, V>`
 
 #### Phase 3: Compiler Coercion Logic
 
-Replace hardcoded tuple-to-array coercion with trait-based expansion:
+Replace hardcoded coercion with trait-based expansion:
 
 ```rust
 // In resolver.rs
-fn try_tuple_coercion(tuple_expr: &Expr, target_type: &Type) -> Option<Expr> {
-    // 1. Check target implements Collectable
-    let element_type = get_collectable_element(target_type)?;
-    let builder_type = get_collectable_builder(target_type)?;
+fn try_literal_coercion(expr: &Expr, target_type: &Type) -> Option<Expr> {
+    match expr.kind {
+        TupleLiteral { elements } => try_tuple_coercion(elements, target_type),
+        ObjectLiteral { entries } => try_object_coercion(entries, target_type),
+        _ => None,
+    }
+}
 
-    // 2. Check each tuple element has Into<Element>
-    for elem in tuple_elements {
+fn try_tuple_coercion(elements: &[Expr], target_type: &Type) -> Option<Expr> {
+    // 1. Check target implements FromTuple
+    let element_type = get_from_tuple_element(target_type)?;
+    let builder_type = get_from_tuple_builder(target_type)?;
+
+    // 2. Check each element has Into<Element>
+    for elem in elements {
         check_into_impl(elem.type, element_type)?;
     }
 
-    // 3. Generate builder chain
-    let mut expr = call_static(builder_type, "new", []);
-    for elem in tuple_elements {
+    // 3. Generate builder expansion
+    let n = elements.len();
+    let mut stmts = vec![
+        let_mut("__builder", call_static(builder_type, "with_capacity", [n]))
+    ];
+    for elem in elements {
         let converted = call_into(elem, element_type);
-        expr = call_method(expr, "add", [converted]);
+        stmts.push(call_method_stmt("__builder", "append", [converted]));
     }
-    expr = call_method(expr, "build", []);
+    stmts.push(call_method("__builder", "into", []));
 
-    return Some(expr);
+    return Some(block_expr(stmts));
 }
 ```
-
-#### Phase 4: Standard Library
-
-Implement `Collectable` for standard collections (Set, Dict, etc.).
 
 ## Consequences
 
 ### Positive
 
-1. **Heterogeneous tuple support**: `[1, "hello", true]` → `JSONArray` works
-2. **Immutable containers**: Collections need not expose mutation
-3. **User extensibility**: Any type can implement `Collectable`
-4. **Compile-time expansion**: No runtime iterator overhead for literals
-5. **Type safety**: Each element conversion is checked at compile time
-6. **Clear semantics**: Builder pattern is well-understood
+1. **Unified design**: Both tuple and object literals use the same pattern
+2. **Heterogeneous support**: `[1, "hello", true]` → `JSONArray` works
+3. **Immutable containers**: Collections need not expose mutation
+4. **User extensibility**: Any type can implement `FromTuple` / `FromObject`
+5. **Compile-time expansion**: No runtime overhead for literals
+6. **Self-as-builder optimization**: `Array` and `Dict` are their own builders
 
 ### Negative
 
-1. **Requires Builder per collection**: Each collection needs a Builder type
-   - **Mitigation**: Can be derived or generated
-2. **More traits to implement**: `Builder`, `Collectable`, `Into`
-   - **Mitigation**: `Into` is useful beyond coercion; Builder is optional
-3. **Trait bounds complexity**: `Builder<Element = E, Output = C>`
-   - **Mitigation**: Users rarely write these directly
+1. **Four traits**: `TupleBuilder`, `FromTuple`, `ObjectBuilder`, `FromObject`
+   - **Mitigation**: Clear separation of concerns; users typically implement one pair
+2. **Requires `Into` implementations**: For heterogeneous coercion
+   - **Mitigation**: `Into` is useful beyond coercion
 
 ### Trade-offs
 
-| Aspect | Iterator-Based | Builder-Based |
-|--------|---------------|---------------|
-| Heterogeneous tuples | ❌ Not supported | ✅ Supported |
-| Immutable containers | ⚠️ Needs internal mutation | ✅ Fully supported |
-| Runtime overhead | ⚠️ Iterator creation | ✅ None (compile-time) |
-| Implementation effort | Low (one trait) | Medium (two traits + Builder type) |
-| Generality | High | High |
+| Aspect | Tuple Literal | Object Literal |
+|--------|---------------|----------------|
+| Default type | Tuple `[T, U, V]` | Anonymous struct `{ a: T, b: U }` |
+| Coercion trait | `FromTuple` | `FromObject` |
+| Builder trait | `TupleBuilder` | `ObjectBuilder` |
+| Key type | N/A | `String` (fixed) |
+| Hetero support | ✅ via `Into<E>` | ✅ via `Into<V>` |
 
 ## Examples
 
-### Basic Array
+### Basic Usage
 
 ```wado
 fn run() with Stdout {
-    // Homogeneous tuple → Array
+    // Tuple literal → Array
     let numbers: Array<i32> = [1, 2, 3, 4, 5];
+
+    // Object literal → Dict
+    let config: Dict<String, i32> = {
+        "width": 1920,
+        "height": 1080,
+    };
 
     for let n of numbers {
         println(`{n}`);
@@ -474,24 +605,24 @@ fn run() with Stdout {
 
 ```wado
 fn run() with Stdout {
-    // Heterogeneous tuple → JSONArray
-    let data: JSONArray = [
-        42,
-        "hello",
-        true,
-        null,
-        [1, 2, 3],  // Nested array
-    ];
+    // Nested JSON structure
+    let user: JSONObject = {
+        "name": "Alice",
+        "age": 30,
+        "tags": [1, 2, 3],  // Nested JSONArray
+        "metadata": {        // Nested JSONObject
+            "created": "2024-01-01",
+            "active": true,
+        },
+    };
 
-    println(data.stringify());
-    // [42, "hello", true, null, [1, 2, 3]]
+    println(user.stringify());
 }
 ```
 
 ### Custom Collection
 
 ```wado
-// User-defined sorted set
 struct SortedSet<T: Ord> {
     items: Array<T>,
 }
@@ -500,64 +631,44 @@ struct SortedSetBuilder<T: Ord> {
     items: Array<T>,
 }
 
-impl Builder for SortedSetBuilder<T: Ord> {
+impl TupleBuilder for SortedSetBuilder<T: Ord> {
     type Element = T;
     type Output = SortedSet<T>;
 
-    fn new() -> Self {
-        return SortedSetBuilder { items: [] };
+    fn with_capacity(n: i32) -> Self {
+        return SortedSetBuilder { items: Array::<T>::with_capacity(n) };
     }
 
-    fn add(self, element: T) -> Self {
+    fn append(&mut self, element: T) {
         // Insert in sorted order, skip duplicates
-        // ... implementation ...
-        return self;
+        // ...
     }
 
-    fn build(self) -> SortedSet<T> {
+    fn into(self) -> SortedSet<T> {
         return SortedSet { items: self.items };
     }
 }
 
-impl Collectable for SortedSet<T: Ord> {
+impl FromTuple for SortedSet<T: Ord> {
     type Element = T;
     type Builder = SortedSetBuilder<T>;
 }
 
 fn run() {
-    // Automatically sorted and deduplicated!
     let set: SortedSet<i32> = [3, 1, 4, 1, 5, 9, 2, 6];
     // set.items = [1, 2, 3, 4, 5, 6, 9]
 }
 ```
 
-### Dict from Pairs
-
-```wado
-impl Collectable for Dict<K, V> {
-    type Element = [K, V];  // Key-value tuple
-    type Builder = DictBuilder<K, V>;
-}
-
-fn run() {
-    // Tuple of pairs → Dict
-    let config: Dict<String, i32> = [
-        ["width", 1920],
-        ["height", 1080],
-        ["fps", 60],
-    ];
-}
-```
-
 ## Related WEPs
 
-- [Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md) - Defines tuple literal syntax
-- [Iterator Traits Design](./wep-2026-01-24-iterator-traits.md) - Iterator traits (orthogonal to Builder)
-- [Struct and Trait System](./wep-2026-01-13-struct-and-trait.md) - Foundation for traits
+- [Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md) - Tuple literal syntax
+- [Iterator Traits Design](./wep-2026-01-24-iterator-traits.md) - Iterator traits (orthogonal)
+- [Struct and Trait System](./wep-2026-01-13-struct-and-trait.md) - Trait foundation
 
 ## References
 
-- [Rust std::iter::FromIterator](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)
 - [Swift ExpressibleByArrayLiteral](https://developer.apple.com/documentation/swift/expressiblebyarrayliteral)
+- [Swift ExpressibleByDictionaryLiteral](https://developer.apple.com/documentation/swift/expressiblebydictionaryliteral)
 - [C# Collection Initializers](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers)
-- [Kotlin buildList](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/build-list.html)
+- [Kotlin buildList / buildMap](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/build-list.html)

--- a/docs/wep-2026-01-18-iterator-based-literal-coercion.md
+++ b/docs/wep-2026-01-18-iterator-based-literal-coercion.md
@@ -473,12 +473,12 @@ let empty_dict: Dict<String, i32> = {};
 
 Builder-based coercion and Iterator traits serve different purposes:
 
-| Mechanism | Purpose | Hetero Support |
-|-----------|---------|----------------|
-| **TupleBuilder** | Tuple literal → Collection | ✅ Yes |
-| **ObjectBuilder** | Object literal → Collection | ✅ Yes |
-| **FromIterator** | Iterator → Collection | ❌ Homo only |
-| **IntoIterator** | Collection → Iterator | N/A |
+| Mechanism         | Purpose                     | Hetero Support |
+| ----------------- | --------------------------- | -------------- |
+| **TupleBuilder**  | Tuple literal → Collection  | ✅ Yes         |
+| **ObjectBuilder** | Object literal → Collection | ✅ Yes         |
+| **FromIterator**  | Iterator → Collection       | ❌ Homo only   |
+| **IntoIterator**  | Collection → Iterator       | N/A            |
 
 They coexist and can be combined:
 
@@ -537,6 +537,7 @@ let m: MyType = [1, 2, 3];
 #### Phase 1: Core Traits
 
 Define traits in prelude:
+
 - `Into<T>`
 - `TupleBuilder` / `FromTuple`
 - `ObjectBuilder` / `FromObject`
@@ -607,13 +608,13 @@ fn try_tuple_coercion(elements: &[Expr], target_type: &Type) -> Option<Expr> {
 
 ### Trade-offs
 
-| Aspect | Tuple Literal | Object Literal |
-|--------|---------------|----------------|
-| Default type | Tuple `[T, U, V]` | Anonymous struct `{ a: T, b: U }` |
-| Coercion trait | `FromTuple` | `FromObject` |
-| Builder trait | `TupleBuilder` | `ObjectBuilder` |
-| Key type | N/A | `String` (fixed) |
-| Hetero support | ✅ via `Into<E>` | ✅ via `Into<V>` |
+| Aspect         | Tuple Literal     | Object Literal                    |
+| -------------- | ----------------- | --------------------------------- |
+| Default type   | Tuple `[T, U, V]` | Anonymous struct `{ a: T, b: U }` |
+| Coercion trait | `FromTuple`       | `FromObject`                      |
+| Builder trait  | `TupleBuilder`    | `ObjectBuilder`                   |
+| Key type       | N/A               | `String` (fixed)                  |
+| Hetero support | ✅ via `Into<E>`  | ✅ via `Into<V>`                  |
 
 ## Examples
 


### PR DESCRIPTION
## Summary

This WEP revises the approach for tuple-to-collection literal coercion from an iterator-based mechanism (`IntoIterator`/`FromIterator`) to a builder-pattern approach. The builder pattern better supports heterogeneous tuples and immutable containers while maintaining compile-time expansion with no runtime overhead.

## Key Changes

- **Renamed WEP title**: "Iterator-Based Literal Coercion" → "Tuple-to-Collection Coercion" to reflect broader scope
- **Replaced core mechanism**: Removed `IntoIterator`/`FromIterator` approach in favor of `Builder` and `Collectable` traits
- **Added heterogeneous tuple support**: `[1, "hello", true]` can now coerce to `JSONArray` via `Into<JSONValue>` conversions
- **Improved immutable container support**: Collections no longer need to expose mutation methods; builders handle construction internally
- **Simplified compiler logic**: Replaced complex iterator trait checking with straightforward builder chain generation
- **Added concrete examples**: Included implementations for `ArrayBuilder`, `JSONArrayBuilder`, `SortedSetBuilder`, and `ImmutableListBuilder`
- **Clarified design rationale**: Added comparison table showing builder vs. iterator trade-offs and relationship with iterator traits

## Implementation Details

The builder pattern works as follows:

1. **Builder trait**: Provides `new()`, `add(element)`, and `build()` methods for fluent construction
2. **Collectable trait**: Associates a collection type with its builder implementation
3. **Into trait**: Enables element-wise type conversions (e.g., `i32` → `JSONValue`)
4. **Compiler expansion**: Tuple literals desugar to builder chains at compile time:
   ```wado
   let arr: Array<i32> = [1, 2, 3];
   // Expands to: Array::Builder::new().add(1).add(2).add(3).build()
   ```

This approach eliminates the need for homogeneous tuple restrictions and allows users to define custom collections with literal syntax by implementing `Collectable`.

## Benefits Over Iterator Approach

- ✅ Heterogeneous tuple support (e.g., JSON arrays with mixed types)
- ✅ Immutable containers (no internal mutation exposure)
- ✅ Compile-time expansion (zero runtime overhead for literals)
- ✅ Type-safe element conversions via `Into` trait
- ✅ Clear, well-understood builder pattern semantics