### PR TITLE
Add re-export syntax (`pub use`) and visibility documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Module Loader Design](./docs/wep-2026-01-24-module-loader.md)
 - [Closure Parameter Monomorphization](./docs/wep-2026-01-25-closure-parameter-monomorphization.md)
 - [128-bit Integer Types (i128/u128)](./docs/wep-2026-01-24-i128-u128-types.md)
+- [Re-export Syntax (`pub use`)](./docs/wep-2026-01-25-pub-use-reexport.md)
 
 ### Structure
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -246,7 +246,7 @@ export fn entry() { }         // world export
 pub export fn both() { }      // both
 ```
 
-The `pub` modifier applies to functions, structs, fields, variants, traits, and type aliases.
+All entity definitions can have `pub` visibility.
 
 ## Methods
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -234,10 +234,10 @@ A function must have `return` if it returns a value. This is applied to methods 
 
 Wado has two kinds of "public":
 
-| Keyword | Term | Scope |
-|---------|------|-------|
-| `pub` | module public | Other Wado modules |
-| `export` | world export | Component Model boundary |
+| Keyword  | Term          | Scope                    |
+| -------- | ------------- | ------------------------ |
+| `pub`    | module public | Other Wado modules       |
+| `export` | world export  | Component Model boundary |
 
 ```wado
 fn private_fn() { }           // module-private (default)

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -219,13 +219,34 @@ fn greet(name: String) with Stdout {
     println(`Hello, {name}!`);
 }
 
-// Public
+// Module public (accessible from other Wado modules)
 pub fn api_function() -> i32 {
     return 42;
 }
+
+// World export (exposed at CM boundary)
+export fn run() { ... }
 ```
 
 A function must have `return` if it returns a value. This is applied to methods and closures as well.
+
+## Visibility
+
+Wado has two kinds of "public":
+
+| Keyword | Term | Scope |
+|---------|------|-------|
+| `pub` | module public | Other Wado modules |
+| `export` | world export | Component Model boundary |
+
+```wado
+fn private_fn() { }           // module-private (default)
+pub fn public_fn() { }        // module public
+export fn entry() { }         // world export
+pub export fn both() { }      // both
+```
+
+The `pub` modifier applies to functions, structs, fields, variants, traits, and type aliases.
 
 ## Methods
 

--- a/docs/wep-2026-01-25-pub-use-reexport.md
+++ b/docs/wep-2026-01-25-pub-use-reexport.md
@@ -1,0 +1,128 @@
+# Re-export Syntax (`pub use`)
+
+## Context
+
+Wado needs a way to re-export symbols from other modules. This is a common pattern in module systems where a library wants to expose items from its dependencies or internal modules as part of its public API.
+
+### Terminology
+
+Wado distinguishes between two kinds of "public":
+
+| Keyword | Term | Meaning |
+|---------|------|---------|
+| `pub` | **module public** | Visible to other Wado modules that import this module |
+| `export` | **world export** | Exposed at the Component Model boundary (WASI world conformance) |
+
+The `pub use` syntax combines module public visibility with import, creating a **re-export**.
+
+### Motivation
+
+Without re-export, users must import from the original source:
+
+```wado
+// math/internal/trig.wado
+pub fn sin(x: f64) -> f64 { ... }
+pub fn cos(x: f64) -> f64 { ... }
+
+// math/internal/exp.wado
+pub fn exp(x: f64) -> f64 { ... }
+pub fn log(x: f64) -> f64 { ... }
+
+// User must know internal structure
+use {sin, cos} from "math/internal/trig.wado";
+use {exp, log} from "math/internal/exp.wado";
+```
+
+With re-export, the library can provide a unified API:
+
+```wado
+// math/mod.wado
+pub use {sin, cos} from "./internal/trig.wado";
+pub use {exp, log} from "./internal/exp.wado";
+
+// User imports from the public API
+use {sin, cos, exp, log} from "math";
+```
+
+## Decision
+
+### Syntax
+
+Re-export uses `pub use` followed by the standard import syntax:
+
+```wado
+// Re-export specific items
+pub use {foo, bar} from "./internal.wado";
+
+// Re-export with rename
+pub use {internal_name as public_name} from "./internal.wado";
+
+// Re-export from core/wasi modules
+pub use {Option, Result} from "core:prelude";
+pub use {Stdout} from "wasi:cli";
+```
+
+### Semantics
+
+1. `pub use` makes imported symbols available to modules that import this module
+2. The re-exported symbol behaves identically to the original
+3. Re-exports are resolved at compile time (no runtime cost)
+4. Circular re-exports are prohibited
+
+### Visibility Levels
+
+| Declaration | Within module | Other Wado modules | CM world boundary |
+|-------------|---------------|-------------------|-------------------|
+| `fn foo()` | Yes | No | No |
+| `pub fn foo()` | Yes | Yes | No |
+| `export fn foo()` | Yes | No | Yes |
+| `pub export fn foo()` | Yes | Yes | Yes |
+| `use {x} from "..."` | Yes | No | - |
+| `pub use {x} from "..."` | Yes | Yes | - |
+
+### Namespace Re-export
+
+Namespace re-export is also supported:
+
+```wado
+// Re-export entire module as namespace
+pub use utils from "./utils.wado";
+
+// Users can then access via namespace
+use {utils} from "mylib";
+utils::helper();
+```
+
+### Restrictions
+
+1. Cannot re-export private (non-`pub`) items from other modules
+2. Cannot add `export` to re-exports (re-exports are module-level only)
+3. Wildcard re-export (`pub use * from "..."`) is not supported (consistent with import rules)
+
+## Consequences
+
+### Positive
+
+- Libraries can organize code internally while presenting a clean public API
+- Refactoring internal module structure doesn't break users
+- Enables facade pattern for complex libraries
+- Consistent with Rust's `pub use` semantics
+
+### Negative
+
+- Adds complexity to the module system
+- Symbol resolution must track re-export chains
+- Error messages must show both original and re-export locations
+
+### Implementation Notes
+
+1. Parser: Extend `use` statement to accept optional `pub` prefix
+2. Symbol table: Track re-export relationships
+3. Name resolution: Follow re-export chains during lookup
+4. Error reporting: Include re-export path in "symbol not found" errors
+
+## Not in Scope
+
+- `pub(crate)` or other visibility modifiers (Wado has no crate concept)
+- Glob re-exports (`pub use * from "..."`)
+- Re-exporting with `export` for CM boundary exposure

--- a/docs/wep-2026-01-25-pub-use-reexport.md
+++ b/docs/wep-2026-01-25-pub-use-reexport.md
@@ -8,10 +8,10 @@ Wado needs a way to re-export symbols from other modules. This is a common patte
 
 Wado distinguishes between two kinds of "public":
 
-| Keyword | Term | Meaning |
-|---------|------|---------|
-| `pub` | **module public** | Visible to other Wado modules that import this module |
-| `export` | **world export** | Exposed at the Component Model boundary (WASI world conformance) |
+| Keyword  | Term              | Meaning                                                          |
+| -------- | ----------------- | ---------------------------------------------------------------- |
+| `pub`    | **module public** | Visible to other Wado modules that import this module            |
+| `export` | **world export**  | Exposed at the Component Model boundary (WASI world conformance) |
 
 The `pub use` syntax combines module public visibility with import, creating a **re-export**.
 
@@ -71,14 +71,14 @@ pub use {Stdout} from "wasi:cli";
 
 ### Visibility Levels
 
-| Declaration | Within module | Other Wado modules | CM world boundary |
-|-------------|---------------|-------------------|-------------------|
-| `fn foo()` | Yes | No | No |
-| `pub fn foo()` | Yes | Yes | No |
-| `export fn foo()` | Yes | No | Yes |
-| `pub export fn foo()` | Yes | Yes | Yes |
-| `use {x} from "..."` | Yes | No | - |
-| `pub use {x} from "..."` | Yes | Yes | - |
+| Declaration              | Within module | Other Wado modules | CM world boundary |
+| ------------------------ | ------------- | ------------------ | ----------------- |
+| `fn foo()`               | Yes           | No                 | No                |
+| `pub fn foo()`           | Yes           | Yes                | No                |
+| `export fn foo()`        | Yes           | No                 | Yes               |
+| `pub export fn foo()`    | Yes           | Yes                | Yes               |
+| `use {x} from "..."`     | Yes           | No                 | -                 |
+| `pub use {x} from "..."` | Yes           | Yes                | -                 |
 
 ### Namespace Re-export
 

--- a/spec.md
+++ b/spec.md
@@ -1794,10 +1794,10 @@ Wado uses an ESM-like import syntax with `use {...} from "source"`. This aligns 
 
 Wado distinguishes between two kinds of "public" visibility:
 
-| Keyword | Term | Meaning |
-|---------|------|---------|
-| `pub` | **module public** | Visible to other Wado modules that import this module |
-| `export` | **world export** | Exposed at the Component Model boundary (WASI world conformance) |
+| Keyword  | Term              | Meaning                                                          |
+| -------- | ----------------- | ---------------------------------------------------------------- |
+| `pub`    | **module public** | Visible to other Wado modules that import this module            |
+| `export` | **world export**  | Exposed at the Component Model boundary (WASI world conformance) |
 
 The `pub` keyword controls **module public** visibility - whether a symbol can be accessed by other Wado modules:
 
@@ -1815,12 +1815,12 @@ export fn run() { ... }
 pub export fn shared_entry() { ... }
 ```
 
-| Declaration | Within module | Other Wado modules | CM world boundary |
-|-------------|---------------|-------------------|-------------------|
-| `fn foo()` | Yes | No | No |
-| `pub fn foo()` | Yes | Yes | No |
-| `export fn foo()` | Yes | No | Yes |
-| `pub export fn foo()` | Yes | Yes | Yes |
+| Declaration           | Within module | Other Wado modules | CM world boundary |
+| --------------------- | ------------- | ------------------ | ----------------- |
+| `fn foo()`            | Yes           | No                 | No                |
+| `pub fn foo()`        | Yes           | Yes                | No                |
+| `export fn foo()`     | Yes           | No                 | Yes               |
+| `pub export fn foo()` | Yes           | Yes                | Yes               |
 
 The `pub` modifier can be applied to:
 

--- a/spec.md
+++ b/spec.md
@@ -1822,14 +1822,7 @@ pub export fn shared_entry() { ... }
 | `export fn foo()`     | Yes           | No                 | Yes               |
 | `pub export fn foo()` | Yes           | Yes                | Yes               |
 
-The `pub` modifier can be applied to:
-
-- Functions: `pub fn`
-- Structs: `pub struct`
-- Struct fields: `pub field_name: Type`
-- Variants: `pub variant`
-- Traits: `pub trait`
-- Type aliases: `pub type`
+All entity definitions can have `pub` visibility.
 
 ### Module Source Types
 

--- a/spec.md
+++ b/spec.md
@@ -1790,6 +1790,47 @@ d["key"]
 
 Wado uses an ESM-like import syntax with `use {...} from "source"`. This aligns with JavaScript/TypeScript conventions, as JavaScript is a primary host environment for Wado.
 
+### Visibility
+
+Wado distinguishes between two kinds of "public" visibility:
+
+| Keyword | Term | Meaning |
+|---------|------|---------|
+| `pub` | **module public** | Visible to other Wado modules that import this module |
+| `export` | **world export** | Exposed at the Component Model boundary (WASI world conformance) |
+
+The `pub` keyword controls **module public** visibility - whether a symbol can be accessed by other Wado modules:
+
+```wado
+// Private to this module (default)
+fn internal_helper() { ... }
+
+// Module public - accessible from other Wado modules
+pub fn api_function() -> i32 { ... }
+
+// World export - exposed at CM boundary
+export fn run() { ... }
+
+// Both module public and world export
+pub export fn shared_entry() { ... }
+```
+
+| Declaration | Within module | Other Wado modules | CM world boundary |
+|-------------|---------------|-------------------|-------------------|
+| `fn foo()` | Yes | No | No |
+| `pub fn foo()` | Yes | Yes | No |
+| `export fn foo()` | Yes | No | Yes |
+| `pub export fn foo()` | Yes | Yes | Yes |
+
+The `pub` modifier can be applied to:
+
+- Functions: `pub fn`
+- Structs: `pub struct`
+- Struct fields: `pub field_name: Type`
+- Variants: `pub variant`
+- Traits: `pub trait`
+- Type aliases: `pub type`
+
 ### Module Source Types
 
 | Source Type   | Syntax                        | Example                              |


### PR DESCRIPTION
## Summary

This PR introduces the `pub use` re-export syntax to Wado's module system and documents the distinction between module public (`pub`) and world export (`export`) visibility levels.

## Changes

- **New WEP document** (`wep-2026-01-25-pub-use-reexport.md`): Comprehensive specification for re-export syntax including:
  - Motivation and use cases for re-exporting symbols
  - Syntax and semantics of `pub use` statements
  - Visibility level matrix showing scope of different declaration types
  - Support for namespace re-exports and renaming
  - Restrictions and implementation notes

- **Updated specification** (`spec.md`): Added "Visibility" section documenting:
  - Two-tier visibility model: module public vs. world export
  - Visibility matrix for different declaration types
  - Applicable modifiers for functions, structs, fields, variants, traits, and type aliases

- **Updated cheatsheet** (`docs/cheatsheet.md`): 
  - Clarified `pub` as "module public" with scope limited to other Wado modules
  - Added `export` keyword for Component Model boundary exposure
  - New "Visibility" section with terminology table and examples
  - Documented that `pub` modifier applies to multiple declaration types

- **Updated AGENTS.md**: Added reference to the new WEP document in the list of language proposals

## Key Features

- **Re-export syntax**: `pub use {item} from "module"` allows libraries to expose internal symbols as part of their public API
- **Visibility clarity**: Distinguishes between module-level public access and Component Model world boundary exposure
- **Flexible re-exports**: Supports item selection, renaming, and namespace re-exports
- **Consistent semantics**: Aligns with Rust's `pub use` pattern while fitting Wado's Component Model integration

## Implementation Notes

- Re-exports are resolved at compile time with no runtime cost
- Circular re-exports are prohibited
- Private items cannot be re-exported
- Wildcard re-exports are not supported (consistent with import rules)