### PR TITLE
Rename ADR to WEP in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The result: a language where common agentic coding pitfalls are eliminated by de
 - [Language Specification](spec.md) - Full language reference
 - [Compiler Implementation](docs/compiler.md) - Compiler internals and feature checklist
 - [Benchmarks](benchmark/README.md) - Performance benchmarks vs C and JavaScript, and so on
-- [Other Documentation](docs) - ADR, research notes, TODOs, etc.
+- [Other Documentation](docs) - WEP, research notes, TODOs, etc.
 
 ## Development
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -973,7 +973,7 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [x] Option pattern matching (`if let Some(x) = ...`)
 - [ ] Match expressions
 - [x] Closures - pure (no captures)
-- [ ] Closures - with captures (see ADR)
+- [ ] Closures - with captures (see WEP)
 - [ ] Effect handlers
 - [x] Template string type conversion (i8/i16/i32/i64/u8/u16/u32/u64/bool/char → string, f32/f64 → string via wado-bundled)
 - [ ] Template string format specifiers (`.2f`, `0.3f`, etc.)


### PR DESCRIPTION
Update remaining ADR references to WEP in compiler.md and README.md.