### PR TITLE
Add producers section to WebAssembly modules

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -1729,6 +1729,10 @@ impl Codegen {
             module.section(&names);
         }
 
+        // Producers section (always include - small overhead, useful for analysis)
+        let producers = CoreModuleBuilder::build_producers_section();
+        module.section(&producers);
+
         module.finish()
     }
 

--- a/wado-compiler/src/wasm_builder.rs
+++ b/wado-compiler/src/wasm_builder.rs
@@ -7,8 +7,8 @@ use std::collections::{HashMap, HashSet};
 
 use wasm_encoder::{
     ArrayType, CompositeInnerType, CompositeType, EntityType, ExportKind, ExportSection, FieldType,
-    FunctionSection, ImportSection, MemoryType, NameMap, NameSection, StorageType, SubType,
-    TypeSection, ValType,
+    FunctionSection, ImportSection, MemoryType, NameMap, NameSection, ProducersField,
+    ProducersSection, StorageType, SubType, TypeSection, ValType,
 };
 
 // ============================================================================
@@ -328,6 +328,25 @@ impl CoreModuleBuilder {
         names.types(&type_names);
 
         names
+    }
+
+    /// Build the producers section with language and compiler metadata
+    ///
+    /// This is a standard custom section that records toolchain information.
+    /// See: <https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md>
+    #[must_use]
+    pub fn build_producers_section() -> ProducersSection {
+        let mut language = ProducersField::new();
+        language.value("Wado", "");
+
+        let mut processed_by = ProducersField::new();
+        processed_by.value(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+
+        let mut producers = ProducersSection::new();
+        producers.field("language", &language);
+        producers.field("processed-by", &processed_by);
+
+        producers
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds a producers section to generated WebAssembly modules, which records toolchain metadata about the language and compiler used to generate the module.

## Changes
- **wasm_builder.rs**: 
  - Added imports for `ProducersField` and `ProducersSection` from `wasm_encoder`
  - Implemented `build_producers_section()` method that creates a producers section with:
    - Language field set to "Wado"
    - Processed-by field set to the compiler name and version (from Cargo.toml)

- **codegen.rs**:
  - Integrated producers section generation into the module building pipeline
  - The section is always included in generated modules with minimal overhead

## Implementation Details
The producers section follows the [WebAssembly Tool Conventions specification](https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md) and is a standard custom section that provides useful metadata for analysis and debugging of generated WebAssembly modules.