### PR TITLE
fix: preserve default type parameters in generic param unparsing

### DIFF
--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -335,6 +335,10 @@ impl<'a> Unparser<'a> {
                     self.output.push_str(bound);
                 }
             }
+            if let Some(default_type) = &param.default {
+                self.output.push_str(" = ");
+                self.unparse_type(default_type);
+            }
         }
         self.output.push('>');
     }
@@ -2013,6 +2017,15 @@ impl<'a> TirUnparser<'a> {
                     self.output.push_str(", ");
                 }
                 self.output.push_str(&param.name);
+                if !param.bounds.is_empty() {
+                    self.output.push_str(": ");
+                    self.output.push_str(&param.bounds.join(" + "));
+                }
+                if let Some(default_type) = param.default {
+                    self.output.push_str(" = ");
+                    self.output
+                        .push_str(&self.type_table.type_name(default_type));
+                }
             }
             self.output.push('>');
         }
@@ -2081,6 +2094,15 @@ impl<'a> TirUnparser<'a> {
                     self.output.push_str(", ");
                 }
                 self.output.push_str(&param.name);
+                if !param.bounds.is_empty() {
+                    self.output.push_str(": ");
+                    self.output.push_str(&param.bounds.join(" + "));
+                }
+                if let Some(default_type) = param.default {
+                    self.output.push_str(" = ");
+                    self.output
+                        .push_str(&self.type_table.type_name(default_type));
+                }
             }
             self.output.push('>');
         }

--- a/wado-compiler/tests/fixtures.golden/index-value-option-pattern.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index-value-option-pattern.lowered.wado
@@ -12,7 +12,7 @@ fn __test_0_if_let_some_on_index_value_returning_option() {
         __assert_0: {
             let __cond: bool = (val == 42);
             if !__cond {
-                core::prelude::panic(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move "Assertion failed in ", move "__test_0_if_let_some_on_index_value_returning_option"), move " at "), move "wado-compiler/tests/fixtures/index-value-option-pattern.wado"), move ":"), move "i32::to_string"(21)), move "\ncondition: val == 42\n"), move "val: "), move "i32::to_string"(val)), move "\n"));
+                core::prelude::panic(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move core::internal::string_concat(move "Assertion failed in ", move "__test_0_if_let_some_on_index_value_returning_option"), move " at "), move "wado-compiler/tests/fixtures/index-value-option-pattern.wado"), move ":"), move "i32::to_string"(22)), move "\ncondition: val == 42\n"), move "val: "), move "i32::to_string"(val)), move "\n"));
             }
         }
     }

--- a/wado-compiler/tests/fixtures/array_specialized_bool.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_bool.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<bool> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_char.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_char.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<char> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_f32.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_f32.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<f32> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_f64.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_f64.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<f64> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_i16.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_i16.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<i16> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_i32.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_i32.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<i32> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_i64.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_i64.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<i64> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_i8.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_i8.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<i8> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_string.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_string.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<String> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_tuple.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_tuple.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<[bool, i32, String]> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_u16.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_u16.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<u16> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_u32.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_u32.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<u32> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_u64.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_u64.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<u64> = [];

--- a/wado-compiler/tests/fixtures/array_specialized_u8.wado
+++ b/wado-compiler/tests/fixtures/array_specialized_u8.wado
@@ -1,4 +1,4 @@
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 fn run() with Stdout {
     let mut arr: Array<u8> = [];

--- a/wado-compiler/tests/fixtures/default_type_params.wado
+++ b/wado-compiler/tests/fixtures/default_type_params.wado
@@ -1,7 +1,7 @@
 // Test default type parameters in traits
 // Verifies that `T = DefaultType` syntax parses and compiles correctly
 
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 // Trait with default type parameter
 trait Container<T, Default = i32> {

--- a/wado-compiler/tests/fixtures/generic-struct-import.wado
+++ b/wado-compiler/tests/fixtures/generic-struct-import.wado
@@ -1,6 +1,6 @@
 // Test importing generic structs from prelude
 // This tests that generic structs like TreeMap<K,V> work when defined in prelude
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 fn run() with Stdout {
     // TreeMap is defined in prelude with type params <K, V>

--- a/wado-compiler/tests/fixtures/index-value-option-pattern.wado
+++ b/wado-compiler/tests/fixtures/index-value-option-pattern.wado
@@ -7,6 +7,7 @@ struct Box<T> {
 
 impl IndexValue<i32> for Box<i32> {
     type Output = Option<i32>;
+
     fn index_value(&self, index: i32) -> Self::Output {
         if index == 0 {
             return Option::<i32>::Some(self.value);

--- a/wado-compiler/tests/fixtures/iterator_fold.wado
+++ b/wado-compiler/tests/fixtures/iterator_fold.wado
@@ -23,6 +23,8 @@ fn run() with Stdout {
     } else {
         acc;
     });
+
+
     println(`max: {max}`);
 }
 

--- a/wado-compiler/tests/fixtures/trait_bound_check.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_check.wado
@@ -1,7 +1,7 @@
 // Test trait bound checking
 // A struct with a trait bound that should be checked at instantiation
 
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 trait Printable {
     fn print(&self) -> String;

--- a/wado-compiler/tests/fixtures/trait_bound_ord.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_ord.wado
@@ -1,7 +1,7 @@
 // Test Ord trait bound
 // Primitives have built-in Ord implementation
 
-use {println, Stdout} from "core:cli";
+use { println, Stdout } from "core:cli";
 
 struct SortedPair<T: Ord> {
     first: T,

--- a/wado-compiler/tests/fixtures/treemap-basic.wado
+++ b/wado-compiler/tests/fixtures/treemap-basic.wado
@@ -1,5 +1,5 @@
 // TreeMap basic operations test
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 fn run() with Stdout {
     let mut map = TreeMap::<String, i32>::new();

--- a/wado-compiler/tests/fixtures/treemap-clear.wado
+++ b/wado-compiler/tests/fixtures/treemap-clear.wado
@@ -1,5 +1,5 @@
 // TreeMap clear operation
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 fn run() with Stdout {
     let mut map = TreeMap::<String, i32>::new();

--- a/wado-compiler/tests/fixtures/treemap-index.wado
+++ b/wado-compiler/tests/fixtures/treemap-index.wado
@@ -1,5 +1,5 @@
 // TreeMap index operations (bracket syntax)
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 fn run() with Stdout {
     let mut map = TreeMap::<String, i32>::new();

--- a/wado-compiler/tests/fixtures/treemap-large.wado
+++ b/wado-compiler/tests/fixtures/treemap-large.wado
@@ -1,5 +1,5 @@
 // TreeMap with many elements
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 fn run() with Stdout {
     let mut map = TreeMap::<String, i32>::new();

--- a/wado-compiler/tests/fixtures/treemap-ordering.wado
+++ b/wado-compiler/tests/fixtures/treemap-ordering.wado
@@ -1,5 +1,5 @@
 // TreeMap maintains sorted order
-use {println, print} from "core:cli";
+use { println, print } from "core:cli";
 
 fn run() with Stdout {
     let mut map = TreeMap::<String, i32>::new();
@@ -37,7 +37,9 @@ fn run() with Stdout {
 
     print("keys: ");
     for let mut i = 0; i < keys.len(); i += 1 {
-        if i > 0 { print(", "); }
+        if i > 0 {
+            print(", ");
+        }
         print(keys[i]);
     }
     println("");

--- a/wado-compiler/tests/fixtures/treemap-remove.wado
+++ b/wado-compiler/tests/fixtures/treemap-remove.wado
@@ -1,5 +1,5 @@
 // TreeMap remove and reinsert
-use {println} from "core:cli";
+use { println } from "core:cli";
 
 fn run() with Stdout {
     let mut map = TreeMap::<String, i32>::new();


### PR DESCRIPTION
The unparse functions were only outputting param.name without the default type (e.g., `Default = i32`). This caused the formatter to corrupt code with default type parameters.