### PR TITLE
Separate enum and variant in AST: enum has no payload

### DIFF
--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -459,7 +459,7 @@ async fn run_single(opts: &DumpOptions, input: &str) {
                     format!("struct{{ {} }}", s.fields.join(", "))
                 }
                 wado_compiler::symbol::SymbolKind::Enum(e) => {
-                    format!("enum{{ {} }}", e.variants.join(", "))
+                    format!("enum{{ {} }}", e.cases.join(", "))
                 }
                 wado_compiler::symbol::SymbolKind::Variant(v) => {
                     format!("variant{{ {} }}", v.cases.join(", "))

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -195,7 +195,7 @@ impl Analyzer {
 
                 Item::Enum(enum_decl) => {
                     let kind = SymbolKind::Enum(EnumSymbol {
-                        variants: enum_decl.variants.iter().map(|v| v.name.clone()).collect(),
+                        cases: enum_decl.cases.iter().map(|c| c.name.clone()).collect(),
                     });
 
                     self.symbols

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -975,14 +975,15 @@ pub struct EnumDecl {
     pub is_pub: bool,
     /// Generic type parameters: `enum Option<T> { Some(T), None }`
     pub type_params: Vec<GenericParam>,
-    pub variants: Vec<EnumVariant>,
+    pub cases: Vec<EnumCase>,
     pub span: Span,
 }
 
+/// A case in an enum declaration.
+/// Unlike `VariantCase`, enum cases have no payload.
 #[derive(Debug, Clone)]
-pub struct EnumVariant {
+pub struct EnumCase {
     pub name: String,
-    pub fields: Option<Vec<Type>>,
     pub span: Span,
 }
 

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -5,7 +5,7 @@ use crate::ast::{
     AssertStmt, AssignExpr, AssociatedTypeBinding, AssociatedTypeDecl, Attribute, BinaryExpr,
     BinaryOp, Block, BreakStmt, CallExpr, CastExpr, ChainedComparison, ClosureExpr, ClosureParam,
     ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp, Condition, ContinueStmt, EffectDecl,
-    EffectMethod, EnumDecl, EnumVariant, Expr, ExprStmt, FieldAccessExpr, FlagsDecl, FlagsVariant,
+    EffectMethod, EnumCase, EnumDecl, Expr, ExprStmt, FieldAccessExpr, FlagsDecl, FlagsVariant,
     FloatLiteral, ForOfStmt, ForStmt, FormatSpec, Function, FunctionType, GenericType, IdentExpr,
     IfExpr, IfStmt, ImplBlock, ImportAttributes, IndexExpr, IntLiteral, Item, LabeledBlockStmt,
     LetStmt, Literal, LiteralExpr, LoopStmt, MethodCallExpr, Module, NamedType,
@@ -2573,9 +2573,9 @@ impl Parser {
 
         self.expect(&TokenKind::LBrace)?;
 
-        let mut variants = Vec::new();
+        let mut cases = Vec::new();
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() {
-            variants.push(self.parse_enum_variant()?);
+            cases.push(self.parse_enum_case()?);
             if !self.check(&TokenKind::RBrace) {
                 self.expect(&TokenKind::Comma)?;
             }
@@ -2587,31 +2587,18 @@ impl Parser {
             name,
             is_pub,
             type_params,
-            variants,
+            cases,
             span: start_span.merge(&end_span),
         })
     }
 
-    fn parse_enum_variant(&mut self) -> ParseResult<EnumVariant> {
+    fn parse_enum_case(&mut self) -> ParseResult<EnumCase> {
         let start_span = self.peek().span;
         let name = self.consume_ident()?;
 
-        let fields = if self.check(&TokenKind::LParen) {
-            self.advance();
-            let mut types = vec![self.parse_type()?];
-            while self.check(&TokenKind::Comma) {
-                self.advance();
-                types.push(self.parse_type()?);
-            }
-            self.expect(&TokenKind::RParen)?;
-            Some(types)
-        } else {
-            None
-        };
-
-        Ok(EnumVariant {
+        // Enum cases have no payload (unlike variant cases)
+        Ok(EnumCase {
             name,
-            fields,
             span: start_span,
         })
     }

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -103,8 +103,8 @@ pub struct StructSymbol {
 /// Enum symbol data
 #[derive(Debug, Clone)]
 pub struct EnumSymbol {
-    /// Variant names
-    pub variants: Vec<String>,
+    /// Case names
+    pub cases: Vec<String>,
 }
 
 /// Variant symbol data (tagged union with payloads)

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1372,15 +1372,16 @@ pub struct TirEnum {
     pub type_params: Vec<TirTypeParam>,
     /// If this enum was created by monomorphization, contains the origin info
     pub monomorph_info: Option<MonomorphInfo>,
-    pub variants: Vec<TirVariant>,
+    pub cases: Vec<TirEnumCase>,
     pub span: Span,
 }
 
+/// A case in a TIR enum.
+/// Unlike `TirVariantCase`, enum cases have no payload.
 #[derive(Debug, Clone)]
-pub struct TirVariant {
+pub struct TirEnumCase {
     pub name: String,
     pub index: u32,
-    pub fields: Vec<TypeId>,
     pub span: Span,
 }
 

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -5,7 +5,7 @@
 use crate::ast::{
     AssertStmt, AssignExpr, Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, CallExpr, CastExpr,
     ClosureExpr, ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp, Condition, EffectDecl,
-    EffectMethod, EnumDecl, EnumVariant, Expr, ExprStmt, FieldAccessExpr, ForOfStmt, ForStmt,
+    EffectMethod, EnumCase, EnumDecl, Expr, ExprStmt, FieldAccessExpr, ForOfStmt, ForStmt,
     Function, FunctionType, IfExpr, IfStmt, ImplBlock, ImportAttributes, IndexExpr, Item,
     LabeledBlockStmt, LetStmt, Literal, LoopStmt, MatchArm, MatchExpr, MethodCallExpr, Module,
     Param, Pattern, ResourceDecl, ReturnStmt, SelfKind, StaticMethodCallExpr, Stmt, StructDecl,
@@ -356,8 +356,8 @@ impl<'a> Unparser<'a> {
         self.output.push_str(" {\n");
 
         self.indent_level += 1;
-        for variant in &e.variants {
-            self.unparse_enum_variant(variant);
+        for case in &e.cases {
+            self.unparse_enum_case(case);
         }
         self.indent_level -= 1;
 
@@ -365,19 +365,10 @@ impl<'a> Unparser<'a> {
         self.output.push_str("}\n");
     }
 
-    fn unparse_enum_variant(&mut self, variant: &EnumVariant) {
+    fn unparse_enum_case(&mut self, case: &EnumCase) {
         self.write_indent();
-        self.output.push_str(&variant.name);
-        if let Some(fields) = &variant.fields {
-            self.output.push('(');
-            for (i, ty) in fields.iter().enumerate() {
-                if i > 0 {
-                    self.output.push_str(", ");
-                }
-                self.unparse_type(ty);
-            }
-            self.output.push(')');
-        }
+        self.output.push_str(&case.name);
+        // Enum cases have no payload (unlike variant cases)
         self.output.push_str(",\n");
     }
 
@@ -2057,19 +2048,10 @@ impl<'a> TirUnparser<'a> {
         self.output.push_str(" {\n");
         self.indent_level += 1;
 
-        for variant in &e.variants {
+        for case in &e.cases {
             self.write_indent();
-            self.output.push_str(&variant.name);
-            if !variant.fields.is_empty() {
-                self.output.push('(');
-                for (i, field_ty) in variant.fields.iter().enumerate() {
-                    if i > 0 {
-                        self.output.push_str(", ");
-                    }
-                    self.output.push_str(&self.type_table.type_name(*field_ty));
-                }
-                self.output.push(')');
-            }
+            self.output.push_str(&case.name);
+            // Enum cases have no payload (unlike variant cases)
             self.output.push_str(",\n");
         }
 


### PR DESCRIPTION
- Remove `fields` from `EnumVariant` (enum variants have no payload)
- Rename `TirVariant` to `TirEnumVariant` for clarity
- Update parser to not parse fields for enum variants
- Update unparse (both AST and TIR) to not output fields

Enum is now distinct from variant: enum is payload-free (like C enums),
while variant supports payloads (like Rust enums).