### PR TITLE
refactor: use metadata instead of string search for monomorphized structs

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -3160,6 +3160,7 @@ impl Codegen {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => {
                 if let Some(info) = self.lookup_struct_type(name, module_source) {
                     info.type_idx
@@ -3238,6 +3239,7 @@ impl Codegen {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => {
                 if let Some(info) = self.lookup_struct_type(name, module_source) {
                     self.generate_struct_copy(func, info.type_idx, info.field_count, ctx);
@@ -4575,9 +4577,10 @@ impl Codegen {
                 };
 
             // Only process non-monomorphized struct element types
-            // Monomorphized structs have names like "Pair<i32,String>", non-monomorphized are simple like "String"
             let is_non_monomorphized_struct = match type_table.get(element_type_id) {
-                ResolvedType::Struct { name, .. } => !name.contains('<'),
+                ResolvedType::Struct {
+                    is_monomorphized, ..
+                } => !is_monomorphized,
                 _ => false,
             };
             if !is_non_monomorphized_struct {
@@ -4737,12 +4740,12 @@ impl Codegen {
     ) -> bool {
         match type_table.get(type_id) {
             ResolvedType::GenericInstance { .. } => true,
-            // Check for monomorphized struct types (name contains '<')
-            // that aren't registered yet in struct_types
+            // Check for monomorphized struct types that aren't registered yet in struct_types
             ResolvedType::Struct {
                 name,
                 module_source,
-            } if name.contains('<') => {
+                is_monomorphized: true,
+            } => {
                 let struct_name = StructName::new(module_source.clone(), name.clone());
                 !self.struct_types.contains_key(&struct_name)
             }
@@ -4921,6 +4924,7 @@ impl Codegen {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => {
                 // Special case: String struct - always use the canonical module source
                 let lookup_source = if name == "String" {
@@ -5965,6 +5969,7 @@ impl Codegen {
                     ResolvedType::Struct {
                         name,
                         module_source,
+                        ..
                     } => {
                         // String struct: check for optimized intrinsic methods first
                         let is_string =
@@ -6283,6 +6288,7 @@ impl Codegen {
                         ResolvedType::Struct {
                             name,
                             module_source: type_module_source,
+                            ..
                         } => {
                             // Check if this struct is monomorphized using metadata
                             let struct_lookup =
@@ -6499,6 +6505,7 @@ impl Codegen {
                     ResolvedType::Struct {
                         name,
                         module_source,
+                        ..
                     } => self.lookup_struct_type(name, module_source),
                     ResolvedType::GenericInstance {
                         name, type_args, ..
@@ -9714,6 +9721,7 @@ impl Codegen {
                 ResolvedType::Struct {
                     name,
                     module_source,
+                    ..
                 } => {
                     if let Some(info) = self.lookup_struct_type(name, module_source) {
                         let local_name = format!("__copy_source_{}", info.type_idx);

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -4745,6 +4745,7 @@ impl Codegen {
                 name,
                 module_source,
                 is_monomorphized: true,
+                ..
             } => {
                 let struct_name = StructName::new(module_source.clone(), name.clone());
                 !self.struct_types.contains_key(&struct_name)

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -2193,6 +2193,7 @@ impl ClosureLowerer {
         let specialized_method_info = callee.method_info.as_ref().map(|info| {
             LocalMethodName {
                 struct_name: info.struct_name.clone(),
+                base_struct_name: info.base_struct_name.clone(),
                 trait_name: info.trait_name.clone(),
                 method_name: specialized_method_name.clone(),
                 method_type_args: Vec::new(), // Type args are now in method_name
@@ -3183,6 +3184,7 @@ impl ClosureLowerer {
         let specialized_method_info = func.method_info().map(|info| {
             LocalMethodName {
                 struct_name: info.struct_name.clone(),
+                base_struct_name: info.base_struct_name.clone(),
                 trait_name: info.trait_name.clone(),
                 method_name: format!("{}{}", info.full_method_name(), functor_suffix),
                 method_type_args: Vec::new(), // Type args are now in method_name

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1763,8 +1763,11 @@ impl Monomorphizer {
                 {
                     let type_args = &monomorph.type_args;
                     if !type_args.is_empty() {
-                        let generic_method_name =
-                            MethodName::format_local(&info.base_struct_name, None, &info.method_name);
+                        let generic_method_name = MethodName::format_local(
+                            &info.base_struct_name,
+                            None,
+                            &info.method_name,
+                        );
                         if let Some(generic_func_rc) = generic_functions.get(&generic_method_name) {
                             let generic_func = generic_func_rc.borrow();
                             // Only queue if we have the right number of type args

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1753,91 +1753,25 @@ impl Monomorphizer {
                 func: static_func,
                 args,
             } => {
-                let func_name = static_func.name();
                 // Check if this is a call to a method on a monomorphized struct
-                // e.g., func_name = "Counter<i32>::zero" or "Counter<i32>::default_value"
-                if let Some(sep_pos) = func_name.find("::") {
-                    let struct_part = &func_name[..sep_pos];
-                    let method_name = &func_name[sep_pos + 2..];
-
-                    // Try to get base_struct_name from method_info (preferred) or monomorph_info
-                    let base_struct_and_type_args: Option<(String, Vec<TypeId>)> =
-                        if let FunctionRef::External {
-                            method_info: Some(info),
-                            monomorph_info,
-                            ..
-                        } = static_func
-                        {
-                            // Use base_struct_name from method_info
-                            let type_args = monomorph_info
-                                .as_ref()
-                                .map(|m| m.type_args.clone())
-                                .unwrap_or_default();
-                            if type_args.is_empty() {
-                                None
-                            } else {
-                                Some((info.base_struct_name.clone(), type_args))
-                            }
-                        } else if let FunctionRef::External {
-                            monomorph_info: Some(info),
-                            ..
-                        } = static_func
-                        {
-                            // Fallback: extract base struct from generic_name
-                            // "BTreeNode<K,V>::new_leaf" -> "BTreeNode"
-                            let generic_name = &info.generic_name;
-                            if let Some(generic_sep_pos) = generic_name.find("::") {
-                                let generic_struct_part = &generic_name[..generic_sep_pos];
-                                let base_struct =
-                                    crate::name::strip_type_params(generic_struct_part);
-                                Some((base_struct.to_string(), info.type_args.clone()))
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        };
-
-                    if let Some((base_struct, type_args)) = base_struct_and_type_args {
+                // Use method_info metadata to get base_struct_name and method_name
+                if let FunctionRef::External {
+                    method_info: Some(info),
+                    monomorph_info: Some(monomorph),
+                    ..
+                } = static_func
+                {
+                    let type_args = &monomorph.type_args;
+                    if !type_args.is_empty() {
                         let generic_method_name =
-                            MethodName::format_local(&base_struct, None, method_name);
+                            MethodName::format_local(&info.base_struct_name, None, &info.method_name);
                         if let Some(generic_func_rc) = generic_functions.get(&generic_method_name) {
                             let generic_func = generic_func_rc.borrow();
                             // Only queue if we have the right number of type args
                             if type_args.len() == generic_func.impl_type_params.len() {
                                 let key = InstantiationKey {
                                     name: generic_method_name,
-                                    type_args,
-                                };
-                                if !self.function_instantiated.contains_key(&key) {
-                                    let mangled = self.mangle_method_name(
-                                        &key,
-                                        type_table,
-                                        generic_func.impl_type_params.len(),
-                                    );
-                                    self.function_instantiated
-                                        .insert(key.clone(), mangled.clone());
-                                    self.mangled_func_to_key.insert(mangled, key.clone());
-                                    self.function_pending.push(key);
-                                }
-                            }
-                        }
-                    }
-                    // Fallback: check if struct_part is a monomorphized struct via reverse lookup
-                    else if let Some(struct_key) = self.mangled_struct_to_key.get(struct_part) {
-                        let base_struct = &struct_key.name;
-                        let type_args = struct_key.type_args.clone();
-
-                        // Look for generic method: BaseStruct::method
-                        let generic_method_name =
-                            MethodName::format_local(base_struct, None, method_name);
-                        if let Some(generic_func_rc) = generic_functions.get(&generic_method_name) {
-                            let generic_func = generic_func_rc.borrow();
-                            // Only queue if we have the right number of type args
-                            if type_args.len() == generic_func.impl_type_params.len() {
-                                let key = InstantiationKey {
-                                    name: generic_method_name,
-                                    type_args,
+                                    type_args: type_args.clone(),
                                 };
                                 if !self.function_instantiated.contains_key(&key) {
                                     let mangled = self.mangle_method_name(

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1106,8 +1106,11 @@ impl Monomorphizer {
         //   struct Node<T> { left: Option<&mut Node<T>>, right: Option<&mut Node<T>> }
         // When substituting field types, the inner Node<T> needs to resolve to the
         // monomorphized struct type, not a GenericInstance.
-        let concrete_type_id =
-            type_table.make_monomorphized_struct(mangled_name.clone(), ModuleSource::entry_point());
+        let concrete_type_id = type_table.make_monomorphized_struct(
+            mangled_name.clone(),
+            ModuleSource::entry_point(),
+            key.name.clone(), // base_name: the original generic struct name
+        );
 
         // Find the GenericInstance TypeId and record the substitution early
         // so that substitute_type can use it for self-references

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -3377,16 +3377,6 @@ impl Monomorphizer {
             _ => return None,
         };
 
-        // Build the mangled struct name (with type args if any)
-        let mangled_struct_name = if impl_type_args.is_empty() {
-            base_struct_name.clone()
-        } else {
-            format!("{}<{}>", base_struct_name, impl_type_args.join(","))
-        };
-
-        // Build the mangled method name: StructName^TraitName::method
-        let mangled_method_name = format!("{mangled_struct_name}^{trait_name}::{method_name}");
-
         // Choose receiver and argument based on operand order
         let (receiver_expr, arg_expr) = if swap_operands {
             (right.clone(), left.clone())
@@ -3424,12 +3414,13 @@ impl Monomorphizer {
             method_name.to_string(),
         )
         .with_struct_type_args(&impl_type_args);
+        let mangled_name = method_info.to_mangled_name();
 
         let method_call = TirExprKind::MethodCall {
             receiver: Box::new(receiver),
             func: FunctionRef::External {
                 module_source: ModuleSource::core("prelude"),
-                name: mangled_method_name.clone(),
+                name: mangled_name,
                 monomorph_info: None,
                 method_info: Some(method_info),
             },

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1107,7 +1107,7 @@ impl Monomorphizer {
         // When substituting field types, the inner Node<T> needs to resolve to the
         // monomorphized struct type, not a GenericInstance.
         let concrete_type_id =
-            type_table.make_struct(mangled_name.clone(), ModuleSource::entry_point());
+            type_table.make_monomorphized_struct(mangled_name.clone(), ModuleSource::entry_point());
 
         // Find the GenericInstance TypeId and record the substitution early
         // so that substitute_type can use it for self-references
@@ -1259,6 +1259,7 @@ impl Monomorphizer {
                         if let ResolvedType::Struct {
                             name: struct_name,
                             module_source: struct_source,
+                            ..
                         } = type_table.get(tid)
                             && struct_name == &name
                             && struct_source == &module_source

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1157,7 +1157,6 @@ impl Monomorphizer {
             type_params: vec![], // Concrete struct has no type params
             monomorph_info: Some(MonomorphInfo {
                 generic_name: generic.name.clone(),
-                base_struct_name: Some(generic.name.clone()),
                 type_args: key.type_args.clone(),
             }),
             fields,
@@ -1761,33 +1760,49 @@ impl Monomorphizer {
                     let struct_part = &func_name[..sep_pos];
                     let method_name = &func_name[sep_pos + 2..];
 
-                    // First, try to use monomorph_info if available
-                    // This handles cases like BTreeNode<String,i32>::new_leaf which has
-                    // generic_name = "BTreeNode<K,V>::new_leaf" and type_args
-                    if let FunctionRef::External {
-                        monomorph_info: Some(info),
-                        ..
-                    } = static_func
-                    {
-                        // Use base_struct_name metadata if available, otherwise extract from generic_name
-                        let base_struct = info.base_struct_name.clone().unwrap_or_else(|| {
+                    // Try to get base_struct_name from method_info (preferred) or monomorph_info
+                    let base_struct_and_type_args: Option<(String, Vec<TypeId>)> =
+                        if let FunctionRef::External {
+                            method_info: Some(info),
+                            monomorph_info,
+                            ..
+                        } = static_func
+                        {
+                            // Use base_struct_name from method_info
+                            let type_args = monomorph_info
+                                .as_ref()
+                                .map(|m| m.type_args.clone())
+                                .unwrap_or_default();
+                            if type_args.is_empty() {
+                                None
+                            } else {
+                                Some((info.base_struct_name.clone(), type_args))
+                            }
+                        } else if let FunctionRef::External {
+                            monomorph_info: Some(info),
+                            ..
+                        } = static_func
+                        {
                             // Fallback: extract base struct from generic_name
                             // "BTreeNode<K,V>::new_leaf" -> "BTreeNode"
                             let generic_name = &info.generic_name;
-                            if let Some(sep_pos) = generic_name.find("::") {
-                                let struct_part = &generic_name[..sep_pos];
-                                crate::name::strip_type_params(struct_part).to_string()
+                            if let Some(generic_sep_pos) = generic_name.find("::") {
+                                let generic_struct_part = &generic_name[..generic_sep_pos];
+                                let base_struct =
+                                    crate::name::strip_type_params(generic_struct_part);
+                                Some((base_struct.to_string(), info.type_args.clone()))
                             } else {
-                                crate::name::strip_type_params(generic_name).to_string()
+                                None
                             }
-                        });
+                        } else {
+                            None
+                        };
+
+                    if let Some((base_struct, type_args)) = base_struct_and_type_args {
                         let generic_method_name =
                             MethodName::format_local(&base_struct, None, method_name);
-                        if let Some(generic_func_rc) =
-                            generic_functions.get(&generic_method_name)
-                        {
+                        if let Some(generic_func_rc) = generic_functions.get(&generic_method_name) {
                             let generic_func = generic_func_rc.borrow();
-                            let type_args = info.type_args.clone();
                             // Only queue if we have the right number of type args
                             if type_args.len() == generic_func.impl_type_params.len() {
                                 let key = InstantiationKey {
@@ -2211,11 +2226,6 @@ impl Monomorphizer {
             impl_type_params: vec![], // Already monomorphized, no impl type params
             monomorph_info: Some(MonomorphInfo {
                 generic_name: generic.name.clone(),
-                // Extract base struct name from method_info if available (strip type params if present)
-                base_struct_name: generic
-                    .method_info
-                    .as_ref()
-                    .map(|info| crate::name::strip_type_params(&info.struct_name).to_string()),
                 type_args: key.type_args.clone(),
             }),
             // Update method_info with mangled struct name including impl type args
@@ -2445,8 +2455,6 @@ impl Monomorphizer {
                 // Handle case where func_name is "StructName^Trait::method" or "StructName::method"
                 // without type params but we're in a generic context
                 // e.g., TreeMap^IndexAssign::index_assign inside TreeMap<K,V>::insert
-                // Note: We check the name for '<' rather than is_monomorphized() because
-                // the function might have type params in its name but not have monomorph_info set yet.
                 if !substitution.is_empty() && !new_func_name.contains('<') {
                     // Find the separator (either ^ for trait methods or :: for regular methods)
                     let separator_pos =
@@ -2492,25 +2500,15 @@ impl Monomorphizer {
                     // Preserve the existing generic_name if we already have monomorph_info
                     // (e.g., Array<T>::append has generic_name: Array::append)
                     // Otherwise use old_func_name as the generic name
-                    let (existing_generic_name, existing_base_struct) = match method_func {
+                    let existing_generic_name = match method_func {
                         FunctionRef::External {
                             monomorph_info: Some(info),
                             ..
-                        } => (
-                            Some(info.generic_name.clone()),
-                            info.base_struct_name.clone(),
-                        ),
-                        _ => (None, None),
+                        } => Some(info.generic_name.clone()),
+                        _ => None,
                     };
-                    // Get base_struct_name from method_info if not already set (strip type params if present)
-                    let base_struct_name = existing_base_struct.or_else(|| {
-                        method_func
-                            .method_info()
-                            .map(|i| crate::name::strip_type_params(&i.struct_name).to_string())
-                    });
                     let monomorph_info = Some(MonomorphInfo {
                         generic_name: existing_generic_name.unwrap_or(old_func_name),
-                        base_struct_name,
                         type_args,
                     });
                     // Preserve original method_info (struct/trait/method names unchanged,
@@ -2542,8 +2540,6 @@ impl Monomorphizer {
                 // Handle case where func_name is "StructName::method" without type params
                 // but we're in a generic context (substitution is not empty)
                 // e.g., TreeMap::new inside TreeMap<K,V>::with_default_degree
-                // Note: We check the name for '<' rather than is_monomorphized() because
-                // the function might have type params in its name but not have monomorph_info set yet.
                 if !substitution.is_empty()
                     && !new_func_name.contains('<')
                     && let Some(sep_pos) = new_func_name.find("::")
@@ -2585,13 +2581,8 @@ impl Monomorphizer {
                     sorted_entries.sort_by_key(|(idx, _)| **idx);
                     let type_args: Vec<TypeId> =
                         sorted_entries.iter().map(|(_, tid)| **tid).collect();
-                    // Get base_struct_name from method_info (strip type params if present)
-                    let base_struct_name = static_func
-                        .method_info()
-                        .map(|i| crate::name::strip_type_params(&i.struct_name).to_string());
                     let monomorph_info = Some(MonomorphInfo {
                         generic_name: old_func_name,
-                        base_struct_name,
                         type_args,
                     });
                     // Preserve original method_info
@@ -3076,10 +3067,6 @@ impl Monomorphizer {
                     if let Some(mangled) = self.function_instantiated.get(&key) {
                         // Preserve original method_info
                         let original_method_info = func.method_info();
-                        // Get base_struct_name from method_info (strip type params if present)
-                        let base_struct_name = original_method_info
-                            .as_ref()
-                            .map(|i| crate::name::strip_type_params(&i.struct_name).to_string());
                         // Use EntryPoint module source since monomorphized functions are
                         // generated in the current (calling) module, not the original
                         // module where the generic function was defined.
@@ -3088,7 +3075,6 @@ impl Monomorphizer {
                             name: mangled.clone(),
                             monomorph_info: Some(MonomorphInfo {
                                 generic_name: func_name,
-                                base_struct_name,
                                 type_args: key.type_args.clone(),
                             }),
                             method_info: original_method_info,
@@ -3137,15 +3123,11 @@ impl Monomorphizer {
                         // Update func to the monomorphized method
                         // Preserve original method_info
                         let original_method_info = method_func.method_info();
-                        // Strip type params from struct_name for base_struct_name
-                        let base_struct_name =
-                            Some(crate::name::strip_type_params(&struct_name).to_string());
                         *method_func = FunctionRef::External {
                             module_source: module_source.clone(),
                             name: mangled.clone(),
                             monomorph_info: Some(MonomorphInfo {
                                 generic_name: full_method_name.clone(),
-                                base_struct_name,
                                 type_args: key.type_args.clone(),
                             }),
                             method_info: original_method_info,
@@ -3177,7 +3159,6 @@ impl Monomorphizer {
                                 name: mangled.clone(),
                                 monomorph_info: Some(MonomorphInfo {
                                     generic_name: generic_method_name,
-                                    base_struct_name: Some(base_struct.clone()),
                                     type_args: combined_key.type_args.clone(),
                                 }),
                                 method_info: original_method_info,
@@ -3242,7 +3223,6 @@ impl Monomorphizer {
                                 name: mangled.clone(),
                                 monomorph_info: Some(MonomorphInfo {
                                     generic_name: key.name.clone(),
-                                    base_struct_name: Some(base_struct.clone()),
                                     type_args: key.type_args.clone(),
                                 }),
                                 method_info: original_method_info,

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1157,6 +1157,7 @@ impl Monomorphizer {
             type_params: vec![], // Concrete struct has no type params
             monomorph_info: Some(MonomorphInfo {
                 generic_name: generic.name.clone(),
+                base_struct_name: Some(generic.name.clone()),
                 type_args: key.type_args.clone(),
             }),
             fields,
@@ -1768,41 +1769,41 @@ impl Monomorphizer {
                         ..
                     } = static_func
                     {
-                        // Extract base struct name from generic_name (strip type params)
-                        // "BTreeNode<K,V>::new_leaf" -> "BTreeNode"
-                        let generic_name = &info.generic_name;
-                        if let Some(generic_sep_pos) = generic_name.find("::") {
-                            let generic_struct_part = &generic_name[..generic_sep_pos];
-                            // Strip type params: "BTreeNode<K,V>" -> "BTreeNode"
-                            let base_struct = generic_struct_part
-                                .find('<')
-                                .map(|pos| &generic_struct_part[..pos])
-                                .unwrap_or(generic_struct_part);
-
-                            let generic_method_name =
-                                MethodName::format_local(base_struct, None, method_name);
-                            if let Some(generic_func_rc) =
-                                generic_functions.get(&generic_method_name)
-                            {
-                                let generic_func = generic_func_rc.borrow();
-                                let type_args = info.type_args.clone();
-                                // Only queue if we have the right number of type args
-                                if type_args.len() == generic_func.impl_type_params.len() {
-                                    let key = InstantiationKey {
-                                        name: generic_method_name,
-                                        type_args,
-                                    };
-                                    if !self.function_instantiated.contains_key(&key) {
-                                        let mangled = self.mangle_method_name(
-                                            &key,
-                                            type_table,
-                                            generic_func.impl_type_params.len(),
-                                        );
-                                        self.function_instantiated
-                                            .insert(key.clone(), mangled.clone());
-                                        self.mangled_func_to_key.insert(mangled, key.clone());
-                                        self.function_pending.push(key);
-                                    }
+                        // Use base_struct_name metadata if available, otherwise extract from generic_name
+                        let base_struct = info.base_struct_name.clone().unwrap_or_else(|| {
+                            // Fallback: extract base struct from generic_name
+                            // "BTreeNode<K,V>::new_leaf" -> "BTreeNode"
+                            let generic_name = &info.generic_name;
+                            if let Some(sep_pos) = generic_name.find("::") {
+                                let struct_part = &generic_name[..sep_pos];
+                                crate::name::strip_type_params(struct_part).to_string()
+                            } else {
+                                crate::name::strip_type_params(generic_name).to_string()
+                            }
+                        });
+                        let generic_method_name =
+                            MethodName::format_local(&base_struct, None, method_name);
+                        if let Some(generic_func_rc) =
+                            generic_functions.get(&generic_method_name)
+                        {
+                            let generic_func = generic_func_rc.borrow();
+                            let type_args = info.type_args.clone();
+                            // Only queue if we have the right number of type args
+                            if type_args.len() == generic_func.impl_type_params.len() {
+                                let key = InstantiationKey {
+                                    name: generic_method_name,
+                                    type_args,
+                                };
+                                if !self.function_instantiated.contains_key(&key) {
+                                    let mangled = self.mangle_method_name(
+                                        &key,
+                                        type_table,
+                                        generic_func.impl_type_params.len(),
+                                    );
+                                    self.function_instantiated
+                                        .insert(key.clone(), mangled.clone());
+                                    self.mangled_func_to_key.insert(mangled, key.clone());
+                                    self.function_pending.push(key);
                                 }
                             }
                         }
@@ -2210,6 +2211,11 @@ impl Monomorphizer {
             impl_type_params: vec![], // Already monomorphized, no impl type params
             monomorph_info: Some(MonomorphInfo {
                 generic_name: generic.name.clone(),
+                // Extract base struct name from method_info if available (strip type params if present)
+                base_struct_name: generic
+                    .method_info
+                    .as_ref()
+                    .map(|info| crate::name::strip_type_params(&info.struct_name).to_string()),
                 type_args: key.type_args.clone(),
             }),
             // Update method_info with mangled struct name including impl type args
@@ -2439,6 +2445,8 @@ impl Monomorphizer {
                 // Handle case where func_name is "StructName^Trait::method" or "StructName::method"
                 // without type params but we're in a generic context
                 // e.g., TreeMap^IndexAssign::index_assign inside TreeMap<K,V>::insert
+                // Note: We check the name for '<' rather than is_monomorphized() because
+                // the function might have type params in its name but not have monomorph_info set yet.
                 if !substitution.is_empty() && !new_func_name.contains('<') {
                     // Find the separator (either ^ for trait methods or :: for regular methods)
                     let separator_pos =
@@ -2484,15 +2492,25 @@ impl Monomorphizer {
                     // Preserve the existing generic_name if we already have monomorph_info
                     // (e.g., Array<T>::append has generic_name: Array::append)
                     // Otherwise use old_func_name as the generic name
-                    let existing_generic_name = match method_func {
+                    let (existing_generic_name, existing_base_struct) = match method_func {
                         FunctionRef::External {
                             monomorph_info: Some(info),
                             ..
-                        } => Some(info.generic_name.clone()),
-                        _ => None,
+                        } => (
+                            Some(info.generic_name.clone()),
+                            info.base_struct_name.clone(),
+                        ),
+                        _ => (None, None),
                     };
+                    // Get base_struct_name from method_info if not already set (strip type params if present)
+                    let base_struct_name = existing_base_struct.or_else(|| {
+                        method_func
+                            .method_info()
+                            .map(|i| crate::name::strip_type_params(&i.struct_name).to_string())
+                    });
                     let monomorph_info = Some(MonomorphInfo {
                         generic_name: existing_generic_name.unwrap_or(old_func_name),
+                        base_struct_name,
                         type_args,
                     });
                     // Preserve original method_info (struct/trait/method names unchanged,
@@ -2524,6 +2542,8 @@ impl Monomorphizer {
                 // Handle case where func_name is "StructName::method" without type params
                 // but we're in a generic context (substitution is not empty)
                 // e.g., TreeMap::new inside TreeMap<K,V>::with_default_degree
+                // Note: We check the name for '<' rather than is_monomorphized() because
+                // the function might have type params in its name but not have monomorph_info set yet.
                 if !substitution.is_empty()
                     && !new_func_name.contains('<')
                     && let Some(sep_pos) = new_func_name.find("::")
@@ -2565,8 +2585,13 @@ impl Monomorphizer {
                     sorted_entries.sort_by_key(|(idx, _)| **idx);
                     let type_args: Vec<TypeId> =
                         sorted_entries.iter().map(|(_, tid)| **tid).collect();
+                    // Get base_struct_name from method_info (strip type params if present)
+                    let base_struct_name = static_func
+                        .method_info()
+                        .map(|i| crate::name::strip_type_params(&i.struct_name).to_string());
                     let monomorph_info = Some(MonomorphInfo {
                         generic_name: old_func_name,
+                        base_struct_name,
                         type_args,
                     });
                     // Preserve original method_info
@@ -3051,6 +3076,10 @@ impl Monomorphizer {
                     if let Some(mangled) = self.function_instantiated.get(&key) {
                         // Preserve original method_info
                         let original_method_info = func.method_info();
+                        // Get base_struct_name from method_info (strip type params if present)
+                        let base_struct_name = original_method_info
+                            .as_ref()
+                            .map(|i| crate::name::strip_type_params(&i.struct_name).to_string());
                         // Use EntryPoint module source since monomorphized functions are
                         // generated in the current (calling) module, not the original
                         // module where the generic function was defined.
@@ -3059,6 +3088,7 @@ impl Monomorphizer {
                             name: mangled.clone(),
                             monomorph_info: Some(MonomorphInfo {
                                 generic_name: func_name,
+                                base_struct_name,
                                 type_args: key.type_args.clone(),
                             }),
                             method_info: original_method_info,
@@ -3107,11 +3137,15 @@ impl Monomorphizer {
                         // Update func to the monomorphized method
                         // Preserve original method_info
                         let original_method_info = method_func.method_info();
+                        // Strip type params from struct_name for base_struct_name
+                        let base_struct_name =
+                            Some(crate::name::strip_type_params(&struct_name).to_string());
                         *method_func = FunctionRef::External {
                             module_source: module_source.clone(),
                             name: mangled.clone(),
                             monomorph_info: Some(MonomorphInfo {
                                 generic_name: full_method_name.clone(),
+                                base_struct_name,
                                 type_args: key.type_args.clone(),
                             }),
                             method_info: original_method_info,
@@ -3143,6 +3177,7 @@ impl Monomorphizer {
                                 name: mangled.clone(),
                                 monomorph_info: Some(MonomorphInfo {
                                     generic_name: generic_method_name,
+                                    base_struct_name: Some(base_struct.clone()),
                                     type_args: combined_key.type_args.clone(),
                                 }),
                                 method_info: original_method_info,
@@ -3207,6 +3242,7 @@ impl Monomorphizer {
                                 name: mangled.clone(),
                                 monomorph_info: Some(MonomorphInfo {
                                     generic_name: key.name.clone(),
+                                    base_struct_name: Some(base_struct.clone()),
                                     type_args: key.type_args.clone(),
                                 }),
                                 method_info: original_method_info,

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -3360,26 +3360,32 @@ impl Monomorphizer {
             _ => return None,
         };
 
-        // Get the struct name from the operand type
+        // Get the base struct name and type args from the operand type
         let operand_type = type_table.get(left.type_id);
-        let struct_name = match operand_type {
-            ResolvedType::Struct { name, .. } => name.clone(),
+        let (base_struct_name, impl_type_args): (String, Vec<String>) = match operand_type {
+            ResolvedType::Struct { name, .. } => (name.clone(), vec![]),
             ResolvedType::GenericInstance {
                 name, type_args, ..
             } => {
-                // For generic instances, build mangled name
                 let args: Vec<String> = type_args
                     .iter()
                     .map(|&t| self.type_id_to_name(t, type_table))
                     .collect();
-                format!("{}<{}>", name, args.join(","))
+                (name.clone(), args)
             }
             // Primitives don't use trait-based comparison
             _ => return None,
         };
 
+        // Build the mangled struct name (with type args if any)
+        let mangled_struct_name = if impl_type_args.is_empty() {
+            base_struct_name.clone()
+        } else {
+            format!("{}<{}>", base_struct_name, impl_type_args.join(","))
+        };
+
         // Build the mangled method name: StructName^TraitName::method
-        let mangled_method_name = format!("{struct_name}^{trait_name}::{method_name}");
+        let mangled_method_name = format!("{mangled_struct_name}^{trait_name}::{method_name}");
 
         // Choose receiver and argument based on operand order
         let (receiver_expr, arg_expr) = if swap_operands {
@@ -3410,18 +3416,22 @@ impl Monomorphizer {
             span,
         );
 
-        // Create the method call
+        // Create the method call with proper method_info
+        // Use base_struct_name for LocalMethodName, then apply type args
+        let method_info = LocalMethodName::new(
+            base_struct_name,
+            Some(trait_name.to_string()),
+            method_name.to_string(),
+        )
+        .with_struct_type_args(&impl_type_args);
+
         let method_call = TirExprKind::MethodCall {
             receiver: Box::new(receiver),
             func: FunctionRef::External {
                 module_source: ModuleSource::core("prelude"),
                 name: mangled_method_name.clone(),
                 monomorph_info: None,
-                method_info: Some(LocalMethodName::new(
-                    struct_name,
-                    Some(trait_name.to_string()),
-                    method_name.to_string(),
-                )),
+                method_info: Some(method_info),
             },
             type_args: vec![],
             args: vec![arg_ref],

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -617,6 +617,23 @@ impl LocalMethodName {
         }
     }
 
+    /// Generate the mangled name from the components.
+    ///
+    /// Produces:
+    /// - `StructName::method` for inherent methods
+    /// - `StructName^TraitName::method` for trait methods
+    /// - `StructName<TypeArgs>::method` for monomorphized methods
+    /// - `StructName<TypeArgs>^TraitName::method` for monomorphized trait methods
+    #[must_use]
+    pub fn to_mangled_name(&self) -> String {
+        let method_part = self.full_method_name();
+        if let Some(trait_name) = &self.trait_name {
+            format!("{}^{}::{}", self.struct_name, trait_name, method_part)
+        } else {
+            format!("{}::{}", self.struct_name, method_part)
+        }
+    }
+
     /// Parse a local method name string into its components.
     ///
     /// Expected formats:

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -537,11 +537,17 @@ pub struct LocalMethodName {
 
 impl LocalMethodName {
     /// Create a new `LocalMethodName` directly from components.
-    /// `base_struct_name` is derived by stripping type params from `struct_name`.
+    ///
+    /// IMPORTANT: `struct_name` must be the base struct name WITHOUT type parameters.
+    /// Use `with_type_args()` or `with_struct_type_args()` to add type parameters.
     #[must_use]
     pub fn new(struct_name: String, trait_name: Option<String>, method_name: String) -> Self {
+        debug_assert!(
+            !struct_name.contains('<'),
+            "LocalMethodName::new() expects base struct name without type params, got: {struct_name}"
+        );
         Self {
-            base_struct_name: strip_type_params(&struct_name).to_string(),
+            base_struct_name: struct_name.clone(),
             struct_name,
             trait_name,
             method_name,
@@ -550,7 +556,9 @@ impl LocalMethodName {
     }
 
     /// Create a new `LocalMethodName` with all components including method type args.
-    /// `base_struct_name` is derived by stripping type params from `struct_name`.
+    ///
+    /// IMPORTANT: `struct_name` must be the base struct name WITHOUT type parameters.
+    /// Use `with_type_args()` to add struct type parameters.
     #[must_use]
     pub fn with_method_type_args(
         struct_name: String,
@@ -558,8 +566,12 @@ impl LocalMethodName {
         method_name: String,
         method_type_args: Vec<String>,
     ) -> Self {
+        debug_assert!(
+            !struct_name.contains('<'),
+            "LocalMethodName::with_method_type_args() expects base struct name without type params, got: {struct_name}"
+        );
         Self {
-            base_struct_name: strip_type_params(&struct_name).to_string(),
+            base_struct_name: struct_name.clone(),
             struct_name,
             trait_name,
             method_name,

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -518,12 +518,15 @@ pub fn extract_local_name(name: &str) -> &str {
 /// Parsed components of a local method name (without module path).
 ///
 /// This is used to extract struct/trait/method info from names like:
-/// - `Point::sum` → `struct_name="Point`", `trait_name=None`, `method_name="sum`"
-/// - `Point^Display::fmt` → `struct_name="Point`", `trait_name=Some("Display`"), `method_name="fmt`"
+/// - `Point::sum` → `struct_name="Point"`, `trait_name=None`, `method_name="sum"`
+/// - `Point^Display::fmt` → `struct_name="Point"`, `trait_name=Some("Display")`, `method_name="fmt"`
 #[derive(Debug, Clone)]
 pub struct LocalMethodName {
-    /// The struct name (e.g., "Point" or "Point<i32>")
+    /// The struct name, possibly with type args (e.g., "Point" or "Point<i32>")
     pub struct_name: String,
+    /// The base struct name without type args (e.g., "Point")
+    /// This is preserved during monomorphization for lookup purposes.
+    pub base_struct_name: String,
     /// The trait name if this is a trait method (e.g., "Display")
     pub trait_name: Option<String>,
     /// The method name (e.g., "sum" or "fmt")
@@ -534,9 +537,11 @@ pub struct LocalMethodName {
 
 impl LocalMethodName {
     /// Create a new `LocalMethodName` directly from components.
+    /// `base_struct_name` is derived by stripping type params from `struct_name`.
     #[must_use]
     pub fn new(struct_name: String, trait_name: Option<String>, method_name: String) -> Self {
         Self {
+            base_struct_name: strip_type_params(&struct_name).to_string(),
             struct_name,
             trait_name,
             method_name,
@@ -545,6 +550,7 @@ impl LocalMethodName {
     }
 
     /// Create a new `LocalMethodName` with all components including method type args.
+    /// `base_struct_name` is derived by stripping type params from `struct_name`.
     #[must_use]
     pub fn with_method_type_args(
         struct_name: String,
@@ -553,6 +559,7 @@ impl LocalMethodName {
         method_type_args: Vec<String>,
     ) -> Self {
         Self {
+            base_struct_name: strip_type_params(&struct_name).to_string(),
             struct_name,
             trait_name,
             method_name,
@@ -564,15 +571,17 @@ impl LocalMethodName {
     ///
     /// `impl_type_args` are applied to the struct name (e.g., "Array" + ["i32"] → "Array<i32>").
     /// `method_type_args` are stored separately (not embedded in `method_name`).
+    /// `base_struct_name` is preserved (not changed by type args).
     #[must_use]
     pub fn with_type_args(&self, impl_type_args: &[String], method_type_args: &[String]) -> Self {
         let mangled_struct = if impl_type_args.is_empty() {
             self.struct_name.clone()
         } else {
-            format!("{}<{}>", self.struct_name, impl_type_args.join(","))
+            format!("{}<{}>", self.base_struct_name, impl_type_args.join(","))
         };
         Self {
             struct_name: mangled_struct,
+            base_struct_name: self.base_struct_name.clone(),
             trait_name: self.trait_name.clone(),
             method_name: self.method_name.clone(),
             method_type_args: method_type_args.to_vec(),
@@ -634,6 +643,7 @@ impl LocalMethodName {
             let trait_name = &prefix[caret_pos + 1..];
             Some(Self {
                 struct_name: struct_name.to_string(),
+                base_struct_name: strip_type_params(struct_name).to_string(),
                 trait_name: Some(trait_name.to_string()),
                 method_name: method_name.to_string(),
                 method_type_args,
@@ -641,6 +651,7 @@ impl LocalMethodName {
         } else {
             Some(Self {
                 struct_name: prefix.to_string(),
+                base_struct_name: strip_type_params(prefix).to_string(),
                 trait_name: None,
                 method_name: method_name.to_string(),
                 method_type_args,

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -693,45 +693,45 @@ fn analyze_expr(
                 match base_receiver_type {
                     ResolvedType::Struct {
                         name,
-                        module_source,
+                        is_monomorphized: true,
                         ..
                     } => {
-                        // Check if this is a monomorphized struct (name contains "<")
-                        // Monomorphized structs are registered as FunctionId::Free, not Method
-                        if name.contains('<') {
-                            // Monomorphized struct method call - use FunctionId::Free
-                            // Include trait name for trait methods
-                            let mangled_func_name = if let Some(ref trait_n) = trait_name {
-                                format!("{name}^{trait_n}::{method_name}")
-                            } else {
-                                format!("{name}::{method_name}")
-                            };
-                            // Extract base generic name (e.g., "TreeMap" from "TreeMap<String,i32>")
-                            let base_struct = name.split('<').next().unwrap_or(&name);
-                            let base_name = if let Some(ref trait_n) = trait_name {
-                                format!("{base_struct}^{trait_n}::{method_name}")
-                            } else {
-                                format!("{base_struct}::{method_name}")
-                            };
-                            // Use empty path because monomorphized functions are added
-                            // to the entry module, not the original struct's module
-                            let callee_id =
-                                FunctionId::Free(FreeFunctionName::with_monomorph_info(
-                                    vec![],
-                                    mangled_func_name,
-                                    base_name,
-                                ));
-                            analysis.callees.insert(callee_id);
+                        // Monomorphized struct method call - use FunctionId::Free
+                        // Include trait name for trait methods
+                        let mangled_func_name = if let Some(ref trait_n) = trait_name {
+                            format!("{name}^{trait_n}::{method_name}")
                         } else {
-                            // Regular struct method call - use FunctionId::Method
-                            let method_id = FunctionId::Method(MethodName::new(
-                                module_source.to_path().join("/"),
-                                name.clone(),
-                                trait_name.clone(),
-                                method_name,
-                            ));
-                            analysis.callees.insert(method_id);
-                        }
+                            format!("{name}::{method_name}")
+                        };
+                        // Extract base generic name (e.g., "TreeMap" from "TreeMap<String,i32>")
+                        let base_struct = name.split('<').next().unwrap_or(&name);
+                        let base_name = if let Some(ref trait_n) = trait_name {
+                            format!("{base_struct}^{trait_n}::{method_name}")
+                        } else {
+                            format!("{base_struct}::{method_name}")
+                        };
+                        // Use empty path because monomorphized functions are added
+                        // to the entry module, not the original struct's module
+                        let callee_id = FunctionId::Free(FreeFunctionName::with_monomorph_info(
+                            vec![],
+                            mangled_func_name,
+                            base_name,
+                        ));
+                        analysis.callees.insert(callee_id);
+                    }
+                    ResolvedType::Struct {
+                        name,
+                        module_source,
+                        is_monomorphized: false,
+                    } => {
+                        // Regular struct method call - use FunctionId::Method
+                        let method_id = FunctionId::Method(MethodName::new(
+                            module_source.to_path().join("/"),
+                            name.clone(),
+                            trait_name.clone(),
+                            method_name,
+                        ));
+                        analysis.callees.insert(method_id);
                     }
                     ResolvedType::Primitive(_) => {
                         // Primitive method call (e.g., i32.to_string())

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -694,6 +694,7 @@ fn analyze_expr(
                     ResolvedType::Struct {
                         name,
                         is_monomorphized: true,
+                        base_name: Some(base_struct),
                         ..
                     } => {
                         // Monomorphized struct method call - use FunctionId::Free
@@ -703,9 +704,8 @@ fn analyze_expr(
                         } else {
                             format!("{name}::{method_name}")
                         };
-                        // Extract base generic name (e.g., "TreeMap" from "TreeMap<String,i32>")
-                        let base_struct = name.split('<').next().unwrap_or(&name);
-                        let base_name = if let Some(ref trait_n) = trait_name {
+                        // Build base method name using the original generic struct name
+                        let base_method_name = if let Some(ref trait_n) = trait_name {
                             format!("{base_struct}^{trait_n}::{method_name}")
                         } else {
                             format!("{base_struct}::{method_name}")
@@ -715,7 +715,7 @@ fn analyze_expr(
                         let callee_id = FunctionId::Free(FreeFunctionName::with_monomorph_info(
                             vec![],
                             mangled_func_name,
-                            base_name,
+                            base_method_name,
                         ));
                         analysis.callees.insert(callee_id);
                     }
@@ -723,6 +723,7 @@ fn analyze_expr(
                         name,
                         module_source,
                         is_monomorphized: false,
+                        ..
                     } => {
                         // Regular struct method call - use FunctionId::Method
                         let method_id = FunctionId::Method(MethodName::new(

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -938,6 +938,7 @@ impl<'a> Resolver<'a> {
                 if let ResolvedType::Struct {
                     name: ref_struct_name,
                     module_source: ref_module_source,
+                    ..
                 } = type_table.get(*field_type_id)
                 {
                     // Skip self-references (same struct or same module)
@@ -1899,11 +1900,7 @@ impl<'a> Resolver<'a> {
                 if struct_lit.name.is_none() {
                     // Check if target type is a struct
                     let target_resolved = self.type_table.borrow().get(target_type).clone();
-                    if let ResolvedType::Struct {
-                        name,
-                        module_source: _,
-                    } = target_resolved
-                    {
+                    if let ResolvedType::Struct { name, .. } = target_resolved {
                         let name = name.clone();
                         let struct_type = target_type;
 
@@ -2578,6 +2575,7 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => (name.clone(), module_source.to_path(), None),
             ResolvedType::GenericInstance {
                 name,
@@ -2711,6 +2709,7 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => (name, module_source.to_path(), None),
             ResolvedType::GenericInstance {
                 name,
@@ -4023,6 +4022,7 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => (name.clone(), module_source.to_path()),
             ResolvedType::GenericInstance {
                 name,
@@ -4300,6 +4300,7 @@ impl<'a> Resolver<'a> {
                 ResolvedType::Struct {
                     name,
                     module_source,
+                    ..
                 } => (name.clone(), module_source.to_path(), name.clone(), vec![]),
                 ResolvedType::GenericInstance {
                     name,
@@ -4685,6 +4686,7 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => (name.clone(), module_source.to_path(), None),
             // Generic instances like Box<i32> use the base name "Box" for method lookup
             ResolvedType::GenericInstance {
@@ -4925,6 +4927,7 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => (name.clone(), module_source.to_path()),
             ResolvedType::GenericInstance {
                 name,
@@ -5834,6 +5837,7 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                ..
             } => (name, module_source.to_path()),
             ResolvedType::GenericInstance {
                 name,
@@ -5863,6 +5867,7 @@ impl<'a> Resolver<'a> {
                 ResolvedType::Struct {
                     name,
                     module_source,
+                    ..
                 } => (name, module_source.to_path(), None),
                 ResolvedType::GenericInstance {
                     name,

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -4109,7 +4109,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Get struct name and monomorph info from base type for mangled method name
-        let (receiver_struct_name, base_struct_name, receiver_type_args) =
+        let (receiver_struct_name, base_struct_name, impl_type_arg_names, receiver_type_args) =
             match self.type_table.borrow().get(base_type_id).clone() {
                 ResolvedType::GenericInstance {
                     name, type_args, ..
@@ -4119,14 +4119,27 @@ impl<'a> Resolver<'a> {
                         .map(|t| self.mangle_type_name(*t))
                         .collect();
                     let mangled = format!("{}<{}>", name, type_arg_names.join(","));
-                    (mangled, Some(name.clone()), Some(type_args.clone()))
+                    (
+                        mangled,
+                        name.clone(),
+                        type_arg_names,
+                        Some(type_args.clone()),
+                    )
                 }
                 ResolvedType::BuiltinArray(elem) => {
                     let elem_name = self.mangle_type_name(elem);
-                    let mangled = format!("Array<{elem_name}>");
-                    (mangled, Some("Array".to_string()), Some(vec![elem]))
+                    let _mangled = format!("Array<{elem_name}>");
+                    (
+                        "Array".to_string(),
+                        "Array".to_string(),
+                        vec![elem_name],
+                        Some(vec![elem]),
+                    )
                 }
-                _ => (self.mangle_type_name(base_type_id), None, None),
+                _ => {
+                    let name = self.mangle_type_name(base_type_id);
+                    (name.clone(), name, vec![], None)
+                }
             };
 
         // Build mangled method name:
@@ -4141,16 +4154,13 @@ impl<'a> Resolver<'a> {
         };
 
         // Build monomorph_info for method calls on generic types
-        let monomorph_info =
-            if let (Some(base), Some(type_args)) = (base_struct_name, receiver_type_args) {
-                let generic_name = format!("{}::{}", base, method_call.method);
-                Some(MonomorphInfo {
-                    generic_name,
-                    type_args,
-                })
-            } else {
-                None
-            };
+        let monomorph_info = receiver_type_args.map(|type_args| {
+            let generic_name = format!("{}::{}", base_struct_name, method_call.method);
+            MonomorphInfo {
+                generic_name,
+                type_args,
+            }
+        });
 
         // Convert method type args to string names for method_info
         // Use inferred type args if available, otherwise use explicit type args
@@ -4159,6 +4169,14 @@ impl<'a> Resolver<'a> {
             .map(|t| self.mangle_type_name(*t))
             .collect();
 
+        // Build method_info with base struct name, then apply impl and method type args
+        let method_info = LocalMethodName::new(
+            base_struct_name, // Use base struct name without type params
+            trait_name,
+            method_call.method.clone(),
+        )
+        .with_type_args(&impl_type_arg_names, &method_type_arg_names);
+
         TirExpr::new(
             TirExprKind::MethodCall {
                 receiver: Box::new(receiver),
@@ -4166,12 +4184,7 @@ impl<'a> Resolver<'a> {
                     module_source: self.current_module_source.clone(),
                     name: mangled_method_name,
                     monomorph_info,
-                    method_info: Some(LocalMethodName::with_method_type_args(
-                        receiver_struct_name,
-                        trait_name,
-                        method_call.method.clone(),
-                        method_type_arg_names,
-                    )),
+                    method_info: Some(method_info),
                 },
                 type_args: method_type_args, // Use inferred type args
                 args,
@@ -4344,16 +4357,32 @@ impl<'a> Resolver<'a> {
         }
 
         // Build monomorph_info for generic instantiations
-        let monomorph_info = if struct_type_args.is_empty() {
-            None
-        } else {
-            // Generic static method: track the original generic name
-            let generic_name = format!("{}::{}", struct_name, static_call.method);
-            Some(MonomorphInfo {
-                generic_name,
-                type_args: struct_type_args,
-            })
-        };
+        let (monomorph_info, impl_type_arg_names): (Option<MonomorphInfo>, Vec<String>) =
+            if struct_type_args.is_empty() {
+                (None, vec![])
+            } else {
+                // Generic static method: track the original generic name
+                let generic_name = format!("{}::{}", struct_name, static_call.method);
+                let type_arg_names: Vec<String> = struct_type_args
+                    .iter()
+                    .map(|t| self.mangle_type_name(*t))
+                    .collect();
+                (
+                    Some(MonomorphInfo {
+                        generic_name,
+                        type_args: struct_type_args,
+                    }),
+                    type_arg_names,
+                )
+            };
+
+        // Build method_info with base struct name, then apply type args
+        let method_info = LocalMethodName::new(
+            struct_name, // Use base struct name without type params
+            None,        // Static methods are inherent, no trait
+            static_call.method.clone(),
+        )
+        .with_struct_type_args(&impl_type_arg_names);
 
         TirExpr::new(
             TirExprKind::StaticCall {
@@ -4361,11 +4390,7 @@ impl<'a> Resolver<'a> {
                     module_source: ModuleSource::from_path(&module_path),
                     name: mangled_func_name,
                     monomorph_info,
-                    method_info: Some(LocalMethodName::new(
-                        mangled_struct_name,
-                        None, // Static methods are inherent, no trait
-                        static_call.method.clone(),
-                    )),
+                    method_info: Some(method_info),
                 },
                 args,
             },

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -1721,6 +1721,7 @@ impl<'a> Resolver<'a> {
             monomorph_info: None, // Not from monomorphization
             method_info: Some(LocalMethodName {
                 struct_name: struct_name.to_string(),
+                base_struct_name: struct_name.to_string(),
                 trait_name: trait_name.map(String::from),
                 method_name: func.name.clone(),
                 method_type_args: vec![],
@@ -4145,7 +4146,6 @@ impl<'a> Resolver<'a> {
                 let generic_name = format!("{}::{}", base, method_call.method);
                 Some(MonomorphInfo {
                     generic_name,
-                    base_struct_name: Some(base.clone()),
                     type_args,
                 })
             } else {
@@ -4351,7 +4351,6 @@ impl<'a> Resolver<'a> {
             let generic_name = format!("{}::{}", struct_name, static_call.method);
             Some(MonomorphInfo {
                 generic_name,
-                base_struct_name: Some(struct_name.clone()),
                 type_args: struct_type_args,
             })
         };
@@ -4929,13 +4928,8 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
-                base_name,
                 ..
-            } => {
-                // Use base_name for monomorphized structs (e.g., "ArrayIter" instead of "ArrayIter<i32>")
-                let effective_name = base_name.as_ref().unwrap_or(name).clone();
-                (effective_name, module_source.to_path())
-            }
+            } => (name.clone(), module_source.to_path()),
             ResolvedType::GenericInstance {
                 name,
                 module_source,
@@ -4976,8 +4970,11 @@ impl<'a> Resolver<'a> {
                     && impl_block.trait_type.is_none()
                 {
                     let impl_type_name = self.get_type_name(&impl_block.ty);
-                    // get_type_name returns just the base name (no type args)
-                    if impl_type_name == struct_name {
+                    // Match impl type name: either exact match or the base name matches
+                    // For generic types like ArrayIter<T>, match if base name "ArrayIter" matches
+                    let impl_base_name =
+                        impl_type_name.split('<').next().unwrap_or(&impl_type_name);
+                    if impl_type_name == struct_name || impl_base_name == struct_name {
                         for method in &impl_block.methods {
                             if method.name == method_name && !method.type_params.is_empty() {
                                 let (tp, pp) = extract_method_info(method);
@@ -4999,8 +4996,9 @@ impl<'a> Resolver<'a> {
                         && impl_block.trait_type.is_none()
                     {
                         let impl_type_name = self.get_type_name(&impl_block.ty);
-                        // get_type_name returns just the base name (no type args)
-                        if impl_type_name == struct_name {
+                        let impl_base_name =
+                            impl_type_name.split('<').next().unwrap_or(&impl_type_name);
+                        if impl_type_name == struct_name || impl_base_name == struct_name {
                             for method in &impl_block.methods {
                                 if method.name == method_name && !method.type_params.is_empty() {
                                     let (tp, pp) = extract_method_info(method);

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -4145,6 +4145,7 @@ impl<'a> Resolver<'a> {
                 let generic_name = format!("{}::{}", base, method_call.method);
                 Some(MonomorphInfo {
                     generic_name,
+                    base_struct_name: Some(base.clone()),
                     type_args,
                 })
             } else {
@@ -4350,6 +4351,7 @@ impl<'a> Resolver<'a> {
             let generic_name = format!("{}::{}", struct_name, static_call.method);
             Some(MonomorphInfo {
                 generic_name,
+                base_struct_name: Some(struct_name.clone()),
                 type_args: struct_type_args,
             })
         };
@@ -4927,8 +4929,13 @@ impl<'a> Resolver<'a> {
             ResolvedType::Struct {
                 name,
                 module_source,
+                base_name,
                 ..
-            } => (name.clone(), module_source.to_path()),
+            } => {
+                // Use base_name for monomorphized structs (e.g., "ArrayIter" instead of "ArrayIter<i32>")
+                let effective_name = base_name.as_ref().unwrap_or(name).clone();
+                (effective_name, module_source.to_path())
+            }
             ResolvedType::GenericInstance {
                 name,
                 module_source,
@@ -4969,11 +4976,8 @@ impl<'a> Resolver<'a> {
                     && impl_block.trait_type.is_none()
                 {
                     let impl_type_name = self.get_type_name(&impl_block.ty);
-                    // Match impl type name: either exact match or the base name matches
-                    // For generic types like ArrayIter<T>, match if base name "ArrayIter" matches
-                    let impl_base_name =
-                        impl_type_name.split('<').next().unwrap_or(&impl_type_name);
-                    if impl_type_name == struct_name || impl_base_name == struct_name {
+                    // get_type_name returns just the base name (no type args)
+                    if impl_type_name == struct_name {
                         for method in &impl_block.methods {
                             if method.name == method_name && !method.type_params.is_empty() {
                                 let (tp, pp) = extract_method_info(method);
@@ -4995,9 +4999,8 @@ impl<'a> Resolver<'a> {
                         && impl_block.trait_type.is_none()
                     {
                         let impl_type_name = self.get_type_name(&impl_block.ty);
-                        let impl_base_name =
-                            impl_type_name.split('<').next().unwrap_or(&impl_type_name);
-                        if impl_type_name == struct_name || impl_base_name == struct_name {
+                        // get_type_name returns just the base name (no type args)
+                        if impl_type_name == struct_name {
                             for method in &impl_block.methods {
                                 if method.name == method_name && !method.type_params.is_empty() {
                                     let (tp, pp) = extract_method_info(method);

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1311,8 +1311,10 @@ pub struct TirTypeParam {
 /// Information about monomorphization origin for instantiated items
 #[derive(Debug, Clone)]
 pub struct MonomorphInfo {
-    /// Original generic name (e.g., "Box" for "Box<i32>")
+    /// Original generic name (e.g., "Box" for "Box<i32>", or "BTreeNode<K,V>::insert" for methods)
     pub generic_name: String,
+    /// Base struct name without type parameters (e.g., "BTreeNode" for "BTreeNode<K,V>::insert")
+    pub base_struct_name: Option<String>,
     /// Concrete type arguments used for this instantiation
     pub type_args: Vec<TypeId>,
 }

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -228,8 +228,12 @@ pub enum ResolvedType {
     Struct {
         name: String,
         module_source: ModuleSource,
-        /// Whether this struct was created by monomorphizing a generic struct
+        /// Whether this struct was created by monomorphizing a generic struct.
+        /// If true, `base_name` contains the original generic struct name.
         is_monomorphized: bool,
+        /// For monomorphized structs, the original generic name (e.g., "`TreeMap`" for "`TreeMap`<String,i32>").
+        /// None for non-monomorphized structs.
+        base_name: Option<String>,
     },
     Enum {
         name: String,
@@ -447,19 +451,25 @@ impl TypeTable {
             name,
             module_source,
             is_monomorphized: false,
+            base_name: None,
         })
     }
 
     /// Create a monomorphized struct type (e.g., "Box<i32>")
+    ///
+    /// - `name`: The fully mangled name (e.g., "`TreeMap`<String,i32>")
+    /// - `base_name`: The original generic struct name (e.g., "`TreeMap`")
     pub fn make_monomorphized_struct(
         &mut self,
         name: String,
         module_source: ModuleSource,
+        base_name: String,
     ) -> TypeId {
         self.intern(ResolvedType::Struct {
             name,
             module_source,
             is_monomorphized: true,
+            base_name: Some(base_name),
         })
     }
 
@@ -477,6 +487,7 @@ impl TypeTable {
             name: name.to_string(),
             module_source: module_source.clone(),
             is_monomorphized: false,
+            base_name: None,
         };
         self.intern_map.get(&key).copied()
     }

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -228,6 +228,8 @@ pub enum ResolvedType {
     Struct {
         name: String,
         module_source: ModuleSource,
+        /// Whether this struct was created by monomorphizing a generic struct
+        is_monomorphized: bool,
     },
     Enum {
         name: String,
@@ -444,6 +446,20 @@ impl TypeTable {
         self.intern(ResolvedType::Struct {
             name,
             module_source,
+            is_monomorphized: false,
+        })
+    }
+
+    /// Create a monomorphized struct type (e.g., "Box<i32>")
+    pub fn make_monomorphized_struct(
+        &mut self,
+        name: String,
+        module_source: ModuleSource,
+    ) -> TypeId {
+        self.intern(ResolvedType::Struct {
+            name,
+            module_source,
+            is_monomorphized: true,
         })
     }
 
@@ -454,12 +470,13 @@ impl TypeTable {
         })
     }
 
-    /// Find the `type_id` for a struct by name and module source (O(1) lookup via `intern_map`)
+    /// Find the `type_id` for a non-monomorphized struct by name and module source (O(1) lookup via `intern_map`)
     pub fn find_struct_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
         // Use the existing intern_map for O(1) lookup
         let key = ResolvedType::Struct {
             name: name.to_string(),
             module_source: module_source.clone(),
+            is_monomorphized: false,
         };
         self.intern_map.get(&key).copied()
     }
@@ -606,11 +623,9 @@ impl TypeTable {
             | ResolvedType::Stream(_)
             | ResolvedType::Future(_)
             | ResolvedType::BuiltinArray(_) => true,
-            // TODO: Monomorphized structs have their type args baked into the name (e.g., "BTreeNode<String,i32>")
-            // These are effectively generic types that were instantiated with concrete type arguments.
-            // This string check should be replaced with proper type metadata once we track
-            // whether a struct is a monomorphized generic.
-            ResolvedType::Struct { name, .. } => name.contains('<'),
+            ResolvedType::Struct {
+                is_monomorphized, ..
+            } => *is_monomorphized,
             // References are generic if inner is generic
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => self.is_generic_type(*inner),
             // Tuples are generic if they contain generic types

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -797,11 +797,7 @@ impl FunctionRef {
                 let func = func.borrow();
                 // Use method_info to create a unique name for methods
                 if let Some(info) = &func.method_info {
-                    if let Some(trait_name) = &info.trait_name {
-                        format!("{}^{}::{}", info.struct_name, trait_name, info.method_name)
-                    } else {
-                        format!("{}::{}", info.struct_name, info.method_name)
-                    }
+                    info.to_mangled_name()
                 } else {
                     func.name.clone()
                 }

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1311,10 +1311,8 @@ pub struct TirTypeParam {
 /// Information about monomorphization origin for instantiated items
 #[derive(Debug, Clone)]
 pub struct MonomorphInfo {
-    /// Original generic name (e.g., "Box" for "Box<i32>", or "BTreeNode<K,V>::insert" for methods)
+    /// Original generic name (e.g., "Box" for "Box<i32>", or "`BTreeNode`<`K,V>::insert`" for methods)
     pub generic_name: String,
-    /// Base struct name without type parameters (e.g., "BTreeNode" for "BTreeNode<K,V>::insert")
-    pub base_struct_name: Option<String>,
     /// Concrete type arguments used for this instantiation
     pub type_args: Vec<TypeId>,
 }


### PR DESCRIPTION
Add `is_monomorphized` field to `ResolvedType::Struct` to explicitly
track whether a struct was created through monomorphization, replacing
string-based checks like `name.contains('<')`.

- Add `is_monomorphized: bool` field to `ResolvedType::Struct`
- Add `make_monomorphized_struct()` method to TypeTable
- Update `is_generic_type()` to use metadata instead of string check
- Update DCE, codegen to use the new metadata