### PR TITLE
Add WEP: Variant Payload Design with explicit syntax and union types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Closure Parameter Monomorphization](./docs/wep-2026-01-25-closure-parameter-monomorphization.md)
 - [128-bit Integer Types (i128/u128)](./docs/wep-2026-01-24-i128-u128-types.md)
 - [Re-export Syntax (`pub use`)](./docs/wep-2026-01-25-pub-use-reexport.md)
+- [Variant Payload Design](./docs/wep-2026-01-25-variant-payload-design.md)
 
 ### Structure
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -973,9 +973,8 @@ This optimization enables ergonomic APIs with methods while maintaining direct W
 - [x] Variant construction (`Option::<T>::Some(x)`, `Color::Red`, `Shape::Circle(r)`)
 - [x] Option pattern matching (`if let Some(x) = ...`)
 - [x] Custom variant pattern matching (single-payload: `if let Circle(r) = shape`)
-- [ ] Custom variant pattern matching (multi-payload)
-- [ ] Custom variant pattern matching (no-payload cases with binding)
-- [ ] Match expressions
+- [ ] Custom variant pattern matching (tuple/struct payloads, see WEP)
+- [ ] Match expressions (see WEP)
 - [x] Closures - pure (no captures)
 - [ ] Closures - with captures (see WEP)
 - [ ] Effect handlers
@@ -1048,19 +1047,9 @@ fn run() with Stdout {
 
 ---
 
-## Variant Implementation Roadmap
+## Variant Implementation
 
-Current status: variant construction, single-payload if-let pattern matching, and value semantics work.
-
-### TODO
-
-- [ ] Multi-payload variant patterns (`if let Rect(w, h) = shape`)
-- [ ] No-payload variant patterns with else binding (`if let Point = shape`)
-- [ ] while let / for let with custom variants
-- [ ] `match` expressions and statements
-- [ ] Generic variant pattern matching (`if let Just(x) = maybe` for `Maybe<T>`)
-- [ ] `Result<T, E>` pattern matching (`if let Ok(v) = result`, `if let Err(e) = result`)
-- [x] Value semantics (copy) for custom variants
+See [WEP: Variant Payload Design](./wep-2026-01-25-variant-payload-design.md) for the variant system design and implementation roadmap.
 
 ---
 

--- a/docs/wep-2026-01-25-variant-payload-design.md
+++ b/docs/wep-2026-01-25-variant-payload-design.md
@@ -40,6 +40,7 @@ function processCircle(c: Circle) { ... }
 ```
 
 This approach:
+
 - Makes each variant a first-class type
 - Uses structural typing for discrimination
 - No special "variant" keyword needed
@@ -50,14 +51,15 @@ This approach:
 
 Wado variants support exactly four payload forms with **consistent syntax**:
 
-| Form | Syntax | Example | Description |
-|------|--------|---------|-------------|
-| **Unit** | `Name` | `Point` | No payload |
-| **Scalar** | `Name(T)` | `Circle(f64)` | Single value |
-| **Tuple** | `Name([T, U, ...])` | `Rectangle([f64, f64])` | Explicit tuple type |
+| Form       | Syntax                    | Example                              | Description                |
+| ---------- | ------------------------- | ------------------------------------ | -------------------------- |
+| **Unit**   | `Name`                    | `Point`                              | No payload                 |
+| **Scalar** | `Name(T)`                 | `Circle(f64)`                        | Single value               |
+| **Tuple**  | `Name([T, U, ...])`       | `Rectangle([f64, f64])`              | Explicit tuple type        |
 | **Struct** | `Name({ field: T, ... })` | `Named({ width: f64, height: f64 })` | Anonymous struct in parens |
 
 Key principles:
+
 - **No implicit tuple expansion**: Multiple values require explicit tuple syntax `[T, U]` or struct syntax `{ a: T, b: U }`
 - **Consistent wrapper**: All non-unit payloads use `Name(payload)` form
 - **Minimal special rules**: Edge cases like single-element tuples `Foo([T])` or zero-element tuples `Foo([])` are allowed
@@ -100,6 +102,7 @@ let shape: Shape = circle;  // OK: implicit upcast
 ```
 
 This enables:
+
 - Functions that accept only specific variants
 - No need for `unreachable!()` in match arms
 - Better type safety and documentation
@@ -174,11 +177,11 @@ fn circle_area(c: Shape::Circle) -> f64 {
 
 **Payload is always at `.0`** - this provides consistent access regardless of payload type:
 
-| Payload Type | Access Syntax | Example |
-|--------------|---------------|---------|
-| Scalar | `.0` | `circle.0` → the value |
-| Tuple | `.0` then `.0`, `.1`, etc. | `rect.0.0`, `rect.0.1` |
-| Struct | `.0` then `.field` | `named.0.width`, `named.0.height` |
+| Payload Type | Access Syntax              | Example                           |
+| ------------ | -------------------------- | --------------------------------- |
+| Scalar       | `.0`                       | `circle.0` → the value            |
+| Tuple        | `.0` then `.0`, `.1`, etc. | `rect.0.0`, `rect.0.1`            |
+| Struct       | `.0` then `.field`         | `named.0.width`, `named.0.height` |
 
 ```wado
 let c: Shape::Circle = Shape::Circle(5.0);
@@ -309,16 +312,17 @@ match x {
 
 This provides set-like operations that named variants cannot express:
 
-| Feature | `variant` | Union Type |
-|---------|-----------|------------|
-| Named cases | ✓ | ✗ (structural) |
-| Exhaustiveness checking | ✓ | ✓ |
-| Subset binding | ✗ | ✓ |
-| Set operations | ✗ | `\|` (union) |
+| Feature                 | `variant` | Union Type     |
+| ----------------------- | --------- | -------------- |
+| Named cases             | ✓         | ✗ (structural) |
+| Exhaustiveness checking | ✓         | ✓              |
+| Subset binding          | ✗         | ✓              |
+| Set operations          | ✗         | `\|` (union)   |
 
 ### Comparison with TypeScript
 
 TypeScript's type narrowing:
+
 ```typescript
 function process(x: A | B | C | D) {
     if (isAB(x)) {
@@ -328,6 +332,7 @@ function process(x: A | B | C | D) {
 ```
 
 Wado's subset binding:
+
 ```wado
 fn process(x: A | B | C | D) {
     if let ab: A | B = x {
@@ -421,6 +426,7 @@ if let Shape::Rectangle([w, _]) = shape {
 ## Migration from Current Syntax
 
 Current:
+
 ```wado
 variant Shape {
     Rectangle(f64, f64),        // implicit tuple
@@ -431,6 +437,7 @@ let n = Shape::Named { width: 10.0, height: 20.0 };
 ```
 
 New:
+
 ```wado
 variant Shape {
     Rectangle([f64, f64]),                   // explicit tuple
@@ -441,6 +448,7 @@ let n = Shape::Named({ width: 10.0, height: 20.0 });
 ```
 
 Migration steps:
+
 1. Wrap multiple payload types in `[...]`
 2. Wrap struct payloads in `({})`
 
@@ -464,14 +472,14 @@ Migration steps:
 
 ### Comparison with Rust
 
-| Aspect | Rust | Wado |
-|--------|------|------|
-| Multiple payloads | `Foo(T, U)` implicit tuple | `Foo([T, U])` explicit |
-| Struct variants | `Foo { a: T }` | `Foo({ a: T })` with parens |
-| Payload access | `.0`, `.1` directly | `.0.0`, `.0.1` (payload at `.0`) |
-| Variant as type | Not supported | `Shape::Circle` is a type |
-| Empty variants | Unit/tuple/struct differ | Unit only: `Foo` |
-| Union types | Not supported | `A \| B` with subset binding |
+| Aspect            | Rust                       | Wado                             |
+| ----------------- | -------------------------- | -------------------------------- |
+| Multiple payloads | `Foo(T, U)` implicit tuple | `Foo([T, U])` explicit           |
+| Struct variants   | `Foo { a: T }`             | `Foo({ a: T })` with parens      |
+| Payload access    | `.0`, `.1` directly        | `.0.0`, `.0.1` (payload at `.0`) |
+| Variant as type   | Not supported              | `Shape::Circle` is a type        |
+| Empty variants    | Unit/tuple/struct differ   | Unit only: `Foo`                 |
+| Union types       | Not supported              | `A \| B` with subset binding     |
 
 ## Implementation Roadmap
 

--- a/docs/wep-2026-01-25-variant-payload-design.md
+++ b/docs/wep-2026-01-25-variant-payload-design.md
@@ -48,30 +48,32 @@ This approach:
 
 ### 1. Payload Forms
 
-Wado variants support exactly four payload forms:
+Wado variants support exactly four payload forms with **consistent syntax**:
 
 | Form | Syntax | Example | Description |
 |------|--------|---------|-------------|
 | **Unit** | `Name` | `Point` | No payload |
 | **Scalar** | `Name(T)` | `Circle(f64)` | Single value |
 | **Tuple** | `Name([T, U, ...])` | `Rectangle([f64, f64])` | Explicit tuple type |
-| **Struct** | `Name { field: T, ... }` | `Named { width: f64, height: f64 }` | Anonymous struct |
+| **Struct** | `Name({ field: T, ... })` | `Named({ width: f64, height: f64 })` | Anonymous struct in parens |
 
-Key principle: **No implicit tuple expansion**. Multiple values require explicit tuple syntax `[T, U]` or struct syntax `{ a: T, b: U }`.
+Key principles:
+- **No implicit tuple expansion**: Multiple values require explicit tuple syntax `[T, U]` or struct syntax `{ a: T, b: U }`
+- **Consistent wrapper**: All non-unit payloads use `Name(payload)` form
 
 ```wado
 variant Shape {
-    Point,                              // unit
-    Circle(f64),                        // scalar
-    Rectangle([f64, f64]),              // explicit tuple
-    Named { width: f64, height: f64 },  // anonymous struct
+    Point,                                    // unit
+    Circle(f64),                              // scalar
+    Rectangle([f64, f64]),                    // explicit tuple
+    Named({ width: f64, height: f64 }),       // struct in parens
 }
 
 // Construction
 let p = Shape::Point;
 let c = Shape::Circle(5.0);
-let r = Shape::Rectangle([10.0, 20.0]);   // tuple literal required
-let n = Shape::Named { width: 10.0, height: 20.0 };
+let r = Shape::Rectangle([10.0, 20.0]);
+let n = Shape::Named({ width: 10.0, height: 20.0 });
 ```
 
 ### 2. Variant Cases as Types
@@ -87,15 +89,13 @@ variant Shape {
 
 // Shape::Circle is a type
 fn process_circle(c: Shape::Circle) {
-    // c.0 is the radius (f64)
     println(`radius: {c.0}`);
 }
 
-// Can construct without full path when type is known
-let circle: Shape::Circle = Shape::Circle(5.0);
-
 // Subtype relationship: Shape::Circle <: Shape
-let shape: Shape = circle;  // OK: upcast
+// Implicit coercion from variant case to variant
+let circle = Shape::Circle(5.0);
+let shape: Shape = circle;  // OK: implicit upcast
 ```
 
 This enables:
@@ -103,16 +103,41 @@ This enables:
 - No need for `unreachable!()` in match arms
 - Better type safety and documentation
 
-### 3. Pattern Matching with Variant Types
+### 3. Turbofish Syntax for Generic Variants
+
+The canonical syntax places type parameters on the variant type:
+
+```wado
+variant Option<T> {
+    Some(T),
+    None,
+}
+
+// Canonical: type parameter on variant, then case
+let some: Option::<i32>::Some = Option::<i32>::Some(42);
+
+// Recommended: rely on type inference
+let some = Option::Some(42);  // inferred as Option::<i32>::Some
+let opt: Option<i32> = some;  // confirms the type
+```
+
+Type inference is encouraged over explicit turbofish notation.
+
+### 4. Pattern Matching
 
 ```wado
 fn area(s: Shape) -> f64 {
     match s {
-        Shape::Circle(r) => 3.14159 * r * r,
-        Shape::Rectangle([w, h]) => w * h,
-        Shape::Named { width, height } => width * height,
-        Shape::Point => 0.0,
+        Circle(r) => 3.14159 * r * r,
+        Rectangle([w, h]) => w * h,
+        Named({ width, height }) => width * height,
+        Point => 0.0,
     }
+}
+
+// if let for single variant
+if let Circle(r) = shape {
+    println(`radius: {r}`);
 }
 
 // When parameter type is Shape::Circle, no match needed
@@ -121,7 +146,7 @@ fn circle_area(c: Shape::Circle) -> f64 {
 }
 ```
 
-### 4. Accessing Payload Fields
+### 5. Accessing Payload Fields
 
 | Payload Type | Access Syntax | Example |
 |--------------|---------------|---------|
@@ -130,96 +155,187 @@ fn circle_area(c: Shape::Circle) -> f64 {
 | Struct | `.field` | `named.width`, `named.height` |
 
 ```wado
-let c = Shape::Circle(5.0);
+let c: Shape::Circle = Shape::Circle(5.0);
 let radius = c.0;           // 5.0
 
-let r = Shape::Rectangle([10.0, 20.0]);
-let width = r.0;            // 10.0
-let height = r.1;           // 20.0
+let r: Shape::Rectangle = Shape::Rectangle([10.0, 20.0]);
+let width = r.0;            // 10.0 (tuple .0)
+let height = r.1;           // 20.0 (tuple .1)
 
-let n = Shape::Named { width: 10.0, height: 20.0 };
+let n: Shape::Named = Shape::Named({ width: 10.0, height: 20.0 });
 let w = n.width;            // 10.0
 ```
 
-### 5. Generic Variants
+## Union Type & Subset Binding
+
+Beyond named variants, Wado supports anonymous union types with a powerful **subset binding** feature.
+
+### Union Types
+
+Union types are anonymous sum types that flatten automatically:
 
 ```wado
-variant Option<T> {
-    Some(T),
-    None,
+type A = { kind: "a", a: i32 };
+type B = { kind: "b", b: i32 };
+type C = { kind: "c", c: i32 };
+type D = { kind: "d", d: i32 };
+
+type AB = A | B;
+type CD = C | D;
+type ABCD = AB | CD;  // flattens to A | B | C | D
+```
+
+Internally, union types have a discriminant (tag) just like variants.
+
+### Subset Binding
+
+**Subset binding** allows pattern matching against any subset of a union type:
+
+```wado
+fn process(x: ABCD) {
+    // Bind to a named subset type
+    if let ab: AB = x {
+        // ab: A | B
+        println("got A or B");
+    }
+
+    // Bind to an inline subset
+    if let bc: B | C = x {
+        // bc: B | C
+        println("got B or C");
+    }
+
+    // Bind to a single type
+    if let a: A = x {
+        // a: A
+        println(`got A with a={a.a}`);
+    }
 }
-
-// Option::Some<i32> is a type
-let some: Option::Some<i32> = Option::Some(42);
-
-// Subtype: Option::Some<i32> <: Option<i32>
-let opt: Option<i32> = some;
 ```
 
-### 6. Integration with Literal Types (Future)
+This provides set-like operations that named variants cannot express:
 
-When literal types are introduced, variant cases naturally integrate:
+| Feature | `variant` | Union Type |
+|---------|-----------|------------|
+| Named cases | ✓ | ✗ (structural) |
+| Exhaustiveness checking | ✓ | ✓ |
+| Subset binding | ✗ | ✓ |
+| Set operations | ✗ | `\|` (union) |
 
+### Comparison with TypeScript
+
+TypeScript's type narrowing:
+```typescript
+function process(x: A | B | C | D) {
+    if (isAB(x)) {
+        // x: A | B (via type guard)
+    }
+}
+```
+
+Wado's subset binding:
 ```wado
-// Discriminant field with literal type
-type Circle = Shape::Circle;  // { tag: "Circle", 0: f64 }
-
-// Could potentially allow structural matching
-type JsonValue =
-    | { type: "null" }
-    | { type: "bool", value: bool }
-    | { type: "number", value: f64 }
-    | { type: "string", value: String };
+fn process(x: A | B | C | D) {
+    if let ab: A | B = x {
+        // ab: A | B (via subset binding)
+    }
+}
 ```
+
+Wado's approach is more declarative - no need for manual type guard functions.
 
 ## Migration from Current Syntax
 
 Current:
 ```wado
 variant Shape {
-    Rectangle(f64, f64),  // implicit tuple
+    Rectangle(f64, f64),        // implicit tuple
+    Named { width: f64, height: f64 },  // struct without parens
 }
 let r = Shape::Rectangle(10.0, 20.0);
+let n = Shape::Named { width: 10.0, height: 20.0 };
 ```
 
 New:
 ```wado
 variant Shape {
-    Rectangle([f64, f64]),  // explicit tuple
+    Rectangle([f64, f64]),                   // explicit tuple
+    Named({ width: f64, height: f64 }),      // struct with parens
 }
 let r = Shape::Rectangle([10.0, 20.0]);
+let n = Shape::Named({ width: 10.0, height: 20.0 });
 ```
 
-The migration is mechanical: wrap multiple payload types in `[...]`.
+Migration steps:
+1. Wrap multiple payload types in `[...]`
+2. Wrap struct payloads in `({})`
 
 ## Consequences
 
 ### Benefits
 
-1. **No ambiguity**: `Foo(T)` is always scalar, `Foo([T, U])` is always tuple
-2. **Variant types**: Functions can accept specific variants, improving type safety
-3. **Consistency**: Payload access follows struct/tuple conventions uniformly
-4. **TypeScript familiarity**: Variant cases as types is similar to TypeScript's discriminated unions
-5. **Future-proof**: Clean integration path with literal types
+1. **No ambiguity**: `Foo(T)` is always scalar, `Foo([T, U])` is always tuple, `Foo({...})` is always struct
+2. **Consistent syntax**: All non-unit payloads use `Name(payload)` form
+3. **Variant types**: Functions can accept specific variants, improving type safety
+4. **Subset binding**: Union types enable flexible pattern matching against type subsets
+5. **TypeScript familiarity**: Variant cases as types and union types align with TypeScript patterns
+6. **Future-proof**: Clean integration path with literal types
 
 ### Trade-offs
 
-1. **More verbose**: `Rectangle([f64, f64])` instead of `Rectangle(f64, f64)`
-2. **Learning curve**: Users from Rust may expect implicit tuple expansion
-3. **Implementation complexity**: Variant cases as types require additional type system work
+1. **More verbose**: `Rectangle([f64, f64])` and `Named({...})` are longer
+2. **Different from Rust**: Users from Rust may expect implicit tuple expansion and `Name { }` syntax
+3. **Implementation complexity**: Variant cases as types and subset binding require additional type system work
 
 ### Comparison with Rust
 
 | Aspect | Rust | Wado |
 |--------|------|------|
 | Multiple payloads | `Foo(T, U)` implicit tuple | `Foo([T, U])` explicit |
-| Struct variants | `Foo { a: T }` | `Foo { a: T }` (same) |
+| Struct variants | `Foo { a: T }` | `Foo({ a: T })` with parens |
 | Variant as type | Not supported | `Shape::Circle` is a type |
-| Empty variants | Unit/tuple/struct behave differently | Unit only: `Foo` |
+| Empty variants | Unit/tuple/struct differ | Unit only: `Foo` |
+| Union types | Not supported | `A \| B` with subset binding |
 
-## Open Questions
+## Implementation Roadmap
 
-1. **Syntax for variant type annotation**: `Shape::Circle` vs `Shape.Circle` vs other?
-2. **Exhaustiveness**: How does the type checker verify all variants are handled?
-3. **Coercion**: Should `Shape::Circle` auto-coerce to `Shape` in all contexts?
-4. **Generic bounds**: Can we write `fn foo<T: Shape::Circle | Shape::Rectangle>(x: T)`?
+Current status: variant construction, single-payload if-let pattern matching, and value semantics work for the old syntax.
+
+### Phase 1: Syntax Update
+
+- [ ] Update parser for explicit tuple payload `Name([T, U])`
+- [ ] Update parser for struct payload with parens `Name({ field: T })`
+- [ ] Reject implicit tuple expansion `Name(T, U)`
+- [ ] Update existing tests and fixtures
+
+### Phase 2: Pattern Matching
+
+- [ ] Tuple payload patterns (`if let Rectangle([w, h]) = shape`)
+- [ ] Struct payload patterns (`if let Named({ width, height }) = shape`)
+- [ ] Unit payload patterns with else (`if let Point = shape { ... } else { ... }`)
+- [ ] `while let` / `for let` with custom variants
+- [ ] `match` expressions and statements
+- [ ] Generic variant pattern matching (`if let Some(x) = maybe` for `Maybe<T>`)
+- [ ] `Result<T, E>` pattern matching (`if let Ok(v) = result`, `if let Err(e) = result`)
+
+### Phase 3: Variant Cases as Types
+
+- [ ] Variant case as standalone type (`Shape::Circle` as a type)
+- [ ] Implicit coercion from variant case to variant type
+- [ ] Field access on variant case types (`.0`, `.field`)
+- [ ] Generic variant case types (`Option::<i32>::Some`)
+
+### Phase 4: Union Types & Subset Binding
+
+- [ ] Union type syntax (`A | B`)
+- [ ] Union type flattening (`(A | B) | C` → `A | B | C`)
+- [ ] Discriminant generation for union types
+- [ ] Subset binding in `if let` (`if let x: A | B = abc`)
+- [ ] Exhaustiveness checking for union types
+
+### Completed
+
+- [x] Variant construction (`Option::<T>::Some(x)`, `Color::Red`, `Shape::Circle(r)`)
+- [x] Option pattern matching (`if let Some(x) = ...`)
+- [x] Custom variant pattern matching (single-payload: `if let Circle(r) = shape`)
+- [x] Value semantics (copy) for custom variants

--- a/docs/wep-2026-01-25-variant-payload-design.md
+++ b/docs/wep-2026-01-25-variant-payload-design.md
@@ -51,12 +51,12 @@ This approach:
 
 Wado variants support exactly four payload forms with **consistent syntax**:
 
-| Form       | Syntax                    | Example                              | Description                |
-| ---------- | ------------------------- | ------------------------------------ | -------------------------- |
-| **Unit**   | `Name`                    | `Point`                              | No payload                 |
-| **Scalar** | `Name(T)`                 | `Circle(f64)`                        | Single value               |
-| **Tuple**  | `Name([T, U, ...])`       | `Rectangle([f64, f64])`              | Explicit tuple type        |
-| **Struct** | `Name({ field: T, ... })` | `Named({ width: f64, height: f64 })` | Anonymous struct in parens |
+| Form       | Syntax                    | Example                              | Description                           |
+| ---------- | ------------------------- | ------------------------------------ | ------------------------------------- |
+| **Unit**   | `Name`                    | `Point`                              | Sugar for `Name(())`, payload is `()` |
+| **Scalar** | `Name(T)`                 | `Circle(f64)`                        | Single value                          |
+| **Tuple**  | `Name([T, U, ...])`       | `Rectangle([f64, f64])`              | Explicit tuple type                   |
+| **Struct** | `Name({ field: T, ... })` | `Named({ width: f64, height: f64 })` | Anonymous struct in parens            |
 
 Key principles:
 
@@ -179,6 +179,7 @@ fn circle_area(c: Shape::Circle) -> f64 {
 
 | Payload Type | Access Syntax              | Example                           |
 | ------------ | -------------------------- | --------------------------------- |
+| Unit         | `.0`                       | `point.0` → `()`                  |
 | Scalar       | `.0`                       | `circle.0` → the value            |
 | Tuple        | `.0` then `.0`, `.1`, etc. | `rect.0.0`, `rect.0.1`            |
 | Struct       | `.0` then `.field`         | `named.0.width`, `named.0.height` |
@@ -372,6 +373,43 @@ let list = List::Cons({
 });
 ```
 
+### Unit Variants as Syntactic Sugar
+
+Unit variants are syntactic sugar for `Name(())` - a variant with unit type payload:
+
+```wado
+variant Maybe<T> {
+    Some(T),
+    None,        // internally None(())
+}
+
+// Construction - all equivalent
+let n = Maybe::<i32>::None;
+let n = Maybe::<i32>::None();
+let n = Maybe::<i32>::None(());
+
+// Access - .0 returns unit
+let unit = n.0;  // ()
+
+// Pattern matching - all equivalent
+match maybe {
+    Some(x) => ...,
+    None => ...,      // preferred (short form)
+}
+match maybe {
+    Some(x) => ...,
+    None() => ...,    // also valid
+}
+match maybe {
+    Some(x) => ...,
+    None(()) => ...,  // also valid (explicit)
+}
+```
+
+This ensures **all variant cases have a payload** (unit cases have `()` payload), making `.0` access uniformly valid.
+
+Display/debug output uses the short form: `None` not `None(())`.
+
 ### Single-Element and Zero-Element Tuples
 
 No special rules - these are allowed even if rarely useful:
@@ -379,15 +417,21 @@ No special rules - these are allowed even if rarely useful:
 ```wado
 variant Wrapper {
     Single([i32]),     // single-element tuple payload
-    Empty([]),         // zero-element tuple payload (not same as unit)
+    Empty([]),         // zero-element tuple payload
+    Unit,              // unit payload = Unit(())
 }
 
 let s = Wrapper::Single([42]);
 let val = s.0.0;  // 42
 
 let e = Wrapper::Empty([]);
-// e.0 is [] (empty tuple)
+// e.0 is [] (empty tuple), NOT same as ()
+
+let u = Wrapper::Unit;
+// u.0 is () (unit value)
 ```
+
+Note: `[]` (empty tuple) and `()` (unit) are distinct types.
 
 ### Pattern Matching Syntax
 

--- a/docs/wep-2026-01-25-variant-payload-design.md
+++ b/docs/wep-2026-01-25-variant-payload-design.md
@@ -60,6 +60,7 @@ Wado variants support exactly four payload forms with **consistent syntax**:
 Key principles:
 - **No implicit tuple expansion**: Multiple values require explicit tuple syntax `[T, U]` or struct syntax `{ a: T, b: U }`
 - **Consistent wrapper**: All non-unit payloads use `Name(payload)` form
+- **Minimal special rules**: Edge cases like single-element tuples `Foo([T])` or zero-element tuples `Foo([])` are allowed
 
 ```wado
 variant Shape {
@@ -123,6 +124,22 @@ let opt: Option<i32> = some;  // confirms the type
 
 Type inference is encouraged over explicit turbofish notation.
 
+#### None and Polymorphic Unit Cases
+
+For unit cases like `None` that don't use the type parameter, the type can be inferred from context:
+
+```wado
+// All equivalent:
+let none: Option<i32> = Option::<i32>::None;  // canonical
+let none: Option<i32> = Option::None;          // type from annotation
+let none: Option<i32> = null;                  // null coerces to Option::None
+
+// Error: T cannot be inferred
+let none = Option::None;  // compile error
+```
+
+The `null` literal is a singleton value that implicitly coerces to `Option::None` for any `T`.
+
 ### 4. Pattern Matching
 
 ```wado
@@ -135,8 +152,15 @@ fn area(s: Shape) -> f64 {
     }
 }
 
+// Full path also works in patterns
+match s {
+    Shape::Circle(r) => ...,
+    Shape::Rectangle([w, h]) => ...,
+    ...
+}
+
 // if let for single variant
-if let Circle(r) = shape {
+if let Shape::Circle(r) = shape {
     println(`radius: {r}`);
 }
 
@@ -148,22 +172,34 @@ fn circle_area(c: Shape::Circle) -> f64 {
 
 ### 5. Accessing Payload Fields
 
+**Payload is always at `.0`** - this provides consistent access regardless of payload type:
+
 | Payload Type | Access Syntax | Example |
 |--------------|---------------|---------|
-| Scalar | `.0` | `circle.0` → radius |
-| Tuple | `.0`, `.1`, etc. | `rect.0`, `rect.1` |
-| Struct | `.field` | `named.width`, `named.height` |
+| Scalar | `.0` | `circle.0` → the value |
+| Tuple | `.0` then `.0`, `.1`, etc. | `rect.0.0`, `rect.0.1` |
+| Struct | `.0` then `.field` | `named.0.width`, `named.0.height` |
 
 ```wado
 let c: Shape::Circle = Shape::Circle(5.0);
 let radius = c.0;           // 5.0
 
 let r: Shape::Rectangle = Shape::Rectangle([10.0, 20.0]);
-let width = r.0;            // 10.0 (tuple .0)
-let height = r.1;           // 20.0 (tuple .1)
+let tuple = r.0;            // [f64, f64]
+let width = r.0.0;          // 10.0
+let height = r.0.1;         // 20.0
 
 let n: Shape::Named = Shape::Named({ width: 10.0, height: 20.0 });
-let w = n.width;            // 10.0
+let payload = n.0;          // { width: f64, height: f64 }
+let w = n.0.width;          // 10.0
+```
+
+In practice, pattern matching is preferred (99% of cases):
+
+```wado
+if let Shape::Rectangle([w, h]) = shape {
+    println(`{w} x {h}`);
+}
 ```
 
 ## Union Type & Subset Binding
@@ -172,7 +208,7 @@ Beyond named variants, Wado supports anonymous union types with a powerful **sub
 
 ### Union Types
 
-Union types are anonymous sum types that flatten automatically:
+Union types are anonymous sum types with set semantics:
 
 ```wado
 type A = { kind: "a", a: i32 };
@@ -186,6 +222,54 @@ type ABCD = AB | CD;  // flattens to A | B | C | D
 ```
 
 Internally, union types have a discriminant (tag) just like variants.
+
+#### Union with Primitives
+
+Union types work with any types, including primitives:
+
+```wado
+type IntOrString = i32 | String;
+
+fn process(x: IntOrString) {
+    if let n: i32 = x {
+        println(`int: {n}`);
+    } else if let s: String = x {
+        println(`string: {s}`);
+    }
+}
+```
+
+#### Union of Variant Cases
+
+Variant cases can be combined into union types:
+
+```wado
+variant Shape { Circle(f64), Rectangle([f64, f64]), Point }
+
+type CircleOrRect = Shape::Circle | Shape::Rectangle;
+
+fn process_non_point(s: CircleOrRect) {
+    // Only Circle or Rectangle, Point is excluded at type level
+}
+```
+
+### Normalization Rules
+
+Union types follow set semantics with normalization:
+
+```wado
+// Flattening
+type AB = A | B;
+type BA = B | A;
+type ABBA = AB | BA;      // normalizes to A | B (order: first occurrence)
+
+// Duplicate handling - becomes Union<A>, not bare A
+type AA = A | A;          // Union<A> - requires match binding to use
+
+// Why Union<A> instead of A?
+// Consistency: all union types require subset binding/match
+// Edge case, but consistent rules are more important
+```
 
 ### Subset Binding
 
@@ -210,6 +294,16 @@ fn process(x: ABCD) {
         // a: A
         println(`got A with a={a.a}`);
     }
+}
+```
+
+Subset binding also works in match expressions:
+
+```wado
+match x {
+    ab: A | B => println("A or B"),
+    c: C => println("C"),
+    d: D => println("D"),
 }
 ```
 
@@ -244,6 +338,86 @@ fn process(x: A | B | C | D) {
 
 Wado's approach is more declarative - no need for manual type guard functions.
 
+## Edge Cases
+
+### Empty Variant
+
+Empty variants are allowed (uninhabited type):
+
+```wado
+variant Empty {}  // valid, no values can exist
+```
+
+### Recursive Variants
+
+Self-referential variants are supported:
+
+```wado
+variant List<T> {
+    Cons({ head: T, tail: List<T> }),
+    Nil,
+}
+
+let list = List::Cons({
+    head: 1,
+    tail: List::Cons({
+        head: 2,
+        tail: List::Nil,
+    }),
+});
+```
+
+### Single-Element and Zero-Element Tuples
+
+No special rules - these are allowed even if rarely useful:
+
+```wado
+variant Wrapper {
+    Single([i32]),     // single-element tuple payload
+    Empty([]),         // zero-element tuple payload (not same as unit)
+}
+
+let s = Wrapper::Single([42]);
+let val = s.0.0;  // 42
+
+let e = Wrapper::Empty([]);
+// e.0 is [] (empty tuple)
+```
+
+### Pattern Matching Syntax
+
+Both short and full paths work in patterns:
+
+```wado
+// Short form (within match on known variant type)
+match shape {
+    Circle(r) => ...,
+    Rectangle([w, h]) => ...,
+    Point => ...,
+}
+
+// Full path (always valid)
+match shape {
+    Shape::Circle(r) => ...,
+    Shape::Rectangle([w, h]) => ...,
+    Shape::Point => ...,
+}
+
+// if let requires full path for clarity
+if let Shape::Circle(r) = shape { ... }
+```
+
+### Wildcard in Patterns
+
+Wildcards work as expected:
+
+```wado
+if let Shape::Rectangle([w, _]) = shape {
+    // Ignore height
+    println(`width: {w}`);
+}
+```
+
 ## Migration from Current Syntax
 
 Current:
@@ -276,14 +450,15 @@ Migration steps:
 
 1. **No ambiguity**: `Foo(T)` is always scalar, `Foo([T, U])` is always tuple, `Foo({...})` is always struct
 2. **Consistent syntax**: All non-unit payloads use `Name(payload)` form
-3. **Variant types**: Functions can accept specific variants, improving type safety
-4. **Subset binding**: Union types enable flexible pattern matching against type subsets
-5. **TypeScript familiarity**: Variant cases as types and union types align with TypeScript patterns
-6. **Future-proof**: Clean integration path with literal types
+3. **Consistent access**: Payload is always at `.0`
+4. **Variant types**: Functions can accept specific variants, improving type safety
+5. **Subset binding**: Union types enable flexible pattern matching against type subsets
+6. **TypeScript familiarity**: Variant cases as types and union types align with TypeScript patterns
+7. **Minimal special rules**: Edge cases (empty variants, single-element tuples) just work
 
 ### Trade-offs
 
-1. **More verbose**: `Rectangle([f64, f64])` and `Named({...})` are longer
+1. **More verbose**: `r.0.0` instead of `r.0` for tuple element access
 2. **Different from Rust**: Users from Rust may expect implicit tuple expansion and `Name { }` syntax
 3. **Implementation complexity**: Variant cases as types and subset binding require additional type system work
 
@@ -293,6 +468,7 @@ Migration steps:
 |--------|------|------|
 | Multiple payloads | `Foo(T, U)` implicit tuple | `Foo([T, U])` explicit |
 | Struct variants | `Foo { a: T }` | `Foo({ a: T })` with parens |
+| Payload access | `.0`, `.1` directly | `.0.0`, `.0.1` (payload at `.0`) |
 | Variant as type | Not supported | `Shape::Circle` is a type |
 | Empty variants | Unit/tuple/struct differ | Unit only: `Foo` |
 | Union types | Not supported | `A \| B` with subset binding |
@@ -322,15 +498,16 @@ Current status: variant construction, single-payload if-let pattern matching, an
 
 - [ ] Variant case as standalone type (`Shape::Circle` as a type)
 - [ ] Implicit coercion from variant case to variant type
-- [ ] Field access on variant case types (`.0`, `.field`)
+- [ ] Field access on variant case types (`.0` for payload)
 - [ ] Generic variant case types (`Option::<i32>::Some`)
 
 ### Phase 4: Union Types & Subset Binding
 
 - [ ] Union type syntax (`A | B`)
-- [ ] Union type flattening (`(A | B) | C` → `A | B | C`)
+- [ ] Union type normalization (flattening, deduplication to `Union<A>`)
 - [ ] Discriminant generation for union types
 - [ ] Subset binding in `if let` (`if let x: A | B = abc`)
+- [ ] Subset binding in `match`
 - [ ] Exhaustiveness checking for union types
 
 ### Completed

--- a/docs/wep-2026-01-25-variant-payload-design.md
+++ b/docs/wep-2026-01-25-variant-payload-design.md
@@ -1,0 +1,225 @@
+# WEP: Variant Payload Design
+
+## Context
+
+Rust's enum payload system has been criticized for being ad-hoc:
+
+1. **Three variant forms**: unit, tuple, and struct variants with subtly different behaviors
+2. **Implicit tuple expansion**: `Foo(a, b)` vs `Foo((a, b))` distinction is confusing
+3. **Variants are not types**: Cannot write `fn process(c: Shape::Circle)` directly
+4. **Inconsistencies**: Unit vs empty tuple vs empty struct have different initialization rules
+
+Wado's variant system should learn from these issues and provide a cleaner, more consistent design.
+
+### Current Wado Syntax
+
+```wado
+variant Shape {
+    Circle(f64),           // single payload
+    Rectangle(f64, f64),   // multiple payloads (implicit tuple)
+    Point,                 // unit
+}
+```
+
+The `Rectangle(f64, f64)` form implicitly creates a tuple, which mirrors Rust's problematic design.
+
+### TypeScript's Approach
+
+TypeScript uses discriminated unions with literal types:
+
+```typescript
+type Shape =
+    | { kind: "circle"; radius: number }
+    | { kind: "rectangle"; width: number; height: number }
+    | { kind: "point" };
+
+// Each variant is a standalone type
+type Circle = Extract<Shape, { kind: "circle" }>;
+
+function processCircle(c: Circle) { ... }
+```
+
+This approach:
+- Makes each variant a first-class type
+- Uses structural typing for discrimination
+- No special "variant" keyword needed
+
+## Decision
+
+### 1. Payload Forms
+
+Wado variants support exactly four payload forms:
+
+| Form | Syntax | Example | Description |
+|------|--------|---------|-------------|
+| **Unit** | `Name` | `Point` | No payload |
+| **Scalar** | `Name(T)` | `Circle(f64)` | Single value |
+| **Tuple** | `Name([T, U, ...])` | `Rectangle([f64, f64])` | Explicit tuple type |
+| **Struct** | `Name { field: T, ... }` | `Named { width: f64, height: f64 }` | Anonymous struct |
+
+Key principle: **No implicit tuple expansion**. Multiple values require explicit tuple syntax `[T, U]` or struct syntax `{ a: T, b: U }`.
+
+```wado
+variant Shape {
+    Point,                              // unit
+    Circle(f64),                        // scalar
+    Rectangle([f64, f64]),              // explicit tuple
+    Named { width: f64, height: f64 },  // anonymous struct
+}
+
+// Construction
+let p = Shape::Point;
+let c = Shape::Circle(5.0);
+let r = Shape::Rectangle([10.0, 20.0]);   // tuple literal required
+let n = Shape::Named { width: 10.0, height: 20.0 };
+```
+
+### 2. Variant Cases as Types
+
+Each variant case is also a type that can be used independently:
+
+```wado
+variant Shape {
+    Circle(f64),
+    Rectangle([f64, f64]),
+    Point,
+}
+
+// Shape::Circle is a type
+fn process_circle(c: Shape::Circle) {
+    // c.0 is the radius (f64)
+    println(`radius: {c.0}`);
+}
+
+// Can construct without full path when type is known
+let circle: Shape::Circle = Shape::Circle(5.0);
+
+// Subtype relationship: Shape::Circle <: Shape
+let shape: Shape = circle;  // OK: upcast
+```
+
+This enables:
+- Functions that accept only specific variants
+- No need for `unreachable!()` in match arms
+- Better type safety and documentation
+
+### 3. Pattern Matching with Variant Types
+
+```wado
+fn area(s: Shape) -> f64 {
+    match s {
+        Shape::Circle(r) => 3.14159 * r * r,
+        Shape::Rectangle([w, h]) => w * h,
+        Shape::Named { width, height } => width * height,
+        Shape::Point => 0.0,
+    }
+}
+
+// When parameter type is Shape::Circle, no match needed
+fn circle_area(c: Shape::Circle) -> f64 {
+    return 3.14159 * c.0 * c.0;
+}
+```
+
+### 4. Accessing Payload Fields
+
+| Payload Type | Access Syntax | Example |
+|--------------|---------------|---------|
+| Scalar | `.0` | `circle.0` → radius |
+| Tuple | `.0`, `.1`, etc. | `rect.0`, `rect.1` |
+| Struct | `.field` | `named.width`, `named.height` |
+
+```wado
+let c = Shape::Circle(5.0);
+let radius = c.0;           // 5.0
+
+let r = Shape::Rectangle([10.0, 20.0]);
+let width = r.0;            // 10.0
+let height = r.1;           // 20.0
+
+let n = Shape::Named { width: 10.0, height: 20.0 };
+let w = n.width;            // 10.0
+```
+
+### 5. Generic Variants
+
+```wado
+variant Option<T> {
+    Some(T),
+    None,
+}
+
+// Option::Some<i32> is a type
+let some: Option::Some<i32> = Option::Some(42);
+
+// Subtype: Option::Some<i32> <: Option<i32>
+let opt: Option<i32> = some;
+```
+
+### 6. Integration with Literal Types (Future)
+
+When literal types are introduced, variant cases naturally integrate:
+
+```wado
+// Discriminant field with literal type
+type Circle = Shape::Circle;  // { tag: "Circle", 0: f64 }
+
+// Could potentially allow structural matching
+type JsonValue =
+    | { type: "null" }
+    | { type: "bool", value: bool }
+    | { type: "number", value: f64 }
+    | { type: "string", value: String };
+```
+
+## Migration from Current Syntax
+
+Current:
+```wado
+variant Shape {
+    Rectangle(f64, f64),  // implicit tuple
+}
+let r = Shape::Rectangle(10.0, 20.0);
+```
+
+New:
+```wado
+variant Shape {
+    Rectangle([f64, f64]),  // explicit tuple
+}
+let r = Shape::Rectangle([10.0, 20.0]);
+```
+
+The migration is mechanical: wrap multiple payload types in `[...]`.
+
+## Consequences
+
+### Benefits
+
+1. **No ambiguity**: `Foo(T)` is always scalar, `Foo([T, U])` is always tuple
+2. **Variant types**: Functions can accept specific variants, improving type safety
+3. **Consistency**: Payload access follows struct/tuple conventions uniformly
+4. **TypeScript familiarity**: Variant cases as types is similar to TypeScript's discriminated unions
+5. **Future-proof**: Clean integration path with literal types
+
+### Trade-offs
+
+1. **More verbose**: `Rectangle([f64, f64])` instead of `Rectangle(f64, f64)`
+2. **Learning curve**: Users from Rust may expect implicit tuple expansion
+3. **Implementation complexity**: Variant cases as types require additional type system work
+
+### Comparison with Rust
+
+| Aspect | Rust | Wado |
+|--------|------|------|
+| Multiple payloads | `Foo(T, U)` implicit tuple | `Foo([T, U])` explicit |
+| Struct variants | `Foo { a: T }` | `Foo { a: T }` (same) |
+| Variant as type | Not supported | `Shape::Circle` is a type |
+| Empty variants | Unit/tuple/struct behave differently | Unit only: `Foo` |
+
+## Open Questions
+
+1. **Syntax for variant type annotation**: `Shape::Circle` vs `Shape.Circle` vs other?
+2. **Exhaustiveness**: How does the type checker verify all variants are handled?
+3. **Coercion**: Should `Shape::Circle` auto-coerce to `Shape` in all contexts?
+4. **Generic bounds**: Can we write `fn foo<T: Shape::Circle | Shape::Rectangle>(x: T)`?


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive design document for Wado's variant system that addresses ambiguities in Rust's enum design. It establishes a cleaner, more consistent approach to variant payloads with explicit syntax, variant cases as types, and support for union types with subset binding.

## Key Changes

- **New WEP Document**: Added `docs/wep-2026-01-25-variant-payload-design.md` with complete variant system design
  - Defines four explicit payload forms: unit, scalar, tuple `[T, U]`, and struct `{ field: T }`
  - Eliminates implicit tuple expansion (Rust's `Foo(T, U)` becomes `Foo([T, U])`)
  - Establishes consistent payload access via `.0` for all non-unit variants
  
- **Variant Cases as Types**: Each variant case becomes a usable type
  - Functions can accept specific variants: `fn process(c: Shape::Circle)`
  - Implicit coercion from variant case to parent variant type
  - Enables better type safety and eliminates need for `unreachable!()` patterns

- **Union Types & Subset Binding**: Introduces anonymous union types with powerful pattern matching
  - Union syntax: `A | B | C` with set semantics and normalization
  - Subset binding allows matching against any subset: `if let x: A | B = abc`
  - Works with both named variants and primitive types

- **Updated Compiler Roadmap**: Reorganized `docs/compiler.md` to reference the new WEP
  - Consolidated variant-related TODOs into the WEP document
  - Updated pattern matching checklist with clearer descriptions
  - Replaced "Variant Implementation Roadmap" section with reference to WEP

- **Updated AGENTS.md**: Added link to new WEP in the WEPs list

## Notable Design Decisions

1. **Explicit over Implicit**: `Foo([T, U])` instead of `Foo(T, U)` eliminates ambiguity with single-value payloads
2. **Consistent Wrapper**: All non-unit payloads use `Name(payload)` form, including struct variants `Name({ field: T })`
3. **Payload Always at `.0`**: Provides uniform access regardless of payload type (scalar, tuple, or struct)
4. **Normalization Rules**: Union types flatten and deduplicate, with `A | A` becoming `Union<A>` for consistency
5. **Four-Phase Implementation**: Syntax update → pattern matching → variant types → union types

## Migration Path

The design includes a clear migration path from current syntax:
- `Rectangle(f64, f64)` → `Rectangle([f64, f64])`
- `Named { width: f64 }` → `Named({ width: f64 })`

This PR establishes the foundation for implementing a more principled variant system that learns from Rust's design while providing additional capabilities like union types and subset binding.