### PR TITLE
Add SIMD v128 types specification (WEP-2026-01-31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Global Variables](./docs/wep-2026-01-27-global-variables.md)
 - [WIT and Wado Mapping](./docs/wep-2026-01-29-wit-wado-mapping.md)
 - [Newtype Semantics](./docs/wep-2026-01-29-newtype-semantics.md)
+- [SIMD v128 Types](./docs/wep-2026-01-31-simd-v128.md)
 
 ### Structure
 

--- a/docs/wep-2026-01-31-simd-v128.md
+++ b/docs/wep-2026-01-31-simd-v128.md
@@ -10,6 +10,13 @@ Key constraints from Wasm GC:
 - v128 cannot be referenced (no `&v128`)
 - v128 can only exist as locals, parameters, return values, and globals
 
+## Prerequisites
+
+This proposal depends on:
+
+- **Const generics**: Required for `replace_lane::<N>()` and `shuffle::<L0, L1, ...>()`
+- **Non-reference self**: v128 cannot be referenced, so methods use `self` (by value) instead of `&self`
+
 ## Decision
 
 ### Base Types
@@ -214,19 +221,19 @@ Shuffle signature varies by type:
 
 ```wado
 impl i32x4 {
-    fn shuffle<const L0, const L1, const L2, const L3>(&self, other: i32x4) -> i32x4;
+    fn shuffle<const L0, const L1, const L2, const L3>(self, other: i32x4) -> i32x4;
 }
 
 impl i16x8 {
     fn shuffle<const L0, const L1, const L2, const L3,
-               const L4, const L5, const L6, const L7>(&self, other: i16x8) -> i16x8;
+               const L4, const L5, const L6, const L7>(self, other: i16x8) -> i16x8;
 }
 
 impl i8x16 {
     fn shuffle<const L0, const L1, const L2, const L3,
                const L4, const L5, const L6, const L7,
                const L8, const L9, const L10, const L11,
-               const L12, const L13, const L14, const L15>(&self, other: i8x16) -> i8x16;
+               const L12, const L13, const L14, const L15>(self, other: i8x16) -> i8x16;
 }
 ```
 

--- a/docs/wep-2026-01-31-simd-v128.md
+++ b/docs/wep-2026-01-31-simd-v128.md
@@ -73,15 +73,15 @@ Type-level separation provides sufficient safety while keeping usage ergonomic.
 
 v128 types have special restrictions enforced by the compiler:
 
-| Operation | Allowed |
-|-----------|---------|
-| Struct field | ❌ No |
-| Array element | ❌ No |
-| Reference (`&v128`) | ❌ No |
-| Function parameter | ✅ Yes |
-| Function return | ✅ Yes |
-| Local variable | ✅ Yes |
-| Global variable | ✅ Yes |
+| Operation           | Allowed |
+| ------------------- | ------- |
+| Struct field        | ❌ No   |
+| Array element       | ❌ No   |
+| Reference (`&v128`) | ❌ No   |
+| Function parameter  | ✅ Yes  |
+| Function return     | ✅ Yes  |
+| Local variable      | ✅ Yes  |
+| Global variable     | ✅ Yes  |
 
 ### Construction
 
@@ -114,12 +114,12 @@ let fourth = v.3;   // 40: i32
 
 Lane indices are validated at compile time based on the type:
 
-| Type | Valid lanes |
-|------|-------------|
-| `i8x16`, `u8x16` | `.0` to `.15` |
-| `i16x8`, `u16x8` | `.0` to `.7` |
-| `i32x4`, `u32x4`, `f32x4` | `.0` to `.3` |
-| `i64x2`, `u64x2`, `f64x2` | `.0` to `.1` |
+| Type                      | Valid lanes   |
+| ------------------------- | ------------- |
+| `i8x16`, `u8x16`          | `.0` to `.15` |
+| `i16x8`, `u16x8`          | `.0` to `.7`  |
+| `i32x4`, `u32x4`, `f32x4` | `.0` to `.3`  |
+| `i64x2`, `u64x2`, `f64x2` | `.0` to `.1`  |
 
 ### Lane Replacement
 

--- a/docs/wep-2026-01-31-simd-v128.md
+++ b/docs/wep-2026-01-31-simd-v128.md
@@ -58,6 +58,17 @@ pub type f32x4_relaxed = v128_relaxed;
 pub type f64x2_relaxed = v128_relaxed;
 ```
 
+### Relaxed SIMD is Not an Effect
+
+Relaxed SIMD's non-determinism is handled via separate types (`v128_relaxed`), not effects. Rationale:
+
+1. **Deterministic within environment**: Results vary across hardware but are consistent within a single runtime
+2. **Not handleable**: Unlike I/O effects, hardware behavior cannot be intercepted or mocked
+3. **Consistency with floats**: Standard f32/f64 also have NaN non-determinism but are not effects
+4. **Performance focus**: Relaxed SIMD exists for speed; effect propagation would add friction
+
+Type-level separation provides sufficient safety while keeping usage ergonomic.
+
 ### Restrictions
 
 v128 types have special restrictions enforced by the compiler:

--- a/docs/wep-2026-01-31-simd-v128.md
+++ b/docs/wep-2026-01-31-simd-v128.md
@@ -1,0 +1,323 @@
+# SIMD v128 Types
+
+## Context
+
+WebAssembly SIMD provides 128-bit vector operations for parallel data processing. Wado needs to expose these capabilities while maintaining type safety and clarity about deterministic vs non-deterministic operations.
+
+Key constraints from Wasm GC:
+
+- v128 cannot be stored in GC struct or array fields
+- v128 cannot be referenced (no `&v128`)
+- v128 can only exist as locals, parameters, return values, and globals
+
+## Decision
+
+### Base Types
+
+Two primitive base types that provide no operations directly:
+
+```wado
+#[primitive]
+type v128;           // Deterministic SIMD
+
+#[primitive]
+type v128_relaxed;   // Non-deterministic (Relaxed SIMD)
+```
+
+### Interpretation Types (Newtypes)
+
+Concrete interpretations as newtypes with operator overloading:
+
+```wado
+// Signed integer interpretations
+pub type i8x16 = v128;
+pub type i16x8 = v128;
+pub type i32x4 = v128;
+pub type i64x2 = v128;
+
+// Unsigned integer interpretations
+pub type u8x16 = v128;
+pub type u16x8 = v128;
+pub type u32x4 = v128;
+pub type u64x2 = v128;
+
+// Floating-point interpretations
+pub type f32x4 = v128;
+pub type f64x2 = v128;
+
+// Relaxed variants (non-deterministic)
+pub type i8x16_relaxed = v128_relaxed;
+pub type i16x8_relaxed = v128_relaxed;
+pub type i32x4_relaxed = v128_relaxed;
+pub type i64x2_relaxed = v128_relaxed;
+pub type u8x16_relaxed = v128_relaxed;
+pub type u16x8_relaxed = v128_relaxed;
+pub type u32x4_relaxed = v128_relaxed;
+pub type u64x2_relaxed = v128_relaxed;
+pub type f32x4_relaxed = v128_relaxed;
+pub type f64x2_relaxed = v128_relaxed;
+```
+
+### Restrictions
+
+v128 types have special restrictions enforced by the compiler:
+
+| Operation | Allowed |
+|-----------|---------|
+| Struct field | ❌ No |
+| Array element | ❌ No |
+| Reference (`&v128`) | ❌ No |
+| Function parameter | ✅ Yes |
+| Function return | ✅ Yes |
+| Local variable | ✅ Yes |
+| Global variable | ✅ Yes |
+
+### Construction
+
+From tuple literals via coercion:
+
+```wado
+let v: i32x4 = [1, 2, 3, 4];
+let f: f32x4 = [1.0, 2.0, 3.0, 4.0];
+let bytes: u8x16 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+```
+
+Splat (broadcast single value to all lanes):
+
+```wado
+let zeros = i32x4::splat(0);       // [0, 0, 0, 0]
+let ones = f64x2::splat(1.0);      // [1.0, 1.0]
+```
+
+### Lane Access
+
+Read lanes using tuple-style dot notation:
+
+```wado
+let v: i32x4 = [10, 20, 30, 40];
+let first = v.0;    // 10: i32
+let second = v.1;   // 20: i32
+let third = v.2;    // 30: i32
+let fourth = v.3;   // 40: i32
+```
+
+Lane indices are validated at compile time based on the type:
+
+| Type | Valid lanes |
+|------|-------------|
+| `i8x16`, `u8x16` | `.0` to `.15` |
+| `i16x8`, `u16x8` | `.0` to `.7` |
+| `i32x4`, `u32x4`, `f32x4` | `.0` to `.3` |
+| `i64x2`, `u64x2`, `f64x2` | `.0` to `.1` |
+
+### Lane Replacement
+
+Create a new vector with one lane replaced (v128 is immutable):
+
+```wado
+let v: i32x4 = [10, 20, 30, 40];
+let v2 = v.replace_lane::<2>(99);  // [10, 20, 99, 40]
+
+// Lane index is a const generic, validated at compile time
+let v3 = v.replace_lane::<0>(100); // [100, 20, 30, 40]
+```
+
+### Operators
+
+Arithmetic operators via trait implementations:
+
+```wado
+let a: i32x4 = [1, 2, 3, 4];
+let b: i32x4 = [10, 20, 30, 40];
+
+// Arithmetic
+let sum = a + b;        // [11, 22, 33, 44]
+let diff = a - b;       // [-9, -18, -27, -36]
+let prod = a * b;       // [10, 40, 90, 160]
+
+// Bitwise
+let and = a & b;
+let or = a | b;
+let xor = a ^ b;
+let not = ~a;
+
+// Shifts (by scalar)
+let shl = a << 2;       // Each lane shifted left by 2
+let shr = a >> 1;       // Each lane shifted right by 1
+
+// Negation
+let neg = -a;           // [-1, -2, -3, -4]
+```
+
+Floating-point operations:
+
+```wado
+let a: f32x4 = [1.0, 2.0, 3.0, 4.0];
+let b: f32x4 = [2.0, 2.0, 2.0, 2.0];
+
+let sum = a + b;        // [3.0, 4.0, 5.0, 6.0]
+let div = a / b;        // [0.5, 1.0, 1.5, 2.0]
+let neg = -a;           // [-1.0, -2.0, -3.0, -4.0]
+```
+
+### Type Conversion
+
+Bitwise reinterpretation via `as` cast (zero-cost):
+
+```wado
+let ints: i32x4 = [1, 2, 3, 4];
+let floats: f32x4 = ints as f32x4;           // Reinterpret bits
+let unsigned: u32x4 = ints as u32x4;         // Same bits, different ops
+```
+
+Standard to Relaxed conversion:
+
+```wado
+let std: i32x4 = [1, 2, 3, 4];
+let relaxed: i32x4_relaxed = std as i32x4_relaxed;  // Explicit opt-in
+
+// Relaxed back to standard (bits unchanged, but now deterministic ops)
+let back: i32x4 = relaxed as i32x4;
+```
+
+### Shuffle
+
+Generic shuffle with const generic lane indices:
+
+```wado
+// Two-operand shuffle: select lanes from a (0-3) or b (4-7)
+let a: i32x4 = [10, 20, 30, 40];
+let b: i32x4 = [50, 60, 70, 80];
+
+// Reverse first operand
+let rev = a.shuffle::<3, 2, 1, 0>(a);        // [40, 30, 20, 10]
+
+// Interleave low lanes
+let zip = a.shuffle::<0, 4, 1, 5>(b);        // [10, 50, 20, 60]
+
+// Broadcast lane 0 of a
+let broadcast = a.shuffle::<0, 0, 0, 0>(a);  // [10, 10, 10, 10]
+```
+
+Shuffle signature varies by type:
+
+```wado
+impl i32x4 {
+    fn shuffle<const L0, const L1, const L2, const L3>(&self, other: i32x4) -> i32x4;
+}
+
+impl i16x8 {
+    fn shuffle<const L0, const L1, const L2, const L3,
+               const L4, const L5, const L6, const L7>(&self, other: i16x8) -> i16x8;
+}
+
+impl i8x16 {
+    fn shuffle<const L0, const L1, const L2, const L3,
+               const L4, const L5, const L6, const L7,
+               const L8, const L9, const L10, const L11,
+               const L12, const L13, const L14, const L15>(&self, other: i8x16) -> i8x16;
+}
+```
+
+Single-operand swizzle (runtime indices via i8x16):
+
+```wado
+let v: i8x16 = [...];
+let indices: i8x16 = [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0];
+let reversed = v.swizzle(indices);  // Runtime lane selection
+```
+
+### Global Variables
+
+v128 types can be used in global variables:
+
+```wado
+global ZERO: i32x4 = [0, 0, 0, 0];
+global ONES: f32x4 = [1.0, 1.0, 1.0, 1.0];
+global mut counter: i32x4 = [0, 0, 0, 0];
+
+fn increment() {
+    counter = counter + i32x4::splat(1);
+}
+```
+
+### Comparison Operations
+
+Comparison returns a mask vector (all 1s or all 0s per lane):
+
+```wado
+let a: i32x4 = [1, 5, 3, 8];
+let b: i32x4 = [2, 3, 3, 7];
+
+let eq = a.eq(b);       // i32x4: [0, 0, -1, 0]  (-1 = all bits set)
+let lt = a.lt(b);       // i32x4: [-1, 0, 0, 0]
+let gt = a.gt(b);       // i32x4: [0, -1, 0, -1]
+
+// Use mask for selection
+let max = a.select(gt, b);  // Select a where gt is true, else b
+```
+
+### Builtin Functions
+
+Low-level Wasm instructions exposed as builtins in `builtin.wado`:
+
+```wado
+// Arithmetic
+fn v128_add_i32x4(a: v128, b: v128) -> v128;    // i32x4.add
+fn v128_sub_i32x4(a: v128, b: v128) -> v128;    // i32x4.sub
+fn v128_mul_i32x4(a: v128, b: v128) -> v128;    // i32x4.mul
+
+// Bitwise
+fn v128_and(a: v128, b: v128) -> v128;          // v128.and
+fn v128_or(a: v128, b: v128) -> v128;           // v128.or
+fn v128_xor(a: v128, b: v128) -> v128;          // v128.xor
+fn v128_not(a: v128) -> v128;                   // v128.not
+
+// Lane operations
+fn v128_extract_lane_i32x4<const LANE>(a: v128) -> i32;
+fn v128_replace_lane_i32x4<const LANE>(a: v128, value: i32) -> v128;
+
+// Shuffle (16 const generic lane indices)
+fn v128_shuffle<const L0, const L1, ...>(a: v128, b: v128) -> v128;
+
+// Swizzle (runtime indices)
+fn v128_swizzle(a: v128, indices: v128) -> v128;  // i8x16.swizzle
+
+// Splat
+fn v128_splat_i32x4(value: i32) -> v128;        // i32x4.splat
+
+// Relaxed SIMD (non-deterministic)
+fn v128_relaxed_madd_f32x4(a: v128, b: v128, c: v128) -> v128;  // a*b+c
+fn v128_relaxed_nmadd_f32x4(a: v128, b: v128, c: v128) -> v128; // -(a*b)+c
+```
+
+## Consequences
+
+### Advantages
+
+- **Type safety**: Newtypes prevent accidental mixing of interpretations
+- **Determinism clarity**: Relaxed SIMD requires explicit type conversion
+- **Ergonomic syntax**: Tuple-style lane access, operator overloading
+- **Wasm alignment**: Restrictions match Wasm GC capabilities exactly
+- **Const generics**: Compile-time validation of lane indices and shuffle patterns
+
+### Trade-offs
+
+- **No v128 in structs/arrays**: Users must use scalar types for storage, then load into SIMD registers
+- **Const generics required**: Shuffle and replace_lane need const generic support in the compiler
+- **Many newtypes**: 20+ types (10 standard + 10 relaxed), but clear semantics
+
+### Implementation Notes
+
+1. Add `v128` and `v128_relaxed` as primitive types in `tir.rs`
+2. Implement const generics for lane indices (subset of full const generics)
+3. Add tuple literal coercion for v128 newtypes in type resolution
+4. Generate appropriate Wasm SIMD instructions in codegen
+5. Validate lane indices at compile time based on vector type
+
+### Future Extensions
+
+- SIMD-optimized math functions (`sin`, `cos`, `exp` for f32x4/f64x2)
+- Horizontal operations (`sum_lanes`, `min_lane`, `max_lane`)
+- Conversion operations (`i32x4_trunc_f32x4`, `f32x4_convert_i32x4`)
+- Load/store from linear memory (if Wado adds linear memory support)


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive specification for WebAssembly SIMD v128 type support in Wado, defining how 128-bit vector operations will be exposed while maintaining type safety and clarity about deterministic vs non-deterministic behavior.

## Changes

- **Added WEP-2026-01-31 specification document** (`docs/wep-2026-01-31-simd-v128.md`) covering:
  - Two primitive base types: `v128` (deterministic) and `v128_relaxed` (non-deterministic)
  - 20 newtype interpretations for different lane configurations (i8x16, i16x8, i32x4, i64x2, u8x16, u16x8, u32x4, u64x2, f32x4, f64x2) and their relaxed variants
  - Compiler-enforced restrictions matching WebAssembly GC constraints (no struct/array fields, no references)
  - Construction via tuple literals and splat operations
  - Lane access using tuple-style dot notation (`.0`, `.1`, etc.)
  - Lane replacement with const generic validation
  - Operator overloading for arithmetic, bitwise, and comparison operations
  - Bitwise reinterpretation via `as` casts
  - Generic shuffle with const generic lane indices
  - Runtime swizzle operations
  - Global variable support
  - Builtin function signatures for low-level Wasm instructions

- **Updated AGENTS.md** to reference the new WEP in the documentation index

## Notable Design Decisions

- **Newtypes for type safety**: Prevents accidental mixing of different interpretations (e.g., treating i32x4 bits as f32x4 without explicit cast)
- **Explicit relaxed SIMD opt-in**: Non-deterministic operations require explicit type conversion, making determinism properties clear
- **Const generics for compile-time validation**: Lane indices and shuffle patterns validated at compile time
- **Wasm GC alignment**: Restrictions exactly match WebAssembly GC capabilities (v128 cannot be stored in GC structures)
- **Ergonomic syntax**: Tuple-style lane access and operator overloading for familiar usage patterns

## Implementation Notes

This specification provides the foundation for implementing SIMD support. Key compiler work will include:
- Adding `v128` and `v128_relaxed` as primitive types
- Implementing const generics for lane index validation
- Adding tuple literal coercion for v128 newtypes
- Generating appropriate Wasm SIMD instructions in codegen

https://claude.ai/code/session_013TiyAg6P1EjHWEUBtgyHLD