### PR TITLE
Add Future Considerations section for Flexible Vectors to SIMD WEP

### DIFF
--- a/docs/wep-2026-01-31-simd-v128.md
+++ b/docs/wep-2026-01-31-simd-v128.md
@@ -339,3 +339,60 @@ fn v128_relaxed_nmadd_f32x4(a: v128, b: v128, c: v128) -> v128; // -(a*b)+c
 - Horizontal operations (`sum_lanes`, `min_lane`, `max_lane`)
 - Conversion operations (`i32x4_trunc_f32x4`, `f32x4_convert_i32x4`)
 - Load/store from linear memory (if Wado adds linear memory support)
+
+### Future Considerations: Flexible Vectors
+
+The [WebAssembly Flexible Vectors proposal](https://github.com/WebAssembly/flexible-vectors) introduces variable-width vector types (`vec.i32`, `vec.f32`, etc.) where lane count is determined at runtime rather than compile time. This would enable exploitation of wider SIMD hardware (AVX-512, ARM SVE).
+
+#### Current Status (as of January 2026)
+
+- Proposal remains at Phase 1 since 2019
+- [Cranelift infrastructure work](https://github.com/bytecodealliance/wasmtime/issues/4418) started but stalled on register allocator integration
+- No wasmtime runtime support available
+
+#### Design Implications
+
+| Aspect      | v128 (This WEP)                | Flexible Vectors          |
+| ----------- | ------------------------------ | ------------------------- |
+| Lane count  | Compile-time (4 for i32x4)     | Runtime query             |
+| Lane access | `.0`, `.1`, `.2`, `.3`         | Loop-based iteration      |
+| Type safety | Static validation              | Dynamic bounds checking   |
+| Wasm GC     | Cannot store in structs/arrays | Same restriction expected |
+
+#### Wado's Position
+
+v128 types are the stable baseline for portable SIMD in Wado:
+
+1. **Standardized**: v128 is part of Wasm 3.0, supported by all major runtimes
+2. **Predictable**: Fixed lane count enables compile-time optimization and validation
+3. **Sufficient**: 128-bit SIMD covers most practical use cases
+
+If Flexible Vectors advances to Phase 3+, Wado may add optional support:
+
+```wado
+// Hypothetical future syntax
+use {VecI32} from "core:simd/flexible";
+
+fn sum_vector(v: VecI32) -> i32 {
+    let len = VecI32::lanes();  // Runtime query
+    let mut total = 0;
+    for let mut i = 0; i < len; i += 1 {
+        total += v.lane(i);     // Dynamic access
+    }
+    return total;
+}
+```
+
+Key principles for future flexible vectors support:
+
+- Coexistence with v128 (different use cases, not replacement)
+- Explicit opt-in via separate types
+- Loop-based idioms for lane iteration
+- Same GC restrictions as v128
+
+#### References
+
+- [Flexible Vectors Proposal](https://github.com/WebAssembly/flexible-vectors)
+- [Flexible Vectors Specification](https://github.com/WebAssembly/flexible-vectors/blob/main/proposals/flexible-vectors/FlexibleVectors.md)
+- [Cranelift Dynamic Vector Types (Issue #4418)](https://github.com/bytecodealliance/wasmtime/issues/4418)
+- [Wasm 3.0 Announcement](https://webassembly.org/news/2025-09-17-wasm-3.0/)


### PR DESCRIPTION
Document the relationship between v128 fixed-width SIMD and the
WebAssembly Flexible Vectors proposal, including current status,
design implications, and Wado's position on future support.

https://claude.ai/code/session_019amLBoMgX6knXkGKJaTaH5