### PR TITLE
Document string literal storage in Wasm passive data segments

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1041,6 +1041,10 @@ pub struct FormatSpec {
 - Float interpolation (f32/f64 via `wado-bundled` functions using the `ryu` algorithm)
 - String concatenation using GC array allocation and `array.copy`
 
+### String Literal Data Segments
+
+String literals are stored in Wasm **passive data segments**. This allows direct initialization of GC arrays using `array.init_data`, which is more efficient than loading from linear memory.
+
 ### The `assert` Statement
 
 `assert` behaves like a power-assert, which shows source conditions, collects intermediate values, and prints them if the assertion fails.


### PR DESCRIPTION
## Summary
Added documentation explaining how string literals are stored and initialized in the Wasm compiler implementation.

## Changes
- Added new "String Literal Data Segments" section to the compiler documentation
- Explains that string literals are stored in Wasm passive data segments
- Documents the use of `array.init_data` for efficient GC array initialization
- Clarifies the performance advantage over loading from linear memory

## Details
This documentation addition clarifies an implementation detail of the string handling strategy in the Wasm compiler. By using passive data segments with `array.init_data`, string literals can be directly initialized into GC arrays without the intermediate step of loading from linear memory, resulting in more efficient code generation.

https://claude.ai/code/session_01TbKMUCCUALbUjF4dB2aBcH