### PR TITLE
Update docs: i128/u128 and global variables

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -93,10 +93,13 @@ Global variables map directly to WebAssembly globals. Constant expressions are e
 
 ```wado
 // Primitives
-i8, i16, i32, i64, i128  // signed integers
-u8, u16, u32, u64, u128  // unsigned integers
-f32, f64                 // floats
+i8, i16, i32, i64         // signed integers
+u8, u16, u32, u64         // unsigned integers
+f32, f64                  // floats
 bool, char
+
+// 128-bit integers (prelude types, work like primitives)
+i128, u128
 
 // Composite
 String                  // UTF-8 string
@@ -112,6 +115,27 @@ Result<T, E>            // result type
 // Unit type
 ()
 ```
+
+### 128-bit Integers
+
+`i128` and `u128` are defined in the prelude as structs but work like primitives via operator overloading:
+
+```wado
+let a: u128 = 42;                      // literal coercion
+let b = u128::from_u64(1_000_000);     // explicit construction
+let sum = a + b;                       // arithmetic
+let cmp = a < b;                       // comparison
+
+// Bitwise operations
+let bits = a & b;
+let shifted = a << 10;
+
+// Access low/high 64-bit parts
+let low = a.low();
+let high = a.high();
+```
+
+All arithmetic (`+`, `-`, `*`, `/`, `%`), comparison, and bitwise operations are supported. Addition and subtraction use efficient Wasm Wide Arithmetic instructions.
 
 ## Newtype
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -116,27 +116,6 @@ Result<T, E>            // result type
 ()
 ```
 
-### 128-bit Integers
-
-`i128` and `u128` are defined in the prelude as structs but work like primitives via operator overloading:
-
-```wado
-let a: u128 = 42;                      // literal coercion
-let b = u128::from_u64(1_000_000);     // explicit construction
-let sum = a + b;                       // arithmetic
-let cmp = a < b;                       // comparison
-
-// Bitwise operations
-let bits = a & b;
-let shifted = a << 10;
-
-// Access low/high 64-bit parts
-let low = a.low();
-let high = a.high();
-```
-
-All arithmetic (`+`, `-`, `*`, `/`, `%`), comparison, and bitwise operations are supported. Addition and subtraction use efficient Wasm Wide Arithmetic instructions.
-
 ## Newtype
 
 ```wado

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1351,13 +1351,13 @@ Match expressions are lowered to a series of pattern checks with branching:
 
 **Lowering Strategy:**
 
-| Pattern Type | Lowering |
-| ------------ | -------- |
-| Variant | `br_on_cast_fail` to test discriminant, extract payload |
-| Literal | Equality check with `br_if` |
-| Wildcard `_` | No check (always matches) |
-| Or pattern | Chain of checks with shared arm body |
-| Guard `&&` | Pattern check followed by guard expression check |
+| Pattern Type | Lowering                                                |
+| ------------ | ------------------------------------------------------- |
+| Variant      | `br_on_cast_fail` to test discriminant, extract payload |
+| Literal      | Equality check with `br_if`                             |
+| Wildcard `_` | No check (always matches)                               |
+| Or pattern   | Chain of checks with shared arm body                    |
+| Guard `&&`   | Pattern check followed by guard expression check        |
 
 **Codegen to Wasm:**
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1329,6 +1329,22 @@ Key design decisions:
 - Uses auto-dereference so `a.len()` and `a.get(i)` work on references
 - Byte-by-byte comparison (UTF-8 safe since equal strings have identical byte sequences)
 
+### Global Variables
+
+Global variables compile to WebAssembly globals with two initialization strategies:
+
+| Category | Condition                                    | Strategy                                                  |
+| -------- | -------------------------------------------- | --------------------------------------------------------- |
+| Constant | Primitive type with Wasm constant expression | Direct initialization in Wasm global section              |
+| Lazy     | Object types or non-constant expressions     | Null/zero default, initialized in `__initialize_module()` |
+
+**Module Initialization:**
+
+- Each module with lazy globals generates `pub fn __initialize_module()`
+- Entry module generates `fn __initialize_modules()` which calls all modules' initializers
+- Initialization order: topologically sorted by dependencies (within module and across modules)
+- Re-initialization prevented via flag check
+
 ---
 
 ## Implemented

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1345,6 +1345,43 @@ Global variables compile to WebAssembly globals with two initialization strategi
 - Initialization order: topologically sorted by dependencies (within module and across modules)
 - Re-initialization prevented via flag check
 
+### Match Expression
+
+Match expressions are lowered to a series of pattern checks with branching:
+
+**Lowering Strategy:**
+
+| Pattern Type | Lowering |
+| ------------ | -------- |
+| Variant | `br_on_cast_fail` to test discriminant, extract payload |
+| Literal | Equality check with `br_if` |
+| Wildcard `_` | No check (always matches) |
+| Or pattern | Chain of checks with shared arm body |
+| Guard `&&` | Pattern check followed by guard expression check |
+
+**Codegen to Wasm:**
+
+For dense integer patterns (e.g., enum discriminants), the codegen emits `br_table` for O(1) dispatch:
+
+```wat
+;; match color { Red => 0, Green => 1, Blue => 2 }
+(block $arm2
+  (block $arm1
+    (block $arm0
+      (br_table $arm0 $arm1 $arm2 (local.get $color)))
+    (i32.const 0)  ;; Red
+    (br $end))
+  (i32.const 1)    ;; Green
+  (br $end))
+(i32.const 2)      ;; Blue
+```
+
+For variant patterns, `br_on_cast_fail` tests the discriminant and extracts the payload in one instruction.
+
+**Exhaustiveness:**
+
+Checked during analysis phase. Non-exhaustive patterns are compile errors.
+
 ---
 
 ## Implemented

--- a/spec.md
+++ b/spec.md
@@ -589,12 +589,11 @@ if opt matches { Some(_) } {
 **Scope:** Pattern bindings are scoped to the guard only and do not escape:
 
 ```wado
-// Bindings don't escape - use if let for value extraction
+// Bindings don't escape
 if opt matches { Some(x) } && x > 0 { }  // ERROR: x not in scope
 
-if let Some(x) = opt {  // Use if let instead
-    if x > 0 { ... }
-}
+// Use guard inside the pattern instead
+if opt matches { Some(x) && x > 0 } { }  // OK
 ```
 
 ## Memory Model

--- a/spec.md
+++ b/spec.md
@@ -507,6 +507,96 @@ outer: {
 
 **Design Rationale**: The label is mandatory because `{ field: value }` without context could be either a block with a labeled statement or a struct literal. Requiring the label removes this ambiguity.
 
+### Match Expression
+
+Match expression provides exhaustive pattern matching on variants and other types.
+
+```wado
+// Match expression (produces a value)
+let result = match opt {
+    Some(x) => x * 2,
+    None => 0,
+};
+
+// Match with custom variants
+let area = match shape {
+    Circle(r) => 3.14159 * r * r,
+    Rectangle([w, h]) => w * h,
+    Point => 0.0,
+};
+
+// Match statement (no value produced)
+match command {
+    Start => engine.start(),
+    Stop => engine.stop(),
+}
+```
+
+**Pattern Syntax:**
+
+| Pattern  | Example                | Description            |
+| -------- | ---------------------- | ---------------------- |
+| Wildcard | `_`                    | Matches anything       |
+| Variable | `x`                    | Binds matched value    |
+| Literal  | `0`, `"hello"`, `true` | Matches exact value    |
+| Variant  | `Some(x)`, `None`      | Matches variant case   |
+| Tuple    | `[a, b, c]`            | Destructures tuple     |
+| Or       | `Red \| Blue`          | Matches either pattern |
+| Guard    | `Some(x) && x > 0`     | Pattern with condition |
+
+**Exhaustiveness:**
+
+Match must cover all possible cases. Use `_` wildcard for catch-all:
+
+```wado
+match color {
+    Red => "red",
+    Green => "green",
+    _ => "other",  // Required for exhaustiveness
+}
+```
+
+**Guard Expressions:**
+
+Guards use `&&` to reflect left-to-right evaluation (pattern first, then guard):
+
+```wado
+match customer {
+    Premium(years) && years > 5 => 0.3,
+    Premium(_) => 0.2,
+    _ => 0.1,
+}
+```
+
+### Matches Operator
+
+The `matches` infix operator tests if a value matches a pattern, returning `bool`.
+
+```wado
+// Basic usage
+let is_some = opt matches { Some(_) };
+let is_circle = shape matches { Circle(_) };
+
+// With guard
+let is_large = shape matches { Circle(r) && r > 10.0 };
+
+// In conditions
+if opt matches { Some(_) } {
+    println("has value");
+}
+```
+
+**Scope:** Pattern bindings are scoped to the guard only and do not escape:
+
+```wado
+// Bindings don't escape - use if let for value extraction
+if opt matches { Some(x) } && x > 0 { }  // ERROR: x not in scope
+
+if let Some(x) = opt {  // Use if let instead
+    if x > 0 { ... }
+}
+```
+
 ## Memory Model
 
 ### Core Principles
@@ -1860,12 +1950,11 @@ if let Fail = result {
     println("Failed");
 }
 
-// match is not yet implemented
-// match s {
-//     Shape::Circle(r) => calculate_circle_area(r),
-//     Shape::Rectangle([w, h]) => w * h,
-//     Shape::Point => 0.0,
-// }
+match s {
+    Circle(r) => calculate_circle_area(r),
+    Rectangle([w, h]) => w * h,
+    Point => 0.0,
+}
 ```
 
 **Implementation Status**:
@@ -1874,9 +1963,10 @@ if let Fail = result {
 - `if let` pattern matching for `Option<T>`: implemented
 - `if let` pattern matching for non-generic custom variants: implemented
 - Tuple payload pattern destructuring (`if let Foo([a, b]) = x`): implemented
+- `match` expression/statement: implemented
+- `matches` operator: implemented
 - Generic custom variant pattern matching (e.g., `Maybe<T>`): not yet implemented
 - `Result<T, E>` pattern matching: not yet implemented
-- `match` statements: not yet implemented
 
 Note: `Option<T>` and `Result<T, E>` are declared as variants in `core:prelude`.
 

--- a/spec.md
+++ b/spec.md
@@ -171,15 +171,7 @@ global mut counter: i32 = 0;
 pub global VERSION: i32 = 1;
 ```
 
-**Initialization:**
-
-Currently, only literal initializers are supported:
-
-```wado
-global ANSWER: i32 = 42;       // OK: literal
-global PI: f64 = 3.14159;      // OK: literal
-global FLAG: bool = true;      // OK: literal
-```
+Any type is supported. Any pure expression (no effects) can be used as an initializer.
 
 **Mutability:**
 
@@ -194,34 +186,6 @@ fn example() {
     CONSTANT = 10;    // Error: cannot assign to immutable global
 }
 ```
-
-**Supported Types:**
-
-- Integers: `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`
-- Floats: `f32`, `f64`
-- Boolean: `bool`
-- Character: `char`
-
-Object types (`String`, `Array<T>`, structs) are not yet supported.
-
-#### Module Initialization (not yet implemented)
-
-For complex initializers that cannot be expressed as Wasm constant expressions, a future `#[module_init]` attribute will allow user-defined initialization:
-
-```wado
-global mut cache: Array<i32> = [];  // Default value
-
-#[module_init]
-fn setup() {
-    cache = Array::<i32>::with_capacity(100);
-}
-```
-
-The compiler will:
-
-1. Initialize globals with default/literal values in the Wasm global section
-2. Generate a module initialization function that runs before `run()`
-3. Call `#[module_init]` functions in declaration order
 
 ### Operators
 
@@ -627,6 +591,7 @@ The **prelude** (`core:prelude`) is automatically imported into every module, pr
 - `Stream<T>` - Component Model async stream
 - `Future<T>` - Component Model async future
 - `Pollable` - WASI I/O polling resource
+- `i128`, `u128` - 128-bit integer types
 
 **Disabling the Prelude:**
 
@@ -643,14 +608,40 @@ Wasm primitive types are built into the language (no import required):
 
 ```wado
 // Numeric
-i8, i16, i32, i64, i128
-u8, u16, u32, u64, u128
+i8, i16, i32, i64
+u8, u16, u32, u64
 f32, f64
 
 // Basic
 bool
 char
 ```
+
+### 128-bit Integer Types (i128/u128)
+
+Unlike primitive types, `i128` and `u128` are implemented as structs in the prelude. They can be used like primitives thanks to operator overloading:
+
+```wado
+let a: u128 = 42;                      // literal coercion
+let b = u128::from_u64(1_000_000);     // explicit construction
+let sum = a + b;                       // via Add trait
+let cmp = a < b;                       // via Ord trait
+
+// Access low/high 64-bit parts
+let low = a.low();
+let high = a.high();
+```
+
+WebAssembly has no native 128-bit integer type, so Wado represents them as pairs of 64-bit values. Addition and subtraction use Wasm Wide Arithmetic instructions (`i64.add128`, `i64.sub128`) for efficiency. Other operations (division, bitwise, etc.) use software implementations.
+
+Available operations:
+
+| Category   | Operations                                    |
+| ---------- | --------------------------------------------- |
+| Arithmetic | `+`, `-`, `*`, `/`, `%`, unary `-` (i128)     |
+| Comparison | `==`, `!=`, `<`, `<=`, `>`, `>=`              |
+| Bitwise    | `&`, `\|`, `^`, `~`, `<<`, `>>`               |
+| Conversion | `from_u64()`, `from_i64()`, `low()`, `high()` |
 
 ### Reference Types
 


### PR DESCRIPTION
- spec.md: Add i128/u128 section explaining they are prelude types with
  primitive-like usage; simplify global variables section
- cheatsheet.md: Add i128/u128 section with usage examples
- compiler.md: Add global variables implementation details

https://claude.ai/code/session_01UHN72Np5fwoAtmDAdqJAqj