### PR TITLE
Refactor: Use metadata instead of parsing mangled names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ This project relies on the following Wasm features:
 
 - The principle: `codegen.rs` emits the `Project` as is, which does not have the knowledge of the previous phases.
 - Use utilities in `name.rs` to handle name mangling and monomorphization. Other components must not know the details of name formats.
+- Do not parse mangled / formatted names even in `name.rs`. Use parsed objects instead.
 - Minimize hard-coded logic for compiler builtins. Define builtin and internal functions in Wado source files in `lib/core/*.wado`.
 - Minimize hard-coded logic for WASI. Use metadata extracted from `lib/wasi/*.wado`.
 

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -15,6 +15,7 @@ use crate::component_model::{
 use crate::copy_context::{ArrayCopyLocals, CopyContext};
 use crate::name::{
     FreeFunctionName, FunctionId, MethodName, ModuleSource, StructName, build_core_internal_name,
+    mangle_array_type, mangle_generic_name, mangle_result_type,
 };
 use crate::project::Project;
 use crate::symbol::SymbolTable;
@@ -547,62 +548,6 @@ impl Codegen {
         self.struct_types.get(&simple)
     }
 
-    /// Mangle a type name for use in struct names (e.g., i32 for Box<i32>)
-    fn mangle_type_for_struct_name(&self, type_id: TypeId, type_table: &TypeTable) -> String {
-        match type_table.get(type_id) {
-            ResolvedType::Primitive(prim) => prim.as_str().to_string(),
-            ResolvedType::Unit => "unit".to_string(),
-            ResolvedType::Struct { name, .. } => name.clone(),
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => {
-                let args: Vec<String> = type_args
-                    .iter()
-                    .map(|t| self.mangle_type_for_struct_name(*t, type_table))
-                    .collect();
-                format!("{}<{}>", name, args.join(","))
-            }
-            // Function types: Fn<paramCount,returnType>
-            ResolvedType::Function {
-                params,
-                return_type,
-                ..
-            } => {
-                let ret_name = self.mangle_type_for_struct_name(*return_type, type_table);
-                format!("Fn<{},{}>", params.len(), ret_name)
-            }
-            ResolvedType::Tuple(elems) => {
-                let elem_names: Vec<String> = elems
-                    .iter()
-                    .map(|t| self.mangle_type_for_struct_name(*t, type_table))
-                    .collect();
-                format!("Tuple<{}>", elem_names.join(","))
-            }
-            ResolvedType::Option(inner) => {
-                let inner_name = self.mangle_type_for_struct_name(*inner, type_table);
-                format!("Option<{inner_name}>")
-            }
-            ResolvedType::Result { ok, err } => {
-                let ok_name = self.mangle_type_for_struct_name(*ok, type_table);
-                let err_name = self.mangle_type_for_struct_name(*err, type_table);
-                format!("Result<{ok_name},{err_name}>")
-            }
-            ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                // For references, use the inner type's name
-                self.mangle_type_for_struct_name(*inner, type_table)
-            }
-            ResolvedType::Resource { name, .. } => {
-                // Resource types are i32 handles, use the name for identification
-                name.clone()
-            }
-            ResolvedType::Enum { name, .. } => {
-                // Enum types are i32, use the name for identification
-                name.clone()
-            }
-            _ => "unknown".to_string(),
-        }
-    }
-
     /// Extract struct names that a type depends on (for field types)
     /// Returns mangled names for `GenericInstance` types (e.g., "`BTreeNode`<String,i32>")
     /// Get type dependencies (struct and variant names) for a given type.
@@ -611,12 +556,10 @@ impl Codegen {
         match type_table.get(type_id) {
             ResolvedType::Struct { name, .. } => vec![name.clone()],
             ResolvedType::Variant { name, .. } => vec![name.clone()],
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => {
+            ResolvedType::GenericInstance { type_args, .. } => {
                 // Get dependencies from type arguments
                 // Use mangled name for the generic instance (e.g., "BTreeNode<String,i32>")
-                let mangled_name = Self::mangle_generic_instance_name(name, type_args, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 let mut deps = vec![mangled_name];
                 for arg in type_args {
                     deps.extend(Self::get_type_dependencies(type_table, *arg));
@@ -640,39 +583,6 @@ impl Codegen {
                 .flat_map(|e| Self::get_type_dependencies(type_table, *e))
                 .collect(),
             _ => vec![],
-        }
-    }
-
-    /// Mangle a generic instance name for dependency tracking (static version)
-    /// e.g., ("`BTreeNode`", [String, i32]) -> "`BTreeNode`<String,i32>"
-    fn mangle_generic_instance_name(
-        name: &str,
-        type_args: &[TypeId],
-        type_table: &TypeTable,
-    ) -> String {
-        if type_args.is_empty() {
-            return name.to_string();
-        }
-        let args: Vec<String> = type_args
-            .iter()
-            .map(|t| Self::mangle_type_for_dependency(*t, type_table))
-            .collect();
-        format!("{}<{}>", name, args.join(","))
-    }
-
-    /// Mangle a type for dependency tracking (static version of `mangle_type_for_struct_name`)
-    fn mangle_type_for_dependency(type_id: TypeId, type_table: &TypeTable) -> String {
-        match type_table.get(type_id) {
-            ResolvedType::Primitive(prim) => prim.as_str().to_string(),
-            ResolvedType::Unit => "unit".to_string(),
-            ResolvedType::Struct { name, .. } => name.clone(),
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => Self::mangle_generic_instance_name(name, type_args, type_table),
-            ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                Self::mangle_type_for_dependency(*inner, type_table)
-            }
-            _ => "unknown".to_string(),
         }
     }
 
@@ -700,13 +610,11 @@ impl Codegen {
                 // Exact name match only
                 name == struct_name
             }
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => {
+            ResolvedType::GenericInstance { type_args, .. } => {
                 // Check if this GenericInstance IS the struct we're looking for.
                 // E.g., Node<String> is represented as GenericInstance { name: "Node", type_args: [String] }
                 // and we need to check if "Node<String>" matches struct_name.
-                let mangled_name = Self::mangle_generic_instance_name(name, type_args, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 if mangled_name == struct_name {
                     return true;
                 }
@@ -989,23 +897,15 @@ impl Codegen {
             if module_source.is_wasi() {
                 continue;
             }
-            // Methods are stored as functions with mangled names like "Point::sum" or "String^Eq::eq"
+            // Methods are stored as functions with method_info metadata
             // (resolver adds them to functions, not impls)
             for func_rc in &tir_mod.functions {
                 let func = func_rc.borrow();
-                // Check if this is a method (name contains ::)
-                if let Some(sep_pos) = func.name.find("::") {
-                    let prefix = &func.name[..sep_pos];
-                    let method_name = &func.name[sep_pos + 2..];
-
-                    // Parse struct name and optional trait name from prefix
-                    // Format: "StructName" or "StructName^TraitName"
-                    let (struct_name, trait_name): (&str, Option<&str>) =
-                        if let Some(caret_pos) = prefix.find('^') {
-                            (&prefix[..caret_pos], Some(&prefix[caret_pos + 1..]))
-                        } else {
-                            (prefix, None)
-                        };
+                // Check if this is a method using metadata
+                if let Some(ref info) = func.method_info {
+                    let struct_name = &info.struct_name;
+                    let trait_name = info.trait_name.as_deref();
+                    let method_name = &info.method_name;
 
                     // Skip non-pub methods (except monomorphized ones which are generated for
                     // concrete instantiation sites and must be included)
@@ -1046,10 +946,10 @@ impl Codegen {
                     // Determine struct lookup name - use qualified name if there's a collision
                     let struct_lookup_name = if main_module_struct_names.contains(struct_name) {
                         // Collision - use qualified StructName
-                        StructName::new(module_source.clone(), struct_name.to_string())
+                        StructName::new(module_source.clone(), struct_name.clone())
                     } else {
                         // No collision - use simple StructName (entry point)
-                        StructName::new(ModuleSource::entry_point(), struct_name.to_string())
+                        StructName::new(ModuleSource::entry_point(), struct_name.clone())
                     };
                     // Use the same fully mangled name for registration
                     // This ensures consistency between DCE tracking and codegen
@@ -1544,22 +1444,13 @@ impl Codegen {
                 vec![self.type_id_to_valtype(type_table, tir_func.return_type)]
             };
 
-            // For methods, build the type name from method_info (struct name, trait name)
-            // and parse the method name from tir_func.name (which includes method type args)
+            // For methods, build the type name from method_info metadata
             let type_name = if let Some(ref info) = tir_func.method_info {
-                // Extract method name with type args from func.name
-                // func.name is like "Container<i32>::transform<i64>"
-                // We need the part after "::" which is "transform<i64>"
-                let method_name_with_args = if let Some(sep_pos) = tir_func.name.find("::") {
-                    tir_func.name[sep_pos + 2..].to_string()
-                } else {
-                    info.method_name.clone()
-                };
                 MethodName::new(
                     entry_module_source.to_path().join("/"),
                     info.struct_name.clone(),
                     info.trait_name.clone(),
-                    method_name_with_args,
+                    info.full_method_name(),
                 )
                 .to_string()
             } else {
@@ -4126,8 +4017,8 @@ impl Codegen {
                 ));
 
                 // 2. Array struct type (use mangled name for consistency)
-                let elem_mangled = self.mangle_type_for_struct_name(element_type_id, type_table);
-                let array_struct_name = format!("Array<{elem_mangled}>");
+                let elem_mangled = type_table.mangle_type_name(element_type_id);
+                let array_struct_name = mangle_generic_name("Array", &[elem_mangled]);
                 let array_struct_fields = vec![
                     FieldType {
                         element_type: StorageType::Val(ValType::Ref(RefType {
@@ -4215,8 +4106,8 @@ impl Codegen {
                 .insert(canonical_name.clone(), raw_array_idx);
 
             // Register Array struct type in struct_types (unified with other generic structs)
-            let elem_mangled = self.mangle_type_for_struct_name(element_type_id, type_table);
-            let array_struct_mangled = format!("Array<{elem_mangled}>");
+            let elem_mangled = type_table.mangle_type_name(element_type_id);
+            let array_struct_mangled = mangle_generic_name("Array", &[elem_mangled]);
             let array_struct_name =
                 StructName::new(ModuleSource::entry_point(), array_struct_mangled);
             self.struct_types.insert(
@@ -4354,7 +4245,7 @@ impl Codegen {
                 // Check if this is a variant (has a declaration in tir_module.variants)
                 let is_variant = tir_module.variants.iter().any(|v| v.name == *name);
                 if is_variant {
-                    let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+                    let mangled_name = type_table.mangle_type_name(type_id);
                     // Skip if already registered
                     if !self.variant_types.borrow().contains_key(&mangled_name) {
                         generic_variants.push((name.clone(), type_args.clone()));
@@ -4385,7 +4276,7 @@ impl Codegen {
             let mangled_name = {
                 let arg_names: Vec<String> = type_args
                     .iter()
-                    .map(|&tid| self.mangle_type_for_struct_name(tid, type_table))
+                    .map(|&tid| type_table.mangle_type_name(tid))
                     .collect();
                 format!("{}<{}>", base_name, arg_names.join(","))
             };
@@ -4464,7 +4355,7 @@ impl Codegen {
 
         for type_id in type_table.iter_type_ids() {
             if let ResolvedType::Result { ok, err } = type_table.get(type_id) {
-                let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 // Skip if already registered
                 if !self.variant_types.borrow().contains_key(&mangled_name) {
                     result_types.push((type_id, *ok, *err));
@@ -4474,7 +4365,7 @@ impl Codegen {
 
         // Register each Result type as a variant with subtype hierarchy
         for (type_id, ok_type_id, err_type_id) in result_types {
-            let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+            let mangled_name = type_table.mangle_type_name(type_id);
 
             // Define the base type with just the tag field
             let base_fields = vec![FieldType {
@@ -4619,7 +4510,7 @@ impl Codegen {
             }
             ResolvedType::GenericInstance { .. } => {
                 // All generic instances (including Array<T>) use the mangled name lookup
-                let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 if let Some(info) =
                     self.lookup_struct_type(&mangled_name, &ModuleSource::entry_point())
                 {
@@ -5198,7 +5089,7 @@ impl Codegen {
         match type_table.get(type_id) {
             ResolvedType::GenericInstance { .. } => {
                 // Check if this generic instance is registered
-                let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 !self
                     .struct_types
                     .contains_key(&StructName::new(ModuleSource::entry_point(), mangled_name))
@@ -5378,8 +5269,8 @@ impl Codegen {
         builder: &mut CoreModuleBuilder,
     ) -> u32 {
         // Construct the mangled name for Array<T> (e.g., "Array<i32>")
-        let element_name = self.mangle_type_for_struct_name(element_type_id, type_table);
-        let mangled_name = format!("Array<{element_name}>");
+        let element_name = type_table.mangle_type_name(element_type_id);
+        let mangled_name = mangle_array_type(&element_name);
 
         // Check if already registered in struct_types
         if let Some(info) = self.lookup_struct_type(&mangled_name, &ModuleSource::entry_point()) {
@@ -5408,7 +5299,7 @@ impl Codegen {
             },
         ];
 
-        let type_name = format!("Array<{element_name}>");
+        let type_name = mangle_generic_name("Array", &[element_name.clone()]);
         let type_idx = builder.define_gc_struct_type(&type_name, &fields);
 
         // Register in struct_types for consistency with other generic structs
@@ -5432,8 +5323,8 @@ impl Codegen {
         element_type_id: TypeId,
         type_table: &TypeTable,
     ) -> Option<u32> {
-        let element_name = self.mangle_type_for_struct_name(element_type_id, type_table);
-        let mangled_name = format!("Array<{element_name}>");
+        let element_name = type_table.mangle_type_name(element_type_id);
+        let mangled_name = mangle_array_type(&element_name);
         self.lookup_struct_type(&mangled_name, &ModuleSource::entry_point())
             .map(|info| info.type_idx)
     }
@@ -5639,7 +5530,7 @@ impl Codegen {
                 }
 
                 // Check if this GenericInstance is already registered in struct_types
-                let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 let is_registered_in_struct_types = self
                     .lookup_struct_type(&mangled_name, &ModuleSource::entry_point())
                     .is_some();
@@ -6212,7 +6103,7 @@ impl Codegen {
             // Generic instances (other than Array, which is handled above)
             // Look up the monomorphized struct or variant type
             ResolvedType::GenericInstance { .. } => {
-                let mangled_name = self.mangle_type_for_struct_name(type_id, type_table);
+                let mangled_name = type_table.mangle_type_name(type_id);
                 // Check pending_type_indices first (for rec group construction)
                 if let Some(&type_idx) = self.pending_type_indices.borrow().get(&mangled_name) {
                     return ValType::Ref(RefType {
@@ -6458,9 +6349,9 @@ impl Codegen {
                         // Build mangled name for generic variant: Result<i32,String>
                         let type_arg_names: Vec<String> = type_args
                             .iter()
-                            .map(|t| self.mangle_type_for_struct_name(*t, type_table))
+                            .map(|t| type_table.mangle_type_name(*t))
                             .collect();
-                        format!("{}<{}>", name, type_arg_names.join(","))
+                        mangle_generic_name(name, &type_arg_names)
                     }
                     other => panic!("Expected Variant type for VariantConstruct, got: {other:?}"),
                 };
@@ -7180,9 +7071,9 @@ impl Codegen {
                         let module_path = module_source.to_path();
                         let type_arg_names: Vec<String> = type_args
                             .iter()
-                            .map(|t| self.mangle_type_for_struct_name(*t, type_table))
+                            .map(|t| type_table.mangle_type_name(*t))
                             .collect();
-                        let mangled_struct_name = format!("{}<{}>", name, type_arg_names.join(","));
+                        let mangled_struct_name = mangle_generic_name(&name, &type_arg_names);
 
                         // For trait methods, use the trait name in the method reference
                         // e.g., Triple<i32>^IndexValue<i32>::index_value
@@ -7600,49 +7491,13 @@ impl Codegen {
                                 None
                             }
                         })
-                } else if let Some(sep_pos) = func_name.find("::") {
-                    // No method_info, parse from func_name (legacy path for primitives)
-                    let struct_name = &func_name[..sep_pos];
-                    let method_name = &func_name[sep_pos + 2..];
-
-                    // Build the mangled name (no trait info available)
-                    let mangled_name = MethodName::new(
-                        module_path.join("/"),
-                        struct_name.to_string(),
-                        None,
-                        method_name.to_string(),
-                    )
-                    .to_string();
-
-                    // Check struct metadata for fallback
-                    let struct_lookup_name =
-                        StructName::from_path_and_name(&module_path, struct_name);
-                    let struct_info = self.struct_types.get(&struct_lookup_name);
-
-                    builder
-                        .try_func_idx(&mangled_name)
-                        .or_else(|| builder.try_func_idx(&func_name))
-                        .or_else(|| {
-                            // For monomorphized generic types, try the generic version
-                            let generic_name = base_struct_name
-                                .as_ref()
-                                .or_else(|| struct_info.and_then(|s| s.base_name.as_ref()));
-
-                            if let Some(generic_struct_name) = generic_name {
-                                let generic_mangled_name = MethodName::new(
-                                    module_path.join("/"),
-                                    generic_struct_name.clone(),
-                                    None,
-                                    method_name.to_string(),
-                                )
-                                .to_string();
-                                builder.try_func_idx(&generic_mangled_name)
-                            } else {
-                                None
-                            }
-                        })
                 } else {
-                    // No :: separator, try as a regular function call
+                    // Method calls (containing ::) should always have method_info
+                    assert!(
+                        !func_name.contains("::"),
+                        "StaticCall to method '{func_name}' missing method_info"
+                    );
+                    // Free function call (no :: separator)
                     let full_name = if module_path.is_empty() {
                         func_name.clone()
                     } else {
@@ -7665,9 +7520,9 @@ impl Codegen {
                             // Build the mangled struct name (e.g., Box<i32>)
                             let type_arg_names: Vec<String> = type_args
                                 .iter()
-                                .map(|t| self.mangle_type_for_struct_name(*t, type_table))
+                                .map(|t| type_table.mangle_type_name(*t))
                                 .collect();
-                            let mangled = format!("{}<{}>", name, type_arg_names.join(","));
+                            let mangled = mangle_generic_name(name, &type_arg_names);
                             Some((mangled, type_module_source.clone()))
                         }
                         ResolvedType::Struct {
@@ -7782,8 +7637,7 @@ impl Codegen {
 
                             // Get Result type info for Ok and Err subtypes
                             let result_type_id = expr.type_id;
-                            let mangled_name =
-                                self.mangle_type_for_struct_name(result_type_id, type_table);
+                            let mangled_name = type_table.mangle_type_name(result_type_id);
                             let variant_types = self.variant_types.borrow();
                             let result_info =
                                 variant_types.get(&mangled_name).unwrap_or_else(|| {
@@ -8073,9 +7927,9 @@ impl Codegen {
                         // Generic struct literal - look up the monomorphized struct name
                         let type_arg_names: Vec<String> = type_args
                             .iter()
-                            .map(|t| self.mangle_type_for_struct_name(*t, type_table))
+                            .map(|t| type_table.mangle_type_name(*t))
                             .collect();
-                        let mangled_name = format!("{}<{}>", name, type_arg_names.join(","));
+                        let mangled_name = mangle_generic_name(name, &type_arg_names);
                         self.lookup_struct_type(&mangled_name, module_source)
                     }
                     _ => {
@@ -10219,8 +10073,7 @@ impl Codegen {
                 },
             ) => {
                 // Look up variant type info - for GenericInstance, use the mangled name
-                let variant_lookup_name =
-                    self.mangle_type_for_struct_name(scrutinee.type_id, type_table);
+                let variant_lookup_name = type_table.mangle_type_name(scrutinee.type_id);
                 let variant_types = self.variant_types.borrow();
                 let variant_info = variant_types.get(&variant_lookup_name).unwrap_or_else(|| {
                     // Fallback to base name for non-generic variants
@@ -10478,8 +10331,7 @@ impl Codegen {
                     ..
                 },
             ) => {
-                let variant_lookup_name =
-                    self.mangle_type_for_struct_name(scrutinee.type_id, type_table);
+                let variant_lookup_name = type_table.mangle_type_name(scrutinee.type_id);
                 let variant_types = self.variant_types.borrow();
                 let variant_info = variant_types.get(&variant_lookup_name).unwrap_or_else(|| {
                     variant_types.get(name).unwrap_or_else(|| {
@@ -11150,9 +11002,9 @@ impl Codegen {
                 },
             ) => {
                 // Build mangled name for Result<ok, err>
-                let ok_name = self.mangle_type_for_struct_name(*ok, _type_table);
-                let err_name = self.mangle_type_for_struct_name(*err, _type_table);
-                let mangled_name = format!("Result<{ok_name},{err_name}>");
+                let ok_name = _type_table.mangle_type_name(*ok);
+                let err_name = _type_table.mangle_type_name(*err);
+                let mangled_name = mangle_result_type(&ok_name, &err_name);
 
                 let variant_types = self.variant_types.borrow();
                 let variant_info = variant_types.get(&mangled_name).unwrap_or_else(|| {
@@ -11227,9 +11079,9 @@ impl Codegen {
                 // Build mangled name including type arguments
                 let type_arg_names: Vec<String> = type_args
                     .iter()
-                    .map(|t| self.mangle_type_for_struct_name(*t, _type_table))
+                    .map(|t| _type_table.mangle_type_name(*t))
                     .collect();
-                let mangled_name = format!("{}<{}>", name, type_arg_names.join(","));
+                let mangled_name = mangle_generic_name(name, &type_arg_names);
 
                 let variant_types = self.variant_types.borrow();
                 let variant_info = variant_types.get(&mangled_name).unwrap_or_else(|| {
@@ -11359,9 +11211,9 @@ impl Codegen {
             ) => {
                 if let Some(binding) = bindings.first() {
                     // Build mangled name for Result<ok, err>
-                    let ok_name = self.mangle_type_for_struct_name(ok, type_table);
-                    let err_name = self.mangle_type_for_struct_name(err, type_table);
-                    let mangled_name = format!("Result<{ok_name},{err_name}>");
+                    let ok_name = type_table.mangle_type_name(ok);
+                    let err_name = type_table.mangle_type_name(err);
+                    let mangled_name = mangle_result_type(&ok_name, &err_name);
 
                     let variant_types = self.variant_types.borrow();
                     let variant_info = variant_types.get(&mangled_name).unwrap();
@@ -11450,9 +11302,9 @@ impl Codegen {
                     // Build mangled name including type arguments
                     let type_arg_names: Vec<String> = type_args
                         .iter()
-                        .map(|t| self.mangle_type_for_struct_name(*t, type_table))
+                        .map(|t| type_table.mangle_type_name(*t))
                         .collect();
-                    let mangled_name = format!("{}<{}>", name, type_arg_names.join(","));
+                    let mangled_name = mangle_generic_name(&name, &type_arg_names);
 
                     let variant_types = self.variant_types.borrow();
                     let variant_info = variant_types.get(&mangled_name).unwrap();

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -53,9 +53,10 @@ pub fn lower(mut module: TirModule) -> TirModule {
     // Phase 3: Collect string literals and their function mappings
     let mut collector = StringCollector::new();
     collector.collect_module(&module);
-    let (strings, function_strings) = collector.into_results();
+    let (strings, function_strings, function_method_info) = collector.into_results();
     module.string_literals = strings;
     module.function_strings = function_strings;
+    module.function_method_info = function_method_info;
 
     module
 }
@@ -4678,6 +4679,8 @@ struct StringCollector {
     strings: Vec<String>,
     /// Map of function name → strings in that function (for DCE filtering)
     function_strings: HashMap<String, Vec<String>>,
+    /// Map of function name → method info (for DCE to avoid parsing)
+    function_method_info: HashMap<String, Option<LocalMethodName>>,
     /// Current function being collected (for tracking)
     current_function: Option<String>,
 }
@@ -4687,12 +4690,23 @@ impl StringCollector {
         Self {
             strings: Vec::new(),
             function_strings: HashMap::new(),
+            function_method_info: HashMap::new(),
             current_function: None,
         }
     }
 
-    fn into_results(self) -> (Vec<String>, HashMap<String, Vec<String>>) {
-        (self.strings, self.function_strings)
+    fn into_results(
+        self,
+    ) -> (
+        Vec<String>,
+        HashMap<String, Vec<String>>,
+        HashMap<String, Option<LocalMethodName>>,
+    ) {
+        (
+            self.strings,
+            self.function_strings,
+            self.function_method_info,
+        )
     }
 
     fn add_string(&mut self, s: String) {
@@ -4713,6 +4727,8 @@ impl StringCollector {
             let func = func_rc.borrow();
             if let Some(body) = &func.body {
                 self.current_function = Some(func.name.clone());
+                self.function_method_info
+                    .insert(func.name.clone(), func.method_info.clone());
                 self.collect_block(body);
                 self.current_function = None;
             }
@@ -4722,6 +4738,8 @@ impl StringCollector {
             for method in &impl_block.methods {
                 if let Some(body) = &method.body {
                     self.current_function = Some(method.name.clone());
+                    self.function_method_info
+                        .insert(method.name.clone(), method.method_info.clone());
                     self.collect_block(body);
                     self.current_function = None;
                 }

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 
 use indexmap::IndexMap;
 
-use crate::name::{LocalMethodName, MethodName, ModuleSource};
+use crate::name::{LocalMethodName, MethodName, ModuleSource, mangle_generic_name};
 use crate::project::Project;
 use crate::tir::{
     FunctionRef, InstantiationKey, MonomorphInfo, ResolvedType, TirBinaryOp, TirBlock, TirExpr,
@@ -776,9 +776,9 @@ impl Monomorphizer {
                             // Build mangled name from GenericInstance
                             let type_names: Vec<String> = type_args
                                 .iter()
-                                .map(|&arg| self.type_id_to_name(arg, type_table))
+                                .map(|&arg| type_table.mangle_type_name(arg))
                                 .collect();
-                            *struct_name = format!("{}<{}>", name, type_names.join(","));
+                            *struct_name = mangle_generic_name(name, &type_names);
                         }
                         _ => {}
                     }
@@ -974,9 +974,9 @@ impl Monomorphizer {
                 // Build the mangled name using type names (not TypeIds)
                 let type_names: Vec<String> = type_args
                     .iter()
-                    .map(|&arg| self.type_id_to_name(arg, type_table))
+                    .map(|&arg| type_table.mangle_type_name(arg))
                     .collect();
-                let mangled_name = format!("{}<{}>", name, type_names.join(","));
+                let mangled_name = mangle_generic_name(&name, &type_names);
 
                 // Look for existing Struct with this mangled name (ignore module_source)
                 for tid in type_table.iter_type_ids() {
@@ -1033,10 +1033,11 @@ impl Monomorphizer {
                     let key = InstantiationKey {
                         name: name.clone(),
                         type_args: type_args.clone(),
+                        method_info: None, // Struct instantiation
                     };
 
                     if !self.instantiated.contains_key(&key) {
-                        let mangled = self.mangle_name(&key, type_table);
+                        let mangled = self.instantiation_name(&key, type_table);
                         self.instantiated.insert(key.clone(), mangled.clone());
                         self.mangled_struct_to_key.insert(mangled, key.clone());
                         self.pending.push(key);
@@ -1046,62 +1047,14 @@ impl Monomorphizer {
         }
     }
 
-    /// Generate mangled name for instantiation: Box<i32> -> Box<i32>
-    fn mangle_name(&self, key: &InstantiationKey, type_table: &TypeTable) -> String {
-        if key.type_args.is_empty() {
-            return key.name.clone();
-        }
+    /// Generate monomorphized struct name: `Box` + `[i32]` -> `"Box<i32>"`
+    fn instantiation_name(&self, key: &InstantiationKey, type_table: &TypeTable) -> String {
         let args: Vec<String> = key
             .type_args
             .iter()
-            .map(|&t| self.type_id_to_name_component(t, type_table))
+            .map(|&t| type_table.mangle_type_name(t))
             .collect();
-        format!("{}<{}>", key.name, args.join(","))
-    }
-
-    /// Convert a `TypeId` to a mangled name component
-    fn type_id_to_name_component(&self, type_id: TypeId, type_table: &TypeTable) -> String {
-        match type_table.get(type_id) {
-            ResolvedType::Primitive(p) => format!("{p:?}").to_lowercase(),
-            ResolvedType::Unit => "unit".to_string(),
-            ResolvedType::Struct { name, .. } => name.clone(),
-            ResolvedType::Option(inner) => {
-                format!(
-                    "Option<{}>",
-                    self.type_id_to_name_component(*inner, type_table)
-                )
-            }
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => {
-                let args: Vec<String> = type_args
-                    .iter()
-                    .map(|arg| self.type_id_to_name_component(*arg, type_table))
-                    .collect();
-                format!("{}<{}>", name, args.join(","))
-            }
-            // Function types: Fn<paramCount,returnType>
-            ResolvedType::Function {
-                params,
-                return_type,
-                ..
-            } => {
-                let ret_name = self.type_id_to_name_component(*return_type, type_table);
-                format!("Fn<{},{}>", params.len(), ret_name)
-            }
-            ResolvedType::Tuple(elems) => {
-                let elem_names: Vec<String> = elems
-                    .iter()
-                    .map(|t| self.type_id_to_name_component(*t, type_table))
-                    .collect();
-                format!("Tuple<{}>", elem_names.join(","))
-            }
-            ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                // For references, use the inner type's name
-                self.type_id_to_name_component(*inner, type_table)
-            }
-            _ => format!("T{type_id}"),
-        }
+        mangle_generic_name(&key.name, &args)
     }
 
     /// Instantiate a generic struct with concrete type arguments
@@ -1253,9 +1206,9 @@ impl Monomorphizer {
                         // Build name using new format: Name<Type1,Type2>
                         let type_names: Vec<String> = indexed_args
                             .iter()
-                            .map(|(_, arg_id)| self.type_id_to_name(*arg_id, type_table))
+                            .map(|(_, arg_id)| type_table.mangle_type_name(*arg_id))
                             .collect();
-                        let mangled_name = format!("{}<{}>", name, type_names.join(","));
+                        let mangled_name = mangle_generic_name(&name, &type_names);
 
                         // Look for monomorphized struct with this name
                         for tid in type_table.iter_type_ids() {
@@ -1296,9 +1249,9 @@ impl Monomorphizer {
                 // Build the mangled name: Container<i32> (using type names)
                 let type_names: Vec<String> = new_args
                     .iter()
-                    .map(|&arg| self.type_id_to_name(arg, type_table))
+                    .map(|&arg| type_table.mangle_type_name(arg))
                     .collect();
-                let mangled_name = format!("{}<{}>", name, type_names.join(","));
+                let mangled_name = mangle_generic_name(&name, &type_names);
 
                 // Look for existing struct with this name
                 for tid in type_table.iter_type_ids() {
@@ -1538,9 +1491,10 @@ impl Monomorphizer {
                     let key = InstantiationKey {
                         name: func_name.clone(),
                         type_args: type_args.clone(),
+                        method_info: func.method_info(),
                     };
                     if !self.function_instantiated.contains_key(&key) {
-                        let mangled = self.mangle_function_name(&key, type_table);
+                        let mangled = self.function_instantiation_name(&key, type_table);
                         self.function_instantiated
                             .insert(key.clone(), mangled.clone());
                         self.mangled_func_to_key.insert(mangled, key.clone());
@@ -1576,12 +1530,18 @@ impl Monomorphizer {
                         let full_method_name =
                             MethodName::format_local(&struct_name, None, &method_name);
                         if generic_functions.contains_key(&full_method_name) {
+                            let method_info = LocalMethodName::new(
+                                struct_name.clone(),
+                                None,
+                                method_name.clone(),
+                            );
                             let key = InstantiationKey {
                                 name: full_method_name,
                                 type_args: type_args.clone(),
+                                method_info: Some(method_info),
                             };
                             if !self.function_instantiated.contains_key(&key) {
-                                let mangled = self.mangle_function_name(&key, type_table);
+                                let mangled = self.function_instantiation_name(&key, type_table);
                                 self.function_instantiated
                                     .insert(key.clone(), mangled.clone());
                                 self.mangled_func_to_key.insert(mangled, key.clone());
@@ -1609,12 +1569,18 @@ impl Monomorphizer {
                                     let mut combined_type_args = impl_type_args;
                                     combined_type_args.extend(type_args.iter().copied());
 
+                                    let method_info = LocalMethodName::new(
+                                        base_struct.clone(),
+                                        None,
+                                        method_name.clone(),
+                                    );
                                     let key = InstantiationKey {
                                         name: generic_method_name,
                                         type_args: combined_type_args,
+                                        method_info: Some(method_info),
                                     };
                                     if !self.function_instantiated.contains_key(&key) {
-                                        let mangled = self.mangle_method_name(
+                                        let mangled = self.method_instantiation_name(
                                             &key,
                                             type_table,
                                             generic_func.impl_type_params.len(),
@@ -1663,12 +1629,14 @@ impl Monomorphizer {
                                 if has_method_type_params && !type_args.is_empty() {
                                     combined_type_args.extend(type_args.iter().copied());
                                 }
+                                let method_info = generic_func.method_info.clone();
                                 let key = InstantiationKey {
                                     name: generic_method_name.clone(),
                                     type_args: combined_type_args,
+                                    method_info,
                                 };
                                 if !self.function_instantiated.contains_key(&key) {
-                                    let mangled = self.mangle_method_name(
+                                    let mangled = self.method_instantiation_name(
                                         &key,
                                         type_table,
                                         generic_func.impl_type_params.len(),
@@ -1721,12 +1689,14 @@ impl Monomorphizer {
                                 if has_method_type_params && !type_args.is_empty() {
                                     combined_type_args.extend(type_args.iter().copied());
                                 }
+                                let method_info = generic_func.method_info.clone();
                                 let key = InstantiationKey {
                                     name: generic_method_name.clone(),
                                     type_args: combined_type_args,
+                                    method_info,
                                 };
                                 if !self.function_instantiated.contains_key(&key) {
-                                    let mangled = self.mangle_method_name(
+                                    let mangled = self.method_instantiation_name(
                                         &key,
                                         type_table,
                                         generic_func.impl_type_params.len(),
@@ -1787,12 +1757,14 @@ impl Monomorphizer {
                             let generic_func = generic_func_rc.borrow();
                             // Only queue if we have the right number of type args
                             if type_args.len() == generic_func.impl_type_params.len() {
+                                let method_info = generic_func.method_info.clone();
                                 let key = InstantiationKey {
                                     name: generic_method_name,
                                     type_args: type_args.clone(),
+                                    method_info,
                                 };
                                 if !self.function_instantiated.contains_key(&key) {
-                                    let mangled = self.mangle_method_name(
+                                    let mangled = self.method_instantiation_name(
                                         &key,
                                         type_table,
                                         generic_func.impl_type_params.len(),
@@ -1978,15 +1950,11 @@ impl Monomorphizer {
                 name, type_args, ..
             } => {
                 // Return the mangled name with type args (e.g., "Array<i32>", "Box<String>")
-                if type_args.is_empty() {
-                    Some(name.clone())
-                } else {
-                    let args: Vec<String> = type_args
-                        .iter()
-                        .map(|arg| self.type_id_to_name_component(*arg, type_table))
-                        .collect();
-                    Some(format!("{}<{}>", name, args.join(",")))
-                }
+                let args: Vec<String> = type_args
+                    .iter()
+                    .map(|arg| type_table.mangle_type_name(*arg))
+                    .collect();
+                Some(mangle_generic_name(name, &args))
             }
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
                 self.get_struct_name_from_type(*inner, type_table)
@@ -2022,102 +1990,62 @@ impl Monomorphizer {
         }
     }
 
-    /// Generate mangled name for function instantiation: identity<i32> -> identity<i32>
-    fn mangle_function_name(&self, key: &InstantiationKey, type_table: &TypeTable) -> String {
-        if key.type_args.is_empty() {
-            return key.name.clone();
-        }
-        format!(
-            "{}<{}>",
-            key.name,
-            key.type_args
-                .iter()
-                .map(|t| self.type_id_to_name(*t, type_table))
-                .collect::<Vec<_>>()
-                .join(",")
-        )
+    /// Generate instantiated function name: `identity` + `[i32]` -> `"identity<i32>"`
+    fn function_instantiation_name(
+        &self,
+        key: &InstantiationKey,
+        type_table: &TypeTable,
+    ) -> String {
+        let args: Vec<String> = key
+            .type_args
+            .iter()
+            .map(|t| type_table.mangle_type_name(*t))
+            .collect();
+        mangle_generic_name(&key.name, &args)
     }
 
-    /// Generate mangled name for method instantiation
+    /// Generate instantiated method name
     /// Format: `StructWithImplArgs::methodWithMethodArgs`
-    /// e.g., `Container::transform` with [i32, i64] and `impl_type_params_count=1` -> Container<i32>`::transform`<i64>
-    fn mangle_method_name(
+    /// e.g., `Container::transform` with `[i32, i64]` and `impl_type_params_count=1` -> `"Container<i32>::transform<i64>"`
+    fn method_instantiation_name(
         &self,
         key: &InstantiationKey,
         type_table: &TypeTable,
         impl_type_params_count: usize,
     ) -> String {
-        // key.name is like "Container::transform" or "Triple^IndexValue::index_value"
-        if let Some(parsed) = LocalMethodName::parse(&key.name) {
-            // Split type_args into impl args and method args
-            let (impl_args, method_args) = key
-                .type_args
-                .split_at(std::cmp::min(impl_type_params_count, key.type_args.len()));
+        // Use method_info metadata instead of parsing key.name
+        let Some(ref method_info) = key.method_info else {
+            // Fallback to regular function naming if no method_info
+            return self.function_instantiation_name(key, type_table);
+        };
 
-            // Build mangled struct name with type args
-            // e.g., "Triple^IndexValue" -> "Triple<i32>^IndexValue"
-            let impl_arg_names: Vec<String> = impl_args
-                .iter()
-                .map(|t| self.type_id_to_name(*t, type_table))
-                .collect();
+        // Split type_args into impl args and method args
+        let (impl_args, method_args) = key
+            .type_args
+            .split_at(std::cmp::min(impl_type_params_count, key.type_args.len()));
 
-            let mangled_struct = MethodName::format_struct_with_args(
-                &parsed.struct_name,
-                &impl_arg_names,
-                parsed.trait_name.as_deref(),
-            );
+        // Build mangled struct name with type args
+        // e.g., "Triple^IndexValue" -> "Triple<i32>^IndexValue"
+        let impl_arg_names: Vec<String> = impl_args
+            .iter()
+            .map(|t| type_table.mangle_type_name(*t))
+            .collect();
 
-            // Build mangled method name: transform<i64> (using method type args)
-            let method_arg_names: Vec<String> = method_args
-                .iter()
-                .map(|t| self.type_id_to_name(*t, type_table))
-                .collect();
-            let mangled_method =
-                MethodName::format_method_with_args(&parsed.method_name, &method_arg_names);
+        let mangled_struct = MethodName::format_struct_with_args(
+            &method_info.struct_name,
+            &impl_arg_names,
+            method_info.trait_name.as_deref(),
+        );
 
-            MethodName::join_struct_method(&mangled_struct, &mangled_method)
-        } else {
-            // Fallback to regular function mangling
-            self.mangle_function_name(key, type_table)
-        }
-    }
+        // Build method name: transform<i64> (using method type args)
+        let method_arg_names: Vec<String> = method_args
+            .iter()
+            .map(|t| type_table.mangle_type_name(*t))
+            .collect();
+        let mangled_method =
+            MethodName::format_method_with_args(&method_info.method_name, &method_arg_names);
 
-    /// Convert a `TypeId` to its string representation for name mangling
-    fn type_id_to_name(&self, type_id: TypeId, type_table: &TypeTable) -> String {
-        match type_table.get(type_id) {
-            ResolvedType::Primitive(p) => format!("{p:?}").to_lowercase(),
-            ResolvedType::Struct { name, .. } => name.clone(),
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => {
-                let args: Vec<String> = type_args
-                    .iter()
-                    .map(|&t| self.type_id_to_name(t, type_table))
-                    .collect();
-                format!("{}<{}>", name, args.join(","))
-            }
-            // Function types: Fn<paramCount,returnType>
-            ResolvedType::Function {
-                params,
-                return_type,
-                ..
-            } => {
-                let ret_name = self.type_id_to_name(*return_type, type_table);
-                format!("Fn<{},{}>", params.len(), ret_name)
-            }
-            ResolvedType::Tuple(elems) => {
-                let elem_names: Vec<String> = elems
-                    .iter()
-                    .map(|t| self.type_id_to_name(*t, type_table))
-                    .collect();
-                format!("Tuple<{}>", elem_names.join(","))
-            }
-            ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                self.type_id_to_name(*inner, type_table)
-            }
-            ResolvedType::TypeParam { name, .. } => name.clone(),
-            _ => type_id.to_string(),
-        }
+        MethodName::join_struct_method(&mangled_struct, &mangled_method)
     }
 
     /// Instantiate a generic function with concrete type arguments
@@ -2201,14 +2129,14 @@ impl Monomorphizer {
                     .type_args
                     .iter()
                     .take(impl_type_args_count)
-                    .map(|&t| self.type_id_to_name(t, type_table))
+                    .map(|&t| type_table.mangle_type_name(t))
                     .collect();
                 // Method type args are the remaining elements (from method's own type params)
                 let method_type_args: Vec<String> = key
                     .type_args
                     .iter()
                     .skip(impl_type_args_count)
-                    .map(|&t| self.type_id_to_name(t, type_table))
+                    .map(|&t| type_table.mangle_type_name(t))
                     .collect();
                 info.with_type_args(&impl_type_args, &method_type_args)
             }),
@@ -2416,80 +2344,47 @@ impl Monomorphizer {
 
                 // Also update the method func name if receiver type contains type params
                 // e.g., Array<T>::len -> Array<i32>::len when T->i32
-                let old_func_name = method_func.name();
-                let module_source = method_func.module_source();
-                let mut new_func_name = old_func_name.clone();
+                if !substitution.is_empty()
+                    && let Some(info) = method_func.method_info()
+                {
+                    // Use structured method_info instead of parsing strings
+                    let old_func_name = method_func.name();
+                    let module_source = method_func.module_source();
 
-                // Handle case where func_name is "StructName^Trait::method" or "StructName::method"
-                // without type params but we're in a generic context
-                // e.g., TreeMap^IndexAssign::index_assign inside TreeMap<K,V>::insert
-                if !substitution.is_empty() && !new_func_name.contains('<') {
-                    // Find the separator (either ^ for trait methods or :: for regular methods)
-                    let separator_pos =
-                        new_func_name.find('^').or_else(|| new_func_name.find("::"));
-                    if let Some(sep_pos) = separator_pos {
-                        let struct_part = &new_func_name[..sep_pos];
-                        let rest_part = &new_func_name[sep_pos..];
-
-                        // Build type args from substitution
-                        let mut sorted_entries: Vec<_> = substitution.iter().collect();
-                        sorted_entries.sort_by_key(|(idx, _)| **idx);
-                        let type_names: Vec<String> = sorted_entries
-                            .iter()
-                            .map(|(_, tid)| self.type_id_to_name(**tid, type_table))
-                            .collect();
-                        new_func_name =
-                            format!("{}<{}>{}", struct_part, type_names.join(","), rest_part);
-                    }
-                }
-
-                // Multiple TypeParams can have the same index (e.g., T from Result and K from TreeMap)
-                // Try all of them to handle cross-module generic types
-                for (&param_index, &concrete_type_id) in substitution {
-                    let concrete_name = self.type_id_to_name(concrete_type_id, type_table);
-                    for tid in type_table.iter_type_ids() {
-                        if let ResolvedType::TypeParam { name, index } = type_table.get(tid)
-                            && *index == param_index
-                        {
-                            // Replace type param in angle bracket syntax: <T> -> <i32>
-                            // Don't break - try all TypeParams with this index
-                            new_func_name = new_func_name
-                                .replace(&format!("<{name}>"), &format!("<{concrete_name}>"))
-                                .replace(&format!("<{name},"), &format!("<{concrete_name},"))
-                                .replace(&format!(",{name}>"), &format!(",{concrete_name}>"))
-                                .replace(&format!(",{name},"), &format!(",{concrete_name},"));
-                        }
-                    }
-                }
-                if new_func_name != old_func_name {
-                    // Collect type_args in order by param index (key)
+                    // Build type args from substitution
                     let mut sorted_entries: Vec<_> = substitution.iter().collect();
                     sorted_entries.sort_by_key(|(idx, _)| **idx);
+                    let type_names: Vec<String> = sorted_entries
+                        .iter()
+                        .map(|(_, tid)| type_table.mangle_type_name(**tid))
+                        .collect();
                     let type_args: Vec<TypeId> =
                         sorted_entries.iter().map(|(_, tid)| **tid).collect();
-                    // Preserve the existing generic_name if we already have monomorph_info
-                    // (e.g., Array<T>::append has generic_name: Array::append)
-                    // Otherwise use old_func_name as the generic name
-                    let existing_generic_name = match method_func {
-                        FunctionRef::External {
-                            monomorph_info: Some(info),
-                            ..
-                        } => Some(info.generic_name.clone()),
-                        _ => None,
-                    };
-                    let monomorph_info = Some(MonomorphInfo {
-                        generic_name: existing_generic_name.unwrap_or(old_func_name),
-                        type_args,
-                    });
-                    // Preserve original method_info (struct/trait/method names unchanged,
-                    // only the mangled name in `name` field changes)
-                    let original_method_info = method_func.method_info();
-                    *method_func = FunctionRef::External {
-                        module_source,
-                        name: new_func_name,
-                        monomorph_info,
-                        method_info: original_method_info,
-                    };
+
+                    // Apply type args to get monomorphized method info
+                    let new_info = info.with_struct_type_args(&type_names);
+                    let new_func_name = new_info.to_mangled_name();
+
+                    if new_func_name != old_func_name {
+                        // Preserve the existing generic_name if we already have monomorph_info
+                        let existing_generic_name = match method_func {
+                            FunctionRef::External {
+                                monomorph_info: Some(mi),
+                                ..
+                            } => Some(mi.generic_name.clone()),
+                            _ => None,
+                        };
+                        let monomorph_info = Some(MonomorphInfo {
+                            generic_name: existing_generic_name.unwrap_or(old_func_name),
+                            type_args,
+                        });
+                        *method_func = FunctionRef::External {
+                            module_source,
+                            name: new_func_name,
+                            monomorph_info,
+                            method_info: Some(new_info),
+                        };
+                    }
                 }
             }
             TirExprKind::EffectCall { args, .. } => {
@@ -2501,70 +2396,41 @@ impl Monomorphizer {
                 func: static_func,
                 args,
             } => {
-                let old_func_name = static_func.name();
-                let module_source = static_func.module_source();
                 // Substitute type parameter names in func_name
                 // e.g., "Box<T>::new" with T->i32 becomes "Box<i32>::new"
-                let mut new_func_name = old_func_name.clone();
-
-                // Handle case where func_name is "StructName::method" without type params
-                // but we're in a generic context (substitution is not empty)
-                // e.g., TreeMap::new inside TreeMap<K,V>::with_default_degree
                 if !substitution.is_empty()
-                    && !new_func_name.contains('<')
-                    && let Some(sep_pos) = new_func_name.find("::")
+                    && let Some(info) = static_func.method_info()
                 {
-                    let struct_part = &new_func_name[..sep_pos];
-                    let method_part = &new_func_name[sep_pos..];
+                    // Use structured method_info instead of parsing strings
+                    let old_func_name = static_func.name();
+                    let module_source = static_func.module_source();
 
                     // Build type args from substitution
                     let mut sorted_entries: Vec<_> = substitution.iter().collect();
                     sorted_entries.sort_by_key(|(idx, _)| **idx);
                     let type_names: Vec<String> = sorted_entries
                         .iter()
-                        .map(|(_, tid)| self.type_id_to_name(**tid, type_table))
+                        .map(|(_, tid)| type_table.mangle_type_name(**tid))
                         .collect();
-                    new_func_name =
-                        format!("{}<{}>{}", struct_part, type_names.join(","), method_part);
-                }
-
-                // Multiple TypeParams can have the same index (e.g., T from Result and K from TreeMap)
-                // Try all of them to handle cross-module generic types
-                for (&param_index, &concrete_type_id) in substitution {
-                    let concrete_name = self.type_id_to_name(concrete_type_id, type_table);
-                    for tid in type_table.iter_type_ids() {
-                        if let ResolvedType::TypeParam { name, index } = type_table.get(tid)
-                            && *index == param_index
-                        {
-                            // Replace type param in angle bracket syntax: <T> -> <i32>
-                            // Don't break - try all TypeParams with this index
-                            new_func_name = new_func_name
-                                .replace(&format!("<{name}>"), &format!("<{concrete_name}>"))
-                                .replace(&format!("<{name},"), &format!("<{concrete_name},"))
-                                .replace(&format!(",{name}>"), &format!(",{concrete_name}>"))
-                                .replace(&format!(",{name},"), &format!(",{concrete_name},"));
-                        }
-                    }
-                }
-                // Update func if name changed
-                if new_func_name != old_func_name {
-                    // Collect type_args in order by param index (key)
-                    let mut sorted_entries: Vec<_> = substitution.iter().collect();
-                    sorted_entries.sort_by_key(|(idx, _)| **idx);
                     let type_args: Vec<TypeId> =
                         sorted_entries.iter().map(|(_, tid)| **tid).collect();
-                    let monomorph_info = Some(MonomorphInfo {
-                        generic_name: old_func_name,
-                        type_args,
-                    });
-                    // Preserve original method_info
-                    let original_method_info = static_func.method_info();
-                    *static_func = FunctionRef::External {
-                        module_source,
-                        name: new_func_name,
-                        monomorph_info,
-                        method_info: original_method_info,
-                    };
+
+                    // Apply type args to get monomorphized method info
+                    let new_info = info.with_struct_type_args(&type_names);
+                    let new_func_name = new_info.to_mangled_name();
+
+                    if new_func_name != old_func_name {
+                        let monomorph_info = Some(MonomorphInfo {
+                            generic_name: old_func_name,
+                            type_args,
+                        });
+                        *static_func = FunctionRef::External {
+                            module_source,
+                            name: new_func_name,
+                            monomorph_info,
+                            method_info: Some(new_info),
+                        };
+                    }
                 }
                 for arg in args {
                     self.substitute_types_in_expr(arg, substitution, type_table);
@@ -2670,16 +2536,16 @@ impl Monomorphizer {
                             sorted_entries.sort_by_key(|(idx, _)| **idx);
                             let args: Vec<String> = sorted_entries
                                 .iter()
-                                .map(|(_, tid)| self.type_id_to_name_component(**tid, type_table))
+                                .map(|(_, tid)| type_table.mangle_type_name(**tid))
                                 .collect();
-                            *struct_name = format!("{}<{}>", name, args.join(","));
+                            *struct_name = mangle_generic_name(name, &args);
                         } else {
                             // For generic instances like Container<i32>, compute the mangled name
                             let args: Vec<String> = type_args
                                 .iter()
-                                .map(|arg| self.type_id_to_name_component(*arg, type_table))
+                                .map(|arg| type_table.mangle_type_name(*arg))
                                 .collect();
-                            *struct_name = format!("{}<{}>", name, args.join(","));
+                            *struct_name = mangle_generic_name(name, &args);
                         }
                     }
                     _ => {}
@@ -3049,15 +2915,15 @@ impl Monomorphizer {
                 args,
             } => {
                 let func_name = func.name();
+                let original_method_info = func.method_info();
                 // If this is a generic call, rewrite to monomorphized name
                 if !type_args.is_empty() {
                     let key = InstantiationKey {
                         name: func_name.clone(),
                         type_args: type_args.clone(),
+                        method_info: original_method_info.clone(),
                     };
                     if let Some(mangled) = self.function_instantiated.get(&key) {
-                        // Preserve original method_info
-                        let original_method_info = func.method_info();
                         // Use EntryPoint module source since monomorphized functions are
                         // generated in the current (calling) module, not the original
                         // module where the generic function was defined.
@@ -3106,9 +2972,11 @@ impl Monomorphizer {
                 {
                     let full_method_name =
                         MethodName::format_local(&struct_name, None, &method_name);
+                    // method_info is not used for lookup (only for name formatting during collection)
                     let key = InstantiationKey {
                         name: full_method_name.clone(),
                         type_args: type_args.clone(),
+                        method_info: None,
                     };
                     if let Some(mangled) = self.function_instantiated.get(&key) {
                         // Update func to the monomorphized method
@@ -3141,6 +3009,7 @@ impl Monomorphizer {
                         let combined_key = InstantiationKey {
                             name: generic_method_name.clone(),
                             type_args: combined_type_args.clone(),
+                            method_info: None,
                         };
                         if let Some(mangled) = self.function_instantiated.get(&combined_key) {
                             // Preserve original method_info
@@ -3197,12 +3066,14 @@ impl Monomorphizer {
                         possible_keys.push(InstantiationKey {
                             name: trait_method_name,
                             type_args: impl_type_args.clone(),
+                            method_info: None,
                         });
                     }
                     // Also try regular method format
                     possible_keys.push(InstantiationKey {
                         name: MethodName::format_local(&base_struct, None, &method_name),
                         type_args: impl_type_args.clone(),
+                        method_info: None,
                     });
 
                     for key in possible_keys {
@@ -3368,7 +3239,7 @@ impl Monomorphizer {
             } => {
                 let args: Vec<String> = type_args
                     .iter()
-                    .map(|&t| self.type_id_to_name(t, type_table))
+                    .map(|&t| type_table.mangle_type_name(t))
                     .collect();
                 (name.clone(), args)
             }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -520,7 +520,7 @@ pub fn extract_local_name(name: &str) -> &str {
 /// This is used to extract struct/trait/method info from names like:
 /// - `Point::sum` → `struct_name="Point"`, `trait_name=None`, `method_name="sum"`
 /// - `Point^Display::fmt` → `struct_name="Point"`, `trait_name=Some("Display")`, `method_name="fmt"`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LocalMethodName {
     /// The struct name, possibly with type args (e.g., "Point" or "Point<i32>")
     pub struct_name: String,
@@ -634,74 +634,6 @@ impl LocalMethodName {
         }
     }
 
-    /// Parse a local method name string into its components.
-    ///
-    /// Expected formats:
-    /// - `StructName::method`
-    /// - `StructName^TraitName::method`
-    /// - `StructName<TypeArgs>::method`
-    /// - `StructName<TypeArgs>^TraitName::method`
-    ///
-    /// Returns `None` if the format is invalid (no `::` separator).
-    pub fn parse(name: &str) -> Option<Self> {
-        let sep_pos = name.find("::")?;
-        let prefix = &name[..sep_pos];
-        let method_part = &name[sep_pos + 2..];
-
-        // Parse method name and type args (e.g., "transform<i64>" -> "transform", ["i64"])
-        let (method_name, method_type_args) = if let Some(angle_pos) = method_part.find('<') {
-            let base_name = &method_part[..angle_pos];
-            // Extract type args from between < and >
-            let type_args_str = method_part
-                .strip_prefix(&format!("{base_name}<"))
-                .and_then(|s| s.strip_suffix('>'))
-                .unwrap_or("");
-            let type_args: Vec<String> = type_args_str
-                .split(',')
-                .filter(|s| !s.is_empty())
-                .map(str::to_string)
-                .collect();
-            (base_name, type_args)
-        } else {
-            (method_part, vec![])
-        };
-
-        // Check for trait separator `^` in the prefix
-        if let Some(caret_pos) = prefix.find('^') {
-            let struct_name = &prefix[..caret_pos];
-            let trait_name = &prefix[caret_pos + 1..];
-            Some(Self {
-                struct_name: struct_name.to_string(),
-                base_struct_name: strip_type_params(struct_name).to_string(),
-                trait_name: Some(trait_name.to_string()),
-                method_name: method_name.to_string(),
-                method_type_args,
-            })
-        } else {
-            Some(Self {
-                struct_name: prefix.to_string(),
-                base_struct_name: strip_type_params(prefix).to_string(),
-                trait_name: None,
-                method_name: method_name.to_string(),
-                method_type_args,
-            })
-        }
-    }
-
-    /// Parse a potentially module-qualified method name.
-    ///
-    /// This first strips the module path (e.g., `./main.wado/`) and then
-    /// parses the local method name.
-    ///
-    /// Examples:
-    /// - `"./main.wado/Point::sum"` → Some(LocalMethodName { `struct_name`: "Point", ... })
-    /// - `"Point^Display::fmt"` → Some(LocalMethodName { `struct_name`: "Point", `trait_name`: Some("Display"), ... })
-    /// - `"run"` → None (not a method)
-    pub fn parse_qualified(name: &str) -> Option<Self> {
-        let local_name = extract_local_name(name);
-        Self::parse(local_name)
-    }
-
     /// Returns true if this is a trait method.
     pub fn is_trait_method(&self) -> bool {
         self.trait_name.is_some()
@@ -810,47 +742,6 @@ impl fmt::Display for StructName {
 }
 
 // =============================================================================
-// Parsing Utilities
-// =============================================================================
-
-/// Parse a mangled method name back into its components.
-///
-/// Returns `None` if the format is invalid.
-///
-/// Expected formats:
-/// - `{filename}/{struct_name}::{method_name}`
-/// - `{filename}/{struct_name}^{trait_name}::{method_name}`
-pub fn parse_method_mangled_name(mangled: &str) -> Option<MethodName> {
-    // Split at the last `/` to separate filename from the rest
-    let slash_pos = mangled.rfind('/')?;
-    let filename = &mangled[..slash_pos];
-    let rest = &mangled[slash_pos + 1..];
-
-    // Split at `::` to separate struct/trait from method name
-    let double_colon_pos = rest.find("::")?;
-    let struct_trait_part = &rest[..double_colon_pos];
-    let method_name = &rest[double_colon_pos + 2..];
-
-    // Check for trait separator `^`
-    if let Some(caret_pos) = struct_trait_part.find('^') {
-        let struct_name = &struct_trait_part[..caret_pos];
-        let trait_name = &struct_trait_part[caret_pos + 1..];
-        Some(MethodName::new(
-            filename.to_string(),
-            struct_name.to_string(),
-            Some(trait_name.to_string()),
-            method_name.to_string(),
-        ))
-    } else {
-        Some(MethodName::new(
-            filename.to_string(),
-            struct_trait_part.to_string(),
-            None,
-            method_name.to_string(),
-        ))
-    }
-}
-
 /// Build a core/internal function name.
 ///
 /// Format: `core/internal/{name}`
@@ -1143,6 +1034,77 @@ fn remove_dot_segments(path: &str) -> String {
 }
 
 // =============================================================================
+// Type Name Formatting
+// =============================================================================
+
+/// Information about a type for name formatting.
+///
+/// This enum represents the structure of a type without requiring
+/// knowledge of `TypeId` or `ResolvedType`. It serves as the interface
+/// between type resolution (in tir.rs) and name formatting (in name.rs).
+#[derive(Debug, Clone)]
+pub enum TypeNameInfo {
+    /// A primitive type (i32, f64, bool, etc.)
+    Primitive(String),
+    /// The unit type ()
+    Unit,
+    /// A named type (struct, enum, variant, resource, newtype, type param)
+    Named(String),
+    /// A generic instance with type argument names already resolved
+    Generic { name: String, args: Vec<String> },
+    /// Option<T> with inner type name
+    Option(String),
+    /// Result<T, E> with ok and err type names
+    Result { ok: String, err: String },
+    /// A tuple type with element type names
+    Tuple(Vec<String>),
+    /// A function type with param count and return type name
+    Function {
+        param_count: usize,
+        return_type: String,
+    },
+    /// Array<T> with element type name
+    Array(String),
+    /// Stream<T> with inner type name
+    Stream(String),
+    /// Future<T> with inner type name
+    Future(String),
+    /// Reactive<T> with inner type name
+    Reactive(String),
+    /// A reference type - formats as inner type (references stripped)
+    Ref(String),
+    /// Never, Unknown, or Error types
+    Unknown,
+}
+
+/// Format a type name from its structural info.
+///
+/// This function centralizes all type name formatting logic.
+/// Other modules should use this instead of formatting type names directly.
+#[must_use]
+pub fn format_type_name(info: TypeNameInfo) -> String {
+    match info {
+        TypeNameInfo::Primitive(name) => name,
+        TypeNameInfo::Unit => "unit".to_string(),
+        TypeNameInfo::Named(name) => name,
+        TypeNameInfo::Generic { name, args } => mangle_generic_name(&name, &args),
+        TypeNameInfo::Option(inner) => mangle_option_type(&inner),
+        TypeNameInfo::Result { ok, err } => mangle_result_type(&ok, &err),
+        TypeNameInfo::Tuple(elems) => mangle_tuple_type(&elems),
+        TypeNameInfo::Function {
+            param_count,
+            return_type,
+        } => mangle_fn_type(param_count, &return_type),
+        TypeNameInfo::Array(elem) => mangle_array_type(&elem),
+        TypeNameInfo::Stream(inner) => mangle_generic_name("Stream", &[inner]),
+        TypeNameInfo::Future(inner) => mangle_generic_name("Future", &[inner]),
+        TypeNameInfo::Reactive(inner) => mangle_generic_name("Reactive", &[inner]),
+        TypeNameInfo::Ref(inner) => inner,
+        TypeNameInfo::Unknown => "unknown".to_string(),
+    }
+}
+
+// =============================================================================
 // Name Mangling Utilities
 // =============================================================================
 
@@ -1156,24 +1118,6 @@ pub fn mangle_generic_name(base_name: &str, type_args: &[String]) -> String {
         base_name.to_string()
     } else {
         format!("{}<{}>", base_name, type_args.join(","))
-    }
-}
-
-/// Strip type parameters from a generic name, returning the base name.
-///
-/// This is the inverse of `mangle_generic_name` - it extracts the base name
-/// from a potentially generic name.
-///
-/// Examples:
-/// - `strip_type_params("IndexValue<i32>")` → `"IndexValue"`
-/// - `strip_type_params("Map<String,i32>")` → `"Map"`
-/// - `strip_type_params("Point")` → `"Point"` (unchanged)
-#[must_use]
-pub fn strip_type_params(name: &str) -> &str {
-    if let Some(bracket_pos) = name.find('<') {
-        &name[..bracket_pos]
-    } else {
-        name
     }
 }
 
@@ -1221,6 +1165,30 @@ pub fn mangle_array_type(elem_type: &str) -> String {
     format!("Array<{elem_type}>")
 }
 
+/// Build a Result type name from ok and error type names.
+///
+/// Examples:
+/// - `mangle_result_type("i32", "String")` → `"Result<i32,String>"`
+pub fn mangle_result_type(ok_type: &str, err_type: &str) -> String {
+    format!("Result<{ok_type},{err_type}>")
+}
+
+/// Build a local method name from struct name and method name.
+///
+/// Examples:
+/// - `mangle_local_method("Point", "sum")` → `"Point::sum"`
+pub fn mangle_local_method(struct_name: &str, method_name: &str) -> String {
+    format!("{struct_name}::{method_name}")
+}
+
+/// Build a local method name with trait from struct name, trait name, and method name.
+///
+/// Examples:
+/// - `mangle_local_trait_method("Point", "Display", "fmt")` → `"Point^Display::fmt"`
+pub fn mangle_local_trait_method(struct_name: &str, trait_name: &str, method_name: &str) -> String {
+    format!("{struct_name}^{trait_name}::{method_name}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1249,60 +1217,6 @@ mod tests {
             "fmt".to_string(),
         );
         assert_eq!(method.to_string(), "./geometry.wado/Point^Display::fmt");
-    }
-
-    #[test]
-    fn test_parse_method_mangled_name_simple() {
-        let parsed = parse_method_mangled_name("./geometry.wado/Point::sum").unwrap();
-        assert_eq!(parsed.filename, "./geometry.wado");
-        assert_eq!(parsed.struct_name, "Point");
-        assert_eq!(parsed.trait_name, None);
-        assert_eq!(parsed.method_name, "sum");
-    }
-
-    #[test]
-    fn test_parse_method_mangled_name_with_trait() {
-        let parsed = parse_method_mangled_name("./geometry.wado/Point^Display::fmt").unwrap();
-        assert_eq!(parsed.filename, "./geometry.wado");
-        assert_eq!(parsed.struct_name, "Point");
-        assert_eq!(parsed.trait_name, Some("Display".to_string()));
-        assert_eq!(parsed.method_name, "fmt");
-    }
-
-    #[test]
-    fn test_roundtrip_simple() {
-        let original = MethodName::new(
-            "./geometry.wado".to_string(),
-            "Point".to_string(),
-            None,
-            "magnitude".to_string(),
-        );
-        let mangled = original.to_string();
-        let parsed = parse_method_mangled_name(&mangled).unwrap();
-        assert_eq!(original, parsed);
-    }
-
-    #[test]
-    fn test_roundtrip_with_trait() {
-        let original = MethodName::new(
-            "./models/user.wado".to_string(),
-            "User".to_string(),
-            Some("Serialize".to_string()),
-            "to_json".to_string(),
-        );
-        let mangled = original.to_string();
-        let parsed = parse_method_mangled_name(&mangled).unwrap();
-        assert_eq!(original, parsed);
-    }
-
-    #[test]
-    fn test_parse_invalid_no_slash() {
-        assert!(parse_method_mangled_name("Point::sum").is_none());
-    }
-
-    #[test]
-    fn test_parse_invalid_no_double_colon() {
-        assert!(parse_method_mangled_name("./geometry.wado/Point").is_none());
     }
 
     // =========================================================================

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -11,7 +11,10 @@ use indexmap::IndexMap;
 use crate::ast::Type;
 use crate::builtin_registry::BuiltinRegistry;
 use crate::component_model::WasiRegistry;
-use crate::name::{FreeFunctionName, FunctionId, LocalMethodName, MethodName, ModuleSource};
+use crate::name::{
+    FreeFunctionName, FunctionId, MethodName, ModuleSource, mangle_generic_name,
+    mangle_local_method, mangle_local_trait_method, mangle_method_generic,
+};
 use crate::project::Project;
 use crate::tir::{
     PrimitiveType, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirImport, TirModule,
@@ -327,34 +330,35 @@ pub fn analyze_project(project: &mut Project) {
             // Build function ID(s) to check if it's reachable
             // Note: monomorphized methods are tracked as FunctionId::Free in the call graph
             // but their names look like methods (e.g., "TreeMap<String,i32>^Index::index")
-            let is_reachable = if let Some(parsed) = LocalMethodName::parse(func_name) {
-                // Method name like "Point::sum" or "Point^Trait::method"
-                // Check as MethodName first (for non-monomorphized methods)
-                let method_id = FunctionId::Method(MethodName::new(
-                    module_path.join("/"),
-                    parsed.struct_name.clone(),
-                    parsed.trait_name.clone(),
-                    parsed.method_name.clone(),
-                ));
-                if reachable.contains(&method_id) {
-                    true
+            let is_reachable =
+                if let Some(Some(method_info)) = module.function_method_info.get(func_name) {
+                    // Method with method_info
+                    // Check as MethodName first (for non-monomorphized methods)
+                    let method_id = FunctionId::Method(MethodName::new(
+                        module_path.join("/"),
+                        method_info.struct_name.clone(),
+                        method_info.trait_name.clone(),
+                        method_info.method_name.clone(),
+                    ));
+                    if reachable.contains(&method_id) {
+                        true
+                    } else {
+                        // For monomorphized methods, also check as FreeFunctionName
+                        // Monomorphized methods have type args in the struct name (e.g., "TreeMap<String,i32>")
+                        let free_id = FunctionId::Free(FreeFunctionName::from_path_and_name(
+                            &module_path,
+                            func_name,
+                        ));
+                        reachable.contains(&free_id)
+                    }
                 } else {
-                    // For monomorphized methods, also check as FreeFunctionName
-                    // Monomorphized methods have type args in the struct name (e.g., "TreeMap<String,i32>")
-                    let free_id = FunctionId::Free(FreeFunctionName::from_path_and_name(
+                    // Regular function (no method_info)
+                    let func_id = FunctionId::Free(FreeFunctionName::from_path_and_name(
                         &module_path,
                         func_name,
                     ));
-                    reachable.contains(&free_id)
-                }
-            } else {
-                // Regular function
-                let func_id = FunctionId::Free(FreeFunctionName::from_path_and_name(
-                    &module_path,
-                    func_name,
-                ));
-                reachable.contains(&func_id)
-            };
+                    reachable.contains(&func_id)
+                };
 
             if is_reachable {
                 for s in strings {
@@ -827,21 +831,19 @@ fn analyze_expr(
                         // Generic instance method call (e.g., Box<i32>.get())
                         let type_arg_names: Vec<String> = type_args
                             .iter()
-                            .map(|t| mangle_type_for_name(*t, type_table))
+                            .map(|t| type_table.mangle_type_name(*t))
                             .collect();
                         // Include trait name for trait methods (e.g., TreeMap<String,i32>^Index::index)
                         let (mangled_func_name, base_name) = if let Some(ref trait_n) = trait_name {
-                            let mangled = format!(
-                                "{}<{}>^{trait_n}::{method_name}",
-                                name,
-                                type_arg_names.join(",")
-                            );
-                            let base = format!("{name}^{trait_n}::{method_name}");
+                            let generic_name = mangle_generic_name(&name, &type_arg_names);
+                            let mangled =
+                                mangle_local_trait_method(&generic_name, trait_n, &method_name);
+                            let base = mangle_local_trait_method(&name, trait_n, &method_name);
                             (mangled, base)
                         } else {
                             let mangled =
-                                format!("{}<{}>::{method_name}", name, type_arg_names.join(","));
-                            let base = format!("{name}::{method_name}");
+                                mangle_method_generic(&name, &type_arg_names, &method_name);
+                            let base = mangle_local_method(&name, &method_name);
                             (mangled, base)
                         };
                         let callee_id = FunctionId::Free(FreeFunctionName::with_monomorph_info(
@@ -853,15 +855,18 @@ fn analyze_expr(
                     }
                     ResolvedType::BuiltinArray(elem_type) => {
                         // Array<T> method call (e.g., arr.len(), arr.append())
-                        let elem_name = mangle_type_for_name(elem_type, type_table);
+                        let elem_name = type_table.mangle_type_name(elem_type);
                         // Include trait name for trait methods (e.g., Array<i32>^Index::index)
                         let (mangled_func_name, base_name) = if let Some(ref trait_n) = trait_name {
-                            let mangled = format!("Array<{elem_name}>^{trait_n}::{method_name}");
-                            let base = format!("Array^{trait_n}::{method_name}");
+                            let array_name = mangle_generic_name("Array", &[elem_name]);
+                            let mangled =
+                                mangle_local_trait_method(&array_name, trait_n, &method_name);
+                            let base = mangle_local_trait_method("Array", trait_n, &method_name);
                             (mangled, base)
                         } else {
-                            let mangled = format!("Array<{elem_name}>::{method_name}");
-                            let base = format!("Array::{method_name}");
+                            let mangled =
+                                mangle_method_generic("Array", &[elem_name], &method_name);
+                            let base = mangle_local_method("Array", &method_name);
                             (mangled, base)
                         };
                         let callee_id = FunctionId::Free(FreeFunctionName::with_monomorph_info(
@@ -1139,47 +1144,6 @@ fn add_to_string_callee(type_id: TypeId, type_table: &TypeTable, analysis: &mut 
 }
 
 /// Mangle a type ID into a string suitable for struct/function names.
-/// Used for creating monomorphized function names like Array<i32>`::len`.
-fn mangle_type_for_name(type_id: TypeId, type_table: &TypeTable) -> String {
-    match type_table.get(type_id) {
-        ResolvedType::Primitive(prim) => prim.as_str().to_string(),
-        ResolvedType::Unit => "unit".to_string(),
-        ResolvedType::Struct { name, .. } => name.clone(),
-        ResolvedType::GenericInstance {
-            name, type_args, ..
-        } => {
-            let args: Vec<String> = type_args
-                .iter()
-                .map(|t| mangle_type_for_name(*t, type_table))
-                .collect();
-            format!("{}<{}>", name, args.join(","))
-        }
-        ResolvedType::Function {
-            params,
-            return_type,
-            ..
-        } => {
-            let ret_name = mangle_type_for_name(*return_type, type_table);
-            format!("Fn<{},{}>", params.len(), ret_name)
-        }
-        ResolvedType::Tuple(elems) => {
-            let elem_names: Vec<String> = elems
-                .iter()
-                .map(|t| mangle_type_for_name(*t, type_table))
-                .collect();
-            format!("Tuple<{}>", elem_names.join(","))
-        }
-        ResolvedType::Option(inner) => {
-            let inner_name = mangle_type_for_name(*inner, type_table);
-            format!("Option<{inner_name}>")
-        }
-        ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-            mangle_type_for_name(*inner, type_table)
-        }
-        _ => "unknown".to_string(),
-    }
-}
-
 /// Compute the set of reachable functions from an entry point
 fn compute_reachable(
     call_graph: &HashMap<FunctionId, HashSet<FunctionId>>,

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -16,9 +16,7 @@ use indexmap::IndexMap;
 
 use crate::builtin_registry::BuiltinRegistry;
 use crate::component_model::WasiRegistry;
-use crate::name::{
-    self as name, LocalMethodName, ModuleSource, mangle_generic_name, strip_type_params,
-};
+use crate::name::{self as name, LocalMethodName, ModuleSource, mangle_generic_name};
 
 use crate::ast::{
     self, BinaryOp, Block, BreakStmt, ContinueStmt, Expr, ExprStmt, ForOfStmt, ForStmt, Function,
@@ -5592,12 +5590,16 @@ impl<'a> Resolver<'a> {
                         name: "prelude/primitives".to_string(),
                     };
                     (
-                        self.mangle_type_name(base_type_id),
+                        self.type_table.borrow().mangle_type_name(base_type_id),
                         prim_module.to_path(),
                         Some(prim_module),
                     )
                 }
-                _ => (self.mangle_type_name(base_type_id), vec![], None),
+                _ => (
+                    self.type_table.borrow().mangle_type_name(base_type_id),
+                    vec![],
+                    None,
+                ),
             };
 
         // Look up method info based on receiver type
@@ -5741,7 +5743,7 @@ impl<'a> Resolver<'a> {
                 } => {
                     let type_arg_names: Vec<String> = type_args
                         .iter()
-                        .map(|t| self.mangle_type_name(*t))
+                        .map(|t| self.type_table.borrow().mangle_type_name(*t))
                         .collect();
                     let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                     (
@@ -5752,7 +5754,7 @@ impl<'a> Resolver<'a> {
                     )
                 }
                 ResolvedType::BuiltinArray(elem) => {
-                    let elem_name = self.mangle_type_name(elem);
+                    let elem_name = self.type_table.borrow().mangle_type_name(elem);
                     let _mangled = format!("Array<{elem_name}>");
                     (
                         "Array".to_string(),
@@ -5762,7 +5764,7 @@ impl<'a> Resolver<'a> {
                     )
                 }
                 _ => {
-                    let name = self.mangle_type_name(base_type_id);
+                    let name = self.type_table.borrow().mangle_type_name(base_type_id);
                     (name.clone(), name, vec![], None)
                 }
             };
@@ -5791,7 +5793,7 @@ impl<'a> Resolver<'a> {
         // Use inferred type args if available, otherwise use explicit type args
         let method_type_arg_names: Vec<String> = method_type_args
             .iter()
-            .map(|t| self.mangle_type_name(*t))
+            .map(|t| self.type_table.borrow().mangle_type_name(*t))
             .collect();
 
         // Build method_info with base struct name, then apply impl and method type args
@@ -6052,7 +6054,7 @@ impl<'a> Resolver<'a> {
                 // Build mangled name for generic type: Array<i32>
                 let type_arg_names: Vec<String> = type_args
                     .iter()
-                    .map(|t| self.mangle_type_name(*t))
+                    .map(|t| self.type_table.borrow().mangle_type_name(*t))
                     .collect();
                 let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                 (
@@ -6077,7 +6079,7 @@ impl<'a> Resolver<'a> {
                     } => {
                         let type_arg_names: Vec<String> = type_args
                             .iter()
-                            .map(|t| self.mangle_type_name(*t))
+                            .map(|t| self.type_table.borrow().mangle_type_name(*t))
                             .collect();
                         let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                         (
@@ -6157,7 +6159,7 @@ impl<'a> Resolver<'a> {
                 let generic_name = format!("{}::{}", struct_name, static_call.method);
                 let type_arg_names: Vec<String> = struct_type_args
                     .iter()
-                    .map(|t| self.mangle_type_name(*t))
+                    .map(|t| self.type_table.borrow().mangle_type_name(*t))
                     .collect();
                 (
                     Some(MonomorphInfo {
@@ -6617,45 +6619,6 @@ impl<'a> Resolver<'a> {
 
         // Default to current module source
         self.current_module_source.clone()
-    }
-
-    /// Mangle a type name for use in function names
-    fn mangle_type_name(&self, type_id: TypeId) -> String {
-        match self.type_table.borrow().get(type_id) {
-            ResolvedType::Primitive(prim) => prim.as_str().to_string(),
-            ResolvedType::Unit => "unit".to_string(),
-            ResolvedType::Struct { name, .. } => name.clone(),
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => {
-                let args: Vec<String> = type_args
-                    .iter()
-                    .map(|t| self.mangle_type_name(*t))
-                    .collect();
-                format!("{}<{}>", name, args.join(","))
-            }
-            ResolvedType::Option(inner) => format!("Option<{}>", self.mangle_type_name(*inner)),
-            ResolvedType::Ref(inner) => format!("ref<{}>", self.mangle_type_name(*inner)),
-            ResolvedType::MutRef(inner) => format!("mutref<{}>", self.mangle_type_name(*inner)),
-            ResolvedType::TypeParam { name, .. } => name.clone(),
-            ResolvedType::Tuple(elems) => {
-                let parts: Vec<String> = elems.iter().map(|e| self.mangle_type_name(*e)).collect();
-                format!("Tuple<{}>", parts.join(","))
-            }
-            ResolvedType::Function {
-                params,
-                return_type,
-                ..
-            } => {
-                let ret_name = self.mangle_type_name(*return_type);
-                format!("Fn<{},{}>", params.len(), ret_name)
-            }
-            ResolvedType::BuiltinArray(elem) => {
-                format!("Array<{}>", self.mangle_type_name(*elem))
-            }
-            ResolvedType::Newtype { name, .. } => name.clone(),
-            _ => "unknown".to_string(),
-        }
     }
 
     /// Look up method info based on receiver type and method name.
@@ -8093,9 +8056,8 @@ impl<'a> Resolver<'a> {
                     // Restore associated type bindings
                     self.current_associated_type_bindings = old_bindings;
 
-                    // Return base trait name (e.g., "IndexValue" not "IndexValue<i32>")
-                    let base_trait_name = strip_type_params(&trait_name).to_string();
-                    return Some((assoc_type, self_kind, base_trait_name));
+                    // trait_name is already base name (get_type_name returns name without type args)
+                    return Some((assoc_type, self_kind, trait_name));
                 }
             }
         }
@@ -8278,7 +8240,13 @@ impl<'a> Resolver<'a> {
                         Some(type_args)
                     },
                 ),
-                _ => (self.mangle_type_name(output_base_type_id), vec![], None),
+                _ => (
+                    self.type_table
+                        .borrow()
+                        .mangle_type_name(output_base_type_id),
+                    vec![],
+                    None,
+                ),
             };
 
         // Look up method info to check if it needs &mut self
@@ -9062,12 +9030,15 @@ impl<'a> Resolver<'a> {
                                     let prim_module = ModuleSource::Core {
                                         name: "prelude/primitives".to_string(),
                                     };
-                                    (self.mangle_type_name(base_type_id), prim_module)
+                                    (
+                                        self.type_table.borrow().mangle_type_name(base_type_id),
+                                        prim_module,
+                                    )
                                 }
                                 _ => {
                                     // Fallback to current module
                                     (
-                                        self.mangle_type_name(resolved.type_id),
+                                        self.type_table.borrow().mangle_type_name(resolved.type_id),
                                         self.current_module_source.clone(),
                                     )
                                 }

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use crate::component_model::CmCallConvention;
-use crate::name::{LocalMethodName, ModuleSource};
+use crate::name::{LocalMethodName, ModuleSource, TypeNameInfo, format_type_name};
 use crate::token::Span;
 
 // ============================================================================
@@ -815,6 +815,87 @@ impl TypeTable {
                 format!("{}<{}>", name, arg_names.join(", "))
             }
             ResolvedType::Newtype { name, .. } => name.clone(),
+        }
+    }
+
+    /// Get a mangled name for a type suitable for use in struct/function names.
+    ///
+    /// Unlike `type_name` which returns human-readable names (e.g., `[i32, String]`),
+    /// this returns mangled names suitable for monomorphization (e.g., `Tuple<i32,String>`).
+    ///
+    /// The format is:
+    /// - Primitives: `i32`, `f64`, `bool`, etc.
+    /// - Unit: `unit`
+    /// - Struct: struct name
+    /// - Tuple: `Tuple<T1,T2,...>`
+    /// - Option: `Option<T>`
+    /// - Result: `Result<T,E>`
+    /// - Array: `Array<T>`
+    /// - Function: `Fn<paramCount,returnType>`
+    /// - `GenericInstance`: `Name<T1,T2,...>`
+    /// - Ref/MutRef: inner type (references are stripped for mangling)
+    #[must_use]
+    pub fn mangle_type_name(&self, id: TypeId) -> String {
+        let info = self.get_type_name_info(id);
+        format_type_name(info)
+    }
+
+    /// Convert a resolved type to its name info for formatting.
+    ///
+    /// This separates type resolution (here in tir.rs) from name formatting
+    /// (in name.rs), following the principle that name format details belong
+    /// in name.rs.
+    fn get_type_name_info(&self, id: TypeId) -> TypeNameInfo {
+        match self.get(id) {
+            ResolvedType::Primitive(prim) => TypeNameInfo::Primitive(prim.as_str().to_string()),
+            ResolvedType::Unit => TypeNameInfo::Unit,
+            ResolvedType::Struct { name, .. }
+            | ResolvedType::Enum { name, .. }
+            | ResolvedType::Resource { name, .. }
+            | ResolvedType::Variant { name, .. }
+            | ResolvedType::Newtype { name, .. }
+            | ResolvedType::TypeParam { name, .. } => TypeNameInfo::Named(name.clone()),
+            ResolvedType::GenericInstance {
+                name, type_args, ..
+            } => {
+                let args: Vec<String> = type_args
+                    .iter()
+                    .map(|t| self.mangle_type_name(*t))
+                    .collect();
+                TypeNameInfo::Generic {
+                    name: name.clone(),
+                    args,
+                }
+            }
+            ResolvedType::Option(inner) => TypeNameInfo::Option(self.mangle_type_name(*inner)),
+            ResolvedType::Result { ok, err } => TypeNameInfo::Result {
+                ok: self.mangle_type_name(*ok),
+                err: self.mangle_type_name(*err),
+            },
+            ResolvedType::Tuple(elems) => {
+                let elem_names: Vec<String> =
+                    elems.iter().map(|t| self.mangle_type_name(*t)).collect();
+                TypeNameInfo::Tuple(elem_names)
+            }
+            ResolvedType::Function {
+                params,
+                return_type,
+                ..
+            } => TypeNameInfo::Function {
+                param_count: params.len(),
+                return_type: self.mangle_type_name(*return_type),
+            },
+            ResolvedType::BuiltinArray(elem) => TypeNameInfo::Array(self.mangle_type_name(*elem)),
+            ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
+                // For references, use the inner type's name (strip reference)
+                TypeNameInfo::Ref(self.mangle_type_name(*inner))
+            }
+            ResolvedType::Stream(inner) => TypeNameInfo::Stream(self.mangle_type_name(*inner)),
+            ResolvedType::Future(inner) => TypeNameInfo::Future(self.mangle_type_name(*inner)),
+            ResolvedType::Reactive(inner) => TypeNameInfo::Reactive(self.mangle_type_name(*inner)),
+            ResolvedType::Never | ResolvedType::Unknown | ResolvedType::Error => {
+                TypeNameInfo::Unknown
+            }
         }
     }
 }
@@ -1727,12 +1808,32 @@ pub struct TirImport {
 }
 
 /// Tracks a requested instantiation of a generic item
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// Note: Only `name` and `type_args` are used for equality/hashing.
+/// `method_info` is auxiliary metadata for name formatting.
+#[derive(Debug, Clone)]
 pub struct InstantiationKey {
     /// Name of the generic item (struct, function, or enum)
     pub name: String,
     /// Concrete type arguments for instantiation
     pub type_args: Vec<TypeId>,
+    /// Method info for method instantiations (None for struct/enum instantiations)
+    /// Not included in equality/hash - used only for name formatting
+    pub method_info: Option<LocalMethodName>,
+}
+
+impl PartialEq for InstantiationKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.type_args == other.type_args
+    }
+}
+
+impl Eq for InstantiationKey {}
+
+impl std::hash::Hash for InstantiationKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.type_args.hash(state);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1759,6 +1860,8 @@ pub struct TirModule {
     pub string_literals: Vec<String>,
     /// Map of function name to string literals it contains (for DCE)
     pub function_strings: HashMap<String, Vec<String>>,
+    /// Map of function name to its method info (for DCE), populated alongside `function_strings`
+    pub function_method_info: HashMap<String, Option<LocalMethodName>>,
     /// Generic struct definitions (before monomorphization)
     /// Key: struct name
     pub generic_structs: HashMap<String, TirStruct>,
@@ -1791,6 +1894,7 @@ impl TirModule {
             data_section: None,
             string_literals: Vec::new(),
             function_strings: HashMap::new(),
+            function_method_info: HashMap::new(),
             generic_structs: HashMap::new(),
             generic_functions: HashMap::new(),
             instantiation_requests: std::collections::HashSet::new(),
@@ -1819,6 +1923,7 @@ impl TirModule {
             data_section: None,
             string_literals: Vec::new(),
             function_strings: HashMap::new(),
+            function_method_info: HashMap::new(),
             generic_structs: HashMap::new(),
             generic_functions: HashMap::new(),
             instantiation_requests: std::collections::HashSet::new(),


### PR DESCRIPTION
Consolidate all name mangling logic in name.rs. Components now use structured metadata (method_info, LocalMethodName) instead of parsing string names.

- Add method_info to InstantiationKey for method name formatting
- Add function_method_info to TirModule for DCE optimization
- Remove parsing functions: LocalMethodName::parse(), parse_qualified(), parse_method_mangled_name(), strip_type_params()
- Update monomorphize.rs to use method_info from generic functions
- Update optimize_dce.rs to use function_method_info lookup