### PR TITLE
Integrate Bind phase into Loader for unified module pipeline

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -16,19 +16,19 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 
 ### Compilation Pipeline
 
-| Phase        | Input         | Output           | Description                                                   |
-| ------------ | ------------- | ---------------- | ------------------------------------------------------------- |
-| Lexer        | Source        | Tokens           | Tokenize, extract `__DATA__` section                          |
-| Parser       | Tokens        | AST              | Build abstract syntax tree                                    |
-| Bind         | AST           | AST (validated)  | Local name resolution, scope/mutability checking              |
-| Load         | AST           | All modules      | Load dependencies; each module: parse → bind → desugar        |
-| Analyze      | All modules   | Symbol table     | Build symbol table, validate imports                          |
-| Resolve      | AST + Symbols | Project          | Type resolution, produce Project                              |
-| Effect Check | Project       | Errors           | Validate function effect requirements                         |
-| Monomorphize | Project       | Project          | Instantiate generics with concrete types                      |
-| Lower        | Project       | Project          | Closure, i128 match, global init, string literal lowering     |
-| Optimize     | Project       | Project          | DCE, usage analysis, feature flags                            |
-| Codegen      | Project       | Wasm bytes       | Generate Component Model Wasm                                 |
+| Phase        | Input         | Output          | Description                                               |
+| ------------ | ------------- | --------------- | --------------------------------------------------------- |
+| Lexer        | Source        | Tokens          | Tokenize, extract `__DATA__` section                      |
+| Parser       | Tokens        | AST             | Build abstract syntax tree                                |
+| Bind         | AST           | AST (validated) | Local name resolution, scope/mutability checking          |
+| Load         | AST           | All modules     | Load dependencies; each module: parse → bind → desugar    |
+| Analyze      | All modules   | Symbol table    | Build symbol table, validate imports                      |
+| Resolve      | AST + Symbols | Project         | Type resolution, produce Project                          |
+| Effect Check | Project       | Errors          | Validate function effect requirements                     |
+| Monomorphize | Project       | Project         | Instantiate generics with concrete types                  |
+| Lower        | Project       | Project         | Closure, i128 match, global init, string literal lowering |
+| Optimize     | Project       | Project         | DCE, usage analysis, feature flags                        |
+| Codegen      | Project       | Wasm bytes      | Generate Component Model Wasm                             |
 
 **Note:** The Desugar phase is integrated into the Load phase. Each module goes through the same frontend pipeline: `lexer → parser → bind → desugar`.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -7,29 +7,30 @@ This document describes the Wado compiler architecture and implementation status
 The compiler follows a multi-phase pipeline:
 
 ```
-Source (.wado) → Lexer → Parser → Bind → Desugar → Load → Analyze → Resolve → Effect Check → Monomorphize → Lower → Optimize → Codegen
-                           ↓                                           ↓                           ↓          ↓
-                       Unparser                                  TIR (Typed IR)              TIR Unparser  TIR Unparser
-                           ↓                                                                      ↓              ↓
-                   Formatted Source                                                       Pseudo-Wado Source (pre/post lower)
+Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve → Effect Check → Monomorphize → Lower → Optimize → Codegen
+                           ↓                        ↓                           ↓          ↓
+                       Unparser                TIR (Typed IR)              TIR Unparser  TIR Unparser
+                           ↓                                                    ↓              ↓
+                   Formatted Source                                     Pseudo-Wado Source (pre/post lower)
 ```
 
 ### Compilation Pipeline
 
-| Phase        | Input         | Output       | Description                              |
-| ------------ | ------------- | ------------ | ---------------------------------------- |
-| Lexer        | Source        | Tokens       | Tokenize, extract `__DATA__` section     |
-| Parser       | Tokens        | AST          | Build abstract syntax tree               |
-| Bind         | AST           | Bind info    | Local name resolution, scope tracking    |
-| Desugar      | AST           | AST          | Transform syntactic sugar                |
-| Load         | AST           | All modules  | Load all dependencies recursively        |
-| Analyze      | All modules   | Symbol table | Build symbol table, validate imports     |
-| Resolve      | AST + Symbols | Project      | Type resolution, produce Project         |
-| Effect Check | Project       | Errors       | Validate function effect requirements    |
-| Monomorphize | Project       | Project      | Instantiate generics with concrete types |
-| Lower        | Project       | Project      | String literal collection                |
-| Optimize     | Project       | Project      | DCE, usage analysis, feature flags       |
-| Codegen      | Project       | Wasm bytes   | Generate Component Model Wasm            |
+| Phase        | Input         | Output           | Description                                                   |
+| ------------ | ------------- | ---------------- | ------------------------------------------------------------- |
+| Lexer        | Source        | Tokens           | Tokenize, extract `__DATA__` section                          |
+| Parser       | Tokens        | AST              | Build abstract syntax tree                                    |
+| Bind         | AST           | AST (validated)  | Local name resolution, scope/mutability checking              |
+| Load         | AST           | All modules      | Load dependencies; each module: parse → bind → desugar        |
+| Analyze      | All modules   | Symbol table     | Build symbol table, validate imports                          |
+| Resolve      | AST + Symbols | Project          | Type resolution, produce Project                              |
+| Effect Check | Project       | Errors           | Validate function effect requirements                         |
+| Monomorphize | Project       | Project          | Instantiate generics with concrete types                      |
+| Lower        | Project       | Project          | Closure, i128 match, global init, string literal lowering     |
+| Optimize     | Project       | Project          | DCE, usage analysis, feature flags                            |
+| Codegen      | Project       | Wasm bytes       | Generate Component Model Wasm                                 |
+
+**Note:** The Desugar phase is integrated into the Load phase. Each module goes through the same frontend pipeline: `lexer → parser → bind → desugar`.
 
 ### Modules
 
@@ -52,7 +53,7 @@ Source (.wado) → Lexer → Parser → Bind → Desugar → Load → Analyze �
 | Resolver         | `resolver.rs`           | Type resolution, AST to TIR, produces Project         |
 | TIR              | `tir.rs`                | Typed Intermediate Representation                     |
 | Monomorphize     | `monomorphize.rs`       | Generic type/function instantiation (Project→Project) |
-| Lower            | `lower.rs`              | String literal collection (Project→Project)           |
+| Lower            | `lower.rs`              | Closure, i128 match, global init, string lowering     |
 | Project          | `project.rs`            | Project: compilation context passed through pipeline  |
 | Optimize         | `optimize.rs`           | Optimization coordinator, dispatches to sub-modules   |
 | OptimizeDCE      | `optimize_dce.rs`       | Dead code elimination via reachability analysis       |
@@ -76,7 +77,7 @@ Source (.wado) → Lexer → Parser → Bind → Desugar → Load → Analyze �
 
 ### Parser and Desugar Separation
 
-The parser preserves source syntax literally to enable accurate formatting via the unparser. Syntactic sugar is transformed in the desugar pass before codegen.
+The parser preserves source syntax literally to enable accurate formatting via the unparser. Syntactic sugar is transformed in the desugar pass, which runs during module loading (not as a separate top-level phase).
 
 | Construct              | Parser Output           | Desugar Output                  |
 | ---------------------- | ----------------------- | ------------------------------- |
@@ -526,7 +527,14 @@ The analyzer validates module paths before loading to provide better error messa
 
 ### Module Loader
 
-The module loader validates module paths before loading:
+The module loader loads all modules and applies the frontend pipeline to each:
+
+**Frontend Pipeline (per module):**
+
+1. **Lexer**: Source → Tokens
+2. **Parser**: Tokens → AST
+3. **Bind**: Validate local scopes, detect use-before-define and duplicate definitions
+4. **Desugar**: Transform syntactic sugar (compound assignment, comparison chains, loops)
 
 **Namespace Validation:**
 

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -270,6 +270,8 @@ pub async fn compile_with_options<H: CompilerHost>(
     let (data_section, _comments, shebang) = lexer.into_parts();
 
     // === Phase 2: Parser (for original AST) ===
+    // Note: The AST is parsed here for early error detection, but the Loader
+    // will re-parse the entry module along with all dependencies.
     let mut parser = Parser::with_metadata(tokens, shebang, data_section);
     let ast = parser.parse().map_err(|e| CompileError::Parser {
         message: e.message,
@@ -278,21 +280,10 @@ pub async fn compile_with_options<H: CompilerHost>(
         filename: filename.clone(),
     })?;
 
-    // === Phase 3: Bind (local name resolution) ===
-    let mut binder = Binder::new();
-    binder.bind_module(&ast).map_err(|errors| {
-        let msg = errors
-            .into_iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        CompileError::Bind {
-            message: msg,
-            filename: filename.clone(),
-        }
-    })?;
+    // Note: Bind phase moved to Loader for all modules (including entry module)
 
-    // === Phase 4: Load all modules upfront ===
+    // === Phase 3: Load all modules upfront ===
+    // Loader performs: parse → bind → desugar for each module
     let load_result = {
         let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{Item, Module};
+use crate::bind::{self, BindError};
 use crate::compiler_host::{Code, CompilerHost, SourceError};
 use crate::desugar::desugar_module;
 use crate::lexer::Lexer;
@@ -26,6 +27,11 @@ pub enum LoadError {
     },
     /// Lexer error
     LexError {
+        module_source: ModuleSource,
+        message: String,
+    },
+    /// Bind error (scope checking)
+    BindError {
         module_source: ModuleSource,
         message: String,
     },
@@ -54,6 +60,12 @@ impl std::fmt::Display for LoadError {
                 message,
             } => {
                 write!(f, "lex error in {module_source}: {message}")
+            }
+            LoadError::BindError {
+                module_source,
+                message,
+            } => {
+                write!(f, "bind error in {module_source}: {message}")
             }
             LoadError::IoError { path, message } => {
                 write!(f, "error reading '{path}': {message}")
@@ -149,22 +161,24 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) -> Result<LoadResult, LoadError> {
         self.logger().span_start("load");
 
-        // Parse entry module
+        // Parse, bind, and desugar entry module
         let entry_module_source = if let Some(filename) = entry_filename {
             ModuleSource::entry_point_with_filename(filename)
         } else {
             ModuleSource::entry_point()
         };
-        let entry_module = self.parse_source(entry_source, &entry_module_source)?;
+        // Parse first to collect imports before binding
+        let entry_ast = self.parse_source(entry_source, &entry_module_source)?;
 
-        // Desugar and store entry module
-        let desugared_entry = desugar_module(&entry_module);
+        // Collect imports from entry module (before bind/desugar)
+        let mut pending: VecDeque<(ModuleSource, ModuleSource)> = VecDeque::new();
+        self.collect_imports(&entry_ast, &entry_module_source, &mut pending)?;
+
+        // Bind and desugar, then store
+        self.bind_module(&entry_ast, &entry_module_source)?;
+        let desugared_entry = desugar_module(&entry_ast);
         self.loaded
             .insert(entry_module_source.clone(), desugared_entry);
-
-        // Collect imports from entry module
-        let mut pending: VecDeque<(ModuleSource, ModuleSource)> = VecDeque::new();
-        self.collect_imports(&entry_module, &entry_module_source, &mut pending)?;
 
         // Load all dependencies iteratively
         while let Some((from_module_source, module_source)) = pending.pop_front() {
@@ -183,13 +197,14 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
 
             // Load and parse the module
             let source = self.get_source(&module_source, &from_module_source).await?;
-            let module = self.parse_source(&source, &module_source)?;
+            let ast = self.parse_source(&source, &module_source)?;
 
-            // Collect its imports
-            self.collect_imports(&module, &module_source, &mut pending)?;
+            // Collect its imports (before bind/desugar)
+            self.collect_imports(&ast, &module_source, &mut pending)?;
 
-            // Desugar and store
-            let desugared = desugar_module(&module);
+            // Bind, desugar, and store
+            self.bind_module(&ast, &module_source)?;
+            let desugared = desugar_module(&ast);
             self.loaded.insert(module_source.clone(), desugared);
             self.loading.remove(&module_source);
         }
@@ -256,16 +271,25 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             {
                 Ok(source) => {
                     match self.parse_source(&source, &module_source) {
-                        Ok(module) => {
+                        Ok(ast) => {
                             // Collect imports from implicit module
                             let mut pending = VecDeque::new();
                             // Implicit modules should only use valid import paths
                             if let Err(e) =
-                                self.collect_imports(&module, &module_source, &mut pending)
+                                self.collect_imports(&ast, &module_source, &mut pending)
                             {
                                 self.logger().warn(
                                     Code::ModuleParseError,
                                     format!("failed to collect imports from implicit module: {e}"),
+                                );
+                                continue;
+                            }
+
+                            // Bind the implicit module
+                            if let Err(e) = self.bind_module(&ast, &module_source) {
+                                self.logger().warn(
+                                    Code::ModuleParseError,
+                                    format!("failed to bind implicit module: {e}"),
                                 );
                                 continue;
                             }
@@ -280,22 +304,23 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                                 if let Ok(dep_source) = self
                                     .get_source(&dep_module_source, &from_module_source)
                                     .await
-                                    && let Ok(dep_module) =
+                                    && let Ok(dep_ast) =
                                         self.parse_source(&dep_source, &dep_module_source)
                                     && self
                                         .collect_imports(
-                                            &dep_module,
+                                            &dep_ast,
                                             &dep_module_source,
                                             &mut pending,
                                         )
                                         .is_ok()
+                                    && self.bind_module(&dep_ast, &dep_module_source).is_ok()
                                 {
-                                    let desugared = desugar_module(&dep_module);
+                                    let desugared = desugar_module(&dep_ast);
                                     self.loaded.insert(dep_module_source, desugared);
                                 }
                             }
 
-                            let desugared = desugar_module(&module);
+                            let desugared = desugar_module(&ast);
                             self.loaded.insert(module_source.clone(), desugared);
                             self.implicit_modules.insert(module_source);
                         }
@@ -470,6 +495,21 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 "line {}, column {}: {}",
                 e.span.line, e.span.column, e.message
             ),
+        })
+    }
+
+    /// Bind a module (local name resolution and scope checking)
+    fn bind_module(&self, module: &Module, module_source: &ModuleSource) -> Result<(), LoadError> {
+        bind::bind_module(module).map_err(|errors| {
+            let message = errors
+                .iter()
+                .map(BindError::to_string)
+                .collect::<Vec<_>>()
+                .join("; ");
+            LoadError::BindError {
+                module_source: module_source.clone(),
+                message,
+            }
         })
     }
 }

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -275,8 +275,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                             // Collect imports from implicit module
                             let mut pending = VecDeque::new();
                             // Implicit modules should only use valid import paths
-                            if let Err(e) =
-                                self.collect_imports(&ast, &module_source, &mut pending)
+                            if let Err(e) = self.collect_imports(&ast, &module_source, &mut pending)
                             {
                                 self.logger().warn(
                                     Code::ModuleParseError,
@@ -307,11 +306,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                                     && let Ok(dep_ast) =
                                         self.parse_source(&dep_source, &dep_module_source)
                                     && self
-                                        .collect_imports(
-                                            &dep_ast,
-                                            &dep_module_source,
-                                            &mut pending,
-                                        )
+                                        .collect_imports(&dep_ast, &dep_module_source, &mut pending)
                                         .is_ok()
                                     && self.bind_module(&dep_ast, &dep_module_source).is_ok()
                                 {

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -107,7 +107,7 @@ pub enum TypeError {
     UnknownFunction { name: String, span: Span },
 
     /// Unknown variable
-    UnknownVariable { name: String, span: Span },
+    UnknownIdentifier { name: String, span: Span },
 
     /// Field not found on struct
     FieldNotFound {
@@ -168,10 +168,10 @@ impl std::fmt::Display for TypeError {
                     span.line, span.column, name
                 )
             }
-            TypeError::UnknownVariable { name, span } => {
+            TypeError::UnknownIdentifier { name, span } => {
                 write!(
                     f,
-                    "{}:{}: unknown variable '{}'",
+                    "{}:{}: unknown identifier '{}'",
                     span.line, span.column, name
                 )
             }
@@ -3276,16 +3276,49 @@ impl<'a> Resolver<'a> {
             );
         }
 
-        // Otherwise it's a global reference (function, constant, etc.)
-        // For now, return Unknown type - will be resolved by looking up in symbol table
-        TirExpr::new(
-            TirExprKind::Global {
-                module_source: ModuleSource::entry_point(),
-                name: ident.name.clone(),
-            },
-            TypeTable::UNKNOWN,
-            ident.span,
-        )
+        // Check if it's a known function (function reference)
+        if self.function_return_types.contains_key(&ident.name)
+            || self.imported_functions.contains(&ident.name)
+        {
+            // It's a function reference - return Global
+            // The function type and proper handling will be done later
+            let module_source = if self.function_return_types.contains_key(&ident.name) {
+                self.current_module_source.clone()
+            } else {
+                // For imported functions, look up the module source from symbols
+                self.symbols
+                    .lookup(&ident.name)
+                    .map(|s| ModuleSource::from_path(&s.module_path))
+                    .unwrap_or_else(ModuleSource::entry_point)
+            };
+            return TirExpr::new(
+                TirExprKind::Global {
+                    module_source,
+                    name: ident.name.clone(),
+                },
+                TypeTable::UNKNOWN,
+                ident.span,
+            );
+        }
+
+        // Check if it's a prelude function (panic, unreachable)
+        if matches!(ident.name.as_str(), "panic" | "unreachable") {
+            return TirExpr::new(
+                TirExprKind::Global {
+                    module_source: ModuleSource::core("prelude"),
+                    name: ident.name.clone(),
+                },
+                TypeTable::UNKNOWN,
+                ident.span,
+            );
+        }
+
+        // Unknown variable - report error
+        self.errors.push(TypeError::UnknownIdentifier {
+            name: ident.name.clone(),
+            span: ident.span,
+        });
+        TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, ident.span)
     }
 
     /// Resolve a binary expression

--- a/wado-compiler/tests/fixtures/bind_error/dep.wado
+++ b/wado-compiler/tests/fixtures/bind_error/dep.wado
@@ -1,0 +1,9 @@
+// Test: bind error in a dependency module
+
+// This module has a bind error - using variable out of scope
+pub fn helper() -> i32 {
+    if true {
+        let x = 42;
+    }
+    return x;  // Error: 'x' is not in scope
+}

--- a/wado-compiler/tests/fixtures/bind_error_duplicate_in_scope.wado
+++ b/wado-compiler/tests/fixtures/bind_error_duplicate_in_scope.wado
@@ -1,0 +1,12 @@
+// Test: bind error - duplicate variable definition in the same scope
+
+use { println, Stdout } from "core:cli";
+
+fn run() with Stdout {
+    let x = 42;
+    let x = 99;  // Error: cannot redeclare 'x' in the same scope
+    println(`{x}`);
+}
+
+__DATA__
+{"compile_error": "cannot redeclare 'x'"}

--- a/wado-compiler/tests/fixtures/bind_error_module.wado
+++ b/wado-compiler/tests/fixtures/bind_error_module.wado
@@ -1,0 +1,12 @@
+// Test: bind error in a dependency module is reported
+
+use { println, Stdout } from "core:cli";
+use { helper } from "./bind_error/dep.wado";
+
+fn run() with Stdout {
+    let x = helper();
+    println(`{x}`);
+}
+
+__DATA__
+{"compile_error": "'x' is not in scope"}

--- a/wado-compiler/tests/fixtures/bind_error_use_before_define.wado
+++ b/wado-compiler/tests/fixtures/bind_error_use_before_define.wado
@@ -1,0 +1,14 @@
+// Test: bind error - using a variable defined in inner scope from outer scope
+
+use { println, Stdout } from "core:cli";
+
+fn run() with Stdout {
+    if true {
+        let x = 42;
+    }
+    // x is defined in inner scope but not accessible here
+    println(`{x}`);
+}
+
+__DATA__
+{"compile_error": "'x' is not in scope"}

--- a/wado-compiler/tests/fixtures/resolver_error_unknown_identifier.wado
+++ b/wado-compiler/tests/fixtures/resolver_error_unknown_identifier.wado
@@ -1,0 +1,11 @@
+// Test: resolver error - using a truly unknown identifier
+
+use { println, Stdout } from "core:cli";
+
+fn run() with Stdout {
+    // unknown_var is not defined anywhere
+    println(`{unknown_var}`);
+}
+
+__DATA__
+{"compile_error": "unknown identifier 'unknown_var'"}


### PR DESCRIPTION
## Summary

This PR refactors the compilation pipeline to integrate the Bind phase into the Loader, creating a unified frontend pipeline for all modules. Previously, the Bind phase only ran on the entry module before loading dependencies. Now, each module (entry and dependencies) goes through the complete pipeline: `lexer → parser → bind → desugar`.

## Key Changes

- **Unified Module Pipeline**: The Loader now applies the full frontend pipeline to each module as it's loaded, rather than binding only the entry module upfront. This ensures consistent scope checking and validation across all modules.

- **Bind Error Handling**: Added `LoadError::BindError` variant to properly report binding errors from any module (entry or dependency) with source location information.

- **Resolver Improvements**: 
  - Renamed `TypeError::UnknownVariable` to `TypeError::UnknownIdentifier` for clarity
  - Enhanced identifier resolution to distinguish between bind-time errors (scope checking) and resolver-time errors (truly unknown identifiers)
  - Added proper handling for function references and prelude functions (panic, unreachable)

- **Documentation Updates**: Updated compiler.md to reflect the new pipeline structure, clarifying that Desugar is now integrated into the Load phase rather than being a separate top-level phase.

- **Test Coverage**: Added comprehensive test fixtures for bind errors:
  - `bind_error_use_before_define.wado`: Variable used outside its scope
  - `bind_error_duplicate_in_scope.wado`: Duplicate variable declarations
  - `bind_error_module.wado`: Bind error in a dependency module
  - `resolver_error_unknown_identifier.wado`: Truly unknown identifier (resolver-time error)

## Implementation Details

- The entry module is now parsed first to collect imports, then bound and desugared along with all dependencies
- Bind errors in any module are caught and reported with proper module source context
- The separation between bind-time errors (scope/mutability) and resolver-time errors (type/name resolution) is now clearer
- Implicit modules also go through the bind phase to ensure consistency

https://claude.ai/code/session_01Qb3uRV4Zagy5UZzF3nyuFJ