### PR TITLE
Refactor wado serve into subcommand, remove --world option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,18 +2584,24 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bytes",
+ "futures",
  "glob",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "jsonschema",
  "lexopt",
  "predicates",
  "serde",
  "serde_json",
- "tempfile",
  "tokio",
  "wado-compiler",
  "wasmprinter 0.244.0",
  "wasmtime",
  "wasmtime-wasi",
+ "wasmtime-wasi-http",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ bytes = { version = "1" }
 futures = { version = "0.3" }
 http = { version = "1" }
 http-body-util = { version = "0.1" }
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1", "server"] }
 assert_cmd = { version = "2" }
 heck = { version = "0.5" }
 lexopt = { version = "0.3.1" }

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -12,14 +12,20 @@ path = "src/main.rs"
 [dependencies]
 wado-compiler = { path = "../wado-compiler" }
 anyhow = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
 glob = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 lexopt = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
 wasmprinter = { workspace = true }
-tempfile = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
+wasmtime-wasi-http = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -63,13 +63,12 @@ pub struct CompileOptions {
     pub opt_level: OptLevel,
     pub wat_to_stdout: bool,
     pub log_level: LogLevel,
-    /// Target world for the component (e.g., "wasi:http/service")
-    /// Defaults to "wasi:cli/command" if not specified
-    pub world: Option<String>,
 }
 
 pub fn print_usage() {
     eprintln!("Usage: wado compile [options] <file.wado>");
+    eprintln!();
+    eprintln!("Compile a Wado source file to WebAssembly (wasi:cli/command world).");
     eprintln!();
     eprintln!("Options:");
     eprintln!("  -o <file>        Output file path (default: <input>.wasm)");
@@ -78,8 +77,6 @@ pub fn print_usage() {
         "  --wat-to-stdout  Output WAT to stdout (shorthand for --format wat -o /dev/stdout)"
     );
     eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
-    eprintln!("  --world <world>  Target world (default: wasi:cli/command)");
-    eprintln!("                   Examples: wasi:http/service, wasi:http/middleware");
     eprintln!("  --log-level <l>  Log level: debug, info, warn, error, off (default: info)");
     eprintln!("  --help           Show this help message");
 }
@@ -103,7 +100,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
     let mut opt_level = OptLevel::default();
     let mut wat_to_stdout = false;
     let mut log_level = LogLevel::default();
-    let mut world: Option<String> = None;
 
     while let Some(arg) = next_arg(&mut parser) {
         match arg {
@@ -146,9 +142,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
                     process::exit(1);
                 }
             }
-            Long("world") => {
-                world = Some(require_string(&mut parser));
-            }
             Long("log-level") => {
                 let level_str = require_string(&mut parser);
                 if let Some(level) = parse_log_level(&level_str) {
@@ -175,7 +168,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
         opt_level,
         wat_to_stdout,
         log_level,
-        world,
     }
 }
 
@@ -262,8 +254,7 @@ fn wasm_to_wat(wasm: &[u8]) -> String {
 }
 
 pub async fn run(opts: CompileOptions) {
-    let wasm =
-        compile_with_full_opts(&opts.input, opts.opt_level, opts.log_level, opts.world).await;
+    let wasm = compile_with_opts(&opts.input, opts.opt_level, opts.log_level).await;
 
     // Handle --wat-to-stdout: output WAT to stdout and return
     if opts.wat_to_stdout {

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -19,6 +19,7 @@ mod dump;
 mod format;
 mod run;
 mod runtime;
+mod serve;
 mod syntax;
 mod test;
 
@@ -33,7 +34,8 @@ fn print_usage() {
     eprintln!();
     eprintln!("Commands:");
     eprintln!("  compile [options] <file.wado>  Compile a Wado source file");
-    eprintln!("  run [options] <file.wado>      Compile and run a Wado source file");
+    eprintln!("  run [options] <file.wado>      Compile and run a Wado CLI program");
+    eprintln!("  serve [options] <file.wado>    Compile and serve a Wado HTTP service");
     eprintln!("  test [options] <files...>      Run tests in Wado source files");
     eprintln!("  format [options] <file.wado>   Format a Wado source file");
     eprintln!("  dump [options] <file.wado>     Dump compiler internal state");
@@ -42,6 +44,13 @@ fn print_usage() {
     eprintln!("Compile options:");
     eprintln!("  -o <file>        Output file path (default: <input>.wasm)");
     eprintln!("  --format <fmt>   Output format: wasm, wat (default: guessed from -o extension)");
+    eprintln!();
+    eprintln!("Run options:");
+    eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
+    eprintln!();
+    eprintln!("Serve options:");
+    eprintln!("  --addr <addr>    Address to listen on (default: 0.0.0.0:8080)");
+    eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
     eprintln!();
     eprintln!("Test options:");
     eprintln!("  -f, --filter <pattern>  Filter tests by name pattern");
@@ -97,6 +106,10 @@ async fn main() {
                 "run" => {
                     let opts = run::parse_args(parser);
                     run::run(opts).await;
+                }
+                "serve" => {
+                    let opts = serve::parse_args(parser);
+                    serve::run(opts).await;
                 }
                 "dump" => {
                     let opts = dump::parse_args(parser);

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1,8 +1,23 @@
-use std::process::{self, Command, Stdio};
+use std::net::SocketAddr;
+use std::process;
+use std::sync::Arc;
 
 use anyhow::Result;
+use bytes::Bytes;
+use futures::try_join;
+use http_body_util::{BodyExt, Empty, Full};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request as HyperRequest, Response as HyperResponse};
+use hyper_util::rt::TokioIo;
 use lexopt::Arg::{Long, Short, Value};
-use tempfile::NamedTempFile;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use wasmtime::component::{Component, Linker, ResourceTable};
+use wasmtime::{Config, Engine, Store};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+use wasmtime_wasi_http::p3::bindings::Service;
+use wasmtime_wasi_http::p3::{Request as WasiRequest, WasiHttpCtx, WasiHttpCtxView, WasiHttpView};
 
 use crate::args::{
     next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
@@ -20,7 +35,7 @@ pub struct ServeOptions {
 pub fn print_usage() {
     eprintln!("Usage: wado serve [options] <file.wado>");
     eprintln!();
-    eprintln!("Compile and serve a Wado HTTP service using wasmtime serve.");
+    eprintln!("Compile and serve a Wado HTTP service using wasmtime.");
     eprintln!();
     eprintln!("Options:");
     eprintln!("  --addr <addr>    Address to listen on (default: 0.0.0.0:8080)");
@@ -103,42 +118,192 @@ pub fn parse_args(mut parser: lexopt::Parser) -> ServeOptions {
     }
 }
 
-fn run_http_service(wasm: &[u8], addr: &str) -> Result<()> {
-    use std::io::Write;
+// ============================================================================
+// HTTP WASI State
+// ============================================================================
 
-    // Write wasm to a temp file
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(wasm)?;
-    temp_file.flush()?;
+struct HttpWasiCtx;
 
-    let temp_path = temp_file.path();
-    eprintln!("Starting HTTP server with wasmtime serve...");
-    eprintln!("Listening on: http://{addr}/");
+impl WasiHttpCtx for HttpWasiCtx {}
 
-    // Run wasmtime serve with P3 support
-    let status = Command::new("wasmtime")
-        .arg("serve")
-        .arg("--addr")
-        .arg(addr)
-        .arg("-W")
-        .arg("all-proposals=y")
-        .arg("-W")
-        .arg("stack-switching=n")
-        .arg("-S")
-        .arg("p3=y")
-        .arg("-S")
-        .arg("http=y")
-        .arg(temp_path)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()?;
+struct HttpWasiState {
+    table: ResourceTable,
+    wasi: WasiCtx,
+    http: HttpWasiCtx,
+}
 
-    if !status.success() {
-        anyhow::bail!("wasmtime serve exited with status: {status}");
+impl WasiView for HttpWasiState {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
     }
+}
 
-    Ok(())
+impl WasiHttpView for HttpWasiState {
+    fn http(&mut self) -> WasiHttpCtxView<'_> {
+        WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+        }
+    }
+}
+
+// ============================================================================
+// HTTP Engine and Linker
+// ============================================================================
+
+fn create_http_engine() -> Result<Engine> {
+    let mut config = Config::new();
+    config.async_support(true);
+    config.wasm_component_model(true);
+    config.wasm_component_model_async(true);
+    config.wasm_component_model_async_stackful(true);
+    config.wasm_component_model_gc(true);
+    config.wasm_gc(true);
+    config.wasm_function_references(true);
+    config.wasm_wide_arithmetic(true);
+    config.wasm_threads(true);
+    config.wasm_simd(true);
+    // Use minimal optimization for faster compilation during development
+    config.cranelift_opt_level(wasmtime::OptLevel::None);
+    Ok(Engine::new(&config)?)
+}
+
+fn create_http_linker(engine: &Engine) -> Result<Linker<HttpWasiState>> {
+    let mut linker: Linker<HttpWasiState> = Linker::new(engine);
+    // Add both P2 and P3 interfaces (like wasmtime tests do)
+    wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
+    wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+    wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
+    Ok(linker)
+}
+
+fn create_http_state() -> HttpWasiState {
+    HttpWasiState {
+        table: ResourceTable::new(),
+        wasi: WasiCtxBuilder::new().inherit_stdio().build(),
+        http: HttpWasiCtx,
+    }
+}
+
+// ============================================================================
+// HTTP Handler
+// ============================================================================
+
+/// Handle a single HTTP request using the Wasm component
+async fn handle_http_request(
+    engine: &Engine,
+    component: &Component,
+    linker: &Linker<HttpWasiState>,
+    req: HyperRequest<hyper::body::Incoming>,
+) -> Result<HyperResponse<Full<Bytes>>> {
+    let state = create_http_state();
+    let mut store = Store::new(engine, state);
+
+    let service = Service::instantiate_async(&mut store, component, linker).await?;
+
+    // Convert hyper request to http::Request with Empty body
+    let (parts, _body) = req.into_parts();
+    let http_req = http::Request::from_parts(parts, Empty::<Bytes>::new());
+
+    let (wasi_req, io) = WasiRequest::from_http(http_req);
+
+    // Channel to receive the response
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    // Run handler and response receiver in parallel
+    let result = try_join!(
+        async {
+            store
+                .run_concurrent(async |store| {
+                    let (res, task) = match service.handle(store, wasi_req).await? {
+                        Ok(pair) => pair,
+                        Err(err) => return Ok(Err(Some(err))),
+                    };
+                    let _ = tx.send(store.with(|store| res.into_http(store, async { Ok(()) }))?);
+                    task.block(store).await;
+                    Ok(Ok(()))
+                })
+                .await?
+        },
+        async {
+            let res = rx.await?;
+            let (parts, body) = res.into_parts();
+            let body = body.collect().await?;
+            anyhow::Ok(http::Response::from_parts(parts, body))
+        }
+    );
+
+    // Drop io - we don't consume request body in simple cases
+    drop(io);
+
+    match result {
+        Ok((Ok(()), res)) => {
+            let (parts, body) = res.into_parts();
+            Ok(HyperResponse::from_parts(parts, Full::new(body.to_bytes())))
+        }
+        Ok((Err(Some(error_code)), _)) => {
+            // Handler returned error code - map to HTTP 500
+            Ok(HyperResponse::builder()
+                .status(500)
+                .body(Full::new(Bytes::from(format!("{error_code:?}"))))?)
+        }
+        Ok((Err(None), _)) => Ok(HyperResponse::builder()
+            .status(500)
+            .body(Full::new(Bytes::from("Handler returned error")))?),
+        Err(e) => Ok(HyperResponse::builder()
+            .status(500)
+            .body(Full::new(Bytes::from(format!("Internal error: {e}"))))?),
+    }
+}
+
+// ============================================================================
+// HTTP Server
+// ============================================================================
+
+async fn run_http_server(wasm: Vec<u8>, addr: &str) -> Result<()> {
+    let engine = create_http_engine()?;
+    let component = Component::new(&engine, &wasm)?;
+    let linker = create_http_linker(&engine)?;
+
+    // Wrap in Arc for sharing across connections
+    let engine = Arc::new(engine);
+    let component = Arc::new(component);
+    let linker = Arc::new(Mutex::new(linker));
+
+    let addr: SocketAddr = addr.parse()?;
+    let listener = TcpListener::bind(addr).await?;
+
+    eprintln!("HTTP server listening on http://{addr}/");
+    eprintln!("Press Ctrl+C to stop");
+
+    loop {
+        let (stream, remote_addr) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+
+        let engine = Arc::clone(&engine);
+        let component = Arc::clone(&component);
+        let linker = Arc::clone(&linker);
+
+        tokio::spawn(async move {
+            let service = service_fn(|req| {
+                let engine = Arc::clone(&engine);
+                let component = Arc::clone(&component);
+                let linker = Arc::clone(&linker);
+
+                async move {
+                    let linker = linker.lock().await;
+                    handle_http_request(&engine, &component, &linker, req).await
+                }
+            });
+
+            if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
+                eprintln!("Error serving {remote_addr}: {e}");
+            }
+        });
+    }
 }
 
 pub async fn run(opts: ServeOptions) {
@@ -150,8 +315,8 @@ pub async fn run(opts: ServeOptions) {
     )
     .await;
 
-    if let Err(e) = run_http_service(&wasm, &opts.addr) {
-        eprintln!("Runtime error: {e}");
+    if let Err(e) = run_http_server(wasm, &opts.addr).await {
+        eprintln!("Server error: {e}");
         process::exit(1);
     }
 }

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1,28 +1,29 @@
-use std::process;
+use std::process::{self, Command, Stdio};
 
 use anyhow::Result;
 use lexopt::Arg::{Long, Short, Value};
-use wasmtime::component::Component;
+use tempfile::NamedTempFile;
 
 use crate::args::{
     next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
 };
 use crate::compile::{self, OptLevel};
-use crate::runtime;
 use wado_compiler::LogLevel;
 
-pub struct RunOptions {
+pub struct ServeOptions {
     pub input: String,
     pub opt_level: OptLevel,
     pub log_level: LogLevel,
+    pub addr: String,
 }
 
 pub fn print_usage() {
-    eprintln!("Usage: wado run [options] <file.wado>");
+    eprintln!("Usage: wado serve [options] <file.wado>");
     eprintln!();
-    eprintln!("Compile and run a Wado CLI program (wasi:cli/command world).");
+    eprintln!("Compile and serve a Wado HTTP service using wasmtime serve.");
     eprintln!();
     eprintln!("Options:");
+    eprintln!("  --addr <addr>    Address to listen on (default: 0.0.0.0:8080)");
     eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
     eprintln!("  --log-level <l>  Log level: debug, info, warn, error, off (default: info)");
     eprintln!("  --help           Show this help message");
@@ -40,16 +41,20 @@ fn parse_log_level(s: &str) -> Option<LogLevel> {
     }
 }
 
-pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
+pub fn parse_args(mut parser: lexopt::Parser) -> ServeOptions {
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
     let mut log_level = LogLevel::default();
+    let mut addr = "0.0.0.0:8080".to_string();
 
     while let Some(arg) = next_arg(&mut parser) {
         match arg {
             Long("help") => {
                 print_usage();
                 process::exit(0);
+            }
+            Long("addr") => {
+                addr = require_string(&mut parser);
             }
             Short('O') => {
                 let val = parser.optional_value();
@@ -90,32 +95,62 @@ pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
         }
     }
 
-    RunOptions {
+    ServeOptions {
         input: require_input(input, print_usage),
         opt_level,
         log_level,
+        addr,
     }
 }
 
-async fn run_cli_component(wasm: &[u8]) -> Result<()> {
-    let engine = runtime::create_engine()?;
-    let component = Component::new(&engine, wasm)?;
-    let linker = runtime::create_linker(&engine)?;
-    let mut store = runtime::create_store(&engine);
+fn run_http_service(wasm: &[u8], addr: &str) -> Result<()> {
+    use std::io::Write;
 
-    let instance = linker.instantiate_async(&mut store, &component).await?;
-    let run_func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, "run")?;
+    // Write wasm to a temp file
+    let mut temp_file = NamedTempFile::new()?;
+    temp_file.write_all(wasm)?;
+    temp_file.flush()?;
 
-    let (result,) = run_func.call_async(&mut store, ()).await?;
-    result.map_err(|()| anyhow::anyhow!("Component returned error"))?;
+    let temp_path = temp_file.path();
+    eprintln!("Starting HTTP server with wasmtime serve...");
+    eprintln!("Listening on: http://{addr}/");
+
+    // Run wasmtime serve with P3 support
+    let status = Command::new("wasmtime")
+        .arg("serve")
+        .arg("--addr")
+        .arg(addr)
+        .arg("-W")
+        .arg("all-proposals=y")
+        .arg("-W")
+        .arg("stack-switching=n")
+        .arg("-S")
+        .arg("p3=y")
+        .arg("-S")
+        .arg("http=y")
+        .arg(temp_path)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!("wasmtime serve exited with status: {status}");
+    }
 
     Ok(())
 }
 
-pub async fn run(opts: RunOptions) {
-    let wasm = compile::compile_with_opts(&opts.input, opts.opt_level, opts.log_level).await;
+pub async fn run(opts: ServeOptions) {
+    let wasm = compile::compile_with_full_opts(
+        &opts.input,
+        opts.opt_level,
+        opts.log_level,
+        Some("wasi:http/service".to_string()),
+    )
+    .await;
 
-    if let Err(e) = run_cli_component(&wasm).await {
+    if let Err(e) = run_http_service(&wasm, &opts.addr) {
         eprintln!("Runtime error: {e}");
         process::exit(1);
     }

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -14,7 +14,7 @@ use lexopt::Arg::{Long, Short, Value};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use wasmtime::component::{Component, Linker, ResourceTable};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::p3::bindings::Service;
 use wasmtime_wasi_http::p3::{Request as WasiRequest, WasiHttpCtx, WasiHttpCtxView, WasiHttpView};
@@ -23,6 +23,7 @@ use crate::args::{
     next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
 };
 use crate::compile::{self, OptLevel};
+use crate::runtime;
 use wado_compiler::LogLevel;
 
 pub struct ServeOptions {
@@ -154,27 +155,8 @@ impl WasiHttpView for HttpWasiState {
 // HTTP Engine and Linker
 // ============================================================================
 
-fn create_http_engine() -> Result<Engine> {
-    let mut config = Config::new();
-    config.async_support(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_stackful(true);
-    config.wasm_component_model_gc(true);
-    config.wasm_gc(true);
-    config.wasm_function_references(true);
-    config.wasm_wide_arithmetic(true);
-    config.wasm_threads(true);
-    config.wasm_simd(true);
-    // Use minimal optimization for faster compilation during development
-    config.cranelift_opt_level(wasmtime::OptLevel::None);
-    Ok(Engine::new(&config)?)
-}
-
 fn create_http_linker(engine: &Engine) -> Result<Linker<HttpWasiState>> {
     let mut linker: Linker<HttpWasiState> = Linker::new(engine);
-    // Add both P2 and P3 interfaces (like wasmtime tests do)
-    wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
     wasmtime_wasi::p3::add_to_linker(&mut linker)?;
     wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
     Ok(linker)
@@ -264,7 +246,7 @@ async fn handle_http_request(
 // ============================================================================
 
 async fn run_http_server(wasm: Vec<u8>, addr: &str) -> Result<()> {
-    let engine = create_http_engine()?;
+    let engine = runtime::create_engine()?;
     let component = Component::new(&engine, &wasm)?;
     let linker = create_http_linker(&engine)?;
 

--- a/wado-compiler/tests/http.rs
+++ b/wado-compiler/tests/http.rs
@@ -93,8 +93,6 @@ async fn run_http_request_async(wasm: Vec<u8>) -> anyhow::Result<HttpTestResult>
         .map_err(|e| anyhow::anyhow!("failed to create component: {e:?}"))?;
 
     let mut linker: Linker<HttpTestState> = Linker::new(&engine);
-    // Add BOTH P2 and P3 interfaces (like wasmtime tests do)
-    wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
     wasmtime_wasi::p3::add_to_linker(&mut linker)?;
     wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
 


### PR DESCRIPTION
- Add `wado serve` subcommand for HTTP service (wasi:http/service world)
- Remove `--world` option from `wado run` and `wado compile`
- `wado run` now exclusively targets wasi:cli/command world
- `wado serve` includes `--addr` option for configuring listen address

https://claude.ai/code/session_01SFuft7VqrmKTjNWAkmWSRe