### PR TITLE
Replace hardcoded "Service" world checks with HTTP handler detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Newtype Semantics](./docs/wep-2026-01-29-newtype-semantics.md)
 - [SIMD v128 Types](./docs/wep-2026-01-31-simd-v128.md)
 - [Format Traits](./docs/wep-2026-02-01-format-traits.md)
+- [Wasm Adapt Phase](./docs/wep-2026-02-03-wasm-adapt-phase.md)
 
 ### Structure
 

--- a/docs/wep-2026-02-03-wasm-adapt-phase.md
+++ b/docs/wep-2026-02-03-wasm-adapt-phase.md
@@ -1,0 +1,130 @@
+# WEP: Wasm Adapt Phase
+
+## Context
+
+The Wado compiler currently handles WebAssembly Component Model (CM) adaptation in the codegen phase. This includes:
+
+1. **CM glue code generation** - HTTP response creation, task-return calls, future operations
+2. **CM helper functions** - `cm_list_string_to_array`, `cm_option_string_to_option`, etc.
+3. **Scratch local allocation** - Temporary variables for CM operations
+4. **Export signature analysis** - Determining what glue code is needed
+
+This mixing of concerns makes codegen complex and harder to maintain. Additionally, CM helper functions are currently hardcoded in `lib/core/internal.wado`, which cannot scale to handle generic type combinations like `Array<Option<String>>` or `Result<Array<i32>, String>`.
+
+## Decision
+
+Introduce a new `wasm_adapt` phase between optimize and codegen:
+
+```
+lower → optimize → wasm_adapt → codegen
+```
+
+### Responsibilities
+
+The `wasm_adapt` phase handles all Wasm-specific preparation:
+
+1. **CM boundary analysis**
+   - Analyze export signatures to determine required glue code
+   - Detect HTTP handler exports, Command exports, etc.
+   - Identify required CM helper function signatures
+
+2. **CM helper function generation (TIR)**
+   - Generate helper functions as TIR based on actual type usage
+   - Handle generic type combinations dynamically
+   - Examples: `__cm_list_option_string_to_array`, `__cm_result_i32_string_to_result`
+
+3. **Scratch local analysis**
+   - Compute required scratch locals for CM operations
+   - Add to `TirFunction.scratch_locals`
+
+4. **CM export metadata**
+   - Add `CmExportInfo` to functions that are world exports
+   - Include signature kind, required imports, etc.
+
+### Design Choices
+
+#### Metadata over TIR for Glue Code
+
+CM glue code (e.g., HTTP response creation in return statements) uses:
+- CM canonical ABI calls (future-new, task-return)
+- Linear memory operations (I32Load/Store at specific offsets)
+- CM type flattening (result<response, error-code> → multiple i32/i64)
+
+These are too low-level and Wasm-specific to represent in TIR cleanly. Instead, we use metadata to tell codegen what glue code to generate.
+
+#### TIR for Helper Functions
+
+CM helper functions (type converters) are generated as TIR because:
+- They appear in golden fixtures for debugging
+- They can be inspected with `--lower --unparse`
+- Codegen simply converts TIR to Wasm without special cases
+
+### Data Structures
+
+```rust
+/// CM export information attached to TirFunction
+pub struct CmExportInfo {
+    /// Kind of CM export signature
+    pub signature_kind: CmSignatureKind,
+    /// Additional scratch locals needed for CM glue code
+    pub scratch_locals: Vec<ScratchLocal>,
+    /// CM functions that must be imported
+    pub required_imports: Vec<String>,
+}
+
+pub enum CmSignatureKind {
+    /// Command world: async fn run() -> Result<(), ()>
+    Command,
+    /// HTTP handler: async fn handle(Request) -> Result<Response, ErrorCode>
+    HttpHandler,
+    /// Other async export with custom signature
+    AsyncExport { return_type: TypeId },
+}
+```
+
+### Generated Helper Functions
+
+The `wasm_adapt` phase generates TIR functions for CM type conversion:
+
+```
+// Example: Converting CM list<option<string>> to Array<Option<String>>
+fn __cm_list_option_string_to_array(ptr: i32, len: i32) -> Array<Option<String>> {
+    let result = Array::<Option<String>>::with_capacity(len);
+    for let mut i = 0; i < len; i += 1 {
+        // Read option discriminant and string from linear memory
+        // Construct Option<String> and append to result
+    }
+    return result;
+}
+```
+
+Function naming convention: `__cm_{operation}_{type_signature}`
+
+### Migration Path
+
+1. Move scratch local analysis for CM operations from codegen to wasm_adapt
+2. Add CmExportInfo metadata to TirFunction
+3. Generate CM helper functions dynamically instead of hardcoding
+4. Simplify codegen to use metadata and generated TIR
+
+## Consequences
+
+### Benefits
+
+1. **Separation of concerns** - Wasm/CM adaptation is isolated from codegen
+2. **Scalability** - Generic type combinations handled dynamically
+3. **Debuggability** - Generated helpers visible in TIR dumps and golden fixtures
+4. **Simpler codegen** - Focuses on TIR → Wasm translation
+
+### Trade-offs
+
+1. **No optimization for generated helpers** - wasm_adapt runs after optimize
+   - Acceptable: helpers are small and unlikely to benefit from optimization
+2. **Additional phase** - Slightly longer compilation
+   - Acceptable: phase is lightweight analysis + targeted TIR generation
+
+### Future Extensions
+
+- Resource handle lifecycle management
+- Stream/future type conversions
+- Custom CM type adapters for user-defined types

--- a/docs/wep-2026-02-03-wasm-adapt-phase.md
+++ b/docs/wep-2026-02-03-wasm-adapt-phase.md
@@ -46,6 +46,7 @@ The `wasm_adapt` phase handles all Wasm-specific preparation:
 #### Metadata over TIR for Glue Code
 
 CM glue code (e.g., HTTP response creation in return statements) uses:
+
 - CM canonical ABI calls (future-new, task-return)
 - Linear memory operations (I32Load/Store at specific offsets)
 - CM type flattening (result<response, error-code> → multiple i32/i64)
@@ -55,6 +56,7 @@ These are too low-level and Wasm-specific to represent in TIR cleanly. Instead, 
 #### TIR for Helper Functions
 
 CM helper functions (type converters) are generated as TIR because:
+
 - They appear in golden fixtures for debugging
 - They can be inspected with `--lower --unparse`
 - Codegen simply converts TIR to Wasm without special cases

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -80,7 +80,7 @@ pub struct Codegen {
     builtin_registry: BuiltinRegistry,
     /// Registry of world definitions from lib/wasi/*.wado
     world_registry: WorldRegistry,
-    /// Whether the target world exports an HTTP handler (returns Result<Response, ErrorCode>).
+    /// Whether the target world exports an HTTP handler (returns Result<Response, `ErrorCode`>).
     /// Computed at the start of `generate_wasm` from `world_registry`.
     has_http_handler_export: bool,
     /// Registry of user-defined struct types (keyed by `StructName` for type safety)
@@ -216,7 +216,7 @@ struct FunctionContext {
     skip_tuple_wrap: bool,
     /// When true, this function is an async export and returns should use task-return
     is_async_export: bool,
-    /// When true, the target world exports an HTTP handler (returns Result<Response, ErrorCode>)
+    /// When true, the target world exports an HTTP handler (returns Result<Response, `ErrorCode`>)
     has_http_handler_export: bool,
 }
 
@@ -730,7 +730,7 @@ impl Codegen {
         self.has_http_handler_export = self
             .world_registry
             .get(&project.target_world)
-            .is_some_and(|w| w.has_http_handler_export());
+            .is_some_and(super::world_registry::WorldInfo::has_http_handler_export);
 
         // Collect pre-computed string literals from all TIR modules
         // Note: String DCE is performed in the optimizer, so we just collect all strings here
@@ -1828,11 +1828,7 @@ impl Codegen {
             }
             // Test functions need task.return wrapper like run
             if tir_func.name.starts_with("__test_") {
-                let wasm_func = self.generate_run_function(
-                    &tir_func,
-                    type_table,
-                    &builder,
-                );
+                let wasm_func = self.generate_run_function(&tir_func, type_table, &builder);
                 code.function(&wasm_func);
             } else {
                 let (wasm_func, hints) =

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -80,6 +80,9 @@ pub struct Codegen {
     builtin_registry: BuiltinRegistry,
     /// Registry of world definitions from lib/wasi/*.wado
     world_registry: WorldRegistry,
+    /// Whether the target world exports an HTTP handler (returns Result<Response, ErrorCode>).
+    /// Computed at the start of `generate_wasm` from `world_registry`.
+    has_http_handler_export: bool,
     /// Registry of user-defined struct types (keyed by `StructName` for type safety)
     struct_types: HashMap<StructName, StructTypeInfo>,
     /// Registry of tuple types (keyed by element `TypeIds`, maps to GC struct type index)
@@ -213,8 +216,8 @@ struct FunctionContext {
     skip_tuple_wrap: bool,
     /// When true, this function is an async export and returns should use task-return
     is_async_export: bool,
-    /// Target world for async export handling
-    target_world: String,
+    /// When true, the target world exports an HTTP handler (returns Result<Response, ErrorCode>)
+    has_http_handler_export: bool,
 }
 
 impl FunctionContext {
@@ -239,7 +242,7 @@ impl FunctionContext {
             copy_context: CopyContext::new(),
             skip_tuple_wrap: false,
             is_async_export: false,
-            target_world: String::new(),
+            has_http_handler_export: false,
         }
     }
 
@@ -264,7 +267,7 @@ impl FunctionContext {
             copy_context: CopyContext::new(),
             skip_tuple_wrap: false,
             is_async_export: false,
-            target_world: String::new(),
+            has_http_handler_export: false,
         }
     }
 
@@ -469,6 +472,7 @@ impl Codegen {
             wasi_registry,
             builtin_registry,
             world_registry,
+            has_http_handler_export: false,
             struct_types: HashMap::new(),
             tuple_types: RefCell::new(HashMap::new()),
             array_types: HashMap::new(),
@@ -723,6 +727,11 @@ impl Codegen {
         let implicit_modules = &project.implicit_modules;
         let module_name = &project.module_name;
 
+        self.has_http_handler_export = self
+            .world_registry
+            .get(&project.target_world)
+            .is_some_and(|w| w.has_http_handler_export());
+
         // Collect pre-computed string literals from all TIR modules
         // Note: String DCE is performed in the optimizer, so we just collect all strings here
         for tir_module in all_tir_modules.values() {
@@ -970,7 +979,7 @@ impl Codegen {
             // - i32: Ok/Err discriminant
             // - i32: Response handle (Ok) or error-code discriminant (Err)
             // - Remaining: Space for largest error-code payload (records with option<string>, etc.)
-            if canonical_name == "task-return" && project.target_world == "Service" {
+            if canonical_name == "task-return" && self.has_http_handler_export {
                 builder.define_func_type(
                     canonical_name,
                     &[
@@ -993,7 +1002,7 @@ impl Codegen {
         }
 
         // Define HTTP function types for Service world
-        if project.target_world == "Service" {
+        if self.has_http_handler_export {
             // [constructor]fields: () -> i32 (resource handle)
             builder.define_func_type("http-fields-constructor", &[], &[ValType::I32]);
 
@@ -1576,7 +1585,7 @@ impl Codegen {
         }
 
         // Import HTTP functions for Service world
-        if project.target_world == "Service" {
+        if self.has_http_handler_export {
             builder.import_func("wasi", "http-fields-constructor");
             builder.import_func("wasi", "http-response-new");
         }
@@ -1823,7 +1832,6 @@ impl Codegen {
                     &tir_func,
                     type_table,
                     &builder,
-                    &project.target_world,
                 );
                 code.function(&wasm_func);
             } else {
@@ -1891,12 +1899,12 @@ impl Codegen {
             let export_wasm_func = if let Some(tir_rc) = export_tir_rc {
                 // Generate function body using the TIR function body generation
                 let tir_func = tir_rc.borrow();
-                self.generate_run_function(&tir_func, type_table, &builder, &project.target_world)
+                self.generate_run_function(&tir_func, type_table, &builder)
             } else {
                 // No matching function - create empty entry point
                 let mut func = Function::new(vec![]);
                 let task_return_idx = builder.func_idx("task-return");
-                if project.target_world == "Service" {
+                if self.has_http_handler_export {
                     // Service world: result<own<response>, error-code> with complex payloads
                     // Flattens to: (i32, i32, i32, i64, i32, i32, i32, i32)
                     func.instruction(&Instruction::I32Const(1)); // Err discriminant
@@ -2388,7 +2396,7 @@ impl Codegen {
         }
 
         // Add lowered HTTP types functions for Service world
-        if project.target_world == "Service" && ctx.has_core_func("http-fields-constructor") {
+        if self.has_http_handler_export && ctx.has_core_func("http-fields-constructor") {
             wasi_exports.push((
                 "http-fields-constructor".to_string(),
                 ExportKind::Func,
@@ -2490,7 +2498,7 @@ impl Codegen {
                 let (_, enc) = builder.ty(Some(&func_type_name));
 
                 // Check if this is the Service world's handle function with Request param
-                let is_service_handle = project.target_world == "Service"
+                let is_service_handle = self.has_http_handler_export
                     && export.name == "handle"
                     && !export.params.is_empty();
 
@@ -2595,7 +2603,7 @@ impl Codegen {
         // For Service world, add the handler interface export
         // This creates a component instance containing the handle function
         // and exports it as wasi:http/handler interface
-        if project.target_world == "Service" {
+        if self.has_http_handler_export {
             Self::append_http_handler_export(&mut component_bytes, &ctx);
         }
 
@@ -3150,7 +3158,7 @@ impl Codegen {
 
         // For Service world, import wasi:http/types to get Request resource type
         // This is needed for the handle function's parameter type
-        if project.target_world == "Service" {
+        if self.has_http_handler_export {
             self.import_http_types_for_service(builder, ctx);
         }
     }
@@ -9300,7 +9308,7 @@ impl Codegen {
             TirStmtKind::Return { value } => {
                 if ctx.is_async_export {
                     // For async exports, call task-return with the result value
-                    if ctx.target_world == "Service" {
+                    if ctx.has_http_handler_export {
                         // Service world: result<response, error-code>
                         // Generate the return expression but drop it for now
                         if let Some(expr) = value {
@@ -10807,14 +10815,13 @@ impl Codegen {
         tir_func: &TirFunction,
         type_table: &TypeTable,
         builder: &CoreModuleBuilder,
-        target_world: &str,
     ) -> Function {
         // Create function context
         let mut func_ctx = FunctionContext::new(tir_func.params.len() as u32);
 
         // Mark this as an async export - returns should use task-return
         func_ctx.is_async_export = true;
-        func_ctx.target_world = target_world.to_string();
+        func_ctx.has_http_handler_export = self.has_http_handler_export;
 
         // Copy address-taken locals from TIR
         func_ctx.address_taken_locals = tir_func.address_taken_locals.clone();
@@ -10863,7 +10870,7 @@ impl Codegen {
         self.allocate_precomputed_scratch_locals(tir_func, type_table, &mut func_ctx);
 
         // Pre-allocate scratch locals for Service world HTTP response creation
-        if func_ctx.is_async_export && func_ctx.target_world == "Service" {
+        if func_ctx.is_async_export && func_ctx.has_http_handler_export {
             func_ctx.alloc_local("_http_future", ValType::I64);
             func_ctx.alloc_local("_trailers_rx", ValType::I32);
             func_ctx.alloc_local("_trailers_tx", ValType::I32);
@@ -10891,7 +10898,7 @@ impl Codegen {
             // For Service world: result<own<response>, error-code> with complex payloads
             // The full error-code variant flattens to: (i32, i32, i32, i64, i32, i32, i32, i32)
             // For Command world: result<_, _> needs just (i32)
-            if func_ctx.target_world == "Service" {
+            if func_ctx.has_http_handler_export {
                 wasm_func.instruction(&Instruction::I32Const(1)); // Err discriminant
                 wasm_func.instruction(&Instruction::I32Const(38)); // internal-error discriminant
                 wasm_func.instruction(&Instruction::I32Const(1)); // option<string> = Some

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -10015,15 +10015,10 @@ impl Codegen {
             // Generate this arm's body
             let arm = &arms[arm_idx];
 
-            // Bind pattern variables (for bindings in the pattern)
-            // For integer literals, there's nothing to bind
-            // For wildcard/binding, bind the scrutinee value
-            if let TirPattern::Binding { name, type_id, .. } = &arm.pattern {
-                let valtype = self.type_id_to_valtype(type_table, *type_id);
-                let local = ctx.alloc_local(name, valtype);
-                ctx.locals.insert(name.clone(), local);
+            if let TirPattern::Binding { local_index, .. } = &arm.pattern {
+                let adjusted_index = *local_index + ctx.local_index_offset;
                 func.instruction(&Instruction::LocalGet(scrutinee_local));
-                func.instruction(&Instruction::LocalSet(local));
+                func.instruction(&Instruction::LocalSet(adjusted_index));
             }
 
             // Generate body expression

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -113,7 +113,7 @@ pub fn analyze_project(project: &mut Project) {
     // Add CM converter functions based on WASI function return types
     // These conversion functions are called from codegen, not Wado code
     // We need to compute transitive closure to include all functions they call
-    let (wasi_registry, _) = WasiRegistry::build_from_stdlib();
+    let (wasi_registry, world_registry) = WasiRegistry::build_from_stdlib();
     let mut needs_list_string_converter = false;
     let mut needs_list_tuple_string_converter = false;
     let mut needs_option_string_converter = false;
@@ -281,9 +281,10 @@ pub fn analyze_project(project: &mut Project) {
 
     // Effect usage requires TaskReturn for async entry point
     // But waitable-set builtins are only needed when effect_wait is actually called
-    // Service world always needs TaskReturn since the handler is an async export
-    let is_async_world = project.target_world == "Service";
-    if !used_wasi_functions.is_empty() || uses_stream_builtins || is_async_world {
+    let has_http_handler_export = world_registry
+        .get(&project.target_world)
+        .is_some_and(|w| w.has_http_handler_export());
+    if !used_wasi_functions.is_empty() || uses_stream_builtins || has_http_handler_export {
         // TaskReturn is always needed for async exports
         add_import_by_name(&mut imports, "task_return");
 
@@ -297,9 +298,9 @@ pub fn analyze_project(project: &mut Project) {
             add_import_by_name(&mut imports, "subtask_drop");
         }
 
-        // Service world needs future intrinsics for response creation
+        // HTTP handler exports need future intrinsics for response creation
         // (trailers parameter to response.new is a future)
-        if is_async_world {
+        if has_http_handler_export {
             add_import_by_name(&mut imports, "future_new");
             add_import_by_name(&mut imports, "future_write");
             add_import_by_name(&mut imports, "future_drop_writable");
@@ -380,7 +381,7 @@ pub fn populate_all_features(project: &mut Project) {
     project.reachable_functions = HashSet::new();
     project.all_reachable = true;
     // Standard WASI functions from the stdlib registry
-    let (wasi_registry, _world_registry) = WasiRegistry::build_from_stdlib();
+    let (wasi_registry, world_registry) = WasiRegistry::build_from_stdlib();
     project.used_wasi_functions = wasi_registry
         .standard_function_names()
         .map(std::string::ToString::to_string)
@@ -389,13 +390,15 @@ pub fn populate_all_features(project: &mut Project) {
     // Build all imports from the builtin registry
     let type_table = RefCell::new(TypeTable::new());
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
-    let is_service_world = project.target_world == "Service";
+    let has_http_handler_export = world_registry
+        .get(&project.target_world)
+        .is_some_and(|w| w.has_http_handler_export());
 
     let mut imports: Vec<TirImport> = Vec::new();
     for info in builtin_registry.imported_builtins() {
         if let Some(canonical_name) = &info.canonical_name {
-            // Skip future intrinsics unless in Service world
-            if canonical_name.starts_with("future-") && !is_service_world {
+            // Skip future intrinsics unless HTTP handler export needs them
+            if canonical_name.starts_with("future-") && !has_http_handler_export {
                 continue;
             }
             imports.push(TirImport {

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -50,16 +50,18 @@ pub fn analyze_project(project: &mut Project) {
     // Build call graph, effect usage, and box primitives from all modules
     let (call_graph, effect_usage, box_primitives_map) = build_analysis_graph(&project.tir_modules);
 
-    // Determine entry functions based on target world
-    // Each world has specific export functions that are entry points
-    let entry_func_names: Vec<&str> = match project.target_world.as_str() {
-        "Service" => vec!["handle"],  // wasi:http/service
-        "Command" | _ => vec!["run"], // wasi:cli/command (default)
-    };
+    // Get world registry to determine entry functions and HTTP handler status
+    let (wasi_registry, world_registry) = WasiRegistry::build_from_stdlib();
+
+    // Determine entry functions from world exports
+    let entry_func_names: Vec<String> = world_registry
+        .get(&project.target_world)
+        .map(|w| w.exports.iter().map(|e| e.name.clone()).collect())
+        .unwrap_or_else(|| vec!["run".to_string()]);
 
     // Compute reachable functions from all entry points
     let mut reachable = HashSet::new();
-    for entry_name in entry_func_names {
+    for entry_name in &entry_func_names {
         let entry_func = FunctionId::Free(FreeFunctionName::from_module_source(
             &project.entry_module_source,
             entry_name,
@@ -113,7 +115,6 @@ pub fn analyze_project(project: &mut Project) {
     // Add CM converter functions based on WASI function return types
     // These conversion functions are called from codegen, not Wado code
     // We need to compute transitive closure to include all functions they call
-    let (wasi_registry, world_registry) = WasiRegistry::build_from_stdlib();
     let mut needs_list_string_converter = false;
     let mut needs_list_tuple_string_converter = false;
     let mut needs_option_string_converter = false;

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -284,7 +284,7 @@ pub fn analyze_project(project: &mut Project) {
     // But waitable-set builtins are only needed when effect_wait is actually called
     let has_http_handler_export = world_registry
         .get(&project.target_world)
-        .is_some_and(|w| w.has_http_handler_export());
+        .is_some_and(super::world_registry::WorldInfo::has_http_handler_export);
     if !used_wasi_functions.is_empty() || uses_stream_builtins || has_http_handler_export {
         // TaskReturn is always needed for async exports
         add_import_by_name(&mut imports, "task_return");
@@ -393,7 +393,7 @@ pub fn populate_all_features(project: &mut Project) {
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
     let has_http_handler_export = world_registry
         .get(&project.target_world)
-        .is_some_and(|w| w.has_http_handler_export());
+        .is_some_and(super::world_registry::WorldInfo::has_http_handler_export);
 
     let mut imports: Vec<TirImport> = Vec::new();
     for info in builtin_registry.imported_builtins() {

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -57,6 +57,13 @@ pub struct Project {
     pub target_world: String,
     /// When true, apply DCE to bundled Wasm module (enabled for -O1+, disabled for -O0)
     pub wasm_dce_enabled: bool,
+
+    // ========================================
+    // CM export characteristics (derived from target_world)
+    // ========================================
+    /// When true, the target world exports an HTTP handler (returns Result<Response, ErrorCode>).
+    /// This determines whether HTTP-related glue code is needed.
+    pub has_http_handler_export: bool,
 }
 
 impl Project {
@@ -83,6 +90,8 @@ impl Project {
             strip_names: false,
             target_world: "Command".to_string(),
             wasm_dce_enabled: true, // Enabled by default, disabled for -O0
+            // CM export characteristics
+            has_http_handler_export: false,
         }
     }
 

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -61,7 +61,7 @@ pub struct Project {
     // ========================================
     // CM export characteristics (derived from target_world)
     // ========================================
-    /// When true, the target world exports an HTTP handler (returns Result<Response, ErrorCode>).
+    /// When true, the target world exports an HTTP handler (returns Result<Response, `ErrorCode`>).
     /// This determines whether HTTP-related glue code is needed.
     pub has_http_handler_export: bool,
 }

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -36,6 +36,25 @@ impl WorldExportInfo {
             return_type: export.return_type.clone(),
         }
     }
+
+    /// Check if this export returns an HTTP response.
+    ///
+    /// Returns true if the return type is `Result<Response, ErrorCode>`,
+    /// which indicates this is an HTTP handler export.
+    pub fn returns_http_response(&self) -> bool {
+        let Some(return_type) = &self.return_type else {
+            return false;
+        };
+
+        if let Type::Generic(generic) = return_type {
+            if generic.name == "Result" && generic.args.len() == 2 {
+                if let Type::Named(ok_type) = &generic.args[0] {
+                    return ok_type.name == "Response";
+                }
+            }
+        }
+        false
+    }
 }
 
 /// Information about a world definition
@@ -45,6 +64,15 @@ pub struct WorldInfo {
     pub name: String,
     /// Exported functions
     pub exports: Vec<WorldExportInfo>,
+}
+
+impl WorldInfo {
+    /// Check if this world has an HTTP handler export.
+    ///
+    /// Returns true if any export returns `Result<Response, ErrorCode>`.
+    pub fn has_http_handler_export(&self) -> bool {
+        self.exports.iter().any(WorldExportInfo::returns_http_response)
+    }
 }
 
 /// Registry of world definitions for code generation

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -46,12 +46,12 @@ impl WorldExportInfo {
             return false;
         };
 
-        if let Type::Generic(generic) = return_type {
-            if generic.name == "Result" && generic.args.len() == 2 {
-                if let Type::Named(ok_type) = &generic.args[0] {
-                    return ok_type.name == "Response";
-                }
-            }
+        if let Type::Generic(generic) = return_type
+            && generic.name == "Result"
+            && generic.args.len() == 2
+            && let Type::Named(ok_type) = &generic.args[0]
+        {
+            return ok_type.name == "Response";
         }
         false
     }
@@ -71,7 +71,9 @@ impl WorldInfo {
     ///
     /// Returns true if any export returns `Result<Response, ErrorCode>`.
     pub fn has_http_handler_export(&self) -> bool {
-        self.exports.iter().any(WorldExportInfo::returns_http_response)
+        self.exports
+            .iter()
+            .any(WorldExportInfo::returns_http_response)
     }
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the codebase to replace hardcoded checks for `target_world == "Service"` with a more flexible `has_http_handler_export` flag. This allows the compiler to support any world that exports an HTTP handler, not just the specific "Service" world.

## Key Changes

- **Added `has_http_handler_export` field to `Codegen` struct**: Computed at the start of `generate_wasm` from the world registry, indicating whether the target world exports an HTTP handler (returns `Result<Response, ErrorCode>`).

- **Updated `FunctionContext`**: Replaced the `target_world: String` field with `has_http_handler_export: bool` to track HTTP handler status at the function level.

- **Added HTTP handler detection to `WorldInfo`**: Implemented `has_http_handler_export()` method that checks if any export returns `Result<Response, ErrorCode>`, and `WorldExportInfo::returns_http_response()` to identify HTTP response returns.

- **Replaced all hardcoded world checks**: Changed ~15 instances of `project.target_world == "Service"` to use `self.has_http_handler_export` or `ctx.has_http_handler_export` throughout the codebase.

- **Updated DCE analysis**: Modified `optimize_dce.rs` to determine entry functions and HTTP handler status from the world registry instead of hardcoding world names.

- **Added field to `Project` struct**: Added `has_http_handler_export` field for consistency (though currently unused in the diff).

## Implementation Details

- The HTTP handler detection is based on the return type signature: if an export returns `Result<Response, ErrorCode>`, it's identified as an HTTP handler export.
- The flag is computed once during `generate_wasm` initialization and reused throughout code generation, avoiding repeated lookups.
- This change maintains backward compatibility while enabling support for custom worlds with HTTP handler exports.
- Fixed a bug in pattern binding code where local indices are now properly adjusted with `local_index_offset`.

https://claude.ai/code/session_01EBay1u9Ro5L325L9uJjAhT