### PR TITLE
Optimize fixed-point iteration: early exit on convergence + batch copy propagation

### DIFF
--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -159,11 +159,15 @@ pub fn optimize(mut project: Project, opt_level: OptLevel) -> Project {
 /// More iterations can find more optimization opportunities but take longer.
 fn run_optimization_passes(project: &mut Project, config: &OptConfig) {
     for _ in 0..config.iterations {
-        inline_functions(project, config.inline_threshold);
-        eliminate_unnecessary_refs(project);
-        propagate_copies(project);
-        fold_constants(project);
-        apply_licm(project);
+        let mut changed = false;
+        changed |= inline_functions(project, config.inline_threshold);
+        changed |= eliminate_unnecessary_refs(project);
+        changed |= propagate_copies(project);
+        changed |= fold_constants(project);
+        changed |= apply_licm(project);
+        if !changed {
+            break;
+        }
     }
 }
 

--- a/wado-compiler/src/optimize_const_fold.rs
+++ b/wado-compiler/src/optimize_const_fold.rs
@@ -15,181 +15,175 @@ use crate::tir::{
 };
 
 /// Apply constant folding to all functions in the project.
-pub fn fold_constants(project: &mut Project) {
+pub fn fold_constants(project: &mut Project) -> bool {
+    let mut changed = false;
     for module in project.tir_modules.values_mut() {
         let type_table = module.type_table.borrow();
         for func_rc in &module.functions {
             let mut func = func_rc.borrow_mut();
-            fold_constants_in_function(&mut func, &type_table);
+            changed |= fold_constants_in_function(&mut func, &type_table);
         }
     }
+    changed
 }
 
-fn fold_constants_in_function(func: &mut TirFunction, type_table: &TypeTable) {
+fn fold_constants_in_function(func: &mut TirFunction, type_table: &TypeTable) -> bool {
     let Some(body) = &mut func.body else {
-        return;
+        return false;
     };
-    fold_constants_in_block(body, type_table);
+    fold_constants_in_block(body, type_table)
 }
 
-fn fold_constants_in_block(block: &mut TirBlock, type_table: &TypeTable) {
+fn fold_constants_in_block(block: &mut TirBlock, type_table: &TypeTable) -> bool {
+    let mut changed = false;
     for stmt in &mut block.stmts {
-        fold_constants_in_stmt(stmt, type_table);
+        changed |= fold_constants_in_stmt(stmt, type_table);
     }
+    changed
 }
 
-fn fold_constants_in_stmt(stmt: &mut TirStmt, type_table: &TypeTable) {
+fn fold_constants_in_stmt(stmt: &mut TirStmt, type_table: &TypeTable) -> bool {
     match &mut stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            fold_constants_in_expr(value, type_table);
-        }
-        TirStmtKind::Expr(expr) => {
-            fold_constants_in_expr(expr, type_table);
-        }
-        TirStmtKind::Return { value } => {
-            if let Some(v) = value {
-                fold_constants_in_expr(v, type_table);
-            }
-        }
+        TirStmtKind::Let { value, .. } => fold_constants_in_expr(value, type_table),
+        TirStmtKind::Expr(expr) => fold_constants_in_expr(expr, type_table),
+        TirStmtKind::Return { value } => value
+            .as_mut()
+            .is_some_and(|v| fold_constants_in_expr(v, type_table)),
         TirStmtKind::If {
             condition,
             then_block,
             else_block,
         } => {
-            fold_constants_in_expr(condition, type_table);
-            fold_constants_in_block(then_block, type_table);
+            let mut changed = fold_constants_in_expr(condition, type_table);
+            changed |= fold_constants_in_block(then_block, type_table);
             if let Some(eb) = else_block {
-                fold_constants_in_block(eb, type_table);
+                changed |= fold_constants_in_block(eb, type_table);
             }
+            changed
         }
-        TirStmtKind::Loop { body } => {
-            fold_constants_in_block(body, type_table);
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            fold_constants_in_block(block, type_table);
-        }
+        TirStmtKind::Loop { body } => fold_constants_in_block(body, type_table),
+        TirStmtKind::LabeledBlock { block, .. } => fold_constants_in_block(block, type_table),
         TirStmtKind::IfPattern {
             scrutinee,
             then_block,
             else_block,
             ..
         } => {
-            fold_constants_in_expr(scrutinee, type_table);
-            fold_constants_in_block(then_block, type_table);
+            let mut changed = fold_constants_in_expr(scrutinee, type_table);
+            changed |= fold_constants_in_block(then_block, type_table);
             if let Some(eb) = else_block {
-                fold_constants_in_block(eb, type_table);
+                changed |= fold_constants_in_block(eb, type_table);
             }
+            changed
         }
-        TirStmtKind::Break { value, .. } => {
-            if let Some(v) = value {
-                fold_constants_in_expr(v, type_table);
-            }
-        }
-        TirStmtKind::Continue => {}
-        TirStmtKind::LetPattern { value, .. } => {
-            fold_constants_in_expr(value, type_table);
-        }
+        TirStmtKind::Break { value, .. } => value
+            .as_mut()
+            .is_some_and(|v| fold_constants_in_expr(v, type_table)),
+        TirStmtKind::Continue => false,
+        TirStmtKind::LetPattern { value, .. } => fold_constants_in_expr(value, type_table),
     }
 }
 
-fn fold_constants_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
+fn fold_constants_in_expr(expr: &mut TirExpr, type_table: &TypeTable) -> bool {
+    let mut changed = false;
+
     // First, recurse into sub-expressions (bottom-up folding)
     match &mut expr.kind {
         TirExprKind::Binary { left, right, .. } => {
-            fold_constants_in_expr(left, type_table);
-            fold_constants_in_expr(right, type_table);
+            changed |= fold_constants_in_expr(left, type_table);
+            changed |= fold_constants_in_expr(right, type_table);
         }
         TirExprKind::Unary { expr: inner, .. } => {
-            fold_constants_in_expr(inner, type_table);
+            changed |= fold_constants_in_expr(inner, type_table);
         }
         TirExprKind::Assign { target, value } => {
-            fold_constants_in_expr(target, type_table);
-            fold_constants_in_expr(value, type_table);
+            changed |= fold_constants_in_expr(target, type_table);
+            changed |= fold_constants_in_expr(value, type_table);
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
         | TirExprKind::EffectCall { args, .. } => {
             for arg in args {
-                fold_constants_in_expr(arg, type_table);
+                changed |= fold_constants_in_expr(arg, type_table);
             }
         }
         TirExprKind::MethodCall { receiver, args, .. } => {
-            fold_constants_in_expr(receiver, type_table);
+            changed |= fold_constants_in_expr(receiver, type_table);
             for arg in args {
-                fold_constants_in_expr(arg, type_table);
+                changed |= fold_constants_in_expr(arg, type_table);
             }
         }
         TirExprKind::IndirectCall { callee, args, .. } => {
-            fold_constants_in_expr(callee, type_table);
+            changed |= fold_constants_in_expr(callee, type_table);
             for arg in args {
-                fold_constants_in_expr(arg, type_table);
+                changed |= fold_constants_in_expr(arg, type_table);
             }
         }
         TirExprKind::ClosureToCanonical { functor, .. } => {
-            fold_constants_in_expr(functor, type_table);
+            changed |= fold_constants_in_expr(functor, type_table);
         }
         TirExprKind::FieldAccess { expr: inner, .. } | TirExprKind::Cast { expr: inner, .. } => {
-            fold_constants_in_expr(inner, type_table);
+            changed |= fold_constants_in_expr(inner, type_table);
         }
         TirExprKind::Index {
             expr: inner, index, ..
         } => {
-            fold_constants_in_expr(inner, type_table);
-            fold_constants_in_expr(index, type_table);
+            changed |= fold_constants_in_expr(inner, type_table);
+            changed |= fold_constants_in_expr(index, type_table);
         }
         TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
-            fold_constants_in_block(block, type_table);
+            changed |= fold_constants_in_block(block, type_table);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            fold_constants_in_expr(condition, type_table);
-            fold_constants_in_block(then_branch, type_table);
+            changed |= fold_constants_in_expr(condition, type_table);
+            changed |= fold_constants_in_block(then_branch, type_table);
             if let Some(eb) = else_branch {
-                fold_constants_in_block(eb, type_table);
+                changed |= fold_constants_in_block(eb, type_table);
             }
         }
         TirExprKind::Match { expr: inner, arms } => {
-            fold_constants_in_expr(inner, type_table);
+            changed |= fold_constants_in_expr(inner, type_table);
             for arm in arms {
-                fold_constants_in_expr(&mut arm.body, type_table);
+                changed |= fold_constants_in_expr(&mut arm.body, type_table);
             }
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for field in fields {
-                fold_constants_in_expr(&mut field.value, type_table);
+                changed |= fold_constants_in_expr(&mut field.value, type_table);
             }
         }
         TirExprKind::ArrayLiteral { elements, .. } | TirExprKind::TupleLiteral { elements, .. } => {
             for elem in elements {
-                fold_constants_in_expr(elem, type_table);
+                changed |= fold_constants_in_expr(elem, type_table);
             }
         }
         TirExprKind::OptionSome { value } => {
-            fold_constants_in_expr(value, type_table);
+            changed |= fold_constants_in_expr(value, type_table);
         }
         TirExprKind::VariantConstruct { payload, .. } => {
             if let Some(payload_expr) = payload {
-                fold_constants_in_expr(payload_expr, type_table);
+                changed |= fold_constants_in_expr(payload_expr, type_table);
             }
         }
         TirExprKind::Move { expr } => {
-            fold_constants_in_expr(expr, type_table);
+            changed |= fold_constants_in_expr(expr, type_table);
         }
         TirExprKind::Closure { body, .. } => {
-            fold_constants_in_expr(body, type_table);
+            changed |= fold_constants_in_expr(body, type_table);
         }
         TirExprKind::GlobalVarSet { value, .. } => {
-            fold_constants_in_expr(value, type_table);
+            changed |= fold_constants_in_expr(value, type_table);
         }
         TirExprKind::IsNotNull { expr }
         | TirExprKind::UnwrapOption { expr, .. }
         | TirExprKind::VariantTag { expr }
         | TirExprKind::VariantTest { expr, .. }
         | TirExprKind::VariantPayload { expr, .. } => {
-            fold_constants_in_expr(expr, type_table);
+            changed |= fold_constants_in_expr(expr, type_table);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -197,11 +191,11 @@ fn fold_constants_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
             default,
             ..
         } => {
-            fold_constants_in_expr(scrutinee, type_table);
+            changed |= fold_constants_in_expr(scrutinee, type_table);
             for arm in arms {
-                fold_constants_in_block(arm, type_table);
+                changed |= fold_constants_in_block(arm, type_table);
             }
-            fold_constants_in_block(default, type_table);
+            changed |= fold_constants_in_block(default, type_table);
         }
         // Leaf nodes - nothing to recurse into
         TirExprKind::Local { .. }
@@ -224,7 +218,10 @@ fn fold_constants_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
             value,
             repr: format_int_value(value, prim),
         };
+        changed = true;
     }
+
+    changed
 }
 
 /// Try to fold a single expression node into a constant.

--- a/wado-compiler/src/optimize_copy_prop.rs
+++ b/wado-compiler/src/optimize_copy_prop.rs
@@ -619,24 +619,24 @@ fn can_propagate_copy(
 }
 
 /// Substitute local references in a block.
-/// Replaces uses of `from_local` with the expression from `source`.
-fn substitute_in_block(block: &mut TirBlock, from_local: u32, source: &CopySource) {
+/// Replaces uses of locals in `substitutions` with the corresponding source expression.
+fn substitute_in_block(block: &mut TirBlock, substitutions: &HashMap<u32, CopySource>) {
     for stmt in &mut block.stmts {
-        substitute_in_stmt(stmt, from_local, source);
+        substitute_in_stmt(stmt, substitutions);
     }
 }
 
-fn substitute_in_stmt(stmt: &mut TirStmt, from_local: u32, source: &CopySource) {
+fn substitute_in_stmt(stmt: &mut TirStmt, substitutions: &HashMap<u32, CopySource>) {
     match &mut stmt.kind {
         TirStmtKind::Let { value, .. } => {
-            substitute_in_expr(value, from_local, source);
+            substitute_in_expr(value, substitutions);
         }
         TirStmtKind::Expr(expr) => {
-            substitute_in_expr(expr, from_local, source);
+            substitute_in_expr(expr, substitutions);
         }
         TirStmtKind::Return { value } => {
             if let Some(v) = value {
-                substitute_in_expr(v, from_local, source);
+                substitute_in_expr(v, substitutions);
             }
         }
         TirStmtKind::If {
@@ -644,17 +644,17 @@ fn substitute_in_stmt(stmt: &mut TirStmt, from_local: u32, source: &CopySource) 
             then_block,
             else_block,
         } => {
-            substitute_in_expr(condition, from_local, source);
-            substitute_in_block(then_block, from_local, source);
+            substitute_in_expr(condition, substitutions);
+            substitute_in_block(then_block, substitutions);
             if let Some(eb) = else_block {
-                substitute_in_block(eb, from_local, source);
+                substitute_in_block(eb, substitutions);
             }
         }
         TirStmtKind::Loop { body } => {
-            substitute_in_block(body, from_local, source);
+            substitute_in_block(body, substitutions);
         }
         TirStmtKind::LabeledBlock { block, .. } => {
-            substitute_in_block(block, from_local, source);
+            substitute_in_block(block, substitutions);
         }
         TirStmtKind::IfPattern {
             scrutinee,
@@ -662,28 +662,28 @@ fn substitute_in_stmt(stmt: &mut TirStmt, from_local: u32, source: &CopySource) 
             else_block,
             ..
         } => {
-            substitute_in_expr(scrutinee, from_local, source);
-            substitute_in_block(then_block, from_local, source);
+            substitute_in_expr(scrutinee, substitutions);
+            substitute_in_block(then_block, substitutions);
             if let Some(eb) = else_block {
-                substitute_in_block(eb, from_local, source);
+                substitute_in_block(eb, substitutions);
             }
         }
         TirStmtKind::Break { value, .. } => {
             if let Some(v) = value {
-                substitute_in_expr(v, from_local, source);
+                substitute_in_expr(v, substitutions);
             }
         }
         TirStmtKind::Continue => {}
         TirStmtKind::LetPattern { value, .. } => {
-            substitute_in_expr(value, from_local, source);
+            substitute_in_expr(value, substitutions);
         }
     }
 }
 
-fn substitute_in_expr(expr: &mut TirExpr, from_local: u32, source: &CopySource) {
+fn substitute_in_expr(expr: &mut TirExpr, substitutions: &HashMap<u32, CopySource>) {
     // Check if this is a local that needs substitution
     if let TirExprKind::Local { index, .. } = &expr.kind
-        && *index == from_local
+        && let Some(source) = substitutions.get(index)
     {
         // Replace with the source expression
         expr.kind = match source {
@@ -714,113 +714,113 @@ fn substitute_in_expr(expr: &mut TirExpr, from_local: u32, source: &CopySource) 
             // Already handled above
         }
         TirExprKind::Binary { left, right, .. } => {
-            substitute_in_expr(left, from_local, source);
-            substitute_in_expr(right, from_local, source);
+            substitute_in_expr(left, substitutions);
+            substitute_in_expr(right, substitutions);
         }
         TirExprKind::Unary { expr: inner, .. } => {
-            substitute_in_expr(inner, from_local, source);
+            substitute_in_expr(inner, substitutions);
         }
         TirExprKind::Assign { target, value } => {
-            substitute_in_expr(target, from_local, source);
-            substitute_in_expr(value, from_local, source);
+            substitute_in_expr(target, substitutions);
+            substitute_in_expr(value, substitutions);
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
         | TirExprKind::EffectCall { args, .. } => {
             for arg in args {
-                substitute_in_expr(arg, from_local, source);
+                substitute_in_expr(arg, substitutions);
             }
         }
         TirExprKind::MethodCall { receiver, args, .. } => {
-            substitute_in_expr(receiver, from_local, source);
+            substitute_in_expr(receiver, substitutions);
             for arg in args {
-                substitute_in_expr(arg, from_local, source);
+                substitute_in_expr(arg, substitutions);
             }
         }
         TirExprKind::IndirectCall { callee, args, .. } => {
-            substitute_in_expr(callee, from_local, source);
+            substitute_in_expr(callee, substitutions);
             for arg in args {
-                substitute_in_expr(arg, from_local, source);
+                substitute_in_expr(arg, substitutions);
             }
         }
         TirExprKind::ClosureToCanonical { functor, .. } => {
-            substitute_in_expr(functor, from_local, source);
+            substitute_in_expr(functor, substitutions);
         }
         TirExprKind::FieldAccess { expr: inner, .. } => {
-            substitute_in_expr(inner, from_local, source);
+            substitute_in_expr(inner, substitutions);
         }
         TirExprKind::Index {
             expr: inner, index, ..
         } => {
-            substitute_in_expr(inner, from_local, source);
-            substitute_in_expr(index, from_local, source);
+            substitute_in_expr(inner, substitutions);
+            substitute_in_expr(index, substitutions);
         }
         TirExprKind::Cast { expr: inner, .. } => {
-            substitute_in_expr(inner, from_local, source);
+            substitute_in_expr(inner, substitutions);
         }
         TirExprKind::Block(block) => {
-            substitute_in_block(block, from_local, source);
+            substitute_in_block(block, substitutions);
         }
         TirExprKind::LabeledBlock { block, .. } => {
-            substitute_in_block(block, from_local, source);
+            substitute_in_block(block, substitutions);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            substitute_in_expr(condition, from_local, source);
-            substitute_in_block(then_branch, from_local, source);
+            substitute_in_expr(condition, substitutions);
+            substitute_in_block(then_branch, substitutions);
             if let Some(eb) = else_branch {
-                substitute_in_block(eb, from_local, source);
+                substitute_in_block(eb, substitutions);
             }
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for field in fields {
-                substitute_in_expr(&mut field.value, from_local, source);
+                substitute_in_expr(&mut field.value, substitutions);
             }
         }
         TirExprKind::ArrayLiteral { elements, .. } => {
             for elem in elements {
-                substitute_in_expr(elem, from_local, source);
+                substitute_in_expr(elem, substitutions);
             }
         }
         TirExprKind::TupleLiteral { elements, .. } => {
             for elem in elements {
-                substitute_in_expr(elem, from_local, source);
+                substitute_in_expr(elem, substitutions);
             }
         }
         TirExprKind::OptionSome { value } => {
-            substitute_in_expr(value, from_local, source);
+            substitute_in_expr(value, substitutions);
         }
         TirExprKind::VariantConstruct { payload, .. } => {
             if let Some(payload_expr) = payload {
-                substitute_in_expr(payload_expr, from_local, source);
+                substitute_in_expr(payload_expr, substitutions);
             }
         }
         TirExprKind::Move { expr } => {
-            substitute_in_expr(expr, from_local, source);
+            substitute_in_expr(expr, substitutions);
         }
         TirExprKind::Closure { body, .. } => {
-            substitute_in_expr(body, from_local, source);
+            substitute_in_expr(body, substitutions);
         }
         TirExprKind::Match { expr: inner, arms } => {
-            substitute_in_expr(inner, from_local, source);
+            substitute_in_expr(inner, substitutions);
             for arm in arms {
-                substitute_in_expr(&mut arm.body, from_local, source);
+                substitute_in_expr(&mut arm.body, substitutions);
             }
         }
         TirExprKind::GlobalVarSet { value, .. } => {
-            substitute_in_expr(value, from_local, source);
+            substitute_in_expr(value, substitutions);
         }
         TirExprKind::IsNotNull { expr }
         | TirExprKind::UnwrapOption { expr, .. }
         | TirExprKind::VariantTag { expr }
         | TirExprKind::VariantTest { expr, .. } => {
-            substitute_in_expr(expr, from_local, source);
+            substitute_in_expr(expr, substitutions);
         }
         TirExprKind::VariantPayload { expr, .. } => {
-            substitute_in_expr(expr, from_local, source);
+            substitute_in_expr(expr, substitutions);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -828,11 +828,11 @@ fn substitute_in_expr(expr: &mut TirExpr, from_local: u32, source: &CopySource) 
             default,
             ..
         } => {
-            substitute_in_expr(scrutinee, from_local, source);
+            substitute_in_expr(scrutinee, substitutions);
             for arm in arms {
-                substitute_in_block(arm, from_local, source);
+                substitute_in_block(arm, substitutions);
             }
-            substitute_in_block(default, from_local, source);
+            substitute_in_block(default, substitutions);
         }
         // Leaf nodes
         TirExprKind::IntLiteral { .. }
@@ -1255,56 +1255,88 @@ fn remove_copy_bindings_in_expr(expr: &mut TirExpr, dead_locals: &HashSet<u32>) 
 }
 
 /// Eliminate trivial copy bindings in a function.
-fn propagate_copies_in_function(func: &mut TirFunction, type_table: &TypeTable) {
+/// Batches non-conflicting substitutions to reduce TIR walk count from O(4K) to O(4) per iteration.
+fn propagate_copies_in_function(func: &mut TirFunction, type_table: &TypeTable) -> bool {
     let Some(body) = &mut func.body else {
-        return;
+        return false;
     };
 
-    // Iterate until no more changes
-    // We process ONE binding per iteration to avoid interference between substitutions
-    // (e.g., if `let a = 5; let x = a;`, substituting both at once would break references)
+    let mut ever_changed = false;
+
     loop {
-        // Collect all copy bindings
+        // Step 1: Collect all copy bindings (single walk)
         let mut copy_bindings: Vec<CopyBinding> = Vec::new();
-        // Start with empty set - bindings inside labeled blocks will get their own set
         collect_copy_bindings(&body.stmts, &mut copy_bindings, &HashSet::new());
 
         if copy_bindings.is_empty() {
             break;
         }
 
-        // Collect usage information
+        // Step 2: Collect usage information (single walk)
         let usage = collect_local_usage(body);
 
-        // Find FIRST binding that can be eliminated (one at a time for safety)
-        let mut to_eliminate: Option<CopyBinding> = None;
-        for binding in copy_bindings {
-            if can_propagate_copy(&binding, &usage, type_table) {
-                to_eliminate = Some(binding);
-                break;
+        // Step 3: Find all eliminable bindings
+        let eliminable: Vec<CopyBinding> = copy_bindings
+            .into_iter()
+            .filter(|b| can_propagate_copy(b, &usage, type_table))
+            .collect();
+
+        if eliminable.is_empty() {
+            break;
+        }
+
+        // Step 4: Build non-conflicting batch.
+        // A binding can be batched if its source local is not a target of another eliminable
+        // binding. This prevents interference when two bindings form a chain
+        // (e.g., `let a = 5; let x = a`).
+        let target_set: HashSet<u32> = eliminable.iter().map(|b| b.target_local).collect();
+
+        let mut substitutions: HashMap<u32, CopySource> = HashMap::new();
+        let mut has_deferred = false;
+
+        for binding in eliminable {
+            let source_conflicts = match &binding.source {
+                CopySource::Local { index, .. } => target_set.contains(index),
+                _ => false,
+            };
+            if source_conflicts {
+                has_deferred = true;
+            } else {
+                substitutions.insert(binding.target_local, binding.source);
             }
         }
 
-        let Some(binding) = to_eliminate else {
+        if substitutions.is_empty() {
+            // All bindings conflict with each other -- cannot make progress
             break;
-        };
+        }
 
-        // Apply substitution for this one binding
-        substitute_in_block(body, binding.target_local, &binding.source);
+        // Step 5: Apply all substitutions in a single walk
+        let dead_locals: HashSet<u32> = substitutions.keys().copied().collect();
+        substitute_in_block(body, &substitutions);
 
-        // Remove the dead binding
-        let dead_locals: HashSet<u32> = [binding.target_local].into_iter().collect();
+        // Step 6: Remove all dead bindings in a single walk
         remove_copy_bindings(&mut body.stmts, &dead_locals);
+        ever_changed = true;
+
+        // If no bindings were deferred, we're done
+        if !has_deferred {
+            break;
+        }
     }
+
+    ever_changed
 }
 
 /// Apply copy propagation to all functions in the project.
-pub fn propagate_copies(project: &mut Project) {
+pub fn propagate_copies(project: &mut Project) -> bool {
+    let mut changed = false;
     for module in project.tir_modules.values_mut() {
         let type_table = module.type_table.borrow();
         for func_rc in &module.functions {
             let mut func = func_rc.borrow_mut();
-            propagate_copies_in_function(&mut func, &type_table);
+            changed |= propagate_copies_in_function(&mut func, &type_table);
         }
     }
+    changed
 }

--- a/wado-compiler/src/optimize_inline.rs
+++ b/wado-compiler/src/optimize_inline.rs
@@ -734,7 +734,7 @@ fn can_reach(
 ///
 /// The `inline_threshold` parameter controls the maximum number of statements
 /// a function can have to be considered for inlining.
-pub fn inline_functions(project: &mut Project, inline_threshold: usize) {
+pub fn inline_functions(project: &mut Project, inline_threshold: usize) -> bool {
     let recursive_functions = find_recursive_functions(&project.tir_modules);
 
     // Collect inline candidates from all modules
@@ -766,8 +766,10 @@ pub fn inline_functions(project: &mut Project, inline_threshold: usize) {
     }
 
     if inline_candidates.is_empty() {
-        return;
+        return false;
     }
+
+    let mut changed = false;
 
     // Inline at call sites in each module
     for module in project.tir_modules.values_mut() {
@@ -797,6 +799,10 @@ pub fn inline_functions(project: &mut Project, inline_threshold: usize) {
                 func.local_types = local_types;
                 func.body = Some(body);
 
+                if !inlined_funcs.is_empty() {
+                    changed = true;
+                }
+
                 // Update function_strings: add strings from inlined functions to the caller
                 for inlined_key in inlined_funcs {
                     if let Some(inlined_strings) = candidate_strings.get(&inlined_key) {
@@ -818,6 +824,7 @@ pub fn inline_functions(project: &mut Project, inline_threshold: usize) {
             }
         }
     }
+    changed
 }
 
 /// Inline function calls in a block

--- a/wado-compiler/src/optimize_licm.rs
+++ b/wado-compiler/src/optimize_licm.rs
@@ -12,27 +12,29 @@ use crate::tir::{
 use std::collections::{HashMap, HashSet};
 
 /// Apply Loop-Invariant Code Motion to all functions in the project.
-pub fn apply_licm(project: &mut Project) {
+pub fn apply_licm(project: &mut Project) -> bool {
+    let mut changed = false;
     for module in project.tir_modules.values_mut() {
         let type_table = module.type_table.borrow();
         for func_rc in &module.functions {
             let mut func = func_rc.borrow_mut();
-            licm_function(&mut func, &type_table);
+            changed |= licm_function(&mut func, &type_table);
         }
     }
+    changed
 }
 
 /// Apply LICM to a function
-fn licm_function(func: &mut TirFunction, type_table: &TypeTable) {
-    if let Some(ref mut body) = func.body {
-        let mut local_count = func.local_count;
-        let mut local_types = func.local_types.clone();
-
-        licm_block(body, &mut local_count, &mut local_types, type_table);
-
-        func.local_count = local_count;
-        func.local_types = local_types;
-    }
+fn licm_function(func: &mut TirFunction, type_table: &TypeTable) -> bool {
+    let Some(ref mut body) = func.body else {
+        return false;
+    };
+    let mut local_count = func.local_count;
+    let mut local_types = func.local_types.clone();
+    let changed = licm_block(body, &mut local_count, &mut local_types, type_table);
+    func.local_count = local_count;
+    func.local_types = local_types;
+    changed
 }
 
 /// Apply LICM to all loops in a block
@@ -41,7 +43,8 @@ fn licm_block(
     local_count: &mut u32,
     local_types: &mut Vec<TypeId>,
     type_table: &TypeTable,
-) {
+) -> bool {
+    let mut changed = false;
     let mut new_stmts = Vec::new();
 
     for mut stmt in std::mem::take(&mut block.stmts) {
@@ -50,6 +53,10 @@ fn licm_block(
                 // Apply LICM to the loop body
                 let empty_set = HashSet::new();
                 let hoist_stmts = licm_loop(body, local_count, local_types, type_table, &empty_set);
+
+                if !hoist_stmts.is_empty() {
+                    changed = true;
+                }
 
                 // Prepend hoisting statements
                 new_stmts.extend(hoist_stmts);
@@ -61,14 +68,14 @@ fn licm_block(
                 ..
             } => {
                 // Recurse into if branches
-                licm_block(then_block, local_count, local_types, type_table);
+                changed |= licm_block(then_block, local_count, local_types, type_table);
                 if let Some(eb) = else_block {
-                    licm_block(eb, local_count, local_types, type_table);
+                    changed |= licm_block(eb, local_count, local_types, type_table);
                 }
                 new_stmts.push(stmt);
             }
             TirStmtKind::LabeledBlock { block: inner, .. } => {
-                licm_block(inner, local_count, local_types, type_table);
+                changed |= licm_block(inner, local_count, local_types, type_table);
                 new_stmts.push(stmt);
             }
             TirStmtKind::IfPattern {
@@ -76,9 +83,9 @@ fn licm_block(
                 else_block,
                 ..
             } => {
-                licm_block(then_block, local_count, local_types, type_table);
+                changed |= licm_block(then_block, local_count, local_types, type_table);
                 if let Some(eb) = else_block {
-                    licm_block(eb, local_count, local_types, type_table);
+                    changed |= licm_block(eb, local_count, local_types, type_table);
                 }
                 new_stmts.push(stmt);
             }
@@ -90,6 +97,7 @@ fn licm_block(
     }
 
     block.stmts = new_stmts;
+    changed
 }
 
 /// Apply LICM to a single loop, returning hoisting statements to prepend

--- a/wado-compiler/src/optimize_ref_elim.rs
+++ b/wado-compiler/src/optimize_ref_elim.rs
@@ -545,9 +545,9 @@ fn replace_ref_field_access_in_stmt(
 ///   ... self.repr ...
 /// This can be optimized to:
 ///   ... arr.repr ...
-fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) {
+fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) -> bool {
     let Some(body) = &mut func.body else {
-        return;
+        return false;
     };
 
     // First pass: find all ref bindings
@@ -555,7 +555,7 @@ fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) {
     collect_ref_bindings(&body.stmts, &mut ref_bindings);
 
     if ref_bindings.is_empty() {
-        return;
+        return false;
     }
 
     // Second pass: for each ref binding, check if all uses are field accesses
@@ -565,6 +565,10 @@ fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) {
         if all_field_access {
             eliminable_bindings.push(binding);
         }
+    }
+
+    if eliminable_bindings.is_empty() {
+        return false;
     }
 
     // Third pass: replace field accesses and remove dead bindings
@@ -581,6 +585,7 @@ fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) {
     // We need to handle nested blocks, so we do this recursively
     let dead_locals: HashSet<u32> = eliminable_bindings.iter().map(|b| b.ref_local).collect();
     remove_dead_ref_bindings(&mut body.stmts, &dead_locals);
+    true
 }
 
 /// Collect ref bindings from statements (only at the top level of each block).
@@ -987,12 +992,14 @@ fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &HashSet<u3
 /// This is the main entry point for reference elimination optimization.
 /// It iterates through all modules and functions, eliminating reference
 /// bindings that are only used for field access.
-pub fn eliminate_unnecessary_refs(project: &mut Project) {
+pub fn eliminate_unnecessary_refs(project: &mut Project) -> bool {
+    let mut changed = false;
     for module in project.tir_modules.values_mut() {
         let type_table = module.type_table.borrow();
         for func_rc in &module.functions {
             let mut func = func_rc.borrow_mut();
-            eliminate_refs_in_function(&mut func, &type_table);
+            changed |= eliminate_refs_in_function(&mut func, &type_table);
         }
     }
+    changed
 }


### PR DESCRIPTION
Phase 1: All 5 optimization passes (inline, ref_elim, copy_prop, const_fold, LICM)
now return bool indicating whether changes were made. The fixed-point loop in
run_optimization_passes breaks early when no pass makes changes, avoiding
redundant iterations (e.g., O3's 100 iterations now stop at convergence).

Phase 2: Copy propagation now batches non-conflicting substitutions into a
single TIR walk using HashMap<u32, CopySource>, reducing walk count from O(4K)
to O(4) per batch iteration where K is the number of eliminable bindings.

https://claude.ai/code/session_01E6vg2fPk1XPHDXgDwVRzzF