### PR TITLE
Always apply walrus DCE to bundled Wasm module

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -1819,15 +1819,11 @@ impl Codegen<'_> {
                 wasm_postprocess::convert_memory_to_import(wado_bundled_wasm(), "env", "memory")
                     .expect("Failed to process wado-bundled module");
 
-            // Apply Wasm-level DCE if enabled (disabled for -O0)
-            let final_module = if project.wasm_dce_enabled {
-                // Build set of exports to keep based on used bundled functions
-                let keep_exports: std::collections::HashSet<_> =
-                    bundled_functions.iter().cloned().collect();
-                wasm_postprocess::eliminate_dead_code(&bundled_module, &keep_exports)
-            } else {
-                bundled_module
-            };
+            // Apply Wasm-level DCE to keep only used bundled functions
+            let keep_exports: std::collections::HashSet<_> =
+                bundled_functions.iter().cloned().collect();
+            let final_module =
+                wasm_postprocess::eliminate_dead_code(&bundled_module, &keep_exports);
 
             ctx.register_core_module("fts-mod");
             builder.core_module_raw(Some("fts-mod"), &final_module);

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -82,8 +82,6 @@ pub fn optimize(mut project: Project, opt_level: OptLevel) -> Project {
             populate_all_features(&mut project);
             // Note: O0 mode only enables standard WASI functions from the stdlib.
             // Non-standard functions like sockets require O2+ to be detected via DCE analysis.
-            // Disable Wasm-level DCE for bundled module (for faster compilation)
-            project.wasm_dce_enabled = false;
         }
         OptLevel::O1 => {
             // Development mode: all optimizations except DCE

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -69,8 +69,6 @@ pub struct Project {
     /// Target world for Component Model export (e.g., "Command", "Service")
     /// Defaults to "Command" (wasi:cli/command)
     pub target_world: String,
-    /// When true, apply DCE to bundled Wasm module (enabled for -O1+, disabled for -O0)
-    pub wasm_dce_enabled: bool,
 
     // ========================================
     // CM export characteristics (derived from target_world)
@@ -115,7 +113,6 @@ impl Project {
             // Codegen options
             strip_names: false,
             target_world: "Command".to_string(),
-            wasm_dce_enabled: true, // Enabled by default, disabled for -O0
             // CM export characteristics
             has_http_handler_export: false,
             // Wasm plan


### PR DESCRIPTION
Previously, wasm-level DCE on the bundled module was skipped in O0 mode,
causing e2e tests to be slow due to including the full unoptimized module.

https://claude.ai/code/session_01QvorJ7qV4LQdQk1fJ4mfEA