### PR TITLE
Clean up all 49 clippy warnings in wado-compiler

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -4525,7 +4525,7 @@ impl Codegen<'_> {
             // Copy this case: cast to case type, read all fields, create new struct
             let case_type_idx = case_info.type_idx;
             // tag + optional payload field
-            let field_count = if case_info.payload_type.is_some() {
+            let field_count: u32 = if case_info.payload_type.is_some() {
                 2
             } else {
                 1
@@ -4534,7 +4534,7 @@ impl Codegen<'_> {
             // Read all fields and push onto stack
             // For each field: get source, cast to case type, read field
             // This duplicates the cast but avoids needing temp locals
-            for field_index in 0..field_count as u32 {
+            for field_index in 0..field_count {
                 func.instruction(&Instruction::LocalGet(source_local));
                 func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
                     case_type_idx,
@@ -5007,7 +5007,7 @@ impl Codegen<'_> {
             },
         ];
 
-        let type_name = mangle_generic_name("Array", &[element_name.clone()]);
+        let type_name = mangle_generic_name("Array", std::slice::from_ref(&element_name));
         let type_idx = builder.define_gc_struct_type(&type_name, &fields);
 
         // Register in struct_types for consistency with other generic structs
@@ -9552,6 +9552,7 @@ impl Codegen<'_> {
         }
 
         // Check density threshold
+        #[allow(clippy::cast_precision_loss)]
         let density = value_to_arm.len() as f64 / range as f64;
         if density < BR_TABLE_DENSITY_THRESHOLD {
             return None;
@@ -9590,7 +9591,7 @@ impl Codegen<'_> {
     ///   ;; falls through to $done
     /// end ;; $done
     /// ```
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::cast_sign_loss)]
     fn generate_match_br_table(
         &self,
         func: &mut Function,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -508,7 +508,7 @@ pub async fn dump_with_host<H: CompilerHost>(
     // Build a Project from lowered modules if available
     let optimized_project = lowered_tir_modules_by_source
         .clone()
-        .map(|modules_by_source| {
+        .and_then(|modules_by_source| {
             let module_name = filename
                 .as_ref()
                 .and_then(|f| std::path::Path::new(f).file_stem())
@@ -538,8 +538,7 @@ pub async fn dump_with_host<H: CompilerHost>(
             );
             let project = optimize(project, opt_level);
             wasm_plan(project).ok()
-        })
-        .flatten();
+        });
 
     Ok(DumpResult {
         source: source.to_string(),

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -11,6 +11,7 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::Write as _;
 use std::rc::Rc;
 
 use indexmap::IndexMap;
@@ -191,7 +192,7 @@ fn create_i128_literal(value: i128, type_id: TypeId, span: Span) -> TirExpr {
     let i64_value = value as i64;
     let inner_literal = TirExpr::new(
         TirExprKind::IntLiteral {
-            value: i64_value as u64,
+            value: i64_value.cast_unsigned(),
             repr: value.to_string(),
         },
         TypeTable::I64,
@@ -724,6 +725,7 @@ fn analyze_match_for_switch(
     }
 
     // Check density threshold
+    #[allow(clippy::cast_precision_loss)]
     let density = value_to_arm.len() as f64 / range as f64;
     if density < SWITCH_DENSITY_THRESHOLD {
         return None;
@@ -738,6 +740,7 @@ fn analyze_match_for_switch(
 }
 
 /// Convert a Match to a Switch expression using the analysis
+#[allow(clippy::cast_sign_loss)]
 fn match_to_switch(
     scrutinee: Box<TirExpr>,
     arms: &[crate::tir::TirMatchArm],
@@ -2215,13 +2218,7 @@ fn generate_initialize_modules(modules: &mut IndexMap<ModuleSource, TirModule>) 
     // For now, put the entry module last (it typically imports from other modules).
     // Non-entry modules are sorted by their appearance order in the IndexMap
     // (which the loader already sorts by dependency).
-    modules_with_init.sort_by_key(|ms| {
-        if ms == &entry_source {
-            1 // Entry module last
-        } else {
-            0 // Other modules first
-        }
-    });
+    modules_with_init.sort_by_key(|ms| i32::from(ms == &entry_source));
 
     let span = Span::new(0, 0, 1, 1);
 
@@ -5662,14 +5659,14 @@ impl ClosureLowerer {
         let callee = callee_rc.borrow();
 
         // Build specialized name: callee$__Closure_0$__Closure_1...
-        let functor_suffix: String = key
-            .functor_types
-            .iter()
-            .map(|(_, tid)| {
+        let functor_suffix: String = key.functor_types.iter().fold(
+            String::new(),
+            |mut acc, (_, tid)| {
                 let name = type_table.type_name(*tid);
-                format!("${name}")
-            })
-            .collect();
+                let _ = write!(acc, "${name}");
+                acc
+            },
+        );
         let specialized_name = format!("{}{}", callee.name, functor_suffix);
 
         // Build map from argument index to functor type
@@ -6849,13 +6846,14 @@ impl ClosureLowerer {
         }
 
         // Build the functor suffix for the specialized method name
-        let functor_suffix: String = functor_types
-            .iter()
-            .map(|(_, tid)| {
-                let name = type_table.type_name(*tid);
-                format!("${name}")
-            })
-            .collect();
+        let functor_suffix: String =
+            functor_types
+                .iter()
+                .fold(String::new(), |mut acc, (_, tid)| {
+                    let name = type_table.type_name(*tid);
+                    let _ = write!(acc, "${name}");
+                    acc
+                });
 
         // Build specialized method_info with the specialized method name
         // The functor suffix goes AFTER type args, so we use full_method_name()

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -5659,14 +5659,14 @@ impl ClosureLowerer {
         let callee = callee_rc.borrow();
 
         // Build specialized name: callee$__Closure_0$__Closure_1...
-        let functor_suffix: String = key.functor_types.iter().fold(
-            String::new(),
-            |mut acc, (_, tid)| {
-                let name = type_table.type_name(*tid);
-                let _ = write!(acc, "${name}");
-                acc
-            },
-        );
+        let functor_suffix: String =
+            key.functor_types
+                .iter()
+                .fold(String::new(), |mut acc, (_, tid)| {
+                    let name = type_table.type_name(*tid);
+                    let _ = write!(acc, "${name}");
+                    acc
+                });
         let specialized_name = format!("{}{}", callee.name, functor_suffix);
 
         // Build map from argument index to functor type

--- a/wado-compiler/src/optimize_const_fold.rs
+++ b/wado-compiler/src/optimize_const_fold.rs
@@ -311,6 +311,7 @@ fn get_int_primitive(type_id: crate::tir::TypeId, type_table: &TypeTable) -> Opt
 /// For unsigned types, zero-extends (masks to width).
 /// For signed types, sign-extends back to 64 bits,
 /// so that codegen's `*value as i32` / `*value as i64` produces the correct signed value.
+#[allow(clippy::cast_sign_loss)]
 fn truncate_int(value: u64, prim: PrimitiveType) -> u64 {
     match prim {
         PrimitiveType::U8 => value & 0xFF,
@@ -338,6 +339,7 @@ fn eval_int_mul(lval: u64, rval: u64, prim: PrimitiveType) -> Option<u64> {
     Some(truncate_int(lval.wrapping_mul(rval), prim))
 }
 
+#[allow(clippy::cast_sign_loss, clippy::invalid_upcast_comparisons)]
 fn eval_int_div(lval: u64, rval: u64, prim: PrimitiveType) -> Option<u64> {
     if rval == 0 {
         return None; // division by zero traps at runtime
@@ -374,6 +376,7 @@ fn eval_int_div(lval: u64, rval: u64, prim: PrimitiveType) -> Option<u64> {
     }
 }
 
+#[allow(clippy::cast_sign_loss, clippy::invalid_upcast_comparisons)]
 fn eval_int_mod(lval: u64, rval: u64, prim: PrimitiveType) -> Option<u64> {
     if rval == 0 {
         return None; // division by zero traps at runtime
@@ -409,6 +412,7 @@ fn eval_int_mod(lval: u64, rval: u64, prim: PrimitiveType) -> Option<u64> {
     }
 }
 
+#[allow(clippy::cast_sign_loss)]
 fn eval_int_neg(value: u64, prim: PrimitiveType) -> Option<u64> {
     match prim {
         PrimitiveType::I8 => {

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -3239,6 +3239,7 @@ impl<'a> Resolver<'a> {
 
     /// Parse an integer literal string into a u64 value
     /// Supports decimal, hex, binary, octal, and scientific notation (e.g., "1e10")
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     fn parse_int_literal(repr: &str) -> Result<u64, String> {
         // Remove underscores for parsing
         let clean: String = repr.chars().filter(|&c| c != '_').collect();
@@ -3293,6 +3294,7 @@ impl<'a> Resolver<'a> {
     }
 
     /// Parse a float literal string into an f64 value
+    #[allow(clippy::cast_precision_loss)]
     fn parse_float_literal(repr: &str) -> Result<f64, String> {
         // Remove underscores for parsing
         let clean: String = repr.chars().filter(|&c| c != '_').collect();
@@ -3389,6 +3391,7 @@ impl<'a> Resolver<'a> {
     }
 
     /// Unpack i128 into (low, high) pair for codegen
+    #[allow(clippy::cast_sign_loss)]
     fn unpack_i128(value: i128) -> (u64, i64) {
         (value as u64, (value >> 64) as i64)
     }
@@ -4230,7 +4233,7 @@ impl<'a> Resolver<'a> {
                     // Fold -N into a negative literal
                     // Use wrapping negation to handle edge cases like -i64::MIN
                     // Store as u64 (two's complement representation)
-                    let neg_value = (*value as i64).wrapping_neg() as u64;
+                    let neg_value = (*value as i64).wrapping_neg().cast_unsigned();
                     return TirExpr::new(
                         TirExprKind::IntLiteral {
                             value: neg_value,
@@ -4257,7 +4260,7 @@ impl<'a> Resolver<'a> {
                     target_type,
                 } => {
                     if let TirExprKind::IntLiteral { value, repr } = &inner.kind {
-                        let neg_value = (*value as i64).wrapping_neg() as u64;
+                        let neg_value = (*value as i64).wrapping_neg().cast_unsigned();
                         let neg_literal = TirExpr::new(
                             TirExprKind::IntLiteral {
                                 value: neg_value,
@@ -5069,7 +5072,7 @@ impl<'a> Resolver<'a> {
         );
         let high_literal = TirExpr::new(
             TirExprKind::IntLiteral {
-                value: high as u64,
+                value: high.cast_unsigned(),
                 repr: high.to_string(),
             },
             if type_name == "u128" {
@@ -5256,7 +5259,7 @@ impl<'a> Resolver<'a> {
                 match Self::parse_int_literal(&num_lit.repr) {
                     Ok(value) => {
                         // Negate as i64 then store as u64 (two's complement)
-                        let neg_value = (value as i64).wrapping_neg() as u64;
+                        let neg_value = (value as i64).wrapping_neg().cast_unsigned();
                         return TirExpr::new(
                             TirExprKind::IntLiteral {
                                 value: neg_value,
@@ -7564,15 +7567,12 @@ impl<'a> Resolver<'a> {
             // If struct_name is a newtype, also check base type names
             if let Some(&newtype_id) = self.type_aliases.get(struct_name) {
                 let mut current = newtype_id;
-                loop {
-                    match self.type_table.borrow().get(current).clone() {
-                        ResolvedType::Newtype { base_type, .. } => {
-                            let base_name = self.type_table.borrow().type_name(base_type);
-                            names.push(base_name);
-                            current = base_type;
-                        }
-                        _ => break,
-                    }
+                while let ResolvedType::Newtype { base_type, .. } =
+                    self.type_table.borrow().get(current).clone()
+                {
+                    let base_name = self.type_table.borrow().type_name(base_type);
+                    names.push(base_name);
+                    current = base_type;
                 }
             }
             names


### PR DESCRIPTION
- codegen.rs: fix cast_sign_loss (use u32 type), cloned_ref_to_slice_refs (use from_ref), cast_precision_loss (allow)
- lower.rs: use cast_unsigned(), fix bool_to_int_with_if, replace format_collect with fold+write!, allow cast_precision_loss/sign_loss
- optimize_const_fold.rs: allow cast_sign_loss and invalid_upcast_comparisons on bit-manipulation functions
- resolver.rs: allow cast_precision_loss/sign_loss on literal parsing, use cast_unsigned(), rewrite while_let_loop
- lib.rs: replace map().flatten() with and_then()

https://claude.ai/code/session_015r5RFDFPtc75T8oLhgiDoQ