### PR TITLE
Remove stale skip_o0 from variant_f64_payload test

### DIFF
--- a/wado-compiler/tests/fixtures/variant_f64_payload.wado
+++ b/wado-compiler/tests/fixtures/variant_f64_payload.wado
@@ -26,4 +26,4 @@ export fn run() with Stdout {
 }
 
 __DATA__
-{"skip_o0": true, "stdout": "done\n"}
+{"stdout": "done\n"}


### PR DESCRIPTION
The f64 variant payload issue (#151) was fixed by the subtype hierarchy
refactor (3befc6f), which eliminated eqref boxing. The skip_o0 flag is
no longer needed as the test passes at all optimization levels.

https://claude.ai/code/session_01TbLabqJnXBVLnMs5DK4nSR