### PR TITLE
Enable WASI resource discovery in O0 mode without DCE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,6 @@ Each test fixture group has the same prefix in their filenames.
 | `trapped`         | `bool`     | Whether the program should trap                            |
 | `compile_error`   | `string`   | Expected compile error (substring match)                   |
 | `TODO`            | `bool`     | Mark as TODO test - must fail until feature is implemented |
-| `skip_o0`         | `bool`     | Skip test in O0 mode (for tests requiring DCE features)    |
 
 #### Examples
 

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -78,10 +78,8 @@ pub enum OptLevel {
 pub fn optimize(mut project: Project, opt_level: OptLevel) -> Project {
     match opt_level {
         OptLevel::O0 => {
-            // No optimizations - enable all standard features
+            // No optimizations - enable all features
             populate_all_features(&mut project);
-            // Note: O0 mode only enables standard WASI functions from the stdlib.
-            // Non-standard functions like sockets require O2+ to be detected via DCE analysis.
         }
         OptLevel::O1 => {
             // Development mode: all optimizations except DCE

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -341,12 +341,19 @@ pub fn analyze_project(project: &mut Project) {
 pub fn populate_all_features(project: &mut Project) {
     project.reachable_functions = HashSet::new();
     project.all_reachable = true;
-    // Standard WASI functions from the stdlib registry
+    // Standard WASI functions + any non-standard WASI functions used in entry module
     project.used_wasi_functions = project
         .wasi_registry
         .standard_function_names()
         .map(std::string::ToString::to_string)
         .collect();
+
+    // Scan entry module for non-standard WASI function usage (e.g., TcpSocket, UdpSocket)
+    // This ensures O0 mode discovers WASI resource methods without full DCE analysis.
+    if let Some(entry_module) = project.tir_modules.get(&project.entry_module_source) {
+        let extra = scan_wasi_usage(entry_module);
+        project.used_wasi_functions.extend(extra);
+    }
 
     // Build all imports from the builtin registry
     let has_http_handler_export = project
@@ -377,6 +384,157 @@ pub fn populate_all_features(project: &mut Project) {
     // Store imports in the entry module
     if let Some(entry_module) = project.tir_modules.get_mut(&project.entry_module_source) {
         entry_module.imports = imports;
+    }
+}
+
+/// Scan a module for WASI function usage without full DCE analysis.
+/// Returns WASI function names in "`Effect::method`" format (e.g., "`TcpSocket::static_tcp_socket_create`").
+fn scan_wasi_usage(module: &TirModule) -> HashSet<String> {
+    let mut wasi_funcs = HashSet::new();
+    for func_rc in &module.functions {
+        let func = func_rc.borrow();
+        if let Some(body) = &func.body {
+            scan_wasi_block(body, &mut wasi_funcs);
+        }
+    }
+    wasi_funcs
+}
+
+fn scan_wasi_block(block: &TirBlock, wasi_funcs: &mut HashSet<String>) {
+    for stmt in &block.stmts {
+        scan_wasi_stmt(stmt, wasi_funcs);
+    }
+}
+
+fn scan_wasi_stmt(stmt: &crate::tir::TirStmt, wasi_funcs: &mut HashSet<String>) {
+    match &stmt.kind {
+        TirStmtKind::Let { value, .. } | TirStmtKind::Expr(value) => {
+            scan_wasi_expr(value, wasi_funcs);
+        }
+        TirStmtKind::Return { value } => {
+            if let Some(expr) = value {
+                scan_wasi_expr(expr, wasi_funcs);
+            }
+        }
+        TirStmtKind::If {
+            condition,
+            then_block,
+            else_block,
+        }
+        | TirStmtKind::IfPattern {
+            scrutinee: condition,
+            then_block,
+            else_block,
+            ..
+        } => {
+            scan_wasi_expr(condition, wasi_funcs);
+            scan_wasi_block(then_block, wasi_funcs);
+            if let Some(else_block) = else_block {
+                scan_wasi_block(else_block, wasi_funcs);
+            }
+        }
+        TirStmtKind::Loop { body } => {
+            scan_wasi_block(body, wasi_funcs);
+        }
+        TirStmtKind::LabeledBlock { block, .. } => {
+            scan_wasi_block(block, wasi_funcs);
+        }
+        TirStmtKind::LetPattern { value, .. } => {
+            scan_wasi_expr(value, wasi_funcs);
+        }
+        TirStmtKind::Break { value, .. } => {
+            if let Some(expr) = value {
+                scan_wasi_expr(expr, wasi_funcs);
+            }
+        }
+        TirStmtKind::Continue => {}
+    }
+}
+
+fn scan_wasi_expr(expr: &TirExpr, wasi_funcs: &mut HashSet<String>) {
+    match &expr.kind {
+        TirExprKind::StaticCall { func, args } => {
+            let module_path = func.module_path();
+            if module_path.len() >= 2 && module_path[0] == "wasi" {
+                let func_name = func.name();
+                if let Some(pos) = func_name.find("::") {
+                    let resource_name = &func_name[..pos];
+                    let method_name = &func_name[pos + 2..];
+                    wasi_funcs.insert(format!("{resource_name}::{method_name}"));
+                }
+            }
+            for arg in args {
+                scan_wasi_expr(arg, wasi_funcs);
+            }
+        }
+        TirExprKind::EffectCall {
+            effect_name,
+            op_name,
+            args,
+            ..
+        } => {
+            wasi_funcs.insert(format!("{effect_name}::{op_name}"));
+            for arg in args {
+                scan_wasi_expr(arg, wasi_funcs);
+            }
+        }
+        TirExprKind::Call { args, .. } | TirExprKind::MethodCall { args, .. } => {
+            for arg in args {
+                scan_wasi_expr(arg, wasi_funcs);
+            }
+        }
+        TirExprKind::Binary { left, right, .. } => {
+            scan_wasi_expr(left, wasi_funcs);
+            scan_wasi_expr(right, wasi_funcs);
+        }
+        TirExprKind::Unary { expr, .. }
+        | TirExprKind::Cast { expr, .. }
+        | TirExprKind::FieldAccess { expr, .. } => {
+            scan_wasi_expr(expr, wasi_funcs);
+        }
+        TirExprKind::Assign { target, value }
+        | TirExprKind::Index {
+            expr: target,
+            index: value,
+        } => {
+            scan_wasi_expr(target, wasi_funcs);
+            scan_wasi_expr(value, wasi_funcs);
+        }
+        TirExprKind::Block(block) => {
+            scan_wasi_block(block, wasi_funcs);
+        }
+        TirExprKind::If {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            scan_wasi_expr(condition, wasi_funcs);
+            scan_wasi_block(then_branch, wasi_funcs);
+            if let Some(else_branch) = else_branch {
+                scan_wasi_block(else_branch, wasi_funcs);
+            }
+        }
+        TirExprKind::StructLiteral { fields, .. } => {
+            for field in fields {
+                scan_wasi_expr(&field.value, wasi_funcs);
+            }
+        }
+        TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                scan_wasi_expr(elem, wasi_funcs);
+            }
+        }
+        TirExprKind::Match { expr, arms } => {
+            scan_wasi_expr(expr, wasi_funcs);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    scan_wasi_expr(guard, wasi_funcs);
+                }
+                scan_wasi_expr(&arm.body, wasi_funcs);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -51,12 +51,6 @@ struct TestSpec {
     #[serde(default)]
     #[serde(rename = "TODO")]
     todo: bool,
-
-    /// Skip this test in O0 mode (no optimization).
-    /// Use for tests that require O2+ features like DCE-based function discovery
-    /// (e.g., tests using wasi:sockets which requires DCE to find function references).
-    #[serde(default)]
-    skip_o0: bool,
 }
 
 // ============================================================================
@@ -128,12 +122,6 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
 
     // Parse the test spec from JSON
     let spec: TestSpec = common::parse_data_section(data_section, &test_id);
-
-    // Skip O0 tests if skip_o0 is set (for tests requiring DCE-based features)
-    if spec.skip_o0 && opt_level == OptLevel::O0 {
-        eprintln!("[{test_id}] skipped (requires O2+ optimization)");
-        return;
-    }
 
     // Handle TODO tests - they must fail
     if spec.todo {

--- a/wado-compiler/tests/fixtures/resource-method-instance.wado
+++ b/wado-compiler/tests/fixtures/resource-method-instance.wado
@@ -17,4 +17,4 @@ export fn run() with Stdout {
 }
 
 __DATA__
-{"stdout_contains": ["Resource extracted"], "skip_o0": true}
+{"stdout_contains": ["Resource extracted"]}

--- a/wado-compiler/tests/fixtures/resource-method-static.wado
+++ b/wado-compiler/tests/fixtures/resource-method-static.wado
@@ -12,4 +12,4 @@ export fn run() with Stdout {
 }
 
 __DATA__
-{"stdout": "Resource static method called\n", "skip_o0": true}
+{"stdout": "Resource static method called\n"}


### PR DESCRIPTION
## Summary
This PR removes the `skip_o0` test fixture flag and enables WASI resource method discovery in O0 (no optimization) mode by scanning the entry module for WASI function usage. Previously, non-standard WASI functions like sockets could only be discovered via Dead Code Elimination (DCE) analysis in O2+ modes, requiring tests to skip O0 mode.

## Key Changes
- **Removed `skip_o0` test fixture flag**: Deleted the `skip_o0` boolean field from test specifications and related test infrastructure, as it's no longer needed
- **Added WASI usage scanning**: Implemented `scan_wasi_usage()` and related helper functions to traverse the entry module's TIR (Typed Intermediate Representation) and extract WASI function calls without full DCE analysis
- **Enhanced `populate_all_features()`**: Modified to scan the entry module for non-standard WASI function usage (e.g., `TcpSocket`, `UdpSocket`) and include discovered functions in the `used_wasi_functions` set
- **Updated test fixtures**: Removed `skip_o0: true` from resource method test fixtures (`resource-method-instance.wado` and `resource-method-static.wado`)
- **Simplified O0 documentation**: Removed notes about O0 mode limitations regarding WASI function discovery

## Implementation Details
The new scanning mechanism:
- Recursively traverses all statements and expressions in the entry module's functions
- Detects both `StaticCall` expressions (standard WASI functions) and `EffectCall` expressions (effect-based WASI operations)
- Extracts function names in "`ResourceName::method_name`" format for inclusion in the WASI registry
- Operates without the overhead of full DCE analysis, making it suitable for O0 mode

This change allows O0 mode to properly discover and include WASI resource methods used in the entry module, eliminating the need for test-specific skip flags while maintaining the lightweight nature of O0 compilation.

https://claude.ai/code/session_01XckAXNNMdTfTitQ9MoDcVR