### PR TITLE
Fix fpfmt benchmark to work with current stdlib API

### DIFF
--- a/rsc-fpfmt/rsc_fpfmt.wado
+++ b/rsc-fpfmt/rsc_fpfmt.wado
@@ -292,7 +292,7 @@ pub fn format_decimal(d: u64, p: i32, nd: i32) -> String {
 
     let mut idx = nd - 1;
     while idx >= 0 {
-        digit_chars.set(idx, ('0' as i32) + ((val % 10) as i32));
+        digit_chars[idx] = ('0' as i32) + ((val % 10) as i32);
         val = val / 10;
         idx = idx - 1;
     }
@@ -308,12 +308,12 @@ pub fn format_decimal(d: u64, p: i32, nd: i32) -> String {
             buf.append_char('0');
         }
         for let mut i = 0; i < nd; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
     } else if decimal_pos >= nd {
         // Integer with trailing zeros: digits000...
         for let mut i = 0; i < nd; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
         for let mut i = 0; i < decimal_pos - nd; i += 1 {
             buf.append_char('0');
@@ -321,11 +321,11 @@ pub fn format_decimal(d: u64, p: i32, nd: i32) -> String {
     } else {
         // Decimal point in the middle: dig.its
         for let mut i = 0; i < decimal_pos; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
         buf.append_char('.');
         for let mut i = decimal_pos; i < nd; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
     }
 
@@ -345,19 +345,19 @@ pub fn format_exp(d: u64, p: i32, nd: i32, upper: bool) -> String {
 
     let mut idx = nd - 1;
     while idx >= 0 {
-        digit_chars.set(idx, ('0' as i32) + ((val % 10) as i32));
+        digit_chars[idx] = ('0' as i32) + ((val % 10) as i32);
         val = val / 10;
         idx = idx - 1;
     }
 
     // First digit
-    buf.append_char(digit_chars.get(0) as char);
+    buf.append_char(digit_chars[0] as char);
 
     // Decimal point and remaining digits
     if nd > 1 {
         buf.append_char('.');
         for let mut i = 1; i < nd; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
     }
 
@@ -514,7 +514,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
 
     let mut idx = nd - 1;
     while idx >= 0 {
-        digit_chars.set(idx, ('0' as i32) + ((val % 10 as i64) as i32));
+        digit_chars[idx] = ('0' as i32) + ((val % 10 as i64) as i32);
         val = val / 10 as i64;
         idx = idx - 1;
     }
@@ -550,7 +550,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
             let remaining_prec = precision - leading_zeros;
             let digits_to_output = if remaining_prec < nd { remaining_prec } else { nd };
             for let mut i = 0; i < digits_to_output; i += 1 {
-                buf.append_char(digit_chars.get(i) as char);
+                buf.append_char(digit_chars[i] as char);
             }
             // Trailing zeros if needed
             let trailing = precision - leading_zeros - digits_to_output;
@@ -561,7 +561,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
     } else if decimal_pos >= nd {
         // Integer part only: digits000...
         for let mut i = 0; i < nd; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
         for let mut i = 0; i < decimal_pos - nd; i += 1 {
             buf.append_char('0');
@@ -575,7 +575,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
     } else {
         // Decimal point in the middle: dig.its
         for let mut i = 0; i < decimal_pos; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
         buf.append_char('.');
         // How many digits after decimal
@@ -583,12 +583,12 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
         if precision <= after_decimal {
             // Only output precision digits
             for let mut i = decimal_pos; i < decimal_pos + precision; i += 1 {
-                buf.append_char(digit_chars.get(i) as char);
+                buf.append_char(digit_chars[i] as char);
             }
         } else {
             // Output all digits then trailing zeros
             for let mut i = decimal_pos; i < nd; i += 1 {
-                buf.append_char(digit_chars.get(i) as char);
+                buf.append_char(digit_chars[i] as char);
             }
             let trailing = precision - after_decimal;
             for let mut i = 0; i < trailing; i += 1 {
@@ -619,13 +619,13 @@ pub fn format_exp_prec(d: i64, p: i32, nd: i32, precision: i32, upper: bool) -> 
 
     let mut idx = nd - 1;
     while idx >= 0 {
-        digit_chars.set(idx, ('0' as i32) + ((val % 10 as i64) as i32));
+        digit_chars[idx] = ('0' as i32) + ((val % 10 as i64) as i32);
         val = val / 10 as i64;
         idx = idx - 1;
     }
 
     // First digit
-    buf.append_char(digit_chars.get(0) as char);
+    buf.append_char(digit_chars[0] as char);
 
     // Decimal point and remaining digits based on precision
     if precision > 0 {
@@ -634,7 +634,7 @@ pub fn format_exp_prec(d: i64, p: i32, nd: i32, precision: i32, upper: bool) -> 
         let available = nd - 1;
         let to_output = if precision < available { precision } else { available };
         for let mut i = 1; i <= to_output; i += 1 {
-            buf.append_char(digit_chars.get(i) as char);
+            buf.append_char(digit_chars[i] as char);
         }
         // Trailing zeros if needed
         let trailing = precision - to_output;

--- a/rsc-fpfmt/rsc_fpfmt_test.wado
+++ b/rsc-fpfmt/rsc_fpfmt_test.wado
@@ -22,7 +22,6 @@ use {
     f64_to_string_center, f64_to_string_fill
 } from "./rsc_fpfmt.wado";
 
-use {char_to_string, f64_to_string as ryu_f64_to_string} from "core:internal";
 use {println, Stdout} from "core:cli";
 use {now, MonotonicClock} from "core:clocks";
 
@@ -1458,7 +1457,7 @@ fn truncate_str(s: String, max_len: i32) -> String {
     }
     let mut result = String::with_capacity(max_len + 3);
     for let mut i = 0; i < max_len - 3; i += 1 {
-        result.append(char_to_string(s.get_byte(i) as char));
+        result.append((s.get_byte(i) as char).to_string());
     }
     result.append("...");
     return result;
@@ -1488,7 +1487,7 @@ fn i32_to_str(n: i32) -> String {
     if is_neg { result.append("-"); }
     let mut i = digits.len() - 1;
     while i >= 0 {
-        result.append(char_to_string((('0' as i32) + digits.get(i)) as char));
+        result.append(((('0' as i32) + digits[i]) as char).to_string());
         i = i - 1;
     }
     return result;
@@ -1507,20 +1506,20 @@ fn u64_to_str(n: u64) -> String {
 
     let mut i = digits.len() - 1;
     while i >= 0 {
-        result.append(char_to_string((('0' as i32) + digits.get(i)) as char));
+        result.append(((('0' as i32) + digits[i]) as char).to_string());
         i = i - 1;
     }
     return result;
 }
 
 // Entry point for running benchmark
-fn run() with Stdout, MonotonicClock {
+export fn run() with Stdout, MonotonicClock {
     println("======================================================================");
-    println("Float-to-String Benchmark: fpfmt vs ryu (internal::f64_to_string)");
+    println("Float-to-String Benchmark: fpfmt vs ryu (f64.to_string)");
     println("======================================================================");
     println("");
     println("fpfmt: Russ Cox's unrounded scaling algorithm (rsc_fpfmt.wado)");
-    println("ryu:   Bundled ryu-based f64_to_buffer (wado-bundled)");
+    println("ryu:   Bundled ryu-based f64_to_buffer (f64.to_string)");
     println("");
 
     // Number of iterations per test
@@ -1560,10 +1559,10 @@ fn benchmark_value(val: f64, iterations: i32) with Stdout, MonotonicClock {
     let end_fpfmt = now();
     let fpfmt_time = ((end_fpfmt - start_fpfmt) as u64) / (iterations as u64);
 
-    // Benchmark ryu (internal::f64_to_string)
+    // Benchmark ryu (f64.to_string)
     let start_ryu = now();
     for let mut i = 0; i < iterations; i += 1 {
-        let _ = ryu_f64_to_string(val);
+        let _ = val.to_string();
     }
     let end_ryu = now();
     let ryu_time = ((end_ryu - start_ryu) as u64) / (iterations as u64);


### PR DESCRIPTION
- Replace removed `core:internal` imports (`char_to_string`, `f64_to_string`) with method syntax (`char.to_string()`, `f64.to_string()`)
- Replace `Array.set()`/`.get()` with index syntax (`arr[i] = val`, `arr[i]`)
- Add `export` keyword to `run()` entry point