### PR TITLE
Refine template desugaring WEP and add compile-time tuple enumeration WEP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Trait Bounds Enforcement](./docs/wep-2026-02-07-trait-bounds.md)
 - [Variant Wasm GC Representation](./docs/wep-2026-02-08-variant-representation.md)
 - [Variant-Independent Types](./docs/wep-2026-02-09-variant-independent-types.md)
+- [Compile-Time Tuple Enumeration](./docs/wep-2026-02-10-compile-time-tuple-enumeration.md)
 
 ### Structure
 

--- a/docs/wep-2026-01-10-tagged-template-literals.md
+++ b/docs/wep-2026-01-10-tagged-template-literals.md
@@ -152,15 +152,21 @@ let query = sql`SELECT * FROM users WHERE id = ?`;  // Validated at compile time
 
 ### Phase 2: Interpolation support (Future)
 
-- Support syntax: `tag`text ${expr} more``
-- Function signature: `fn(Array<String>, Array<Value>) -> T`
-- Compile-time evaluation of interpolated expressions
+- Support syntax: `` tag`text {expr} more` ``
+- Function signature: `fn(CookedStrings/RawStrings, Values) -> T` where `Values` is a tuple type
+- See [String Template Desugaring](./wep-2026-01-20-string-template-desugaring.md) for the full interpolation design
+- See [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md) for iterating over heterogeneous values
 
 ### Phase 3: Compile-time I/O (Future consideration)
 
 - Carefully designed `embed` function for file inclusion
 - Security implications need thorough analysis
 - May require sandboxing or explicit opt-in
+
+## Related WEPs
+
+- [String Template Desugaring](./wep-2026-01-20-string-template-desugaring.md): Defines how tagged templates with interpolation are desugared
+- [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md): Required for iterating over heterogeneous interpolated values in tag functions
 
 ## References
 

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -82,7 +82,7 @@ fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
     let mut params: Array<SqlParam> = [];
     for let [i, v] of values.enumerate() {
         params.append(v.to_sql_param());
-        query.append((i + 1).to_string());
+        query.append("?");
         query.append(strings[i + 1]);
     }
     return SqlQuery { query, params };
@@ -112,7 +112,7 @@ Usage:
 
 ```wado
 String::raw`Hello\nWorld`     // -> "Hello\\nWorld" (12 chars, not 11)
-String::raw`Path: {path}\n`   // -> "Path: " + path.fmt(...) + "\\n"
+String::raw`Path: {path}\n`   // -> "Path: " + display(path) + "\\n"
 ```
 
 ### `String::base64` Implementation
@@ -194,7 +194,7 @@ Lexer change required: `{{` -> `{`, `}}` -> `}` in template strings.
 | ----------------------- | ----------------------- | ------------------------------ |
 | Empty template          | `` ` ` ``               | `""`                           |
 | No interpolation        | `` `hello` ``           | `"hello"`                      |
-| Only interpolation      | `` `{x}` ``             | `to_string(x)`                 |
+| Only interpolation      | `` `{x}` ``             | `Display::fmt` of x            |
 | Adjacent interpolations | `` `{a}{b}` ``          | `strings = ["", "", ""]`       |
 | Escaped braces          | `` `{{x}}` ``           | `"{x}"` (literal)              |
 | Nested template         | `` `outer {`inner`}` `` | Inner template evaluated first |

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -112,7 +112,7 @@ Usage:
 
 ```wado
 String::raw`Hello\nWorld`     // -> "Hello\\nWorld" (12 chars, not 11)
-String::raw`Path: {path}\n`   // -> "Path: " + to_string(path) + "\\n"
+String::raw`Path: {path}\n`   // -> "Path: " + path.fmt(...) + "\\n"
 ```
 
 ### `String::base64` Implementation
@@ -199,31 +199,6 @@ Lexer change required: `{{` -> `{`, `}}` -> `}` in template strings.
 | Escaped braces          | `` `{{x}}` ``           | `"{x}"` (literal)              |
 | Nested template         | `` `outer {`inner`}` `` | Inner template evaluated first |
 | Multiline               | Preserved               | Newlines in cooked/raw         |
-
-## Implementation Plan
-
-### Phase 1: Foundation
-
-- [ ] Add `{{` and `}}` escape support in lexer
-- [ ] Store both cooked and raw strings in `TemplatePart::String`
-- [ ] Define `CookedStrings` and `RawStrings` newtypes in `core:internal`
-
-### Phase 2: Untagged Template Optimization
-
-- [ ] Improve untagged template lowering for efficiency (buffer-based or `StringBuilder`)
-- [ ] Apply format specifiers during direct stringification
-
-### Phase 3: Tagged Templates
-
-- [ ] Implement tag function lookup and signature-based string selection
-- [ ] Generate `CookedStrings` or `RawStrings` based on tag function's first parameter type
-- [ ] Pass values as tuple to tag function
-- [ ] Implement `String::raw` using `RawStrings` and tuple enumeration
-- [ ] Implement `String::base64` with compile-time decoding
-
-### Phase 4: Brace Escaping
-
-- [ ] Implement `{{` / `}}` lexer support
 
 ## Consequences
 

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -45,18 +45,14 @@ Untagged templates are special-cased by the compiler for efficiency. No `CookedS
 `Hello, {name}! You are {age}.`
 ```
 
-The compiler directly emits an efficient append sequence using a mutable string and labeled block expression. All interpolations go through `Formatter` + `Display::fmt` (see [Format Traits](./wep-2026-02-01-format-traits.md)) for predictable behavior, regardless of whether a format specifier is present.
+The compiler directly emits an efficient sequence using a mutable string and labeled block expression. All interpolations go through `Formatter` + `Display::fmt` (see [Format Traits](./wep-2026-02-01-format-traits.md)) for predictable behavior, regardless of whether a format specifier is present. `Formatter` wraps `&mut String` and writes directly into the output buffer with no intermediate allocations.
 
 ```wado
 __tmpl: {
     let mut __r = "Hello, ";
-    let mut __f0 = Formatter::new(FormatSpec::default());
-    Display::fmt(&name, &mut __f0);
-    __r.append(__f0.finish());
+    Display::fmt(&name, &mut Formatter::new(&mut __r, FormatSpec::default()));
     __r.append("! You are ");
-    let mut __f1 = Formatter::new(FormatSpec::default());
-    Display::fmt(&age, &mut __f1);
-    __r.append(__f1.finish());
+    Display::fmt(&age, &mut Formatter::new(&mut __r, FormatSpec::default()));
     __r.append(".");
     __r
 }
@@ -104,9 +100,7 @@ impl String {
     fn raw<Values>(strings: RawStrings, values: Values) -> String {
         let mut result = strings[0];
         for let [i, v] of values.entries() {
-            let mut f = Formatter::new(FormatSpec::default());
-            Display::fmt(&v, &mut f);
-            result.append(f.finish());
+            Display::fmt(&v, &mut Formatter::new(&mut result, FormatSpec::default()));
             result.append(strings[i + 1]);
         }
         return result;
@@ -156,9 +150,7 @@ Desugars to:
 ```wado
 __tmpl: {
     let mut __r = "Pi is ";
-    let mut __f = Formatter::new(FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() });
-    Display::fmt(&pi, &mut __f);
-    __r.append(__f.finish());
+    Display::fmt(&pi, &mut Formatter::new(&mut __r, FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() }));
     __r
 }
 ```
@@ -174,9 +166,9 @@ Desugars to:
 ```wado
 __tmpl: {
     let __strings = CookedStrings::from(["Value: ", ""]);
-    let mut __f = Formatter::new(FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() });
-    Display::fmt(&pi, &mut __f);
-    let __values = [__f.finish()];
+    let mut __formatted = "";
+    Display::fmt(&pi, &mut Formatter::new(&mut __formatted, FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() }));
+    let __values = [__formatted];
     fmt(__strings, __values)
 }
 ```

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -50,9 +50,9 @@ The compiler directly emits an efficient sequence using a mutable string and lab
 ```wado
 __tmpl: {
     let mut __r = "Hello, ";
-    Display::fmt(&name, &mut Formatter::new(&mut __r, FormatSpec::default()));
+    name.fmt(&mut Formatter::new(&mut __r, FormatSpec::default()));
     __r.append("! You are ");
-    Display::fmt(&age, &mut Formatter::new(&mut __r, FormatSpec::default()));
+    age.fmt(&mut Formatter::new(&mut __r, FormatSpec::default()));
     __r.append(".");
     __r
 }
@@ -100,7 +100,7 @@ impl String {
     fn raw<Values>(strings: RawStrings, values: Values) -> String {
         let mut result = strings[0];
         for let [i, v] of values.entries() {
-            Display::fmt(&v, &mut Formatter::new(&mut result, FormatSpec::default()));
+            v.fmt(&mut Formatter::new(&mut result, FormatSpec::default()));
             result.append(strings[i + 1]);
         }
         return result;
@@ -150,7 +150,7 @@ Desugars to:
 ```wado
 __tmpl: {
     let mut __r = "Pi is ";
-    Display::fmt(&pi, &mut Formatter::new(&mut __r, FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() }));
+    pi.fmt(&mut Formatter::new(&mut __r, FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() }));
     __r
 }
 ```
@@ -167,7 +167,7 @@ Desugars to:
 __tmpl: {
     let __strings = CookedStrings::from(["Value: ", ""]);
     let mut __formatted = "";
-    Display::fmt(&pi, &mut Formatter::new(&mut __formatted, FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() }));
+    pi.fmt(&mut Formatter::new(&mut __formatted, FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() }));
     let __values = [__formatted];
     fmt(__strings, __values)
 }

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -104,7 +104,9 @@ impl String {
     fn raw<Values>(strings: RawStrings, values: Values) -> String {
         let mut result = strings[0];
         for let [i, v] of values.entries() {
-            result.append(v.to_string());
+            let mut f = Formatter::new(FormatSpec::default());
+            Display::fmt(&v, &mut f);
+            result.append(f.finish());
             result.append(strings[i + 1]);
         }
         return result;

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -45,14 +45,18 @@ Untagged templates are special-cased by the compiler for efficiency. No `CookedS
 `Hello, {name}! You are {age}.`
 ```
 
-The compiler directly emits an efficient append sequence using a mutable string and labeled block expression. Conceptually equivalent to:
+The compiler directly emits an efficient append sequence using a mutable string and labeled block expression. All interpolations go through `Formatter` + `Display::fmt` (see [Format Traits](./wep-2026-02-01-format-traits.md)) for predictable behavior, regardless of whether a format specifier is present.
 
 ```wado
 __tmpl: {
     let mut __r = "Hello, ";
-    __r.append(name.to_string());
+    let mut __f0 = Formatter::new(FormatSpec::default());
+    Display::fmt(&name, &mut __f0);
+    __r.append(__f0.finish());
     __r.append("! You are ");
-    __r.append(age.to_string());
+    let mut __f1 = Formatter::new(FormatSpec::default());
+    Display::fmt(&age, &mut __f1);
+    __r.append(__f1.finish());
     __r.append(".");
     __r
 }
@@ -139,9 +143,7 @@ Compile error if interpolation is present.
 
 ### Format Specifiers
 
-When a format specifier is present, the interpolation uses `Formatter` (see [Format Traits](./wep-2026-02-01-format-traits.md)) instead of `.to_string()`.
-
-For untagged templates:
+All interpolations use the `Formatter` infrastructure (see [Format Traits](./wep-2026-02-01-format-traits.md)). When a format specifier is present, it becomes a custom `FormatSpec`; otherwise `FormatSpec::default()` is used. This ensures consistent behavior regardless of whether a specifier is present.
 
 ```wado
 `Pi is {pi:.2}`
@@ -159,14 +161,7 @@ __tmpl: {
 }
 ```
 
-Contrast with no format specifier, which uses simple `.to_string()`:
-
-```wado
-`Pi is {pi}`
-// -> __r.append(pi.to_string());
-```
-
-For tagged templates, the formatted value is passed in the values tuple (already stringified):
+For tagged templates, format-specifier interpolations are pre-formatted and passed as strings in the values tuple:
 
 ```wado
 fmt`Value: {pi:.2}`

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -80,7 +80,7 @@ The tag function is a generic function that receives the values as a tuple, pres
 fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
     let mut query = strings[0];
     let mut params: Array<SqlParam> = [];
-    for let [i, v] of values.entries() {
+    for let [i, v] of values.enumerate() {
         params.append(v.to_sql_param());
         query.append((i + 1).to_string());
         query.append(strings[i + 1]);
@@ -89,7 +89,7 @@ fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
 }
 ```
 
-The `for let [i, v] of values.entries()` is compile-time tuple enumeration. See [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md) for the full specification.
+The `for let [i, v] of values.enumerate()` is compile-time tuple enumeration. See [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md) for the full specification.
 
 ### `String::raw` Implementation
 
@@ -99,7 +99,7 @@ The `for let [i, v] of values.entries()` is compile-time tuple enumeration. See 
 impl String {
     fn raw<Values>(strings: RawStrings, values: Values) -> String {
         let mut result = strings[0];
-        for let [i, v] of values.entries() {
+        for let [i, v] of values.enumerate() {
             v.fmt(&mut Formatter::new(&mut result, FormatSpec::default()));
             result.append(strings[i + 1]);
         }

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -139,7 +139,34 @@ Compile error if interpolation is present.
 
 ### Format Specifiers
 
-When a format specifier is present, the value is pre-formatted before being passed to the tag:
+When a format specifier is present, the interpolation uses `Formatter` (see [Format Traits](./wep-2026-02-01-format-traits.md)) instead of `.to_string()`.
+
+For untagged templates:
+
+```wado
+`Pi is {pi:.2}`
+```
+
+Desugars to:
+
+```wado
+__tmpl: {
+    let mut __r = "Pi is ";
+    let mut __f = Formatter::new(FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() });
+    Display::fmt(&pi, &mut __f);
+    __r.append(__f.finish());
+    __r
+}
+```
+
+Contrast with no format specifier, which uses simple `.to_string()`:
+
+```wado
+`Pi is {pi}`
+// -> __r.append(pi.to_string());
+```
+
+For tagged templates, the formatted value is passed in the values tuple (already stringified):
 
 ```wado
 fmt`Value: {pi:.2}`
@@ -150,12 +177,14 @@ Desugars to:
 ```wado
 __tmpl: {
     let __strings = CookedStrings::from(["Value: ", ""]);
-    let __values = [__format__(pi, ".2")];
+    let mut __f = Formatter::new(FormatSpec { precision: Option::<i32>::Some(2), ..FormatSpec::default() });
+    Display::fmt(&pi, &mut __f);
+    let __values = [__f.finish()];
     fmt(__strings, __values)
 }
 ```
 
-For untagged templates, format specifiers are applied during the direct stringification.
+Note: format specifiers are resolved at the call site before the tag function receives them. The tag function sees pre-formatted strings in the values tuple.
 
 ### Brace Escaping
 

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -28,10 +28,10 @@ type RawStrings = Array<String>;     // Escape sequences preserved (\n -> "\\n")
 
 The compiler inspects the tag function's first parameter type and generates only the needed form:
 
-| First parameter type | What the compiler emits | Use case |
-|---|---|---|
-| `CookedStrings` | Cooked strings only | Most tagged templates |
-| `RawStrings` | Raw strings only | `String::raw` |
+| First parameter type | What the compiler emits | Use case              |
+| -------------------- | ----------------------- | --------------------- |
+| `CookedStrings`      | Cooked strings only     | Most tagged templates |
+| `RawStrings`         | Raw strings only        | `String::raw`         |
 
 Untagged templates are special-cased by the compiler and do not construct any array (see below).
 

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -50,9 +50,9 @@ The compiler directly emits an efficient append sequence using a mutable string 
 ```wado
 __tmpl: {
     let mut __r = "Hello, ";
-    __r.append(to_string(name));
+    __r.append(name.to_string());
     __r.append("! You are ");
-    __r.append(to_string(age));
+    __r.append(age.to_string());
     __r.append(".");
     __r
 }
@@ -82,7 +82,7 @@ fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
     let mut params: Array<SqlParam> = [];
     for let [i, v] of values.entries() {
         params.append(v.to_sql_param());
-        query.append(`${i + 1}`);
+        query.append((i + 1).to_string());
         query.append(strings[i + 1]);
     }
     return SqlQuery { query, params };
@@ -100,7 +100,7 @@ impl String {
     fn raw<Values>(strings: RawStrings, values: Values) -> String {
         let mut result = strings[0];
         for let [i, v] of values.entries() {
-            result.append(to_string(v));
+            result.append(v.to_string());
             result.append(strings[i + 1]);
         }
         return result;

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -12,54 +12,49 @@ String templates (`` `Hello, {name}!` ``) are currently lowered in the resolver 
 We need a unified desugaring strategy that:
 
 - Supports tagged templates like JavaScript
-- Provides both cooked and raw string literals
 - Enables `String::raw` and `String::base64` as regular functions
-- Requires compile-time tuple enumeration for heterogeneous values
+- Requires compile-time tuple enumeration for heterogeneous values (see [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md))
 
 ## Decision
 
-### TemplateStrings Structure
+### String Parts Types
 
-All template literals produce a `TemplateStrings` struct containing both processed (cooked) and unprocessed (raw) string parts:
+Tag function signatures determine which form of string parts is provided. Two newtype aliases are defined:
 
 ```wado
-struct TemplateStrings {
-    cooked: Array<String>,  // Escape sequences processed (\n → newline)
-    raw: Array<String>,     // Escape sequences preserved (\n → "\\n")
-}
+type CookedStrings = Array<String>;  // Escape sequences processed (\n -> newline)
+type RawStrings = Array<String>;     // Escape sequences preserved (\n -> "\\n")
 ```
 
-Invariant: `cooked.len() == raw.len() == values.len() + 1`
+The compiler inspects the tag function's first parameter type and generates only the needed form:
 
-### Standard Template Desugaring
+| First parameter type | What the compiler emits | Use case |
+|---|---|---|
+| `CookedStrings` | Cooked strings only | Most tagged templates |
+| `RawStrings` | Raw strings only | `String::raw` |
+
+Untagged templates are special-cased by the compiler and do not construct any array (see below).
+
+Invariant: `strings.len() == values.len() + 1`
+
+### Untagged Template Desugaring
+
+Untagged templates are special-cased by the compiler for efficiency. No `CookedStrings` array or values tuple is constructed.
 
 ```wado
 `Hello, {name}! You are {age}.`
 ```
 
-Desugars to:
+The compiler directly emits an efficient concatenation sequence (the exact form is an implementation detail, not observable). Conceptually equivalent to:
 
 ```wado
-{
-    let __strings = TemplateStrings {
-        cooked: ["Hello, ", "! You are ", "."],
-        raw: ["Hello, ", "! You are ", "."],
-    };
-    let __values = [name, age];
-    __default_template__(__strings, __values)
-}
-```
-
-Where `__default_template__` is implemented as:
-
-```wado
-fn __default_template__<T>(strings: TemplateStrings, values: T) -> String {
-    let mut result = strings.cooked[0];
-    for let [i, v] of values.entries() {
-        result += to_string(v);
-        result += strings.cooked[i + 1];
-    }
-    return result;
+__tmpl: {
+    let mut __r = "Hello, ";
+    __r = String::concat(__r, to_string(name));
+    __r = String::concat(__r, "! You are ");
+    __r = String::concat(__r, to_string(age));
+    __r = String::concat(__r, ".");
+    __r
 }
 ```
 
@@ -72,29 +67,41 @@ sql`SELECT * FROM users WHERE id = {id} AND name = {name}`
 Desugars to:
 
 ```wado
-{
-    let __strings = TemplateStrings {
-        cooked: ["SELECT * FROM users WHERE id = ", " AND name = ", ""],
-        raw: ["SELECT * FROM users WHERE id = ", " AND name = ", ""],
-    };
+__tmpl: {
+    let __strings = CookedStrings::from(["SELECT * FROM users WHERE id = ", " AND name = ", ""]);
     let __values = [id, name];
     sql(__strings, __values)
 }
 ```
 
-The tag function receives the raw values (not stringified), enabling type-safe query building.
+The tag function is a generic function that receives the values as a tuple, preserving each value's original type:
+
+```wado
+fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
+    let mut query = strings[0];
+    let mut params: Array<SqlParam> = [];
+    for let [i, v] of values.entries() {
+        params.append(v.to_sql_param());
+        query = String::concat(query, `${i + 1}`);
+        query = String::concat(query, strings[i + 1]);
+    }
+    return SqlQuery { query, params };
+}
+```
+
+The `for let [i, v] of values.entries()` is compile-time tuple enumeration. See [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md) for the full specification.
 
 ### `String::raw` Implementation
 
-`String::raw` is a regular static method, not special parser syntax:
+`String::raw` is a regular static method. Its first parameter is `RawStrings`, so the compiler emits raw (unescaped) strings:
 
 ```wado
 impl String {
-    fn raw<T>(strings: TemplateStrings, values: T) -> String {
-        let mut result = strings.raw[0];  // Uses raw, not cooked
+    fn raw<Values>(strings: RawStrings, values: Values) -> String {
+        let mut result = strings[0];
         for let [i, v] of values.entries() {
-            result += to_string(v);
-            result += strings.raw[i + 1];
+            result = String::concat(result, to_string(v));
+            result = String::concat(result, strings[i + 1]);
         }
         return result;
     }
@@ -104,20 +111,20 @@ impl String {
 Usage:
 
 ```wado
-String::raw`Hello\nWorld`     // → "Hello\\nWorld" (12 chars, not 11)
-String::raw`Path: {path}\n`   // → "Path: " + to_string(path) + "\\n"
+String::raw`Hello\nWorld`     // -> "Hello\\nWorld" (12 chars, not 11)
+String::raw`Path: {path}\n`   // -> "Path: " + to_string(path) + "\\n"
 ```
 
 ### `String::base64` Implementation
 
-Compile-time base64 decoding:
+Compile-time base64 decoding. Uses `CookedStrings` since there are no escape sequences to preserve:
 
 ```wado
 impl String {
-    fn base64(strings: TemplateStrings, values: []) -> Array<u8> {
+    fn base64(strings: CookedStrings, values: []) -> Array<u8> {
         // values must be empty (no interpolation allowed)
         // Decoded at compile time
-        return __builtin_base64_decode__(strings.raw[0]);
+        return __builtin_base64_decode__(strings[0]);
     }
 }
 ```
@@ -125,14 +132,14 @@ impl String {
 Usage:
 
 ```wado
-let bytes = String::base64`SGVsbG8=`;  // → [72, 101, 108, 108, 111]
+let bytes = String::base64`SGVsbG8=`;  // -> [72, 101, 108, 108, 111]
 ```
 
 Compile error if interpolation is present.
 
 ### Format Specifiers
 
-When a format specifier is present, the value is stringified before being passed to the tag:
+When a format specifier is present, the value is pre-formatted before being passed to the tag:
 
 ```wado
 fmt`Value: {pi:.2}`
@@ -141,20 +148,14 @@ fmt`Value: {pi:.2}`
 Desugars to:
 
 ```wado
-{
-    let __strings = TemplateStrings { ... };
-    let __values = [__format__(pi, ".2")];  // Pre-formatted
+__tmpl: {
+    let __strings = CookedStrings::from(["Value: ", ""]);
+    let __values = [__format__(pi, ".2")];
     fmt(__strings, __values)
 }
 ```
 
-For standard templates, format specifiers are applied during stringification:
-
-```wado
-`Pi is {pi:.2}`
-// → __default_template__(strings, [pi])
-// with format spec passed to to_string or dedicated formatter
-```
+For untagged templates, format specifiers are applied during the direct stringification.
 
 ### Brace Escaping
 
@@ -167,70 +168,7 @@ For standard templates, format specifiers are applied during stringification:
 // values = [value]
 ```
 
-Lexer change required: `{{` → `{`, `}}` → `}` in template strings.
-
-### Compile-Time Tuple Enumeration
-
-`for-of` yields values only for both Array and Tuple, consistent with JavaScript and Rust. To get `[index, value]` pairs, use `.entries()`:
-
-```wado
-// Array (runtime)
-for let v of array { }              // value only
-for let [i, v] of array.entries() { }  // [index, value]
-
-// Tuple (compile-time unrolling)
-for let v of tuple { }              // value only
-for let [i, v] of tuple.entries() { }  // [index, value]
-```
-
-Key difference:
-
-- **Array `.entries()`**: Runtime method, returns `Iterator<[i32, T]>`
-- **Tuple `.entries()`**: Compile-time method, triggers loop unrolling with `[i, v]` pairs
-
-Expansion example:
-
-```wado
-let t: [i32, String, f64] = [1, "hi", 3.14];
-for let [i, v] of t.entries() {
-    println(`{i}: {v}`);
-}
-```
-
-Becomes:
-
-```wado
-{
-    let i = 0;
-    let v = t.0;  // v: i32
-    println(`{i}: {v}`);
-}
-{
-    let i = 1;
-    let v = t.1;  // v: String
-    println(`{i}: {v}`);
-}
-{
-    let i = 2;
-    let v = t.2;  // v: f64
-    println(`{i}: {v}`);
-}
-```
-
-Value-only iteration:
-
-```wado
-for let v of tuple {
-    // v changes type each iteration (comptime unrolling)
-}
-```
-
-Constraints:
-
-- Tuple `for-of` and `.entries()` are compile-time unrolled
-- Loop body must be valid for each element type (checked after expansion)
-- `break` and `continue` are not allowed in tuple iteration (compile error)
-- Index from `.entries()` is a compile-time constant, usable in array/tuple indexing
+Lexer change required: `{{` -> `{`, `}}` -> `}` in template strings.
 
 ### Edge Cases
 
@@ -250,32 +188,24 @@ Constraints:
 
 - [ ] Add `{{` and `}}` escape support in lexer
 - [ ] Store both cooked and raw strings in `TemplatePart::String`
-- [ ] Define `TemplateStrings` struct in `core:internal`
+- [ ] Define `CookedStrings` and `RawStrings` newtypes in `core:internal`
 
-### Phase 2: Desugaring
+### Phase 2: Untagged Template Optimization
 
-- [ ] Implement template desugaring in `desugar.rs`
-- [ ] Generate `TemplateStrings` literal and values tuple
-- [ ] Call `__default_template__` for untagged templates
+- [ ] Improve untagged template lowering for efficiency (buffer-based or `StringBuilder`)
+- [ ] Apply format specifiers during direct stringification
 
-### Phase 3: Compile-Time Tuple Enumeration
+### Phase 3: Tagged Templates
 
-- [ ] Implement `for let v of tuple` (value-only, comptime unrolling)
-- [ ] Implement `tuple.entries()` comptime method
-- [ ] Implement `for let [i, v] of tuple.entries()` (index+value, comptime unrolling)
-- [ ] Implement loop unrolling in desugar phase
-- [ ] Type-check each unrolled block independently
-
-### Phase 4: Tagged Templates
-
-- [ ] Implement `String::raw` using tuple enumeration
+- [ ] Implement tag function lookup and signature-based string selection
+- [ ] Generate `CookedStrings` or `RawStrings` based on tag function's first parameter type
+- [ ] Pass values as tuple to tag function
+- [ ] Implement `String::raw` using `RawStrings` and tuple enumeration
 - [ ] Implement `String::base64` with compile-time decoding
-- [ ] Add format specifier handling
 
-### Phase 5: Optimization
+### Phase 4: Brace Escaping
 
-- [ ] Constant-fold templates with only literals
-- [ ] Inline small templates without function call overhead
+- [ ] Implement `{{` / `}}` lexer support
 
 ## Consequences
 
@@ -285,24 +215,23 @@ Constraints:
 - Tagged templates enable DSLs (SQL, regex, etc.)
 - `String::raw` works naturally without parser special-casing
 - Type-safe interpolation values in tagged templates
-- Compile-time tuple enumeration has broader applications
-- Consistent `for-of` semantics with JavaScript/Rust (value only, `.entries()` for index+value)
+- Signature-based string selection avoids unnecessary wasm bloat (no unused raw/cooked arrays)
 
 ### Negative
 
-- Compile-time tuple enumeration adds complexity to the compiler
-- Tuple `.entries()` as a comptime method is a novel concept requiring careful design
-- TemplateStrings struct adds runtime overhead (two arrays)
+- Depends on compile-time tuple enumeration (separate WEP)
 - Breaking change if existing code relies on current lowering
+- Two newtype aliases (`CookedStrings`, `RawStrings`) for conceptually similar data
 
 ### Risks
 
 - Compile-time tuple enumeration may interact unexpectedly with other features
-- Performance of unrolled loops for large tuples needs monitoring
+- Tag function signature inspection adds complexity to the compiler
 
 ## Related WEPs
 
-- [Tagged Template Literals for Compile-Time Execution](./wep-2026-01-10-tagged-template-literals.md): Covers compile-time evaluation of tag functions. This WEP provides the desugaring mechanism that feeds into that compile-time execution model.
+- [Compile-Time Tuple Enumeration](./wep-2026-02-10-compile-time-tuple-enumeration.md): Required for iterating over heterogeneous values in tag functions
+- [Tagged Template Literals for Compile-Time Execution](./wep-2026-01-10-tagged-template-literals.md): Covers compile-time evaluation of tag functions
 
 ## References
 

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-String templates (`` `Hello, {name}!` ``) are currently lowered in the resolver to chained `string_concat` calls. This approach has limitations:
+String templates (`` `Hello, {name}!` ``) are currently lowered in the resolver to chained `String::concat` calls. This approach has limitations:
 
 1. No support for tagged templates (`sql`...``, `String::raw`...``)
 2. Format specifiers are not fully implemented
@@ -45,15 +45,15 @@ Untagged templates are special-cased by the compiler for efficiency. No `CookedS
 `Hello, {name}! You are {age}.`
 ```
 
-The compiler directly emits an efficient concatenation sequence (the exact form is an implementation detail, not observable). Conceptually equivalent to:
+The compiler directly emits an efficient append sequence using a mutable string and labeled block expression. Conceptually equivalent to:
 
 ```wado
 __tmpl: {
     let mut __r = "Hello, ";
-    __r = String::concat(__r, to_string(name));
-    __r = String::concat(__r, "! You are ");
-    __r = String::concat(__r, to_string(age));
-    __r = String::concat(__r, ".");
+    __r.append(to_string(name));
+    __r.append("! You are ");
+    __r.append(to_string(age));
+    __r.append(".");
     __r
 }
 ```
@@ -82,8 +82,8 @@ fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
     let mut params: Array<SqlParam> = [];
     for let [i, v] of values.entries() {
         params.append(v.to_sql_param());
-        query = String::concat(query, `${i + 1}`);
-        query = String::concat(query, strings[i + 1]);
+        query.append(`${i + 1}`);
+        query.append(strings[i + 1]);
     }
     return SqlQuery { query, params };
 }
@@ -100,8 +100,8 @@ impl String {
     fn raw<Values>(strings: RawStrings, values: Values) -> String {
         let mut result = strings[0];
         for let [i, v] of values.entries() {
-            result = String::concat(result, to_string(v));
-            result = String::concat(result, strings[i + 1]);
+            result.append(to_string(v));
+            result.append(strings[i + 1]);
         }
         return result;
     }

--- a/docs/wep-2026-02-01-format-traits.md
+++ b/docs/wep-2026-02-01-format-traits.md
@@ -21,7 +21,7 @@ This WEP defines the trait system and Formatter infrastructure that backs these 
 
 ### Formatter Infrastructure
 
-Format traits write to a `Formatter` object that holds format options and an output buffer. This design follows Rust's `std::fmt` approach, adapted for Wado's semantics.
+Format traits write to a `Formatter` object that holds format options and a reference to the output buffer. The `Formatter` does not own its buffer; it writes directly into the caller's `&mut String`. This avoids intermediate allocations and follows Rust's `std::fmt::Formatter` design.
 
 ```wado
 /// Text alignment for padding
@@ -42,20 +42,20 @@ struct FormatSpec {
     zero_pad: bool,
 }
 
-/// Formatter that accumulates formatted output
+/// Formatter that writes directly into a referenced output buffer
 struct Formatter {
     spec: FormatSpec,
-    buf: String,
+    buf: &mut String,
 }
 
 impl Formatter {
-    fn write_str(&mut self, s: String);
+    fn new(buf: &mut String, spec: FormatSpec) -> Formatter;
+    fn write_str(&mut self, s: &String);
     fn write_char(&mut self, c: char);
     fn width(&self) -> Option<i32>;
     fn precision(&self) -> Option<i32>;
     fn alternate(&self) -> bool;
     fn sign_plus(&self) -> bool;
-    fn finish(&mut self) -> String;
 }
 ```
 

--- a/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
+++ b/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
@@ -56,7 +56,7 @@ for let v of tuple_expr {
 }
 
 // Indexed iteration
-for let [i, v] of tuple_expr.entries() {
+for let [i, v] of tuple_expr.enumerate() {
     // i: i32 (compile-time constant, 0, 1, 2, ...)
     // v has type T_k in the k-th unrolled iteration
 }
@@ -64,23 +64,21 @@ for let [i, v] of tuple_expr.entries() {
 
 For arrays, `for let v of array` uses `IntoIterator` at runtime. For tuples, the same syntax triggers compile-time unrolling. The distinction is determined by the type of the iterable expression.
 
-### `.entries()` Pseudo-Method
+### `.enumerate()` Pseudo-Method
 
-`.entries()` on a tuple type is a compiler-recognized pattern, not a real method. It produces `[index, element]` pairs for compile-time enumeration.
+`.enumerate()` on a tuple type is a compiler-recognized pattern, not a real method. It produces `[index, element]` pairs for compile-time enumeration. This follows Rust's naming convention for indexed iteration (`iter().enumerate()`), but applied directly to the tuple since tuples cannot produce a runtime iterator.
 
-| Receiver type | `.entries()` behavior | Returns |
+| Receiver type | `.enumerate()` behavior | Returns |
 |---|---|---|
-| `Array<T>` | Runtime method | `ArrayEntriesIter<T>` |
+| Iterator | Runtime combinator (Rust-style) | `EnumerateIter<T>` |
 | Tuple | Compile-time pseudo-method | Unrolled `[i32, T_k]` pairs |
-
-This is consistent with `TreeMap.entries()` (runtime) and follows the principle that the same concept (indexed access to elements) has type-appropriate implementations.
 
 ### Expansion Rules
 
 Given a concrete tuple type `[T_0, T_1, ..., T_{n-1}]`:
 
 ```wado
-for let [i, v] of values.entries() {
+for let [i, v] of values.enumerate() {
     body(i, v);
 }
 ```
@@ -119,7 +117,7 @@ Flow:
 1. A generic function `fn tag<Values>(strings: CookedStrings, values: Values)` is defined
 2. At a call site, `Values` is instantiated to a concrete tuple type (e.g., `[i32, String]`)
 3. The resolver monomorphizes the function body with `Values = [i32, String]`
-4. During monomorphization, the resolver encounters `for let [i, v] of values.entries()`
+4. During monomorphization, the resolver encounters `for let [i, v] of values.enumerate()`
 5. `values` has concrete type `[i32, String]` -> the resolver unrolls the loop
 6. Each unrolled body is resolved independently with the appropriate element type
 
@@ -129,7 +127,7 @@ Wado uses the **C++ template model** for tuple enumeration: the loop body is typ
 
 ```wado
 fn process<Values>(values: Values) {
-    for let v of values.entries() {
+    for let v of values.enumerate() {
         v.some_method();  // Not checked until Values is concrete
     }
 }
@@ -157,7 +155,7 @@ impl ToSqlParam for String {
 fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
     let mut query = strings[0];
     let mut params: Array<SqlParam> = [];
-    for let [i, v] of values.entries() {
+    for let [i, v] of values.enumerate() {
         params.append(v.to_sql_param());
         query.append("?");
         query.append(strings[i + 1]);
@@ -189,7 +187,7 @@ __unroll_1: {
 
 - **Concrete type required**: Tuple enumeration is only valid when the tuple type is fully concrete. Attempting to enumerate a generic `T` that has not been instantiated is a compile error
 - **`break` and `continue` are not allowed**: Since the loop is unrolled into sequential blocks, `break`/`continue` have no natural target. They are compile errors inside tuple enumeration
-- **Index is a compile-time constant**: The `i` binding from `.entries()` is a compile-time `i32` constant, usable in tuple/array indexing expressions
+- **Index is a compile-time constant**: The `i` binding from `.enumerate()` is a compile-time `i32` constant, usable in tuple/array indexing expressions
 - **Empty tuple**: `for let v of []` produces zero unrolled blocks (no-op)
 - **Nested enumeration**: Enumerating a tuple that contains tuples works; inner tuples are elements, not automatically flattened
 
@@ -207,7 +205,7 @@ Example error:
 error: method `to_sql_param` not found on type `bool`
   --> app.wado:10:5
    |
-10 |     for let [i, v] of values.entries() {
+10 |     for let [i, v] of values.enumerate() {
    |                       ^^^^^^^^^^^^^^^^
    |                       element 2 of tuple [i32, String, bool]
    |
@@ -223,7 +221,7 @@ note: tuple type determined here
 
 ## Implementation Plan
 
-- [ ] Detect `for let v of <tuple>` and `for let [i, v] of <tuple>.entries()` patterns in the resolver
+- [ ] Detect `for let v of <tuple>` and `for let [i, v] of <tuple>.enumerate()` patterns in the resolver
 - [ ] Implement loop unrolling during monomorphization
 - [ ] Type-check each unrolled block independently
 - [ ] Emit compile errors for `break`/`continue` inside tuple enumeration
@@ -245,7 +243,7 @@ note: tuple type determined here
 
 - Adopts C++ template model for type checking (monomorphization-time errors)
 - Adds complexity to the resolver's monomorphization logic
-- `.entries()` as a pseudo-method is a novel concept that may surprise users
+- `.enumerate()` as a pseudo-method is a novel concept that may surprise users
 - Error messages require careful engineering to be useful
 
 ### Risks

--- a/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
+++ b/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
@@ -68,10 +68,10 @@ For arrays, `for let v of array` uses `IntoIterator` at runtime. For tuples, the
 
 `.enumerate()` on a tuple type is a compiler-recognized pattern, not a real method. It produces `[index, element]` pairs for compile-time enumeration. This follows Rust's naming convention for indexed iteration (`iter().enumerate()`), but applied directly to the tuple since tuples cannot produce a runtime iterator.
 
-| Receiver type | `.enumerate()` behavior | Returns |
-|---|---|---|
-| Iterator | Runtime combinator (Rust-style) | `EnumerateIter<T>` |
-| Tuple | Compile-time pseudo-method | Unrolled `[i32, T_k]` pairs |
+| Receiver type | `.enumerate()` behavior         | Returns                     |
+| ------------- | ------------------------------- | --------------------------- |
+| Iterator      | Runtime combinator (Rust-style) | `EnumerateIter<T>`          |
+| Tuple         | Compile-time pseudo-method      | Unrolled `[i32, T_k]` pairs |
 
 ### Expansion Rules
 

--- a/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
+++ b/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
@@ -1,0 +1,266 @@
+# Compile-Time Tuple Enumeration
+
+## Context
+
+Tuples in Wado are heterogeneous: each element can have a different type (`[i32, String, f64]`). This means tuples cannot be iterated at runtime using the standard `Iterator` trait, because `next()` must return a single, fixed type.
+
+However, several use cases require processing each element of a tuple individually:
+
+1. **Tagged template literals**: A tag function receives interpolated values as a tuple and must process each value according to its type (e.g., `sql` tag converting each value to a SQL parameter)
+2. **Serialization**: Converting a tuple of heterogeneous values into a serialized form
+3. **Structured logging**: Formatting each value with type-appropriate formatting
+
+The key insight is that for tuples, the element count and element types are always known at compile time. The compiler can **unroll** a loop over a tuple into a sequence of statements, each typed independently.
+
+### Alternatives Considered
+
+#### Builder Protocol
+
+Instead of iterating over a tuple, define a trait with `begin`/`add`/`finish` methods:
+
+```wado
+trait TemplateTag {
+    type Output;
+    fn begin(strings: CookedStrings) -> Self;
+    fn add<T>(&mut self, value: T);
+    fn finish(self) -> Self::Output;
+}
+```
+
+The compiler generates sequential `add()` calls for each interpolated value.
+
+- Does not require a new language feature
+- More boilerplate for tag authors (struct + trait impl + 3 methods vs 1 function)
+- Less general (only useful for builder-pattern scenarios)
+
+#### Type-Erased Array
+
+Pass all values as `Array<String>` (pre-stringified):
+
+- Simple, no new features needed
+- Loses original type information (tag function cannot distinguish `{42}` from `{"42"}`)
+- Not general enough for type-safe DSLs like SQL query builders
+
+## Decision
+
+Adopt compile-time tuple enumeration as a general language feature. When a `for-of` loop targets a tuple with a concrete type, the compiler unrolls the loop body at compile time, binding each element with its specific type.
+
+### Syntax
+
+Two forms, consistent with array iteration:
+
+```wado
+// Value-only iteration
+for let v of tuple_expr {
+    // v has type T_k in the k-th unrolled iteration
+}
+
+// Indexed iteration
+for let [i, v] of tuple_expr.entries() {
+    // i: i32 (compile-time constant, 0, 1, 2, ...)
+    // v has type T_k in the k-th unrolled iteration
+}
+```
+
+For arrays, `for let v of array` uses `IntoIterator` at runtime. For tuples, the same syntax triggers compile-time unrolling. The distinction is determined by the type of the iterable expression.
+
+### `.entries()` Pseudo-Method
+
+`.entries()` on a tuple type is a compiler-recognized pattern, not a real method. It produces `[index, element]` pairs for compile-time enumeration.
+
+| Receiver type | `.entries()` behavior | Returns |
+|---|---|---|
+| `Array<T>` | Runtime method | `ArrayEntriesIter<T>` |
+| Tuple | Compile-time pseudo-method | Unrolled `[i32, T_k]` pairs |
+
+This is consistent with `TreeMap.entries()` (runtime) and follows the principle that the same concept (indexed access to elements) has type-appropriate implementations.
+
+### Expansion Rules
+
+Given a concrete tuple type `[T_0, T_1, ..., T_{n-1}]`:
+
+```wado
+for let [i, v] of values.entries() {
+    body(i, v);
+}
+```
+
+Expands to:
+
+```wado
+__unroll_0: {
+    let i: i32 = 0;
+    let v: T_0 = values.0;
+    body(i, v);
+}
+__unroll_1: {
+    let i: i32 = 1;
+    let v: T_1 = values.1;
+    body(i, v);
+}
+// ...
+__unroll_{n-1}: {
+    let i: i32 = {n-1};
+    let v: T_{n-1} = values.{n-1};
+    body(i, v);
+}
+```
+
+Each unrolled block is a labeled block with a compiler-generated label. Each block is type-checked independently, because `v` has a different type in each block.
+
+Value-only `for let v of values` works the same way without the `i` binding.
+
+### Where Expansion Happens
+
+Expansion occurs in the **resolver during monomorphization**, not in the desugar phase. This is because the concrete tuple type is only known after type parameter substitution.
+
+Flow:
+
+1. A generic function `fn tag<Values>(strings: CookedStrings, values: Values)` is defined
+2. At a call site, `Values` is instantiated to a concrete tuple type (e.g., `[i32, String]`)
+3. The resolver monomorphizes the function body with `Values = [i32, String]`
+4. During monomorphization, the resolver encounters `for let [i, v] of values.entries()`
+5. `values` has concrete type `[i32, String]` -> the resolver unrolls the loop
+6. Each unrolled body is resolved independently with the appropriate element type
+
+### Type Checking Model
+
+Wado uses the **C++ template model** for tuple enumeration: the loop body is type-checked only after expansion, when the concrete element type is known.
+
+```wado
+fn process<Values>(values: Values) {
+    for let v of values.entries() {
+        v.some_method();  // Not checked until Values is concrete
+    }
+}
+```
+
+At definition time, the compiler does not verify that each element type has `some_method()`. This check happens at monomorphization time, when the concrete tuple type is known. If an element type lacks the required method, the compiler reports an error pointing to both the call site (where the concrete type is determined) and the method call (where the error occurs).
+
+Future work: trait bounds on tuple element types (e.g., `Values: TupleOf<ToSqlParam>`) could enable definition-time checking, but this is deferred as YAGNI.
+
+### Concrete Example
+
+```wado
+trait ToSqlParam {
+    fn to_sql_param(&self) -> SqlParam;
+}
+
+impl ToSqlParam for i32 {
+    fn to_sql_param(&self) -> SqlParam { return SqlParam::Int(*self); }
+}
+
+impl ToSqlParam for String {
+    fn to_sql_param(&self) -> SqlParam { return SqlParam::Text(*self); }
+}
+
+fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
+    let mut query = strings[0];
+    let mut params: Array<SqlParam> = [];
+    for let [i, v] of values.entries() {
+        params.append(v.to_sql_param());
+        query = String::concat(query, "?");
+        query = String::concat(query, strings[i + 1]);
+    }
+    return SqlQuery { query, params };
+}
+```
+
+When called as `sql::<[i32, String]>(strings, [42, "Alice"])`, the loop body expands to:
+
+```wado
+__unroll_0: {
+    let i: i32 = 0;
+    let v: i32 = values.0;
+    params.append(v.to_sql_param());      // resolves to i32::to_sql_param
+    query = String::concat(query, "?");
+    query = String::concat(query, strings[1]);
+}
+__unroll_1: {
+    let i: i32 = 1;
+    let v: String = values.1;
+    params.append(v.to_sql_param());      // resolves to String::to_sql_param
+    query = String::concat(query, "?");
+    query = String::concat(query, strings[2]);
+}
+```
+
+### Constraints
+
+- **Concrete type required**: Tuple enumeration is only valid when the tuple type is fully concrete. Attempting to enumerate a generic `T` that has not been instantiated is a compile error
+- **`break` and `continue` are not allowed**: Since the loop is unrolled into sequential blocks, `break`/`continue` have no natural target. They are compile errors inside tuple enumeration
+- **Index is a compile-time constant**: The `i` binding from `.entries()` is a compile-time `i32` constant, usable in tuple/array indexing expressions
+- **Empty tuple**: `for let v of []` produces zero unrolled blocks (no-op)
+- **Nested enumeration**: Enumerating a tuple that contains tuples works; inner tuples are elements, not automatically flattened
+
+### Error Reporting
+
+Since type checking happens at monomorphization time, error messages must include:
+
+1. The call site where the concrete tuple type was determined
+2. The specific element index and type that caused the error
+3. The location in the loop body where the error occurred
+
+Example error:
+
+```
+error: method `to_sql_param` not found on type `bool`
+  --> app.wado:10:5
+   |
+10 |     for let [i, v] of values.entries() {
+   |                       ^^^^^^^^^^^^^^^^
+   |                       element 2 of tuple [i32, String, bool]
+   |
+11 |         params.append(v.to_sql_param());
+   |                       ^^^^^^^^^^^^^^^^ `bool` does not implement `ToSqlParam`
+   |
+note: tuple type determined here
+  --> app.wado:20:9
+   |
+20 |     sql`SELECT * WHERE id = {id} AND name = {name} AND active = {is_active}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## Implementation Plan
+
+- [ ] Detect `for let v of <tuple>` and `for let [i, v] of <tuple>.entries()` patterns in the resolver
+- [ ] Implement loop unrolling during monomorphization
+- [ ] Type-check each unrolled block independently
+- [ ] Emit compile errors for `break`/`continue` inside tuple enumeration
+- [ ] Implement error messages that show call site, element index, and body location
+- [ ] Test with tagged template use cases
+
+## Consequences
+
+### Positive
+
+- General-purpose feature useful beyond templates (serialization, logging, etc.)
+- Tag functions are simple generic functions, no special protocol needed
+- Type-safe: each element processed according to its type
+- Zero runtime overhead: unrolled at compile time
+- No dedicated syntax needed: reuses existing `for-of` syntax
+- Orthogonal to other language features
+
+### Negative
+
+- Adopts C++ template model for type checking (monomorphization-time errors)
+- Adds complexity to the resolver's monomorphization logic
+- `.entries()` as a pseudo-method is a novel concept that may surprise users
+- Error messages require careful engineering to be useful
+
+### Risks
+
+- May create pressure for more compile-time metaprogramming features (tuple length, conditional compilation, etc.)
+- Interaction with future trait bounds on tuple elements needs careful design
+- Large tuples could produce significant code bloat from unrolling
+
+## Related WEPs
+
+- [String Template Desugaring](./wep-2026-01-20-string-template-desugaring.md): Primary motivation; tagged templates use tuple enumeration to process interpolated values
+- [Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md): Defines tuple literal syntax and semantics
+
+## References
+
+- [Zig comptime](https://ziglang.org/documentation/master/#comptime): Zig's compile-time execution model, which includes tuple/struct field iteration
+- [C++ fold expressions](https://en.cppreference.com/w/cpp/language/fold): C++17 mechanism for expanding parameter packs
+- [Rust `macro_rules!` for tuples](https://doc.rust-lang.org/std/macro.impl_for_tuples.html): Rust uses macros to generate per-arity implementations (the problem Wado avoids)

--- a/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
+++ b/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
@@ -159,8 +159,8 @@ fn sql<Values>(strings: CookedStrings, values: Values) -> SqlQuery {
     let mut params: Array<SqlParam> = [];
     for let [i, v] of values.entries() {
         params.append(v.to_sql_param());
-        query = String::concat(query, "?");
-        query = String::concat(query, strings[i + 1]);
+        query.append("?");
+        query.append(strings[i + 1]);
     }
     return SqlQuery { query, params };
 }
@@ -173,15 +173,15 @@ __unroll_0: {
     let i: i32 = 0;
     let v: i32 = values.0;
     params.append(v.to_sql_param());      // resolves to i32::to_sql_param
-    query = String::concat(query, "?");
-    query = String::concat(query, strings[1]);
+    query.append("?");
+    query.append(strings[1]);
 }
 __unroll_1: {
     let i: i32 = 1;
     let v: String = values.1;
     params.append(v.to_sql_param());      // resolves to String::to_sql_param
-    query = String::concat(query, "?");
-    query = String::concat(query, strings[2]);
+    query.append("?");
+    query.append(strings[2]);
 }
 ```
 

--- a/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
+++ b/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
@@ -127,7 +127,7 @@ Wado uses the **C++ template model** for tuple enumeration: the loop body is typ
 
 ```wado
 fn process<Values>(values: Values) {
-    for let v of values.enumerate() {
+    for let v of values {
         v.some_method();  // Not checked until Values is concrete
     }
 }


### PR DESCRIPTION
- Replace TemplateStrings (both cooked+raw) with CookedStrings/RawStrings newtypes
- Signature-based selection: compiler emits only the form the tag function needs
- Untagged templates are special-cased (no array allocation)
- Fix bare blocks to labeled blocks in desugaring examples
- Extract compile-time tuple enumeration into separate WEP
- Tuple enumeration: compile-time unrolling during monomorphization (C++ model)

https://claude.ai/code/session_01Cbge9z1cs2u8chnyq9but9