### PR TITLE
Embed FormatSpec fields into Formatter to save one GC struct allocation

### DIFF
--- a/docs/wep-2026-02-01-format-traits.md
+++ b/docs/wep-2026-02-01-format-traits.md
@@ -21,39 +21,35 @@ This WEP defines the trait system and Formatter infrastructure that backs these 
 
 ### Formatter Infrastructure
 
-Format traits write to a `Formatter` object that holds format options and a reference to the output buffer. The `Formatter` does not own its buffer; it writes directly into the caller's `&mut String`. This avoids intermediate allocations and follows Rust's `std::fmt::Formatter` design.
+Format traits write to a `Formatter` object that holds format options and a reference to the output buffer. The `Formatter` does not own its buffer; it writes directly into the caller's `&mut String`. Format specification fields are embedded directly into `Formatter` to avoid an extra GC struct allocation.
 
 ```wado
 /// Text alignment for padding
-enum Alignment {
+variant Alignment {
     Left,
     Center,
     Right,
 }
 
-/// Format specification parsed from `{expr:spec}`
-struct FormatSpec {
-    width: Option<i32>,
-    precision: Option<i32>,
+/// Formatter that writes directly into a referenced output buffer.
+/// Format specification fields are embedded to save one GC struct allocation.
+struct Formatter {
     fill: char,
     align: Alignment,
     sign_plus: bool,
     alternate: bool,
     zero_pad: bool,
-}
-
-/// Formatter that writes directly into a referenced output buffer
-struct Formatter {
-    spec: FormatSpec,
+    width: i32,        // -1 = not specified
+    precision: i32,    // -1 = not specified
     buf: &mut String,
 }
 
 impl Formatter {
-    fn new(buf: &mut String, spec: FormatSpec) -> Formatter;
+    fn new(buf: &mut String) -> Formatter;
     fn write_str(&mut self, s: &String);
     fn write_char(&mut self, c: char);
-    fn width(&self) -> Option<i32>;
-    fn precision(&self) -> Option<i32>;
+    fn width(&self) -> i32;
+    fn precision(&self) -> i32;
     fn alternate(&self) -> bool;
     fn sign_plus(&self) -> bool;
 }
@@ -139,7 +135,7 @@ Zero padding (`{x:08}`) inserts zeros after sign/prefix but before digits:
 
 ### Negative
 
-1. **Infrastructure complexity**: Requires `Formatter`, `FormatSpec`, `Alignment` types
+1. **Infrastructure complexity**: Requires `Formatter` and `Alignment` types
 2. **Implementation effort**: All primitive formatting needs trait implementations
 
 ### Future Extensions

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -12,7 +12,7 @@ pub use {
     Display, Binary, Octal, LowerHex, UpperHex, LowerExp, UpperExp,
 } from "core:prelude/traits.wado";
 
-pub use { Alignment, FormatSpec, Formatter } from "core:prelude/format.wado";
+pub use { Alignment, Formatter } from "core:prelude/format.wado";
 pub use { i128, u128 } from "core:prelude/int128.wado";
 pub use { Option, Result, Stream, Future } from "core:prelude/types.wado";
 use { __PRIMITIVES_MODULE_LOADED } from "core:prelude/primitives.wado";

--- a/wado-compiler/lib/core/prelude/format.wado
+++ b/wado-compiler/lib/core/prelude/format.wado
@@ -1,6 +1,6 @@
 // Format Infrastructure
 //
-// This module defines the Formatter, FormatSpec, and Alignment types that
+// This module defines the Formatter and Alignment types that
 // back template string format specifiers (`{x:spec}`).
 //
 // See WEP: Format Traits (wep-2026-02-01-format-traits.md)
@@ -17,11 +17,15 @@ pub variant Alignment {
     /// Right-aligned (default for numbers): `{x:>5}` -> "   42"
     Right,
 }
-/// Format specification parsed from `{expr:spec}`.
-/// Matches Rust's format syntax: `[[fill]align][sign][#][0][width][.precision]type`
+/// Formatter that writes directly into a referenced output buffer.
+/// The Formatter does not own its buffer; it writes into the caller's `&mut String`.
+/// This avoids intermediate allocations.
+///
+/// Format specification fields match Rust's format syntax:
+/// `[[fill]align][sign][#][0][width][.precision]type`
 ///
 /// Width and precision use -1 as sentinel for "not specified".
-pub struct FormatSpec {
+pub struct Formatter {
     /// Fill character for padding (default: ' ')
     fill: char,
     /// Text alignment mode
@@ -36,12 +40,14 @@ pub struct FormatSpec {
     width: i32,
     /// Precision for floats (decimal places) or strings (max width) (-1 = default)
     precision: i32,
+    /// Reference to the output buffer
+    buf: &mut String,
 }
 
-impl FormatSpec {
-    /// Create the default format spec (no special formatting).
-    pub fn default() -> FormatSpec {
-        return FormatSpec {
+impl Formatter {
+    /// Create a new Formatter with default format spec that writes into the given buffer.
+    pub fn new(buf: &mut String) -> Formatter {
+        return Formatter {
             fill: ' ',
             align: Alignment::Right,
             sign_plus: false,
@@ -49,23 +55,8 @@ impl FormatSpec {
             zero_pad: false,
             width: -1,
             precision: -1,
+            buf,
         };
-    }
-}
-/// Formatter that writes directly into a referenced output buffer.
-/// The Formatter does not own its buffer; it writes into the caller's `&mut String`.
-/// This avoids intermediate allocations.
-pub struct Formatter {
-    /// Format specification
-    spec: FormatSpec,
-    /// Reference to the output buffer
-    buf: &mut String,
-}
-
-impl Formatter {
-    /// Create a new Formatter that writes into the given buffer with the given spec.
-    pub fn new(buf: &mut String, spec: FormatSpec) -> Formatter {
-        return Formatter { spec, buf };
     }
 
     /// Write a string to the output buffer.
@@ -80,24 +71,25 @@ impl Formatter {
 
     /// Get the width specification (-1 means not specified).
     pub fn width(&self) -> i32 {
-        return self.spec.width;
+        return self.width;
     }
 
     /// Get the precision specification (-1 means not specified).
     pub fn precision(&self) -> i32 {
-        return self.spec.precision;
+        return self.precision;
     }
 
     /// Check if alternate form (`#`) is requested.
     pub fn alternate(&self) -> bool {
-        return self.spec.alternate;
+        return self.alternate;
     }
 
     /// Check if sign display (`+`) is requested.
     pub fn sign_plus(&self) -> bool {
-        return self.spec.sign_plus;
+        return self.sign_plus;
     }
-}// Defined here (not in string.wado) to avoid string.wado depending on format.wado,
+}
+// Defined here (not in string.wado) to avoid string.wado depending on format.wado,
 // which would cause codegen struct registration order issues.
 
 impl Display for String {

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -58,7 +58,7 @@ pub const CORE_PRELUDE_TYPES: &str = include_str!("../lib/core/prelude/types.wad
 /// Located in prelude/ subdirectory and imported by prelude.wado
 pub const CORE_PRELUDE_PRIMITIVES: &str = include_str!("../lib/core/prelude/primitives.wado");
 
-/// Embedded source for core:prelude/format (Alignment, `FormatSpec`, Formatter)
+/// Embedded source for core:prelude/format (Alignment, Formatter)
 /// Located in prelude/ subdirectory and re-exported by prelude.wado
 pub const CORE_PRELUDE_FORMAT: &str = include_str!("../lib/core/prelude/format.wado");
 

--- a/wado-compiler/tests/fixtures.golden/display_custom.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_custom.lowered.wado
@@ -44,25 +44,19 @@ fn run() with Stdout {
     let mut buf: String = __inline_String__with_capacity_0: {
         break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    let mut f: Formatter = __inline_Formatter__new_2: {
+    let mut f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_1: {
-            break __inline_FormatSpec__default_1: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_2: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
     p."Point^Display::fmt"(&mut f);
     core::cli::println(buf);
     let o: Point = move Point { x: 0, y: 0 };
-    buf = __inline_String__with_capacity_3: {
-        break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(64), used: 0 };
+    buf = __inline_String__with_capacity_2: {
+        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    f = __inline_Formatter__new_5: {
+    f = __inline_Formatter__new_3: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_4: {
-            break __inline_FormatSpec__default_4: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_5: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
     o."Point^Display::fmt"(&mut f);
     core::cli::println(buf);

--- a/wado-compiler/tests/fixtures.golden/display_formatter_methods.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_formatter_methods.lowered.wado
@@ -13,34 +13,31 @@ fn run() with Stdout {
     let mut buf: String = __inline_String__with_capacity_0: {
         break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    let spec: FormatSpec = __inline_FormatSpec__default_1: {
-        break __inline_FormatSpec__default_1: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-    };
-    let f: Formatter = __inline_Formatter__new_2: {
+    let f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
-        break __inline_Formatter__new_2: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
-    core::cli::println(move "String::concat"(move "width: ", move __inline_Formatter__width_3: {
-        break __inline_Formatter__width_3: f.spec.width;
+    core::cli::println(move "String::concat"(move "width: ", move __inline_Formatter__width_2: {
+        break __inline_Formatter__width_2: f.width;
     }."i32::to_string"()));
-    core::cli::println(move "String::concat"(move "precision: ", move __inline_Formatter__precision_4: {
-        break __inline_Formatter__precision_4: f.spec.precision;
+    core::cli::println(move "String::concat"(move "precision: ", move __inline_Formatter__precision_3: {
+        break __inline_Formatter__precision_3: f.precision;
     }."i32::to_string"()));
-    core::cli::println(move "String::concat"(move "alternate: ", __inline_bool__to_string_6: {
-        let self: bool = __inline_Formatter__alternate_5: {
-            break __inline_Formatter__alternate_5: f.spec.alternate;
+    core::cli::println(move "String::concat"(move "alternate: ", __inline_bool__to_string_5: {
+        let self: bool = __inline_Formatter__alternate_4: {
+            break __inline_Formatter__alternate_4: f.alternate;
         };
-        break __inline_bool__to_string_6: if self {
+        break __inline_bool__to_string_5: if self {
             "true";
         } else {
             "false";
         };
     }));
-    core::cli::println(move "String::concat"(move "sign_plus: ", __inline_bool__to_string_8: {
-        let self: bool = __inline_Formatter__sign_plus_7: {
-            break __inline_Formatter__sign_plus_7: f.spec.sign_plus;
+    core::cli::println(move "String::concat"(move "sign_plus: ", __inline_bool__to_string_7: {
+        let self: bool = __inline_Formatter__sign_plus_6: {
+            break __inline_Formatter__sign_plus_6: f.sign_plus;
         };
-        break __inline_bool__to_string_8: if self {
+        break __inline_bool__to_string_7: if self {
             "true";
         } else {
             "false";

--- a/wado-compiler/tests/fixtures.golden/display_primitives.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_primitives.lowered.wado
@@ -17,34 +17,28 @@ fn run() with Stdout {
     let mut buf: String = __inline_String__with_capacity_0: {
         break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    let mut f: Formatter = __inline_Formatter__new_2: {
+    let mut f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_1: {
-            break __inline_FormatSpec__default_1: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_2: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
-    __inline_i32_Display__fmt_3: {
-        __inline_Formatter__write_str_4: {
+    __inline_i32_Display__fmt_2: {
+        __inline_Formatter__write_str_3: {
             let s: String = move 42."i32::to_string"();
             f.buf."String::append"(s);
         };
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_5: {
-        break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(64), used: 0 };
+    buf = __inline_String__with_capacity_4: {
+        break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    f = __inline_Formatter__new_7: {
+    f = __inline_Formatter__new_5: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_6: {
-            break __inline_FormatSpec__default_6: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_7: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
-    __inline_bool_Display__fmt_8: {
-        __inline_Formatter__write_str_9: {
-            let s: String = __inline_bool__to_string_10: {
-                break __inline_bool__to_string_10: if true {
+    __inline_bool_Display__fmt_6: {
+        __inline_Formatter__write_str_7: {
+            let s: String = __inline_bool__to_string_8: {
+                break __inline_bool__to_string_8: if true {
                     "true";
                 } else {
                     "false";
@@ -54,20 +48,17 @@ fn run() with Stdout {
         };
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_11: {
-        break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(64), used: 0 };
+    buf = __inline_String__with_capacity_9: {
+        break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    f = __inline_Formatter__new_13: {
+    f = __inline_Formatter__new_10: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_12: {
-            break __inline_FormatSpec__default_12: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_13: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
-    __inline_bool_Display__fmt_14: {
-        __inline_Formatter__write_str_15: {
-            let s: String = __inline_bool__to_string_16: {
-                break __inline_bool__to_string_16: if false {
+    __inline_bool_Display__fmt_11: {
+        __inline_Formatter__write_str_12: {
+            let s: String = __inline_bool__to_string_13: {
+                break __inline_bool__to_string_13: if false {
                     "true";
                 } else {
                     "false";
@@ -77,35 +68,29 @@ fn run() with Stdout {
         };
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_17: {
-        break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(64), used: 0 };
+    buf = __inline_String__with_capacity_14: {
+        break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    f = __inline_Formatter__new_19: {
+    f = __inline_Formatter__new_15: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_18: {
-            break __inline_FormatSpec__default_18: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_19: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_15: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
-    __inline_char_Display__fmt_20: {
-        __inline_Formatter__write_str_21: {
+    __inline_char_Display__fmt_16: {
+        __inline_Formatter__write_str_17: {
             let s: String = move 'A'."char::to_string"();
             f.buf."String::append"(s);
         };
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_22: {
-        break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(64), used: 0 };
+    buf = __inline_String__with_capacity_18: {
+        break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    f = __inline_Formatter__new_24: {
+    f = __inline_Formatter__new_19: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_23: {
-            break __inline_FormatSpec__default_23: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_24: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_19: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
-    __inline_i32_Display__fmt_25: {
-        __inline_Formatter__write_str_26: {
+    __inline_i32_Display__fmt_20: {
+        __inline_Formatter__write_str_21: {
             let s: String = move -123."i32::to_string"();
             f.buf."String::append"(s);
         };

--- a/wado-compiler/tests/fixtures.golden/display_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_string.lowered.wado
@@ -13,36 +13,30 @@ fn run() with Stdout {
     let mut buf: String = __inline_String__with_capacity_0: {
         break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    let mut f: Formatter = __inline_Formatter__new_2: {
+    let mut f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_1: {
-            break __inline_FormatSpec__default_1: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_2: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
     let s: String = move "Hello, World!";
-    __inline_String_Display__fmt_3: {
+    __inline_String_Display__fmt_2: {
         let self: &String = &s;
-        __inline_Formatter__write_str_4: {
+        __inline_Formatter__write_str_3: {
             let s: String = *self;
             f.buf."String::append"(s);
         };
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_5: {
-        break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(64), used: 0 };
+    buf = __inline_String__with_capacity_4: {
+        break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(64), used: 0 };
     };
-    f = __inline_Formatter__new_7: {
+    f = __inline_Formatter__new_5: {
         let buf: &mut String = &mut buf;
-        let spec: FormatSpec = __inline_FormatSpec__default_6: {
-            break __inline_FormatSpec__default_6: FormatSpec { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1 };
-        };
-        break __inline_Formatter__new_7: Formatter { spec: spec, buf: buf };
+        break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
     let empty: String = move "";
-    __inline_String_Display__fmt_8: {
+    __inline_String_Display__fmt_6: {
         let self: &String = &empty;
-        __inline_Formatter__write_str_9: {
+        __inline_Formatter__write_str_7: {
             let s: String = *self;
             f.buf."String::append"(s);
         };

--- a/wado-compiler/tests/fixtures/display_custom.wado
+++ b/wado-compiler/tests/fixtures/display_custom.wado
@@ -19,14 +19,14 @@ impl Display for Point {
 export fn run() with Stdout {
     let p = Point { x: 10, y: 20 };
     let mut buf = String::with_capacity(64);
-    let mut f = Formatter::new(&mut buf, FormatSpec::default());
+    let mut f = Formatter::new(&mut buf);
     p.fmt(&mut f);
     println(buf);
 
     // Origin
     let o = Point { x: 0, y: 0 };
     buf = String::with_capacity(64);
-    f = Formatter::new(&mut buf, FormatSpec::default());
+    f = Formatter::new(&mut buf);
     o.fmt(&mut f);
     println(buf);
 }

--- a/wado-compiler/tests/fixtures/display_formatter_methods.wado
+++ b/wado-compiler/tests/fixtures/display_formatter_methods.wado
@@ -3,8 +3,7 @@ use { println, Stdout } from "core:cli";
 
 export fn run() with Stdout {
     let mut buf = String::with_capacity(64);
-    let spec = FormatSpec::default();
-    let f = Formatter::new(&mut buf, spec);
+    let f = Formatter::new(&mut buf);
 
     // Default spec values
     println(`width: {f.width()}`);

--- a/wado-compiler/tests/fixtures/display_primitives.wado
+++ b/wado-compiler/tests/fixtures/display_primitives.wado
@@ -4,7 +4,7 @@ use { println, Stdout } from "core:cli";
 export fn run() with Stdout {
     // Integer Display
     let mut buf = String::with_capacity(64);
-    let mut f = Formatter::new(&mut buf, FormatSpec::default());
+    let mut f = Formatter::new(&mut buf);
 
     // i32
     let x: i32 = 42;
@@ -13,25 +13,25 @@ export fn run() with Stdout {
 
     // bool
     buf = String::with_capacity(64);
-    f = Formatter::new(&mut buf, FormatSpec::default());
+    f = Formatter::new(&mut buf);
     true.fmt(&mut f);
     println(buf);
 
     buf = String::with_capacity(64);
-    f = Formatter::new(&mut buf, FormatSpec::default());
+    f = Formatter::new(&mut buf);
     false.fmt(&mut f);
     println(buf);
 
     // char
     buf = String::with_capacity(64);
-    f = Formatter::new(&mut buf, FormatSpec::default());
+    f = Formatter::new(&mut buf);
     let c = 'A';
     c.fmt(&mut f);
     println(buf);
 
     // Negative i32
     buf = String::with_capacity(64);
-    f = Formatter::new(&mut buf, FormatSpec::default());
+    f = Formatter::new(&mut buf);
     let neg: i32 = -123;
     neg.fmt(&mut f);
     println(buf);

--- a/wado-compiler/tests/fixtures/display_string.wado
+++ b/wado-compiler/tests/fixtures/display_string.wado
@@ -3,7 +3,7 @@ use { println, Stdout } from "core:cli";
 
 export fn run() with Stdout {
     let mut buf = String::with_capacity(64);
-    let mut f = Formatter::new(&mut buf, FormatSpec::default());
+    let mut f = Formatter::new(&mut buf);
 
     // String Display
     let s = "Hello, World!";
@@ -12,7 +12,7 @@ export fn run() with Stdout {
 
     // Empty string
     buf = String::with_capacity(64);
-    f = Formatter::new(&mut buf, FormatSpec::default());
+    f = Formatter::new(&mut buf);
     let empty = "";
     empty.fmt(&mut f);
     println(`[{buf}]`);


### PR DESCRIPTION
FormatSpec was never used independently of Formatter — it was always
immediately passed to Formatter::new(). Embedding its 7 fields directly
into Formatter eliminates one GC struct allocation per format operation.

https://claude.ai/code/session_01M6rsokzNFbWJw6gRJWCSo3