### PR TITLE
Refactor error reporting to logger-based ErrorLog with bail support

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -232,8 +232,8 @@ pub async fn compile_with_full_opts(
 
     match result {
         Ok(result) => result.wasm,
-        Err(e) => {
-            eprintln!("{e}");
+        Err(_bail) => {
+            // Errors already printed by host via emit_diagnostic
             process::exit(1);
         }
     }

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -369,7 +369,7 @@ async fn generate_output_params(
     // Dump using async API
     let result = wado_compiler::dump_with_host(&source, &host, Some(input), opt_level)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|_bail| "compilation failed".to_string())?;
 
     let mut output = Vec::new();
 
@@ -432,8 +432,8 @@ async fn run_single(opts: &DumpOptions, input: &str) {
     let result =
         match wado_compiler::dump_with_host(&source, &host, Some(input), opts.opt_level).await {
             Ok(r) => r,
-            Err(e) => {
-                eprintln!("{e}");
+            Err(_bail) => {
+                // Errors already printed by host via emit_diagnostic
                 process::exit(1);
             }
         };

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -6,6 +6,7 @@
 //! 3. Name resolution (binding identifiers to their definitions)
 
 use crate::ast::{Item, Module, UseItem};
+use crate::logger::{Bail, ErrorLog};
 use crate::name::{ModuleSource, resolve_import, validate_module_path};
 use crate::symbol::{
     EffectSymbol, EnumSymbol, FlagsSymbol, FunctionSymbol, GlobalSymbol, NewtypeSymbol,
@@ -102,7 +103,7 @@ pub struct Analyzer {
     /// The symbol table being built
     pub symbols: SymbolTable,
     /// Collected errors
-    errors: Vec<AnalyzeError>,
+    errors: ErrorLog<AnalyzeError>,
     /// Modules loaded implicitly by the compiler (not by user imports)
     implicit_modules: std::collections::HashSet<ModuleSource>,
 }
@@ -112,7 +113,7 @@ impl Analyzer {
     pub fn new() -> Self {
         Self {
             symbols: SymbolTable::new(),
-            errors: Vec::new(),
+            errors: ErrorLog::new(),
             implicit_modules: std::collections::HashSet::new(),
         }
     }
@@ -385,15 +386,22 @@ impl Analyzer {
         }
 
         // Third pass: validate imports in each module
+        let bail = self.validate_all_imports(modules).is_err();
+        if bail {
+            return Err(self.errors.take());
+        }
+
+        self.errors.finish()
+    }
+
+    fn validate_all_imports(
+        &mut self,
+        modules: &std::collections::HashMap<ModuleSource, Module>,
+    ) -> Result<(), Bail> {
         for (source, module) in modules {
             self.validate_imports(module, source, modules)?;
         }
-
-        if self.errors.is_empty() {
-            Ok(())
-        } else {
-            Err(std::mem::take(&mut self.errors))
-        }
+        Ok(())
     }
 
     /// Process pub use declarations (re-exports) in a module
@@ -466,16 +474,16 @@ impl Analyzer {
         module: &Module,
         from_module_source: &ModuleSource,
         all_modules: &std::collections::HashMap<ModuleSource, Module>,
-    ) -> Result<(), Vec<AnalyzeError>> {
+    ) -> Result<(), Bail> {
         for item in &module.items {
             if let Item::Use(use_decl) = item {
                 // Validate the import source
                 if let Err(message) = validate_module_path(&use_decl.source) {
-                    self.errors.push(AnalyzeError::InvalidModulePath {
+                    self.errors.error(AnalyzeError::InvalidModulePath {
                         path: use_decl.source.clone(),
                         message,
                         span: use_decl.span,
-                    });
+                    })?;
                     continue;
                 }
 
@@ -484,10 +492,10 @@ impl Analyzer {
 
                 // Check the module exists in pre-loaded modules
                 if !all_modules.contains_key(&module_source) {
-                    self.errors.push(AnalyzeError::ModuleNotFound {
+                    self.errors.error(AnalyzeError::ModuleNotFound {
                         module_source: module_source.clone(),
                         span: use_decl.span,
-                    });
+                    })?;
                     continue;
                 }
 
@@ -502,11 +510,11 @@ impl Analyzer {
                                 let import_name = alias.as_ref().unwrap_or(name);
                                 self.symbols.register_import(import_name, symbol_id);
                             } else {
-                                self.errors.push(AnalyzeError::ImportNotFound {
+                                self.errors.error(AnalyzeError::ImportNotFound {
                                     module_source: module_source.clone(),
                                     name: name.clone(),
                                     span: use_decl.span,
-                                });
+                                })?;
                             }
                         }
                         UseItem::EffectFunctions {
@@ -523,11 +531,11 @@ impl Analyzer {
                                         func_item.alias.as_ref().unwrap_or(&func_item.name);
                                     self.symbols.register_import(import_name, symbol_id);
                                 } else {
-                                    self.errors.push(AnalyzeError::ImportNotFound {
+                                    self.errors.error(AnalyzeError::ImportNotFound {
                                         module_source: module_source.clone(),
                                         name: lookup_name,
                                         span: use_decl.span,
-                                    });
+                                    })?;
                                 }
                             }
                         }
@@ -535,12 +543,7 @@ impl Analyzer {
                 }
             }
         }
-
-        if self.errors.is_empty() {
-            Ok(())
-        } else {
-            Err(std::mem::take(&mut self.errors))
-        }
+        Ok(())
     }
 
     /// Get a copy of the implicit modules set

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -6,7 +6,8 @@
 //! 3. Name resolution (binding identifiers to their definitions)
 
 use crate::ast::{Item, Module, UseItem};
-use crate::logger::{Bail, ErrorLog};
+use crate::compiler_host::CompilerHost;
+use crate::logger::{Bail, Logger};
 use crate::name::{ModuleSource, resolve_import, validate_module_path};
 use crate::symbol::{
     EffectSymbol, EnumSymbol, FlagsSymbol, FunctionSymbol, GlobalSymbol, NewtypeSymbol,
@@ -96,24 +97,74 @@ impl std::fmt::Display for AnalyzeError {
 
 impl std::error::Error for AnalyzeError {}
 
+impl From<AnalyzeError> for crate::compiler_host::Diagnostic {
+    fn from(e: AnalyzeError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        let (code, message, span) = match &e {
+            AnalyzeError::ModuleNotFound {
+                module_source,
+                span,
+            } => (
+                Code::ModuleNotFound,
+                format!("module not found: '{module_source}'"),
+                *span,
+            ),
+            AnalyzeError::ImportNotFound {
+                module_source,
+                name,
+                span,
+            } => (
+                Code::UndefinedVariable,
+                format!("symbol '{name}' not found in module '{module_source}'"),
+                *span,
+            ),
+            AnalyzeError::DuplicateDefinition { name, span } => (
+                Code::DuplicateDefinition,
+                format!("duplicate definition '{name}'"),
+                *span,
+            ),
+            AnalyzeError::UndefinedSymbol { name, span } => (
+                Code::UndefinedVariable,
+                format!("undefined symbol '{name}'"),
+                *span,
+            ),
+            AnalyzeError::InvalidModulePath {
+                path,
+                message,
+                span,
+            } => (
+                Code::ModuleNotFound,
+                format!("invalid module path '{path}': {message}"),
+                *span,
+            ),
+        };
+        crate::compiler_host::Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span: Some(DiagnosticSpan::from_span(&span, None)),
+        }
+    }
+}
+
 /// Semantic analyzer
 ///
 /// Builds a symbol table from pre-loaded modules and validates imports.
-pub struct Analyzer {
+pub struct Analyzer<'a, H: CompilerHost> {
     /// The symbol table being built
     pub symbols: SymbolTable,
-    /// Collected errors
-    errors: ErrorLog<AnalyzeError>,
+    /// Logger for emitting diagnostics
+    logger: &'a Logger<'a, H>,
     /// Modules loaded implicitly by the compiler (not by user imports)
     implicit_modules: std::collections::HashSet<ModuleSource>,
 }
 
-impl Analyzer {
+impl<'a, H: CompilerHost> Analyzer<'a, H> {
     /// Create a new analyzer
-    pub fn new() -> Self {
+    pub fn new(logger: &'a Logger<'a, H>) -> Self {
         Self {
             symbols: SymbolTable::new(),
-            errors: ErrorLog::new(),
+            logger,
             implicit_modules: std::collections::HashSet::new(),
         }
     }
@@ -372,7 +423,7 @@ impl Analyzer {
         modules: &std::collections::HashMap<ModuleSource, Module>,
         _entry_source: &ModuleSource,
         implicit_modules: std::collections::HashSet<ModuleSource>,
-    ) -> Result<(), Vec<AnalyzeError>> {
+    ) -> Result<(), Bail> {
         self.implicit_modules = implicit_modules;
 
         // First pass: collect definitions from all modules (excluding pub use)
@@ -386,12 +437,9 @@ impl Analyzer {
         }
 
         // Third pass: validate imports in each module
-        let bail = self.validate_all_imports(modules).is_err();
-        if bail {
-            return Err(self.errors.take());
-        }
+        let _ = self.validate_all_imports(modules);
 
-        self.errors.finish()
+        self.logger.ok_or_bail(())
     }
 
     fn validate_all_imports(
@@ -479,7 +527,7 @@ impl Analyzer {
             if let Item::Use(use_decl) = item {
                 // Validate the import source
                 if let Err(message) = validate_module_path(&use_decl.source) {
-                    self.errors.error(AnalyzeError::InvalidModulePath {
+                    self.logger.error(AnalyzeError::InvalidModulePath {
                         path: use_decl.source.clone(),
                         message,
                         span: use_decl.span,
@@ -492,7 +540,7 @@ impl Analyzer {
 
                 // Check the module exists in pre-loaded modules
                 if !all_modules.contains_key(&module_source) {
-                    self.errors.error(AnalyzeError::ModuleNotFound {
+                    self.logger.error(AnalyzeError::ModuleNotFound {
                         module_source: module_source.clone(),
                         span: use_decl.span,
                     })?;
@@ -510,7 +558,7 @@ impl Analyzer {
                                 let import_name = alias.as_ref().unwrap_or(name);
                                 self.symbols.register_import(import_name, symbol_id);
                             } else {
-                                self.errors.error(AnalyzeError::ImportNotFound {
+                                self.logger.error(AnalyzeError::ImportNotFound {
                                     module_source: module_source.clone(),
                                     name: name.clone(),
                                     span: use_decl.span,
@@ -531,7 +579,7 @@ impl Analyzer {
                                         func_item.alias.as_ref().unwrap_or(&func_item.name);
                                     self.symbols.register_import(import_name, symbol_id);
                                 } else {
-                                    self.errors.error(AnalyzeError::ImportNotFound {
+                                    self.logger.error(AnalyzeError::ImportNotFound {
                                         module_source: module_source.clone(),
                                         name: lookup_name,
                                         span: use_decl.span,
@@ -549,11 +597,5 @@ impl Analyzer {
     /// Get a copy of the implicit modules set
     pub fn get_implicit_modules(&self) -> &std::collections::HashSet<ModuleSource> {
         &self.implicit_modules
-    }
-}
-
-impl Default for Analyzer {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -17,7 +17,8 @@ use crate::ast::{
     AssertStmt, Block, ClosureExpr, Condition, Expr, ExprStmt, ForOfStmt, ForStmt, Function,
     IfExpr, IfStmt, Item, LetStmt, LoopStmt, MatchExpr, Module, ReturnStmt, Stmt, WhileStmt,
 };
-use crate::logger::{Bail, ErrorLog};
+use crate::compiler_host::CompilerHost;
+use crate::logger::{Bail, Logger};
 use crate::token::Span;
 
 /// Binding information for a local variable
@@ -100,28 +101,58 @@ impl std::fmt::Display for BindError {
 
 impl std::error::Error for BindError {}
 
+impl From<BindError> for crate::compiler_host::Diagnostic {
+    fn from(e: BindError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        let (code, message, span) = match &e {
+            BindError::UseBeforeDefine { name, used_at } => (
+                Code::UndefinedVariable,
+                format!("'{name}' is not in scope"),
+                *used_at,
+            ),
+            BindError::DuplicateInScope {
+                name,
+                first,
+                second,
+            } => (
+                Code::DuplicateDefinition,
+                format!(
+                    "cannot redeclare '{name}' in the same scope (first defined at {}:{})",
+                    first.line, first.column
+                ),
+                *second,
+            ),
+            BindError::AssignToImmutable { name, span } => (
+                Code::ImmutableAssignment,
+                format!("cannot assign to immutable variable '{name}'"),
+                *span,
+            ),
+        };
+        crate::compiler_host::Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span: Some(DiagnosticSpan::from_span(&span, None)),
+        }
+    }
+}
+
 /// The binder performs local name resolution
-pub struct Binder {
+pub struct Binder<'a, H: CompilerHost> {
     scopes: Vec<Scope>,
-    errors: ErrorLog<BindError>,
+    logger: &'a Logger<'a, H>,
     current_depth: u32,
     /// All local variable names defined in the current function
     /// Used to distinguish "out of scope" errors from "global reference"
     local_names_in_function: HashSet<String>,
 }
 
-impl Default for Binder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Binder {
+impl<'a, H: CompilerHost> Binder<'a, H> {
     /// Create a new binder
-    pub fn new() -> Self {
+    pub fn new(logger: &'a Logger<'a, H>) -> Self {
         Self {
             scopes: vec![Scope::new()], // Global scope
-            errors: ErrorLog::new(),
+            logger,
             current_depth: 0,
             local_names_in_function: HashSet::new(),
         }
@@ -129,13 +160,13 @@ impl Binder {
 
     /// Bind all local names in a module
     ///
-    /// Returns Ok(()) if successful, or Err with all binding errors found.
-    pub fn bind_module(&mut self, module: &Module) -> Result<(), Vec<BindError>> {
+    /// Errors are emitted to the logger. Returns `Err(Bail)` if any errors found.
+    pub fn bind_module(&mut self, module: &Module) -> Result<(), Bail> {
         let bail = self.bind_module_inner(module).is_err();
-        if bail {
-            return Err(self.errors.take());
+        if bail || self.logger.has_errors() {
+            return Err(Bail);
         }
-        self.errors.finish()
+        Ok(())
     }
 
     fn bind_module_inner(&mut self, module: &Module) -> Result<(), Bail> {
@@ -403,7 +434,7 @@ impl Binder {
                     // Unknown names might be global functions/constants - those are
                     // resolved later by the analyzer.
                     if self.local_names_in_function.contains(&ident.name) {
-                        self.errors.error(BindError::UseBeforeDefine {
+                        self.logger.error(BindError::UseBeforeDefine {
                             name: ident.name.clone(),
                             used_at: ident.span,
                         })?;
@@ -417,7 +448,7 @@ impl Binder {
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
                 {
-                    self.errors.error(BindError::AssignToImmutable {
+                    self.logger.error(BindError::AssignToImmutable {
                         name: ident.name.clone(),
                         span: assign.span,
                     })?;
@@ -432,7 +463,7 @@ impl Binder {
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
                 {
-                    self.errors.error(BindError::AssignToImmutable {
+                    self.logger.error(BindError::AssignToImmutable {
                         name: ident.name.clone(),
                         span: compound.span,
                     })?;
@@ -694,7 +725,7 @@ impl Binder {
 
         // Check for duplicate in the same scope
         if let Some(existing) = scope.bindings.get(name) {
-            self.errors.error(BindError::DuplicateInScope {
+            self.logger.error(BindError::DuplicateInScope {
                 name: name.to_string(),
                 first: existing.defined_at,
                 second: span,
@@ -731,14 +762,15 @@ impl Binder {
 }
 
 /// Convenience function to bind a module
-pub fn bind_module(module: &Module) -> Result<(), Vec<BindError>> {
-    let mut binder = Binder::new();
+pub fn bind_module<H: CompilerHost>(module: &Module, logger: &Logger<H>) -> Result<(), Bail> {
+    let mut binder = Binder::new(logger);
     binder.bind_module(module)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler_host::{InMemoryCompilerHost, LogLevel, Severity};
     use crate::lexer::Lexer;
     use crate::parser::Parser;
 
@@ -747,6 +779,13 @@ mod tests {
         let tokens = lexer.tokenize().unwrap();
         let mut parser = Parser::new(tokens);
         parser.parse().unwrap()
+    }
+
+    fn bind_and_check(module: &Module) -> (bool, Vec<crate::compiler_host::Diagnostic>) {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Error);
+        let result = bind_module(module, &logger);
+        (result.is_ok(), host.diagnostics())
     }
 
     #[test]
@@ -759,12 +798,13 @@ mod tests {
             }
         "#,
         );
-        assert!(bind_module(&module).is_ok());
+        let (ok, diags) = bind_and_check(&module);
+        assert!(ok);
+        assert!(diags.is_empty());
     }
 
     #[test]
     fn test_out_of_scope() {
-        // Test that a variable defined in an inner scope is not accessible outside
         let module = parse(
             r#"
             fn run() {
@@ -775,10 +815,11 @@ mod tests {
             }
         "#,
         );
-        let result = bind_module(&module);
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        assert!(matches!(errors[0], BindError::UseBeforeDefine { .. }));
+        let (ok, diags) = bind_and_check(&module);
+        assert!(!ok);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert!(diags[0].message.contains("is not in scope"));
     }
 
     #[test]
@@ -791,15 +832,14 @@ mod tests {
             }
         "#,
         );
-        let result = bind_module(&module);
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        assert!(matches!(errors[0], BindError::DuplicateInScope { .. }));
+        let (ok, diags) = bind_and_check(&module);
+        assert!(!ok);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("cannot redeclare"));
     }
 
     #[test]
     fn test_shadowing_in_nested_scope() {
-        // Shadowing in nested scope is allowed
         let module = parse(
             r#"
             fn run() {
@@ -810,7 +850,9 @@ mod tests {
             }
         "#,
         );
-        assert!(bind_module(&module).is_ok());
+        let (ok, diags) = bind_and_check(&module);
+        assert!(ok);
+        assert!(diags.is_empty());
     }
 
     #[test]
@@ -823,10 +865,10 @@ mod tests {
             }
         "#,
         );
-        let result = bind_module(&module);
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        assert!(matches!(errors[0], BindError::AssignToImmutable { .. }));
+        let (ok, diags) = bind_and_check(&module);
+        assert!(!ok);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("cannot assign to immutable"));
     }
 
     #[test]
@@ -839,6 +881,8 @@ mod tests {
             }
         "#,
         );
-        assert!(bind_module(&module).is_ok());
+        let (ok, diags) = bind_and_check(&module);
+        assert!(ok);
+        assert!(diags.is_empty());
     }
 }

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -17,6 +17,7 @@ use crate::ast::{
     AssertStmt, Block, ClosureExpr, Condition, Expr, ExprStmt, ForOfStmt, ForStmt, Function,
     IfExpr, IfStmt, Item, LetStmt, LoopStmt, MatchExpr, Module, ReturnStmt, Stmt, WhileStmt,
 };
+use crate::logger::{Bail, ErrorLog};
 use crate::token::Span;
 
 /// Binding information for a local variable
@@ -102,7 +103,7 @@ impl std::error::Error for BindError {}
 /// The binder performs local name resolution
 pub struct Binder {
     scopes: Vec<Scope>,
-    errors: Vec<BindError>,
+    errors: ErrorLog<BindError>,
     current_depth: u32,
     /// All local variable names defined in the current function
     /// Used to distinguish "out of scope" errors from "global reference"
@@ -120,7 +121,7 @@ impl Binder {
     pub fn new() -> Self {
         Self {
             scopes: vec![Scope::new()], // Global scope
-            errors: Vec::new(),
+            errors: ErrorLog::new(),
             current_depth: 0,
             local_names_in_function: HashSet::new(),
         }
@@ -130,38 +131,42 @@ impl Binder {
     ///
     /// Returns Ok(()) if successful, or Err with all binding errors found.
     pub fn bind_module(&mut self, module: &Module) -> Result<(), Vec<BindError>> {
-        for item in &module.items {
-            self.bind_item(item);
+        let bail = self.bind_module_inner(module).is_err();
+        if bail {
+            return Err(self.errors.take());
         }
+        self.errors.finish()
+    }
 
-        if self.errors.is_empty() {
-            Ok(())
-        } else {
-            Err(std::mem::take(&mut self.errors))
+    fn bind_module_inner(&mut self, module: &Module) -> Result<(), Bail> {
+        for item in &module.items {
+            self.bind_item(item)?;
         }
+        Ok(())
     }
 
     /// Bind an item (only functions have local scopes)
-    fn bind_item(&mut self, item: &Item) {
+    fn bind_item(&mut self, item: &Item) -> Result<(), Bail> {
         if let Item::Function(func) = item {
-            self.bind_function(func);
+            self.bind_function(func)?;
         }
         // Impl blocks contain functions
         if let Item::Impl(impl_block) = item {
             for method in &impl_block.methods {
-                self.bind_function(method);
+                self.bind_function(method)?;
             }
         }
         // Trait declarations contain method signatures (with optional bodies)
         if let Item::Trait(trait_decl) = item {
             for method in &trait_decl.methods {
-                self.bind_function(method);
+                self.bind_function(method)?;
             }
         }
+        Ok(())
     }
 
     /// Bind a function's local variables
-    fn bind_function(&mut self, func: &Function) {
+    fn bind_function(&mut self, func: &Function) -> Result<(), Bail> {
         // Clear local names for this function
         self.local_names_in_function.clear();
 
@@ -169,53 +174,57 @@ impl Binder {
 
         // Bind parameters as local variables
         for param in &func.params {
-            self.define(&param.name, false, false, param.span);
+            self.define(&param.name, false, false, param.span)?;
         }
 
         // Bind body
         if let Some(ref body) = func.body {
-            self.bind_block_contents(body);
+            self.bind_block_contents(body)?;
         }
 
         self.exit_scope();
+        Ok(())
     }
 
     /// Bind statements in a block (without creating a new scope)
-    fn bind_block_contents(&mut self, block: &Block) {
+    fn bind_block_contents(&mut self, block: &Block) -> Result<(), Bail> {
         for stmt in &block.stmts {
-            self.bind_stmt(stmt);
+            self.bind_stmt(stmt)?;
         }
+        Ok(())
     }
 
     /// Bind a block (creates a new scope)
-    fn bind_block(&mut self, block: &Block) {
+    fn bind_block(&mut self, block: &Block) -> Result<(), Bail> {
         self.enter_scope();
-        self.bind_block_contents(block);
+        self.bind_block_contents(block)?;
         self.exit_scope();
+        Ok(())
     }
 
     /// Bind a statement
-    fn bind_stmt(&mut self, stmt: &Stmt) {
+    fn bind_stmt(&mut self, stmt: &Stmt) -> Result<(), Bail> {
         match stmt {
-            Stmt::Let(let_stmt) => self.bind_let(let_stmt),
-            Stmt::Expr(expr_stmt) => self.bind_expr_stmt(expr_stmt),
-            Stmt::Return(ret_stmt) => self.bind_return(ret_stmt),
-            Stmt::If(if_stmt) => self.bind_if_stmt(if_stmt),
-            Stmt::While(while_stmt) => self.bind_while(while_stmt),
-            Stmt::For(for_stmt) => self.bind_for(for_stmt),
-            Stmt::ForOf(for_of_stmt) => self.bind_for_of(for_of_stmt),
-            Stmt::Loop(loop_stmt) => self.bind_loop(loop_stmt),
+            Stmt::Let(let_stmt) => self.bind_let(let_stmt)?,
+            Stmt::Expr(expr_stmt) => self.bind_expr_stmt(expr_stmt)?,
+            Stmt::Return(ret_stmt) => self.bind_return(ret_stmt)?,
+            Stmt::If(if_stmt) => self.bind_if_stmt(if_stmt)?,
+            Stmt::While(while_stmt) => self.bind_while(while_stmt)?,
+            Stmt::For(for_stmt) => self.bind_for(for_stmt)?,
+            Stmt::ForOf(for_of_stmt) => self.bind_for_of(for_of_stmt)?,
+            Stmt::Loop(loop_stmt) => self.bind_loop(loop_stmt)?,
             Stmt::Break(_) => {}    // No bindings for break
             Stmt::Continue(_) => {} // No bindings for continue
-            Stmt::Assert(assert_stmt) => self.bind_assert(assert_stmt),
-            Stmt::LabeledBlock(labeled_block) => self.bind_block(&labeled_block.block),
+            Stmt::Assert(assert_stmt) => self.bind_assert(assert_stmt)?,
+            Stmt::LabeledBlock(labeled_block) => self.bind_block(&labeled_block.block)?,
         }
+        Ok(())
     }
 
     /// Bind a let statement
-    fn bind_let(&mut self, let_stmt: &LetStmt) {
+    fn bind_let(&mut self, let_stmt: &LetStmt) -> Result<(), Bail> {
         // First bind the value expression (uses variables from outer scope)
-        self.bind_expr(&let_stmt.value);
+        self.bind_expr(&let_stmt.value)?;
 
         // Then define the variables from the pattern
         self.bind_let_pattern(
@@ -223,7 +232,7 @@ impl Binder {
             let_stmt.is_mut,
             let_stmt.is_reactive,
             let_stmt.span,
-        );
+        )
     }
 
     /// Bind a let pattern with mutability and reactivity information
@@ -233,14 +242,14 @@ impl Binder {
         is_mut: bool,
         is_reactive: bool,
         span: Span,
-    ) {
+    ) -> Result<(), Bail> {
         match pattern {
             crate::ast::Pattern::Ident(name) => {
-                self.define(name, is_mut, is_reactive, span);
+                self.define(name, is_mut, is_reactive, span)?;
             }
             crate::ast::Pattern::Tuple(patterns) => {
                 for p in patterns {
-                    self.bind_let_pattern(p, is_mut, is_reactive, span);
+                    self.bind_let_pattern(p, is_mut, is_reactive, span)?;
                 }
             }
             crate::ast::Pattern::Wildcard => {
@@ -251,29 +260,31 @@ impl Binder {
                 // This would be caught by the type checker
             }
         }
+        Ok(())
     }
 
     /// Bind an expression statement
-    fn bind_expr_stmt(&mut self, expr_stmt: &ExprStmt) {
-        self.bind_expr(&expr_stmt.expr);
+    fn bind_expr_stmt(&mut self, expr_stmt: &ExprStmt) -> Result<(), Bail> {
+        self.bind_expr(&expr_stmt.expr)
     }
 
     /// Bind a return statement
-    fn bind_return(&mut self, ret_stmt: &ReturnStmt) {
+    fn bind_return(&mut self, ret_stmt: &ReturnStmt) -> Result<(), Bail> {
         if let Some(ref value) = ret_stmt.value {
-            self.bind_expr(value);
+            self.bind_expr(value)?;
         }
+        Ok(())
     }
 
     /// Bind an if statement
-    fn bind_if_stmt(&mut self, if_stmt: &IfStmt) {
+    fn bind_if_stmt(&mut self, if_stmt: &IfStmt) -> Result<(), Bail> {
         // Handle optional init binding (scoped to this if statement)
         if if_stmt.init.is_some() {
             self.enter_scope();
         }
 
         if let Some(init) = &if_stmt.init {
-            self.bind_let(init);
+            self.bind_let(init)?;
         }
 
         // For pattern conditions, enter scope before the condition so pattern bindings
@@ -283,24 +294,25 @@ impl Binder {
             self.enter_scope();
         }
 
-        self.bind_condition(&if_stmt.condition);
-        self.bind_block(&if_stmt.then_block);
+        self.bind_condition(&if_stmt.condition)?;
+        self.bind_block(&if_stmt.then_block)?;
 
         if is_pattern {
             self.exit_scope();
         }
 
         if let Some(ref else_block) = if_stmt.else_block {
-            self.bind_block(else_block);
+            self.bind_block(else_block)?;
         }
 
         if if_stmt.init.is_some() {
             self.exit_scope();
         }
+        Ok(())
     }
 
     /// Bind a while statement
-    fn bind_while(&mut self, while_stmt: &WhileStmt) {
+    fn bind_while(&mut self, while_stmt: &WhileStmt) -> Result<(), Bail> {
         // For pattern conditions, enter scope before the condition so pattern bindings
         // are visible in the body
         let is_pattern = matches!(while_stmt.condition, Condition::Pattern { .. });
@@ -308,43 +320,45 @@ impl Binder {
             self.enter_scope();
         }
 
-        self.bind_condition(&while_stmt.condition);
-        self.bind_block(&while_stmt.body);
+        self.bind_condition(&while_stmt.condition)?;
+        self.bind_block(&while_stmt.body)?;
 
         if is_pattern {
             self.exit_scope();
         }
+        Ok(())
     }
 
     /// Bind a for statement
-    fn bind_for(&mut self, for_stmt: &ForStmt) {
+    fn bind_for(&mut self, for_stmt: &ForStmt) -> Result<(), Bail> {
         self.enter_scope();
 
         // Bind init statement
         if let Some(ref init) = for_stmt.init {
-            self.bind_stmt(init);
+            self.bind_stmt(init)?;
         }
 
         // Bind condition (may be pattern or expression)
         if let Some(ref condition) = for_stmt.condition {
-            self.bind_condition(condition);
+            self.bind_condition(condition)?;
         }
 
         // Bind update
         if let Some(ref update) = for_stmt.update {
-            self.bind_expr(update);
+            self.bind_expr(update)?;
         }
 
         // Bind body
-        self.bind_block(&for_stmt.body);
+        self.bind_block(&for_stmt.body)?;
 
         self.exit_scope();
+        Ok(())
     }
 
     /// Bind a for-of statement: `for let item of array { ... }`
-    fn bind_for_of(&mut self, for_of_stmt: &ForOfStmt) {
+    fn bind_for_of(&mut self, for_of_stmt: &ForOfStmt) -> Result<(), Bail> {
         // First bind the iterable expression (uses variables from outer scope)
-        self.bind_expr(&for_of_stmt.iterable);
+        self.bind_expr(&for_of_stmt.iterable)?;
 
         // Enter a new scope for the loop binding and body
         self.enter_scope();
@@ -355,29 +369,31 @@ impl Binder {
             for_of_stmt.is_mut,
             false, // not reactive
             for_of_stmt.span,
-        );
+        )?;
 
         // Bind body
-        self.bind_block(&for_of_stmt.body);
+        self.bind_block(&for_of_stmt.body)?;
 
         self.exit_scope();
+        Ok(())
     }
 
     /// Bind a loop statement
-    fn bind_loop(&mut self, loop_stmt: &LoopStmt) {
-        self.bind_block(&loop_stmt.body);
+    fn bind_loop(&mut self, loop_stmt: &LoopStmt) -> Result<(), Bail> {
+        self.bind_block(&loop_stmt.body)
     }
 
     /// Bind an assert statement
-    fn bind_assert(&mut self, assert_stmt: &AssertStmt) {
-        self.bind_expr(&assert_stmt.condition);
+    fn bind_assert(&mut self, assert_stmt: &AssertStmt) -> Result<(), Bail> {
+        self.bind_expr(&assert_stmt.condition)?;
         if let Some(ref message) = assert_stmt.message {
-            self.bind_expr(message);
+            self.bind_expr(message)?;
         }
+        Ok(())
     }
 
     /// Bind an expression
-    fn bind_expr(&mut self, expr: &Expr) {
+    fn bind_expr(&mut self, expr: &Expr) -> Result<(), Bail> {
         match expr {
             Expr::Ident(ident) => {
                 // Check if the identifier is defined in any scope
@@ -387,10 +403,10 @@ impl Binder {
                     // Unknown names might be global functions/constants - those are
                     // resolved later by the analyzer.
                     if self.local_names_in_function.contains(&ident.name) {
-                        self.errors.push(BindError::UseBeforeDefine {
+                        self.errors.error(BindError::UseBeforeDefine {
                             name: ident.name.clone(),
                             used_at: ident.span,
-                        });
+                        })?;
                     }
                 }
             }
@@ -401,13 +417,13 @@ impl Binder {
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
                 {
-                    self.errors.push(BindError::AssignToImmutable {
+                    self.errors.error(BindError::AssignToImmutable {
                         name: ident.name.clone(),
                         span: assign.span,
-                    });
+                    })?;
                 }
-                self.bind_expr(&assign.target);
-                self.bind_expr(&assign.value);
+                self.bind_expr(&assign.target)?;
+                self.bind_expr(&assign.value)?;
             }
 
             Expr::CompoundAssign(compound) => {
@@ -416,118 +432,118 @@ impl Binder {
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
                 {
-                    self.errors.push(BindError::AssignToImmutable {
+                    self.errors.error(BindError::AssignToImmutable {
                         name: ident.name.clone(),
                         span: compound.span,
-                    });
+                    })?;
                 }
-                self.bind_expr(&compound.target);
-                self.bind_expr(&compound.value);
+                self.bind_expr(&compound.target)?;
+                self.bind_expr(&compound.value)?;
             }
 
             Expr::Binary(binary) => {
-                self.bind_expr(&binary.left);
-                self.bind_expr(&binary.right);
+                self.bind_expr(&binary.left)?;
+                self.bind_expr(&binary.right)?;
             }
 
             Expr::Unary(unary) => {
-                self.bind_expr(&unary.expr);
+                self.bind_expr(&unary.expr)?;
             }
 
             Expr::Call(call) => {
-                self.bind_expr(&call.callee);
+                self.bind_expr(&call.callee)?;
                 for arg in &call.args {
-                    self.bind_expr(arg);
+                    self.bind_expr(arg)?;
                 }
             }
 
             Expr::MethodCall(method_call) => {
-                self.bind_expr(&method_call.receiver);
+                self.bind_expr(&method_call.receiver)?;
                 for arg in &method_call.args {
-                    self.bind_expr(arg);
+                    self.bind_expr(arg)?;
                 }
             }
 
             Expr::StaticMethodCall(static_call) => {
                 for arg in &static_call.args {
-                    self.bind_expr(arg);
+                    self.bind_expr(arg)?;
                 }
             }
 
             Expr::FieldAccess(field_access) => {
-                self.bind_expr(&field_access.expr);
+                self.bind_expr(&field_access.expr)?;
             }
 
             Expr::Index(index) => {
-                self.bind_expr(&index.expr);
-                self.bind_expr(&index.index);
+                self.bind_expr(&index.expr)?;
+                self.bind_expr(&index.index)?;
             }
 
             Expr::Block(block) => {
-                self.bind_block(block);
+                self.bind_block(block)?;
             }
 
             Expr::If(if_expr) => {
-                self.bind_if_expr(if_expr);
+                self.bind_if_expr(if_expr)?;
             }
 
             Expr::Match(match_expr) => {
-                self.bind_match_expr(match_expr);
+                self.bind_match_expr(match_expr)?;
             }
 
             Expr::Closure(closure) => {
-                self.bind_closure(closure);
+                self.bind_closure(closure)?;
             }
 
             Expr::TemplateString(template) => {
                 for part in &template.parts {
                     if let crate::ast::TemplatePart::Interpolation { expr, .. } = part {
-                        self.bind_expr(expr);
+                        self.bind_expr(expr)?;
                     }
                 }
             }
 
             Expr::Cast(cast) => {
-                self.bind_expr(&cast.expr);
+                self.bind_expr(&cast.expr)?;
             }
 
             Expr::StructLiteral(struct_lit) => {
                 for field in &struct_lit.fields {
-                    self.bind_expr(&field.value);
+                    self.bind_expr(&field.value)?;
                 }
             }
 
             Expr::ComparisonChain(chain) => {
-                self.bind_expr(&chain.first);
+                self.bind_expr(&chain.first)?;
                 for comparison in &chain.comparisons {
-                    self.bind_expr(&comparison.right);
+                    self.bind_expr(&comparison.right)?;
                 }
             }
 
             Expr::TupleLiteral(tuple_lit) => {
                 for element in &tuple_lit.elements {
-                    self.bind_expr(element);
+                    self.bind_expr(element)?;
                 }
             }
 
             Expr::LabeledBlock(lb) => {
                 // Labeled block expression creates a new scope for its block
                 self.enter_scope();
-                self.bind_block(&lb.block);
+                self.bind_block(&lb.block)?;
                 self.exit_scope();
             }
 
             Expr::Matches(matches_expr) => {
                 // Bind the scrutinee expression
-                self.bind_expr(&matches_expr.expr);
+                self.bind_expr(&matches_expr.expr)?;
                 // Pattern bindings are scoped to the matches expression only
                 // (specifically, they're only visible in the guard if present)
                 // Always enter a scope and bind pattern to track variable names,
                 // so we can detect "use after scope exit" errors
                 self.enter_scope();
-                self.bind_pattern(&matches_expr.pattern, matches_expr.span);
+                self.bind_pattern(&matches_expr.pattern, matches_expr.span)?;
                 if let Some(guard) = &matches_expr.guard {
-                    self.bind_expr(guard);
+                    self.bind_expr(guard)?;
                 }
                 self.exit_scope();
             }
@@ -535,17 +551,18 @@ impl Binder {
             // Literals don't reference variables
             Expr::Literal(_) => {}
         }
+        Ok(())
     }
 
     /// Bind an if expression
-    fn bind_if_expr(&mut self, if_expr: &IfExpr) {
+    fn bind_if_expr(&mut self, if_expr: &IfExpr) -> Result<(), Bail> {
         // Handle optional init binding (scoped to this if expression)
         if if_expr.init.is_some() {
             self.enter_scope();
         }
 
         if let Some(init) = &if_expr.init {
-            self.bind_let(init);
+            self.bind_let(init)?;
         }
 
         // For pattern conditions, enter scope before the condition so pattern bindings
@@ -555,66 +572,69 @@ impl Binder {
             self.enter_scope();
         }
 
-        self.bind_condition(&if_expr.condition);
-        self.bind_block(&if_expr.then_block);
+        self.bind_condition(&if_expr.condition)?;
+        self.bind_block(&if_expr.then_block)?;
 
         if is_pattern {
             self.exit_scope();
         }
 
         if let Some(ref else_block) = if_expr.else_block {
-            self.bind_block(else_block);
+            self.bind_block(else_block)?;
         }
 
         if if_expr.init.is_some() {
             self.exit_scope();
         }
+        Ok(())
     }
 
     /// Bind an if condition (expression or pattern match)
-    fn bind_condition(&mut self, condition: &Condition) {
+    fn bind_condition(&mut self, condition: &Condition) -> Result<(), Bail> {
         match condition {
             Condition::Expr(expr) => {
-                self.bind_expr(expr);
+                self.bind_expr(expr)?;
             }
             Condition::Pattern { pattern, expr, .. } => {
                 // First bind the expression being matched
-                self.bind_expr(expr);
+                self.bind_expr(expr)?;
                 // Then bind the pattern (introduces variables)
                 // Note: pattern variables are scoped to the then-block
                 // This is handled by the caller entering/exiting scope
-                self.bind_pattern(pattern, expr.span());
+                self.bind_pattern(pattern, expr.span())?;
             }
         }
+        Ok(())
     }
 
     /// Bind a match expression
-    fn bind_match_expr(&mut self, match_expr: &MatchExpr) {
-        self.bind_expr(&match_expr.expr);
+    fn bind_match_expr(&mut self, match_expr: &MatchExpr) -> Result<(), Bail> {
+        self.bind_expr(&match_expr.expr)?;
         for arm in &match_expr.arms {
             self.enter_scope();
             // Bind pattern (introduces variables)
-            self.bind_pattern(&arm.pattern, arm.span);
+            self.bind_pattern(&arm.pattern, arm.span)?;
             // Bind optional guard
             if let Some(guard) = &arm.guard {
-                self.bind_expr(guard);
+                self.bind_expr(guard)?;
             }
             // Bind arm body
-            self.bind_expr(&arm.body);
+            self.bind_expr(&arm.body)?;
             self.exit_scope();
         }
+        Ok(())
     }
 
     /// Bind a pattern (may introduce variables)
-    fn bind_pattern(&mut self, pattern: &crate::ast::Pattern, span: Span) {
+    fn bind_pattern(&mut self, pattern: &crate::ast::Pattern, span: Span) -> Result<(), Bail> {
         match pattern {
             crate::ast::Pattern::Ident(name) => {
                 // Pattern bindings are immutable by default
-                self.define(name, false, false, span);
+                self.define(name, false, false, span)?;
             }
             crate::ast::Pattern::Tuple(patterns) => {
                 for p in patterns {
-                    self.bind_pattern(p, span);
+                    self.bind_pattern(p, span)?;
                 }
             }
             crate::ast::Pattern::Variant {
@@ -624,28 +644,30 @@ impl Binder {
             } => {
                 // Bind nested patterns in variant
                 for p in bindings {
-                    self.bind_pattern(p, *variant_span);
+                    self.bind_pattern(p, *variant_span)?;
                 }
             }
             crate::ast::Pattern::Literal(_) | crate::ast::Pattern::Wildcard => {
                 // No variables introduced
             }
         }
+        Ok(())
     }
 
     /// Bind a closure
-    fn bind_closure(&mut self, closure: &ClosureExpr) {
+    fn bind_closure(&mut self, closure: &ClosureExpr) -> Result<(), Bail> {
         self.enter_scope();
 
         // Bind parameters
         for param in &closure.params {
-            self.define(&param.name, false, false, closure.span);
+            self.define(&param.name, false, false, closure.span)?;
         }
 
         // Bind body
-        self.bind_expr(&closure.body);
+        self.bind_expr(&closure.body)?;
 
         self.exit_scope();
+        Ok(())
     }
 
     /// Enter a new scope
@@ -661,17 +683,23 @@ impl Binder {
     }
 
     /// Define a variable in the current scope
-    fn define(&mut self, name: &str, is_mut: bool, is_reactive: bool, span: Span) {
+    fn define(
+        &mut self,
+        name: &str,
+        is_mut: bool,
+        is_reactive: bool,
+        span: Span,
+    ) -> Result<(), Bail> {
         let scope = self.scopes.last_mut().unwrap();
 
         // Check for duplicate in the same scope
         if let Some(existing) = scope.bindings.get(name) {
-            self.errors.push(BindError::DuplicateInScope {
+            self.errors.error(BindError::DuplicateInScope {
                 name: name.to_string(),
                 first: existing.defined_at,
                 second: span,
-            });
-            return;
+            })?;
+            return Ok(());
         }
 
         // Track this name as a local variable in the current function
@@ -687,6 +715,7 @@ impl Binder {
                 scope_depth: self.current_depth,
             },
         );
+        Ok(())
     }
 
     /// Look up a variable by name (searches all scopes)

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -31,6 +31,8 @@ pub enum LogLevel {
 /// Severity level for diagnostics
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
+    /// Fatal error (immediately stops compilation, e.g., too many errors)
+    Fatal,
     /// Compilation error (prevents successful compilation)
     Error,
     /// Warning (compilation continues but may indicate issues)
@@ -44,6 +46,7 @@ pub enum Severity {
 impl std::fmt::Display for Severity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Severity::Fatal => write!(f, "fatal"),
             Severity::Error => write!(f, "error"),
             Severity::Warning => write!(f, "warning"),
             Severity::Info => write!(f, "info"),

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -11,7 +11,8 @@ use std::collections::HashSet;
 
 use indexmap::IndexMap;
 
-use crate::logger::{Bail, ErrorLog};
+use crate::compiler_host::CompilerHost;
+use crate::logger::{Bail, Logger};
 use crate::name::ModuleSource;
 use crate::tir::{
     FunctionRef, TirBlock, TirExpr, TirExprKind, TirFunction, TirModule, TirStmt, TirStmtKind,
@@ -41,29 +42,47 @@ impl std::fmt::Display for EffectError {
 
 impl std::error::Error for EffectError {}
 
+impl From<EffectError> for crate::compiler_host::Diagnostic {
+    fn from(e: EffectError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        crate::compiler_host::Diagnostic {
+            severity: Severity::Error,
+            code: Code::TypeMismatch,
+            message: format!(
+                "missing effect '{}' required by '{}'",
+                e.missing_effect, e.callee
+            ),
+            span: Some(DiagnosticSpan::from_span(&e.span, None)),
+        }
+    }
+}
+
 /// Check effects for all modules
 ///
-/// Returns a list of effect errors. If empty, all effect requirements are satisfied.
-pub fn check_effects(modules: &IndexMap<ModuleSource, TirModule>) -> Vec<EffectError> {
-    let mut checker = EffectChecker::new(modules);
-    // Ignore Bail - just return whatever errors were collected
+/// Errors are emitted to the logger. Returns `Err(Bail)` if any errors found.
+pub fn check_effects<H: CompilerHost>(
+    modules: &IndexMap<ModuleSource, TirModule>,
+    logger: &Logger<H>,
+) -> Result<(), Bail> {
+    let mut checker = EffectChecker::new(modules, logger);
+    // Ignore Bail from limit - just check if there were any errors
     let _ = checker.check_all();
-    checker.errors.take()
+    logger.ok_or_bail(())
 }
 
 /// Effect checker that walks TIR and validates effect requirements
-struct EffectChecker<'a> {
+struct EffectChecker<'a, H: CompilerHost> {
     modules: &'a IndexMap<ModuleSource, TirModule>,
-    errors: ErrorLog<EffectError>,
+    logger: &'a Logger<'a, H>,
     /// Current function's effects (set when entering a function)
     current_effects: HashSet<String>,
 }
 
-impl<'a> EffectChecker<'a> {
-    fn new(modules: &'a IndexMap<ModuleSource, TirModule>) -> Self {
+impl<'a, H: CompilerHost> EffectChecker<'a, H> {
+    fn new(modules: &'a IndexMap<ModuleSource, TirModule>, logger: &'a Logger<'a, H>) -> Self {
         Self {
             modules,
-            errors: ErrorLog::new(),
+            logger,
             current_effects: HashSet::new(),
         }
     }
@@ -204,7 +223,7 @@ impl<'a> EffectChecker<'a> {
             } => {
                 // Effect calls require the effect
                 if !self.current_effects.contains(effect_name) {
-                    self.errors.error(EffectError {
+                    self.logger.error(EffectError {
                         callee: effect_name.clone(),
                         missing_effect: effect_name.clone(),
                         span: expr.span,
@@ -348,7 +367,7 @@ impl<'a> EffectChecker<'a> {
 
         for effect in &callee_effects {
             if !self.current_effects.contains(effect) {
-                self.errors.error(EffectError {
+                self.logger.error(EffectError {
                     callee: func_ref.name(),
                     missing_effect: effect.clone(),
                     span,

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 
 use indexmap::IndexMap;
 
+use crate::logger::{Bail, ErrorLog};
 use crate::name::ModuleSource;
 use crate::tir::{
     FunctionRef, TirBlock, TirExpr, TirExprKind, TirFunction, TirModule, TirStmt, TirStmtKind,
@@ -45,14 +46,15 @@ impl std::error::Error for EffectError {}
 /// Returns a list of effect errors. If empty, all effect requirements are satisfied.
 pub fn check_effects(modules: &IndexMap<ModuleSource, TirModule>) -> Vec<EffectError> {
     let mut checker = EffectChecker::new(modules);
-    checker.check_all();
-    checker.errors
+    // Ignore Bail - just return whatever errors were collected
+    let _ = checker.check_all();
+    checker.errors.take()
 }
 
 /// Effect checker that walks TIR and validates effect requirements
 struct EffectChecker<'a> {
     modules: &'a IndexMap<ModuleSource, TirModule>,
-    errors: Vec<EffectError>,
+    errors: ErrorLog<EffectError>,
     /// Current function's effects (set when entering a function)
     current_effects: HashSet<String>,
 }
@@ -61,39 +63,41 @@ impl<'a> EffectChecker<'a> {
     fn new(modules: &'a IndexMap<ModuleSource, TirModule>) -> Self {
         Self {
             modules,
-            errors: Vec::new(),
+            errors: ErrorLog::new(),
             current_effects: HashSet::new(),
         }
     }
 
     /// Check all modules
-    fn check_all(&mut self) {
+    fn check_all(&mut self) -> Result<(), Bail> {
         for module in self.modules.values() {
-            self.check_module(module);
+            self.check_module(module)?;
         }
+        Ok(())
     }
 
     /// Check a single module
-    fn check_module(&mut self, module: &TirModule) {
+    fn check_module(&mut self, module: &TirModule) -> Result<(), Bail> {
         // Check all functions
         for func_rc in &module.functions {
             let func = func_rc.borrow();
-            self.check_function(&func);
+            self.check_function(&func)?;
         }
 
         // Check impl methods
         for impl_block in &module.impls {
             for method in &impl_block.methods {
-                self.check_function(method);
+                self.check_function(method)?;
             }
         }
+        Ok(())
     }
 
     /// Check a single function
-    fn check_function(&mut self, func: &TirFunction) {
+    fn check_function(&mut self, func: &TirFunction) -> Result<(), Bail> {
         // Skip test functions - they implicitly have all effects
         if func.name.starts_with("__test_") {
-            return;
+            return Ok(());
         }
 
         // Set current context
@@ -101,27 +105,29 @@ impl<'a> EffectChecker<'a> {
 
         // Check the body if present
         if let Some(body) = &func.body {
-            self.check_block(body);
+            self.check_block(body)?;
         }
+        Ok(())
     }
 
     /// Check a block
-    fn check_block(&mut self, block: &TirBlock) {
+    fn check_block(&mut self, block: &TirBlock) -> Result<(), Bail> {
         for stmt in &block.stmts {
-            self.check_stmt(stmt);
+            self.check_stmt(stmt)?;
         }
+        Ok(())
     }
 
     /// Check a statement
-    fn check_stmt(&mut self, stmt: &TirStmt) {
+    fn check_stmt(&mut self, stmt: &TirStmt) -> Result<(), Bail> {
         match &stmt.kind {
             TirStmtKind::Let { value, .. } => {
-                self.check_expr(value);
+                self.check_expr(value)?;
             }
-            TirStmtKind::Expr(expr) => self.check_expr(expr),
+            TirStmtKind::Expr(expr) => self.check_expr(expr)?,
             TirStmtKind::Return { value } => {
                 if let Some(e) = value {
-                    self.check_expr(e);
+                    self.check_expr(e)?;
                 }
             }
             TirStmtKind::If {
@@ -129,23 +135,23 @@ impl<'a> EffectChecker<'a> {
                 then_block,
                 else_block,
             } => {
-                self.check_expr(condition);
-                self.check_block(then_block);
+                self.check_expr(condition)?;
+                self.check_block(then_block)?;
                 if let Some(else_blk) = else_block {
-                    self.check_block(else_blk);
+                    self.check_block(else_blk)?;
                 }
             }
             TirStmtKind::Loop { body } => {
-                self.check_block(body);
+                self.check_block(body)?;
             }
             TirStmtKind::Break { value, .. } => {
                 if let Some(expr) = value {
-                    self.check_expr(expr);
+                    self.check_expr(expr)?;
                 }
             }
             TirStmtKind::Continue => {}
             TirStmtKind::LabeledBlock { block, .. } => {
-                self.check_block(block);
+                self.check_block(block)?;
             }
             TirStmtKind::IfPattern {
                 scrutinee,
@@ -153,25 +159,26 @@ impl<'a> EffectChecker<'a> {
                 else_block,
                 ..
             } => {
-                self.check_expr(scrutinee);
-                self.check_block(then_block);
+                self.check_expr(scrutinee)?;
+                self.check_block(then_block)?;
                 if let Some(else_blk) = else_block {
-                    self.check_block(else_blk);
+                    self.check_block(else_blk)?;
                 }
             }
             TirStmtKind::LetPattern { value, .. } => {
-                self.check_expr(value);
+                self.check_expr(value)?;
             }
         }
+        Ok(())
     }
 
     /// Check an expression for effect violations
-    fn check_expr(&mut self, expr: &TirExpr) {
+    fn check_expr(&mut self, expr: &TirExpr) -> Result<(), Bail> {
         match &expr.kind {
             TirExprKind::Call { func, args, .. } => {
-                self.check_call(func, expr.span);
+                self.check_call(func, expr.span)?;
                 for arg in args {
-                    self.check_expr(arg);
+                    self.check_expr(arg)?;
                 }
             }
             TirExprKind::MethodCall {
@@ -180,16 +187,16 @@ impl<'a> EffectChecker<'a> {
                 args,
                 ..
             } => {
-                self.check_expr(receiver);
-                self.check_call(func, expr.span);
+                self.check_expr(receiver)?;
+                self.check_call(func, expr.span)?;
                 for arg in args {
-                    self.check_expr(arg);
+                    self.check_expr(arg)?;
                 }
             }
             TirExprKind::StaticCall { func, args } => {
-                self.check_call(func, expr.span);
+                self.check_call(func, expr.span)?;
                 for arg in args {
-                    self.check_expr(arg);
+                    self.check_expr(arg)?;
                 }
             }
             TirExprKind::EffectCall {
@@ -197,114 +204,114 @@ impl<'a> EffectChecker<'a> {
             } => {
                 // Effect calls require the effect
                 if !self.current_effects.contains(effect_name) {
-                    self.errors.push(EffectError {
+                    self.errors.error(EffectError {
                         callee: effect_name.clone(),
                         missing_effect: effect_name.clone(),
                         span: expr.span,
-                    });
+                    })?;
                 }
                 for arg in args {
-                    self.check_expr(arg);
+                    self.check_expr(arg)?;
                 }
             }
             TirExprKind::IndirectCall { callee, args } => {
-                self.check_expr(callee);
+                self.check_expr(callee)?;
                 for arg in args {
-                    self.check_expr(arg);
+                    self.check_expr(arg)?;
                 }
                 // TODO: Check closure effects when we have effect types on closures
             }
             TirExprKind::ClosureToCanonical { functor, .. } => {
-                self.check_expr(functor);
+                self.check_expr(functor)?;
             }
             TirExprKind::Binary { left, right, .. } => {
-                self.check_expr(left);
-                self.check_expr(right);
+                self.check_expr(left)?;
+                self.check_expr(right)?;
             }
             TirExprKind::Unary { expr, .. } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
             }
             TirExprKind::Assign { target, value } => {
-                self.check_expr(target);
-                self.check_expr(value);
+                self.check_expr(target)?;
+                self.check_expr(value)?;
             }
             TirExprKind::Cast { expr, .. } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
             }
             TirExprKind::FieldAccess { expr, .. } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
             }
             TirExprKind::Index { expr, index } => {
-                self.check_expr(expr);
-                self.check_expr(index);
+                self.check_expr(expr)?;
+                self.check_expr(index)?;
             }
             TirExprKind::Block(block) => {
-                self.check_block(block);
+                self.check_block(block)?;
             }
             TirExprKind::If {
                 condition,
                 then_branch,
                 else_branch,
             } => {
-                self.check_expr(condition);
-                self.check_block(then_branch);
+                self.check_expr(condition)?;
+                self.check_block(then_branch)?;
                 if let Some(else_blk) = else_branch {
-                    self.check_block(else_blk);
+                    self.check_block(else_blk)?;
                 }
             }
             TirExprKind::Match { expr, arms } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
                 for arm in arms {
                     if let Some(guard) = &arm.guard {
-                        self.check_expr(guard);
+                        self.check_expr(guard)?;
                     }
-                    self.check_expr(&arm.body);
+                    self.check_expr(&arm.body)?;
                 }
             }
             TirExprKind::StructLiteral { fields, .. } => {
                 for field in fields {
-                    self.check_expr(&field.value);
+                    self.check_expr(&field.value)?;
                 }
             }
             TirExprKind::TupleLiteral { elements } => {
                 for elem in elements {
-                    self.check_expr(elem);
+                    self.check_expr(elem)?;
                 }
             }
             TirExprKind::ArrayLiteral { elements } => {
                 for elem in elements {
-                    self.check_expr(elem);
+                    self.check_expr(elem)?;
                 }
             }
             TirExprKind::Closure { body, .. } => {
                 // Closures inherit effects from enclosing function, so we continue checking
-                self.check_expr(body);
+                self.check_expr(body)?;
             }
             TirExprKind::VariantConstruct { payload, .. } => {
                 if let Some(payload_expr) = payload {
-                    self.check_expr(payload_expr);
+                    self.check_expr(payload_expr)?;
                 }
             }
             TirExprKind::OptionSome { value } => {
-                self.check_expr(value);
+                self.check_expr(value)?;
             }
             TirExprKind::Move { expr } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
             }
             TirExprKind::LabeledBlock { block, .. } => {
-                self.check_block(block);
+                self.check_block(block)?;
             }
             TirExprKind::GlobalVarSet { value, .. } => {
-                self.check_expr(value);
+                self.check_expr(value)?;
             }
             TirExprKind::IsNotNull { expr }
             | TirExprKind::UnwrapOption { expr, .. }
             | TirExprKind::VariantTag { expr }
             | TirExprKind::VariantTest { expr, .. } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
             }
             TirExprKind::VariantPayload { expr, .. } => {
-                self.check_expr(expr);
+                self.check_expr(expr)?;
             }
             TirExprKind::Switch {
                 scrutinee,
@@ -312,11 +319,11 @@ impl<'a> EffectChecker<'a> {
                 default,
                 ..
             } => {
-                self.check_expr(scrutinee);
+                self.check_expr(scrutinee)?;
                 for arm in arms {
-                    self.check_block(arm);
+                    self.check_block(arm)?;
                 }
-                self.check_block(default);
+                self.check_block(default)?;
             }
             // Leaf expressions - no sub-expressions to check
             TirExprKind::IntLiteral { .. }
@@ -332,21 +339,23 @@ impl<'a> EffectChecker<'a> {
             | TirExprKind::Capture { .. }
             | TirExprKind::EnumConstruct { .. } => {}
         }
+        Ok(())
     }
 
     /// Check a function call for effect violations
-    fn check_call(&mut self, func_ref: &FunctionRef, span: Span) {
+    fn check_call(&mut self, func_ref: &FunctionRef, span: Span) -> Result<(), Bail> {
         let callee_effects = self.get_function_effects(func_ref);
 
         for effect in &callee_effects {
             if !self.current_effects.contains(effect) {
-                self.errors.push(EffectError {
+                self.errors.error(EffectError {
                     callee: func_ref.name(),
                     missing_effect: effect.clone(),
                     span,
-                });
+                })?;
             }
         }
+        Ok(())
     }
 
     /// Get the effects required by a function

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -35,6 +35,18 @@ pub struct LexError {
     pub span: Span,
 }
 
+impl From<LexError> for crate::compiler_host::Diagnostic {
+    fn from(e: LexError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        Self {
+            severity: Severity::Error,
+            code: Code::InvalidSyntax,
+            message: format!("lexer error: {}", e.message),
+            span: Some(DiagnosticSpan::from_span(&e.span, None)),
+        }
+    }
+}
+
 impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
         Self {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -115,7 +115,7 @@ pub use codegen::Codegen;
 pub use compiler_host::{
     Code, CompilerHost, Diagnostic, DiagnosticSpan, LogLevel, Severity, SourceError,
 };
-pub use logger::Logger;
+pub use logger::{Bail, ErrorLog, Logger};
 
 #[cfg(test)]
 pub use compiler_host::InMemoryCompilerHost;

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -115,7 +115,7 @@ pub use codegen::Codegen;
 pub use compiler_host::{
     Code, CompilerHost, Diagnostic, DiagnosticSpan, LogLevel, Severity, SourceError,
 };
-pub use logger::{Bail, ErrorLog, Logger};
+pub use logger::{Bail, Logger};
 
 #[cfg(test)]
 pub use compiler_host::InMemoryCompilerHost;
@@ -205,7 +205,7 @@ pub async fn compile_with_host<H: CompilerHost>(
     host: &H,
     filename: Option<&str>,
     opt_level: OptLevel,
-) -> Result<CompileResult, CompileError> {
+) -> Result<CompileResult, Bail> {
     let options = CompilerOptions {
         opt_level,
         target_world: None,
@@ -260,16 +260,18 @@ pub async fn compile_with_options<H: CompilerHost>(
     host: &H,
     filename: Option<&str>,
     options: CompilerOptions,
-) -> Result<CompileResult, CompileError> {
+) -> Result<CompileResult, Bail> {
+    let logger = Logger::new(host, compiler_host::LogLevel::default());
     let filename = filename.map(String::from);
+    if let Some(ref f) = filename {
+        logger.set_file(f);
+    }
 
     // === Phase 1: Lexer (for original AST) ===
     let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| CompileError::Lexer {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: filename.clone(),
+    let tokens = lexer.tokenize().map_err(|e| {
+        let _ = logger.error(e);
+        Bail
     })?;
     let (data_section, _comments, shebang) = lexer.into_parts();
 
@@ -277,11 +279,9 @@ pub async fn compile_with_options<H: CompilerHost>(
     // Note: The AST is parsed here for early error detection, but the Loader
     // will re-parse the entry module along with all dependencies.
     let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-    let ast = parser.parse().map_err(|e| CompileError::Parser {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: filename.clone(),
+    let ast = parser.parse().map_err(|e| {
+        let _ = logger.error(e);
+        Bail
     })?;
 
     // Note: Bind phase moved to Loader for all modules (including entry module)
@@ -293,31 +293,24 @@ pub async fn compile_with_options<H: CompilerHost>(
         module_loader
             .load_all(source, filename.as_deref())
             .await
-            .map_err(|e| CompileError::Analyzer {
-                message: e.to_string(),
-                filename: filename.clone(),
+            .map_err(|e| {
+                let _ = logger.error(compiler_host::Diagnostic {
+                    severity: compiler_host::Severity::Error,
+                    code: compiler_host::Code::ModuleNotFound,
+                    message: e.to_string(),
+                    span: None,
+                });
+                Bail
             })?
     };
 
     // === Phase 5: Analyze all modules ===
-    let mut analyzer = Analyzer::new();
-    analyzer
-        .analyze_loaded_modules(
-            &load_result.modules,
-            &load_result.entry_module_source,
-            load_result.implicit_modules.clone(),
-        )
-        .map_err(|errors| {
-            let msg = errors
-                .into_iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join("; ");
-            CompileError::Analyzer {
-                message: msg,
-                filename: filename.clone(),
-            }
-        })?;
+    let mut analyzer = Analyzer::new(&logger);
+    analyzer.analyze_loaded_modules(
+        &load_result.modules,
+        &load_result.entry_module_source,
+        load_result.implicit_modules.clone(),
+    )?;
 
     let symbols = analyzer.into_symbols();
 
@@ -330,32 +323,11 @@ pub async fn compile_with_options<H: CompilerHost>(
         load_result.entry_module_source.clone(),
         load_result.implicit_modules.clone(),
         module_name,
-    )
-    .map_err(|errors| {
-        let msg = errors
-            .into_iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        CompileError::Analyzer {
-            message: msg,
-            filename: filename.clone(),
-        }
-    })?;
+        &logger,
+    )?;
 
     // === Phase 7: Effect Check ===
-    let effect_errors = check_effects(&project.tir_modules);
-    if !effect_errors.is_empty() {
-        let msg = effect_errors
-            .into_iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(CompileError::Analyzer {
-            message: msg,
-            filename: filename.clone(),
-        });
-    }
+    check_effects(&project.tir_modules, &logger)?;
 
     // === Phase 8: Monomorphize (Project -> Project) ===
     let mut project = monomorphize_project(project);
@@ -373,9 +345,14 @@ pub async fn compile_with_options<H: CompilerHost>(
     let project = optimize(project, options.opt_level);
 
     // === Phase 11: Wasm Plan (Project -> Project) ===
-    let project = wasm_plan(project).map_err(|message| CompileError::Analyzer {
-        message,
-        filename: filename.clone(),
+    let project = wasm_plan(project).map_err(|message| {
+        let _ = logger.error(compiler_host::Diagnostic {
+            severity: compiler_host::Severity::Error,
+            code: compiler_host::Code::UnsupportedFeature,
+            message,
+            span: None,
+        });
+        Bail
     })?;
 
     // === Phase 12: Codegen ===
@@ -396,16 +373,18 @@ pub async fn dump_with_host<H: CompilerHost>(
     host: &H,
     filename: Option<&str>,
     opt_level: OptLevel,
-) -> Result<DumpResult, CompileError> {
+) -> Result<DumpResult, Bail> {
+    let logger = Logger::new(host, compiler_host::LogLevel::default());
     let filename = filename.map(String::from);
+    if let Some(ref f) = filename {
+        logger.set_file(f);
+    }
 
     // === Phase 1: Lexer ===
     let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| CompileError::Lexer {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: filename.clone(),
+    let tokens = lexer.tokenize().map_err(|e| {
+        let _ = logger.error(e);
+        Bail
     })?;
     let (data_section, comments, shebang) = lexer.into_parts();
 
@@ -415,26 +394,14 @@ pub async fn dump_with_host<H: CompilerHost>(
     // === Phase 2: Parser ===
     let tokens_for_dump = tokens.clone();
     let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-    let ast = parser.parse().map_err(|e| CompileError::Parser {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: filename.clone(),
+    let ast = parser.parse().map_err(|e| {
+        let _ = logger.error(e);
+        Bail
     })?;
 
     // === Phase 3: Bind ===
-    let mut binder = Binder::new();
-    binder.bind_module(&ast).map_err(|errors| {
-        let msg = errors
-            .into_iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        CompileError::Bind {
-            message: msg,
-            filename: filename.clone(),
-        }
-    })?;
+    let mut binder = Binder::new(&logger);
+    binder.bind_module(&ast)?;
 
     // === Phase 4: Desugar ===
     let desugared_ast = desugar::desugar_module(&ast);
@@ -445,31 +412,24 @@ pub async fn dump_with_host<H: CompilerHost>(
         module_loader
             .load_all(source, filename.as_deref())
             .await
-            .map_err(|e| CompileError::Analyzer {
-                message: e.to_string(),
-                filename: filename.clone(),
+            .map_err(|e| {
+                let _ = logger.error(compiler_host::Diagnostic {
+                    severity: compiler_host::Severity::Error,
+                    code: compiler_host::Code::ModuleNotFound,
+                    message: e.to_string(),
+                    span: None,
+                });
+                Bail
             })?
     };
 
     // === Phase 6: Analyze all modules ===
-    let mut analyzer = Analyzer::new();
-    analyzer
-        .analyze_loaded_modules(
-            &load_result.modules,
-            &load_result.entry_module_source,
-            load_result.implicit_modules.clone(),
-        )
-        .map_err(|errors| {
-            let msg = errors
-                .into_iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join("; ");
-            CompileError::Analyzer {
-                message: msg,
-                filename: filename.clone(),
-            }
-        })?;
+    let mut analyzer = Analyzer::new(&logger);
+    analyzer.analyze_loaded_modules(
+        &load_result.modules,
+        &load_result.entry_module_source,
+        load_result.implicit_modules.clone(),
+    )?;
 
     let symbols = analyzer.into_symbols();
 
@@ -478,6 +438,7 @@ pub async fn dump_with_host<H: CompilerHost>(
         &symbols,
         &load_result.modules,
         load_result.entry_module_source.clone(),
+        &logger,
     )
     .ok();
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{Item, Module};
-use crate::bind::{self, BindError};
+use crate::bind;
 use crate::compiler_host::{CompilerHost, SourceError};
 use crate::desugar::desugar_module;
 use crate::lexer::Lexer;
@@ -155,10 +155,18 @@ fn cached_core_stdlib() -> &'static HashMap<ModuleSource, Module> {
             let ast = parser
                 .parse()
                 .unwrap_or_else(|e| panic!("parser error in core:{name}: {e:?}"));
-            bind::bind_module(&ast).unwrap_or_else(|errors| {
-                let msgs: Vec<String> = errors.iter().map(ToString::to_string).collect();
-                panic!("bind error in core:{name}: {}", msgs.join("; "));
-            });
+            {
+                let bind_host = crate::compiler_host::InMemoryCompilerHost::new();
+                let bind_logger = Logger::new(&bind_host, LogLevel::Off);
+                bind::bind_module(&ast, &bind_logger).unwrap_or_else(|_| {
+                    let msgs: Vec<String> = bind_host
+                        .diagnostics()
+                        .iter()
+                        .map(|d| d.message.clone())
+                        .collect();
+                    panic!("bind error in core:{name}: {}", msgs.join("; "));
+                });
+            }
             let desugared = desugar_module(&ast);
             cache.insert(module_source, desugared);
         }
@@ -479,15 +487,14 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
 
     /// Bind a module (local name resolution and scope checking)
     fn bind_module(&self, module: &Module, module_source: &ModuleSource) -> Result<(), LoadError> {
-        bind::bind_module(module).map_err(|errors| {
-            let message = errors
-                .iter()
-                .map(BindError::to_string)
-                .collect::<Vec<_>>()
-                .join("; ");
+        // Bind errors are emitted directly to the host via Logger.
+        // We use a temporary logger per module so error counting is per-module.
+        let logger = Logger::new(self.host, self.log_level);
+        bind::bind_module(module, &logger).map_err(|_bail| {
+            let error_count = logger.error_count();
             LoadError::BindError {
                 module_source: module_source.clone(),
-                message,
+                message: format!("{error_count} bind error(s)"),
             }
         })
     }

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -1,14 +1,29 @@
-//! Logger module for structured compiler logging
+//! Logger module for structured compiler diagnostics
 //!
-//! Provides a `Logger` wrapper around `CompilerHost` for convenient logging
-//! with severity levels and span tracking.
+//! Provides a `Logger` wrapper around `CompilerHost` that serves as the single
+//! error reporting channel for the compilation pipeline. All compilation errors
+//! are emitted immediately to the `CompilerHost` via the logger, enabling:
 //!
-//! Also provides `ErrorLog<E>` for collecting typed compilation errors with
-//! a count limit. When errors exceed `MAX_ERRORS`, compilation is aborted
-//! via the `Bail` signal type.
+//! - Real-time error reporting (for IDE/LSP)
+//! - Phase timing via host-side timestamps (compiler stays syscall-free)
+//! - Unified error counting with automatic bail at `MAX_ERRORS`
 //!
-//! Note: Time tracking is intentionally omitted from the compiler to keep it
-//! syscall-free. The CLI or host implementation should add timestamps if needed.
+//! # Architecture
+//!
+//! ```text
+//! Phase (Analyzer, Resolver, ...) → Logger → CompilerHost → CLI/IDE/LSP
+//!                                     ↑
+//!                              error counting + bail
+//! ```
+//!
+//! Each phase calls `logger.error(typed_error)?` which:
+//! 1. Converts the typed error to a `Diagnostic` via `Into<Diagnostic>`
+//! 2. Applies file context (if set) to the diagnostic span
+//! 3. Emits the diagnostic to `CompilerHost::emit_diagnostic()`
+//! 4. Increments the error count
+//! 5. Returns `Err(Bail)` if the error limit is reached
+
+use std::cell::{Cell, RefCell};
 
 use crate::compiler_host::{Code, CompilerHost, Diagnostic, LogLevel, Severity};
 
@@ -18,135 +33,153 @@ pub const MAX_ERRORS: usize = 100;
 /// Signal that compilation has been aborted (too many errors or fatal error).
 ///
 /// Propagated via `Result<T, Bail>` and the `?` operator through internal
-/// compiler methods. Caught at phase boundaries and converted to the
-/// appropriate error return type.
+/// compiler methods. Caught at phase boundaries in the pipeline.
+///
+/// `Bail` carries no error information — all error details have already been
+/// emitted to the `CompilerHost` via the `Logger` before `Bail` is returned.
 #[derive(Debug, Clone, Copy)]
 pub struct Bail;
 
-/// Error log that collects typed compilation errors with a count limit.
-///
-/// Replaces `Vec<E>` for error accumulation in compiler phases.
-/// Tracks the error count and signals `Bail` when the limit is reached.
-///
-/// # Example
-///
-/// ```ignore
-/// let mut errors = ErrorLog::new();
-///
-/// // Log errors - returns Ok(()) normally, Err(Bail) at limit
-/// errors.error(TypeError::TypeMismatch { ... })?;
-///
-/// // Fatal errors always bail immediately
-/// errors.fatal(TypeError::TypeMismatch { ... })?; // always Err(Bail)
-///
-/// // Check results
-/// let tir_module = errors.into_result(tir_module)?;
-/// ```
-pub struct ErrorLog<E> {
-    errors: Vec<E>,
-}
-
-impl<E> ErrorLog<E> {
-    /// Create a new empty error log
-    pub fn new() -> Self {
-        Self { errors: Vec::new() }
-    }
-
-    /// Log an error. Returns `Err(Bail)` if the error count reaches `MAX_ERRORS`.
-    pub fn error(&mut self, err: E) -> Result<(), Bail> {
-        self.errors.push(err);
-        if self.errors.len() >= MAX_ERRORS {
-            Err(Bail)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Log a fatal error that immediately stops compilation.
-    /// Always returns `Err(Bail)`.
-    pub fn fatal(&mut self, err: E) -> Result<(), Bail> {
-        self.errors.push(err);
-        Err(Bail)
-    }
-
-    /// Check if any errors have been logged
-    pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
-    }
-
-    /// Get the number of errors logged
-    pub fn error_count(&self) -> usize {
-        self.errors.len()
-    }
-
-    /// Take all collected errors, leaving the log empty
-    pub fn take(&mut self) -> Vec<E> {
-        std::mem::take(&mut self.errors)
-    }
-
-    /// Extend with errors from another source. Returns `Err(Bail)` if the limit is reached.
-    pub fn extend(&mut self, errors: Vec<E>) -> Result<(), Bail> {
-        for err in errors {
-            self.error(err)?;
-        }
-        Ok(())
-    }
-
-    /// Return `Ok(value)` if no errors, `Err(errors)` otherwise.
-    pub fn into_result<T>(&mut self, value: T) -> Result<T, Vec<E>> {
-        if self.errors.is_empty() {
-            Ok(value)
-        } else {
-            Err(self.take())
-        }
-    }
-
-    /// Return `Ok(())` if no errors, `Err(errors)` otherwise.
-    pub fn finish(&mut self) -> Result<(), Vec<E>> {
-        self.into_result(())
+impl std::fmt::Display for Bail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "compilation failed")
     }
 }
 
-impl<E> Default for ErrorLog<E> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+impl std::error::Error for Bail {}
 
-/// Logger for compiler phases
+/// Logger for the compilation pipeline
 ///
-/// Wraps a `CompilerHost` and provides convenience methods for logging
-/// at different severity levels. Also supports phase span tracking with
-/// RAII guards.
+/// Wraps a `CompilerHost` and provides the unified error reporting channel.
+/// All compilation errors and informational messages go through this logger.
+///
+/// # Error Counting
+///
+/// The logger tracks how many errors have been emitted. When the count reaches
+/// `MAX_ERRORS`, `error()` returns `Err(Bail)` to stop compilation.
+///
+/// # File Context
+///
+/// Phases can set a file context via `set_file()`. This file name is
+/// automatically applied to diagnostic spans that don't already have one.
 ///
 /// # Example
 ///
 /// ```ignore
 /// let logger = Logger::new(&host, LogLevel::Debug);
 ///
-/// // Log messages at different levels
+/// // Set file context for diagnostics
+/// logger.set_file("main.wado");
+///
+/// // Report compilation errors (counted, may bail)
+/// logger.error(TypeError::TypeMismatch { expected, found, span })?;
+///
+/// // Fatal errors always bail
+/// logger.fatal(TypeError::TypeMismatch { ... })?; // always Err(Bail)
+///
+/// // Informational logging (fire-and-forget, filtered by level)
 /// logger.debug("entering function");
 /// logger.info("processing 10 items");
-/// logger.warn("deprecated feature used");
-/// logger.error(Code::TypeMismatch, "expected i32, found String", None);
-/// logger.fatal(Code::TypeMismatch, "too many errors");
 ///
 /// // Track phase timing with RAII guard
 /// {
 ///     let _span = logger.span("parse");
 ///     // ... parsing happens here ...
-/// } // PhaseEnd is emitted when _span is dropped
+/// } // SpanEnd is emitted when _span is dropped
 /// ```
 pub struct Logger<'a, H: CompilerHost> {
     host: &'a H,
     level: LogLevel,
+    error_count: Cell<usize>,
+    current_file: RefCell<Option<String>>,
 }
 
 impl<'a, H: CompilerHost> Logger<'a, H> {
     /// Create a new logger with the given host and log level
     pub fn new(host: &'a H, level: LogLevel) -> Self {
-        Self { host, level }
+        Self {
+            host,
+            level,
+            error_count: Cell::new(0),
+            current_file: RefCell::new(None),
+        }
     }
+
+    // === File context ===
+
+    /// Set the current file context for diagnostics
+    ///
+    /// All subsequent diagnostics will have this file name in their span
+    /// (unless the span already has a file set).
+    pub fn set_file(&self, file: impl Into<String>) {
+        *self.current_file.borrow_mut() = Some(file.into());
+    }
+
+    /// Clear the current file context
+    pub fn clear_file(&self) {
+        *self.current_file.borrow_mut() = None;
+    }
+
+    // === Compilation error methods (counted, may bail) ===
+
+    /// Report a compilation error.
+    ///
+    /// The error is immediately emitted to the `CompilerHost`.
+    /// Returns `Err(Bail)` if the error count reaches `MAX_ERRORS`.
+    pub fn error(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
+        let diag = self.apply_file_context(err.into());
+        let count = self.error_count.get() + 1;
+        self.error_count.set(count);
+        self.host.emit_diagnostic(diag);
+        if count >= MAX_ERRORS {
+            Err(Bail)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Report a fatal compilation error. Always returns `Err(Bail)`.
+    ///
+    /// Use for errors that make it impossible to continue the current phase.
+    pub fn fatal(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
+        let diag = self.apply_file_context(err.into());
+        self.error_count.set(self.error_count.get() + 1);
+        self.host.emit_diagnostic(diag);
+        Err(Bail)
+    }
+
+    /// Report multiple errors from an external source.
+    /// Returns `Err(Bail)` if the error limit is reached.
+    pub fn extend(
+        &self,
+        errors: impl IntoIterator<Item = impl Into<Diagnostic>>,
+    ) -> Result<(), Bail> {
+        for err in errors {
+            self.error(err)?;
+        }
+        Ok(())
+    }
+
+    /// Check if any errors have been reported
+    pub fn has_errors(&self) -> bool {
+        self.error_count.get() > 0
+    }
+
+    /// Get the number of errors reported
+    pub fn error_count(&self) -> usize {
+        self.error_count.get()
+    }
+
+    /// Return `Ok(value)` if no errors have been reported, `Err(Bail)` otherwise.
+    pub fn ok_or_bail<T>(&self, value: T) -> Result<T, Bail> {
+        if self.has_errors() {
+            Err(Bail)
+        } else {
+            Ok(value)
+        }
+    }
+
+    // === Informational logging (fire-and-forget, filtered by level) ===
 
     /// Check if the given severity should be logged at the current level
     fn should_log(&self, severity: Severity) -> bool {
@@ -170,32 +203,7 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         }
     }
 
-    /// Log a fatal error with a diagnostic code.
-    /// Fatal errors indicate unrecoverable conditions (e.g., too many errors).
-    pub fn fatal(&self, code: Code, message: impl Into<String>) {
-        if self.should_log(Severity::Fatal) {
-            self.host.emit_diagnostic(Diagnostic {
-                severity: Severity::Fatal,
-                code,
-                message: message.into(),
-                span: None,
-            });
-        }
-    }
-
-    /// Log an error with a diagnostic code
-    pub fn error(&self, code: Code, message: impl Into<String>) {
-        if self.should_log(Severity::Error) {
-            self.host.emit_diagnostic(Diagnostic {
-                severity: Severity::Error,
-                code,
-                message: message.into(),
-                span: None,
-            });
-        }
-    }
-
-    /// Log a warning with a diagnostic code
+    /// Log a warning (informational, not counted as error)
     pub fn warn(&self, code: Code, message: impl Into<String>) {
         if self.should_log(Severity::Warning) {
             self.host.emit_diagnostic(Diagnostic {
@@ -223,7 +231,7 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     pub fn debug(&self, message: impl Into<String>) {
         if self.should_log(Severity::Debug) {
             self.host.emit_diagnostic(Diagnostic {
-                severity: Severity::Debug, // Use Debug for debug level
+                severity: Severity::Debug,
                 code: Code::Log,
                 message: message.into(),
                 span: None,
@@ -231,19 +239,12 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         }
     }
 
+    // === Span tracking ===
+
     /// Start a span for tracking
     ///
     /// Returns a `SpanGuard` that emits `SpanEnd` when dropped.
     /// The CLI or host implementation can add timestamps to track timing.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// {
-    ///     let _span = logger.span("parse");
-    ///     // ... parsing ...
-    /// } // SpanEnd emitted here
-    /// ```
     pub fn span(&self, name: &str) -> SpanGuard<'_, 'a, H> {
         self.span_start(name);
 
@@ -278,6 +279,19 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
             span: None,
         });
     }
+
+    // === Internal helpers ===
+
+    /// Apply file context to a diagnostic's span if the span has no file set
+    fn apply_file_context(&self, mut diag: Diagnostic) -> Diagnostic {
+        if let Some(ref mut span) = diag.span
+            && span.file.is_empty()
+            && let Some(ref file) = *self.current_file.borrow()
+        {
+            span.file.clone_from(file);
+        }
+        diag
+    }
 }
 
 /// RAII guard for span tracking
@@ -309,7 +323,13 @@ mod tests {
         logger.debug("debug message");
         logger.info("info message");
         logger.warn(Code::UnsupportedFeature, "warning message");
-        logger.error(Code::TypeMismatch, "error message");
+        // Use a direct Diagnostic for error (not a typed error)
+        let _ = logger.error(Diagnostic {
+            severity: Severity::Error,
+            code: Code::TypeMismatch,
+            message: "error message".to_string(),
+            span: None,
+        });
 
         let diags = host.diagnostics();
         assert_eq!(diags.len(), 2);
@@ -341,7 +361,7 @@ mod tests {
         let host = InMemoryCompilerHost::new();
         let logger = Logger::new(&host, LogLevel::Off);
 
-        logger.error(Code::TypeMismatch, "error");
+        // Warnings and info/debug are filtered
         logger.warn(Code::UnsupportedFeature, "warning");
         logger.info("info");
         logger.debug("debug");
@@ -351,66 +371,86 @@ mod tests {
     }
 
     #[test]
-    fn test_error_log_basic() {
-        let mut log: ErrorLog<String> = ErrorLog::new();
-        assert!(!log.has_errors());
-        assert_eq!(log.error_count(), 0);
-
-        log.error("first error".to_string()).unwrap();
-        assert!(log.has_errors());
-        assert_eq!(log.error_count(), 1);
-
-        log.error("second error".to_string()).unwrap();
-        assert_eq!(log.error_count(), 2);
-
-        let errors = log.take();
-        assert_eq!(errors.len(), 2);
-        assert!(!log.has_errors());
-    }
-
-    #[test]
-    fn test_error_log_bail_at_limit() {
-        let mut log: ErrorLog<i32> = ErrorLog::new();
+    fn test_error_counting_and_bail() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Error);
 
         // Push MAX_ERRORS - 1 errors (should all succeed)
         for i in 0..MAX_ERRORS - 1 {
-            assert!(log.error(i as i32).is_ok());
+            let result = logger.error(Diagnostic {
+                severity: Severity::Error,
+                code: Code::TypeMismatch,
+                message: format!("error {i}"),
+                span: None,
+            });
+            assert!(result.is_ok());
         }
 
         // The MAX_ERRORS-th error should trigger Bail
-        assert!(log.error(99).is_err());
-        assert_eq!(log.error_count(), MAX_ERRORS);
+        let result = logger.error(Diagnostic {
+            severity: Severity::Error,
+            code: Code::TypeMismatch,
+            message: "final error".to_string(),
+            span: None,
+        });
+        assert!(result.is_err());
+        assert_eq!(logger.error_count(), MAX_ERRORS);
     }
 
     #[test]
-    fn test_error_log_fatal() {
-        let mut log: ErrorLog<String> = ErrorLog::new();
+    fn test_fatal_always_bails() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Error);
 
-        // Fatal always returns Err(Bail)
-        assert!(log.fatal("fatal error".to_string()).is_err());
-        assert_eq!(log.error_count(), 1);
+        let result = logger.fatal(Diagnostic {
+            severity: Severity::Fatal,
+            code: Code::TypeMismatch,
+            message: "fatal error".to_string(),
+            span: None,
+        });
+        assert!(result.is_err());
+        assert_eq!(logger.error_count(), 1);
     }
 
     #[test]
-    fn test_error_log_into_result() {
-        let mut log: ErrorLog<String> = ErrorLog::new();
+    fn test_ok_or_bail() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Error);
 
         // No errors → Ok
-        assert!(log.into_result(42).is_ok());
+        assert!(logger.ok_or_bail(42).is_ok());
 
         // With errors → Err
-        log.error("error".to_string()).unwrap();
-        let result: Result<i32, Vec<String>> = log.into_result(42);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().len(), 1);
+        let _ = logger.error(Diagnostic {
+            severity: Severity::Error,
+            code: Code::TypeMismatch,
+            message: "error".to_string(),
+            span: None,
+        });
+        assert!(logger.ok_or_bail(42).is_err());
     }
 
     #[test]
-    fn test_error_log_extend() {
-        let mut log: ErrorLog<i32> = ErrorLog::new();
+    fn test_file_context() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Error);
 
-        log.extend(vec![1, 2, 3]).unwrap();
-        assert_eq!(log.error_count(), 3);
+        logger.set_file("test.wado");
+        let _ = logger.error(Diagnostic {
+            severity: Severity::Error,
+            code: Code::TypeMismatch,
+            message: "error".to_string(),
+            span: Some(crate::compiler_host::DiagnosticSpan {
+                file: String::new(),
+                line: 10,
+                column: 5,
+                end_line: None,
+                end_column: None,
+            }),
+        });
+
+        let diags = host.diagnostics();
+        assert_eq!(diags[0].span.as_ref().unwrap().file, "test.wado");
     }
 
     #[test]
@@ -418,7 +458,12 @@ mod tests {
         let host = InMemoryCompilerHost::new();
         let logger = Logger::new(&host, LogLevel::Off);
 
-        logger.fatal(Code::TypeMismatch, "fatal error");
+        let _ = logger.fatal(Diagnostic {
+            severity: Severity::Fatal,
+            code: Code::TypeMismatch,
+            message: "fatal error".to_string(),
+            span: None,
+        });
 
         let diags = host.diagnostics();
         assert_eq!(diags.len(), 1);

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -3,10 +3,115 @@
 //! Provides a `Logger` wrapper around `CompilerHost` for convenient logging
 //! with severity levels and span tracking.
 //!
+//! Also provides `ErrorLog<E>` for collecting typed compilation errors with
+//! a count limit. When errors exceed `MAX_ERRORS`, compilation is aborted
+//! via the `Bail` signal type.
+//!
 //! Note: Time tracking is intentionally omitted from the compiler to keep it
 //! syscall-free. The CLI or host implementation should add timestamps if needed.
 
 use crate::compiler_host::{Code, CompilerHost, Diagnostic, LogLevel, Severity};
+
+/// Maximum number of errors before compilation is aborted
+pub const MAX_ERRORS: usize = 100;
+
+/// Signal that compilation has been aborted (too many errors or fatal error).
+///
+/// Propagated via `Result<T, Bail>` and the `?` operator through internal
+/// compiler methods. Caught at phase boundaries and converted to the
+/// appropriate error return type.
+#[derive(Debug, Clone, Copy)]
+pub struct Bail;
+
+/// Error log that collects typed compilation errors with a count limit.
+///
+/// Replaces `Vec<E>` for error accumulation in compiler phases.
+/// Tracks the error count and signals `Bail` when the limit is reached.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut errors = ErrorLog::new();
+///
+/// // Log errors - returns Ok(()) normally, Err(Bail) at limit
+/// errors.error(TypeError::TypeMismatch { ... })?;
+///
+/// // Fatal errors always bail immediately
+/// errors.fatal(TypeError::TypeMismatch { ... })?; // always Err(Bail)
+///
+/// // Check results
+/// let tir_module = errors.into_result(tir_module)?;
+/// ```
+pub struct ErrorLog<E> {
+    errors: Vec<E>,
+}
+
+impl<E> ErrorLog<E> {
+    /// Create a new empty error log
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    /// Log an error. Returns `Err(Bail)` if the error count reaches `MAX_ERRORS`.
+    pub fn error(&mut self, err: E) -> Result<(), Bail> {
+        self.errors.push(err);
+        if self.errors.len() >= MAX_ERRORS {
+            Err(Bail)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Log a fatal error that immediately stops compilation.
+    /// Always returns `Err(Bail)`.
+    pub fn fatal(&mut self, err: E) -> Result<(), Bail> {
+        self.errors.push(err);
+        Err(Bail)
+    }
+
+    /// Check if any errors have been logged
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Get the number of errors logged
+    pub fn error_count(&self) -> usize {
+        self.errors.len()
+    }
+
+    /// Take all collected errors, leaving the log empty
+    pub fn take(&mut self) -> Vec<E> {
+        std::mem::take(&mut self.errors)
+    }
+
+    /// Extend with errors from another source. Returns `Err(Bail)` if the limit is reached.
+    pub fn extend(&mut self, errors: Vec<E>) -> Result<(), Bail> {
+        for err in errors {
+            self.error(err)?;
+        }
+        Ok(())
+    }
+
+    /// Return `Ok(value)` if no errors, `Err(errors)` otherwise.
+    pub fn into_result<T>(&mut self, value: T) -> Result<T, Vec<E>> {
+        if self.errors.is_empty() {
+            Ok(value)
+        } else {
+            Err(self.take())
+        }
+    }
+
+    /// Return `Ok(())` if no errors, `Err(errors)` otherwise.
+    pub fn finish(&mut self) -> Result<(), Vec<E>> {
+        self.into_result(())
+    }
+}
+
+impl<E> Default for ErrorLog<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Logger for compiler phases
 ///
@@ -24,6 +129,7 @@ use crate::compiler_host::{Code, CompilerHost, Diagnostic, LogLevel, Severity};
 /// logger.info("processing 10 items");
 /// logger.warn("deprecated feature used");
 /// logger.error(Code::TypeMismatch, "expected i32, found String", None);
+/// logger.fatal(Code::TypeMismatch, "too many errors");
 ///
 /// // Track phase timing with RAII guard
 /// {
@@ -45,16 +151,35 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     /// Check if the given severity should be logged at the current level
     fn should_log(&self, severity: Severity) -> bool {
         match self.level {
-            LogLevel::Off => false,
-            LogLevel::Error => severity == Severity::Error,
-            LogLevel::Warn => matches!(severity, Severity::Error | Severity::Warning),
+            // Fatal is always logged regardless of level
+            LogLevel::Off => severity == Severity::Fatal,
+            LogLevel::Error => matches!(severity, Severity::Fatal | Severity::Error),
+            LogLevel::Warn => {
+                matches!(
+                    severity,
+                    Severity::Fatal | Severity::Error | Severity::Warning
+                )
+            }
             LogLevel::Info => {
                 matches!(
                     severity,
-                    Severity::Error | Severity::Warning | Severity::Info
+                    Severity::Fatal | Severity::Error | Severity::Warning | Severity::Info
                 )
             }
             LogLevel::Debug => true,
+        }
+    }
+
+    /// Log a fatal error with a diagnostic code.
+    /// Fatal errors indicate unrecoverable conditions (e.g., too many errors).
+    pub fn fatal(&self, code: Code, message: impl Into<String>) {
+        if self.should_log(Severity::Fatal) {
+            self.host.emit_diagnostic(Diagnostic {
+                severity: Severity::Fatal,
+                code,
+                message: message.into(),
+                span: None,
+            });
         }
     }
 
@@ -223,5 +348,80 @@ mod tests {
 
         let diags = host.diagnostics();
         assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_error_log_basic() {
+        let mut log: ErrorLog<String> = ErrorLog::new();
+        assert!(!log.has_errors());
+        assert_eq!(log.error_count(), 0);
+
+        log.error("first error".to_string()).unwrap();
+        assert!(log.has_errors());
+        assert_eq!(log.error_count(), 1);
+
+        log.error("second error".to_string()).unwrap();
+        assert_eq!(log.error_count(), 2);
+
+        let errors = log.take();
+        assert_eq!(errors.len(), 2);
+        assert!(!log.has_errors());
+    }
+
+    #[test]
+    fn test_error_log_bail_at_limit() {
+        let mut log: ErrorLog<i32> = ErrorLog::new();
+
+        // Push MAX_ERRORS - 1 errors (should all succeed)
+        for i in 0..MAX_ERRORS - 1 {
+            assert!(log.error(i as i32).is_ok());
+        }
+
+        // The MAX_ERRORS-th error should trigger Bail
+        assert!(log.error(99).is_err());
+        assert_eq!(log.error_count(), MAX_ERRORS);
+    }
+
+    #[test]
+    fn test_error_log_fatal() {
+        let mut log: ErrorLog<String> = ErrorLog::new();
+
+        // Fatal always returns Err(Bail)
+        assert!(log.fatal("fatal error".to_string()).is_err());
+        assert_eq!(log.error_count(), 1);
+    }
+
+    #[test]
+    fn test_error_log_into_result() {
+        let mut log: ErrorLog<String> = ErrorLog::new();
+
+        // No errors → Ok
+        assert!(log.into_result(42).is_ok());
+
+        // With errors → Err
+        log.error("error".to_string()).unwrap();
+        let result: Result<i32, Vec<String>> = log.into_result(42);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().len(), 1);
+    }
+
+    #[test]
+    fn test_error_log_extend() {
+        let mut log: ErrorLog<i32> = ErrorLog::new();
+
+        log.extend(vec![1, 2, 3]).unwrap();
+        assert_eq!(log.error_count(), 3);
+    }
+
+    #[test]
+    fn test_fatal_always_logged_even_at_off() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Off);
+
+        logger.fatal(Code::TypeMismatch, "fatal error");
+
+        let diags = host.diagnostics();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Fatal);
     }
 }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -40,6 +40,18 @@ pub struct ParseError {
     pub span: Span,
 }
 
+impl From<ParseError> for crate::compiler_host::Diagnostic {
+    fn from(e: ParseError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        Self {
+            severity: Severity::Error,
+            code: Code::InvalidSyntax,
+            message: format!("parse error: {}", e.message),
+            span: Some(DiagnosticSpan::from_span(&e.span, None)),
+        }
+    }
+}
+
 type ParseResult<T> = Result<T, ParseError>;
 
 /// Groups of comparison operators for chain validation

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -23,7 +23,8 @@ use crate::ast::{
     IfStmt, Item, LetStmt, Literal, LoopStmt, MatchArm, Module, Pattern, ReturnStmt, Stmt, Type,
     UnaryOp,
 };
-use crate::logger::ErrorLog;
+use crate::compiler_host::CompilerHost;
+use crate::logger::{Bail, Logger};
 use crate::project::Project;
 use crate::symbol::{SymbolKind, SymbolTable};
 use crate::tir::{
@@ -254,6 +255,90 @@ impl std::fmt::Display for TypeError {
 
 impl std::error::Error for TypeError {}
 
+impl From<TypeError> for crate::compiler_host::Diagnostic {
+    fn from(e: TypeError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        let (code, message, span) = match &e {
+            TypeError::TypeMismatch {
+                expected,
+                found,
+                span,
+            } => (
+                Code::TypeMismatch,
+                format!("type mismatch: expected '{expected}', found '{found}'"),
+                *span,
+            ),
+            TypeError::UnknownType { name, span } => {
+                (Code::UnknownType, format!("unknown type '{name}'"), *span)
+            }
+            TypeError::UnknownFunction { name, span } => (
+                Code::UndefinedVariable,
+                format!("unknown function '{name}'"),
+                *span,
+            ),
+            TypeError::UnknownIdentifier { name, span } => (
+                Code::UndefinedVariable,
+                format!("unknown identifier '{name}'"),
+                *span,
+            ),
+            TypeError::FieldNotFound {
+                struct_name,
+                field_name,
+                span,
+            } => (
+                Code::TypeMismatch,
+                format!("field '{field_name}' not found on struct '{struct_name}'"),
+                *span,
+            ),
+            TypeError::ArgumentCountMismatch {
+                expected,
+                found,
+                span,
+            } => (
+                Code::TypeMismatch,
+                format!("expected {expected} arguments, found {found}"),
+                *span,
+            ),
+            TypeError::InvalidLiteral { message, span } => {
+                (Code::InvalidSyntax, message.clone(), *span)
+            }
+            TypeError::NotYetImplemented { feature, span } => (
+                Code::UnsupportedFeature,
+                format!("{feature} is not yet implemented"),
+                *span,
+            ),
+            TypeError::CannotAssign { message, span } => (
+                Code::ImmutableAssignment,
+                format!("cannot assign: {message}"),
+                *span,
+            ),
+            TypeError::TraitBoundNotSatisfied {
+                type_name,
+                trait_name,
+                param_name,
+                span,
+            } => (
+                Code::TypeMismatch,
+                format!(
+                    "type '{type_name}' does not implement trait '{trait_name}' required by bound on '{param_name}'"
+                ),
+                *span,
+            ),
+            TypeError::InvalidPattern { message, span } => (
+                Code::InvalidSyntax,
+                format!("invalid pattern: {message}"),
+                *span,
+            ),
+        };
+        crate::compiler_host::Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span: Some(DiagnosticSpan::from_span(&span, None)),
+        }
+    }
+}
+
 /// Local variable information during resolution
 #[derive(Debug, Clone)]
 struct LocalVar {
@@ -455,7 +540,7 @@ enum VarRef {
 }
 
 /// The resolver converts AST to TIR with resolved types
-pub struct Resolver<'a> {
+pub struct Resolver<'a, H: CompilerHost> {
     /// Type table (shared across all modules via Rc<RefCell>)
     type_table: Rc<RefCell<TypeTable>>,
     /// Symbol table from analyzer
@@ -484,8 +569,8 @@ pub struct Resolver<'a> {
     function_return_types: HashMap<String, TypeId>,
     /// Imported function names for the current module
     imported_functions: HashSet<String>,
-    /// Errors collected during resolution
-    errors: ErrorLog<TypeError>,
+    /// Logger for emitting diagnostics
+    logger: &'a Logger<'a, H>,
     /// Current module source being resolved (for struct type `module_source`)
     current_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
@@ -595,12 +680,13 @@ struct ArithmeticTraitInfo {
     trait_name: String,
 }
 
-impl<'a> Resolver<'a> {
+impl<'a, H: CompilerHost> Resolver<'a, H> {
     /// Create a new resolver
     pub fn new(
         symbols: &'a SymbolTable,
         loaded_modules: &'a HashMap<ModuleSource, Module>,
         builtin_registry: &'a BuiltinRegistry,
+        logger: &'a Logger<'a, H>,
     ) -> Self {
         let (wasi_registry, _) = WasiRegistry::build_from_stdlib();
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
@@ -620,7 +706,7 @@ impl<'a> Resolver<'a> {
             all_resource_types: HashMap::new(),
             function_return_types: HashMap::new(),
             imported_functions: HashSet::new(),
-            errors: ErrorLog::new(),
+            logger,
             current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
             current_module_items: Vec::new(),
             current_type_params: HashMap::new(),
@@ -644,7 +730,7 @@ impl<'a> Resolver<'a> {
         &mut self,
         module: &Module,
         module_source: ModuleSource,
-    ) -> Result<TirModule, Vec<TypeError>> {
+    ) -> Result<TirModule, Bail> {
         // Set current module source for struct type creation
         self.current_module_source = module_source.clone();
         // Store current module items for local function parameter lookup
@@ -894,11 +980,7 @@ impl<'a> Resolver<'a> {
             tir_module = tir_module.with_data_section(Some(data.to_string()));
         }
 
-        if self.errors.has_errors() {
-            Err(self.errors.take())
-        } else {
-            Ok(tir_module)
-        }
+        self.logger.ok_or_bail(tir_module)
     }
 
     /// Resolve all modules to TIR
@@ -910,9 +992,9 @@ impl<'a> Resolver<'a> {
         symbols: &'a SymbolTable,
         modules: &'a HashMap<ModuleSource, Module>,
         _entry_module_source: ModuleSource,
-    ) -> Result<IndexMap<ModuleSource, TirModule>, Vec<TypeError>> {
+        logger: &'a Logger<'a, H>,
+    ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
         let mut result = IndexMap::new();
-        let mut all_errors = ErrorLog::new();
 
         // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
@@ -1270,7 +1352,7 @@ impl<'a> Resolver<'a> {
                 all_resource_types: all_resource_types.clone(),
                 function_return_types,
                 imported_functions,
-                errors: ErrorLog::new(),
+                logger,
                 current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"), // Set in resolve_module
                 current_module_items: Vec::new(), // Set in resolve_module
                 current_type_params: HashMap::new(),
@@ -1288,21 +1370,14 @@ impl<'a> Resolver<'a> {
                 module_type_maps_cache: HashMap::new(),
             };
 
-            match resolver.resolve_module(module, module_source.clone()) {
-                Ok(tir_module) => {
-                    // TypeTable is already shared via Rc, no need to merge
-                    result.insert(module_source.clone(), tir_module);
-                }
-                Err(errors) => {
-                    if all_errors.extend(errors).is_err() {
-                        // Too many errors across all modules - stop early
-                        return Err(all_errors.take());
-                    }
-                }
+            // Errors are emitted to the logger; if resolve_module returns Bail,
+            // we continue to resolve remaining modules to collect more errors
+            if let Ok(tir_module) = resolver.resolve_module(module, module_source.clone()) {
+                result.insert(module_source.clone(), tir_module);
             }
         }
 
-        all_errors.into_result(result)
+        logger.ok_or_bail(result)
     }
 
     /// Build a module-specific flat map from per-module entries.
@@ -2112,7 +2187,7 @@ impl<'a> Resolver<'a> {
             && initializer.type_id != TypeTable::UNKNOWN
             && ty != TypeTable::UNKNOWN
         {
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: self.type_table.borrow().type_name(ty),
                 found: self.type_table.borrow().type_name(initializer.type_id),
                 span: global_decl.initializer.span(),
@@ -2656,7 +2731,7 @@ impl<'a> Resolver<'a> {
                             if resolved.type_id != element_type
                                 && resolved.type_id != TypeTable::UNKNOWN
                             {
-                                let _ = self.errors.error(TypeError::TypeMismatch {
+                                let _ = self.logger.error(TypeError::TypeMismatch {
                                     expected: self.type_table.borrow().type_name(element_type),
                                     found: self.type_table.borrow().type_name(resolved.type_id),
                                     span: elem.span(),
@@ -2688,7 +2763,7 @@ impl<'a> Resolver<'a> {
                                     && resolved.type_id != expected_type
                                     && resolved.type_id != TypeTable::UNKNOWN
                                 {
-                                    let _ = self.errors.error(TypeError::TypeMismatch {
+                                    let _ = self.logger.error(TypeError::TypeMismatch {
                                         expected: self.type_table.borrow().type_name(expected_type),
                                         found: self.type_table.borrow().type_name(resolved.type_id),
                                         span: elem.span(),
@@ -2700,7 +2775,7 @@ impl<'a> Resolver<'a> {
 
                         // Also check length mismatch
                         if tuple_lit.elements.len() != expected_elem_types.len() {
-                            let _ = self.errors.error(TypeError::TypeMismatch {
+                            let _ = self.logger.error(TypeError::TypeMismatch {
                                 expected: format!(
                                     "tuple with {} elements",
                                     expected_elem_types.len()
@@ -2756,7 +2831,7 @@ impl<'a> Resolver<'a> {
                         (value, target_type)
                     } else {
                         // Target type is not a struct - error
-                        let _ = self.errors.error(TypeError::TypeMismatch {
+                        let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: self.type_table.borrow().type_name(target_type),
                             found: "implicit struct literal".into(),
                             span: struct_lit.span,
@@ -2795,7 +2870,7 @@ impl<'a> Resolver<'a> {
                 )
             };
             if !is_null_to_option {
-                let _ = self.errors.error(TypeError::TypeMismatch {
+                let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: self.type_table.borrow().type_name(type_id),
                     found: self.type_table.borrow().type_name(value.type_id),
                     span: let_stmt.value.span(),
@@ -2844,7 +2919,7 @@ impl<'a> Resolver<'a> {
             }
             ast::Pattern::Literal(_) | ast::Pattern::Variant { .. } => {
                 // These patterns are not valid in let statements
-                let _ = self.errors.error(TypeError::InvalidPattern {
+                let _ = self.logger.error(TypeError::InvalidPattern {
                     message: "literal and variant patterns are not allowed in let statements"
                         .to_string(),
                     span: let_stmt.span,
@@ -2881,7 +2956,7 @@ impl<'a> Resolver<'a> {
                         elem_types.clone()
                     } else {
                         // Error: expected tuple type
-                        let _ = self.errors.error(TypeError::TypeMismatch {
+                        let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: "tuple type".to_string(),
                             found: type_table.type_name(type_id),
                             span,
@@ -2892,7 +2967,7 @@ impl<'a> Resolver<'a> {
 
                 // Check length
                 if patterns.len() != elem_types.len() {
-                    let _ = self.errors.error(TypeError::TypeMismatch {
+                    let _ = self.logger.error(TypeError::TypeMismatch {
                         expected: format!("tuple with {} elements", elem_types.len()),
                         found: format!("pattern with {} elements", patterns.len()),
                         span,
@@ -2917,7 +2992,7 @@ impl<'a> Resolver<'a> {
             ast::Pattern::Wildcard => TirPattern::Wildcard,
             ast::Pattern::Literal(_) | ast::Pattern::Variant { .. } => {
                 // These patterns are not valid in let statements
-                let _ = self.errors.error(TypeError::InvalidPattern {
+                let _ = self.logger.error(TypeError::InvalidPattern {
                     message: "literal and variant patterns are not allowed in let statements"
                         .to_string(),
                     span,
@@ -3041,7 +3116,7 @@ impl<'a> Resolver<'a> {
                     Literal::Number(n) => {
                         // Float literals cannot be used in match patterns
                         if Self::is_float_only_literal(&n.repr) {
-                            let _ = self.errors.error(TypeError::InvalidPattern {
+                            let _ = self.logger.error(TypeError::InvalidPattern {
                                 message: "float literals cannot be used in match patterns"
                                     .to_string(),
                                 span,
@@ -3130,7 +3205,7 @@ impl<'a> Resolver<'a> {
                         if self.variant_cases.contains_key(name) {
                             self.get_variant_case_payload_type(name, variant_name, type_args, *span)
                         } else {
-                            let _ = self.errors.error(TypeError::TypeMismatch {
+                            let _ = self.logger.error(TypeError::TypeMismatch {
                                 expected: "variant type".to_string(),
                                 found: name.clone(),
                                 span: *span,
@@ -3139,7 +3214,7 @@ impl<'a> Resolver<'a> {
                         }
                     }
                     _ => {
-                        let _ = self.errors.error(TypeError::TypeMismatch {
+                        let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: "variant type (Option or custom variant)".to_string(),
                             found: format!("{resolved_type:?}"),
                             span: *span,
@@ -3197,13 +3272,13 @@ impl<'a> Resolver<'a> {
 
         // Check if variant exists but case not found
         if self.variant_cases.contains_key(variant_name) {
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: format!("valid case of variant {variant_name}"),
                 found: case_name.to_string(),
                 span,
             });
         } else {
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: "known variant type".to_string(),
                 found: variant_name.to_string(),
                 span,
@@ -3225,7 +3300,7 @@ impl<'a> Resolver<'a> {
         if let Some(label) = &break_stmt.label
             && !ctx.active_labels.iter().any(|l| l == label)
         {
-            let _ = self.errors.error(TypeError::UnknownIdentifier {
+            let _ = self.logger.error(TypeError::UnknownIdentifier {
                 name: format!("labeled break target not found: {label}"),
                 span: break_stmt.span,
             });
@@ -3517,7 +3592,7 @@ impl<'a> Resolver<'a> {
                             TypeTable::F64,
                         ),
                         Err(message) => {
-                            let _ = self.errors.error(TypeError::InvalidLiteral {
+                            let _ = self.logger.error(TypeError::InvalidLiteral {
                                 message,
                                 span: lit.span,
                             });
@@ -3541,7 +3616,7 @@ impl<'a> Resolver<'a> {
                             TypeTable::I32,
                         ),
                         Err(message) => {
-                            let _ = self.errors.error(TypeError::InvalidLiteral {
+                            let _ = self.logger.error(TypeError::InvalidLiteral {
                                 message,
                                 span: lit.span,
                             });
@@ -3651,7 +3726,7 @@ impl<'a> Resolver<'a> {
                         ResolvedType::Unit
                     );
                     if !payload_is_unit {
-                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                             expected: 1,
                             found: 0,
                             span: ident.span,
@@ -3765,7 +3840,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Unknown variable - report error
-        let _ = self.errors.error(TypeError::UnknownIdentifier {
+        let _ = self.logger.error(TypeError::UnknownIdentifier {
             name: ident.name.clone(),
             span: ident.span,
         });
@@ -4168,7 +4243,7 @@ impl<'a> Resolver<'a> {
             if (left_is_newtype || right_is_newtype) && left.type_id != right.type_id {
                 let left_name = type_table.type_name(left.type_id);
                 let right_name = type_table.type_name(right.type_id);
-                let _ = self.errors.error(TypeError::TypeMismatch {
+                let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: left_name,
                     found: right_name,
                     span: binary.span,
@@ -4218,7 +4293,7 @@ impl<'a> Resolver<'a> {
             && let Some(local) = ctx.lookup(name)
             && !local.is_mut
         {
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: "mutable variable".to_string(),
                 found: format!("immutable variable '{name}'"),
                 span: unary.span,
@@ -4244,7 +4319,7 @@ impl<'a> Resolver<'a> {
             if matches!(field_type, ResolvedType::Primitive(_))
                 || matches!(base_type, ResolvedType::Primitive(_))
             {
-                let _ = self.errors.error(TypeError::CannotAssign {
+                let _ = self.logger.error(TypeError::CannotAssign {
                     message: "cannot take mutable reference to primitive struct field; use the struct reference directly".to_string(),
                     span: unary.span,
                 });
@@ -4416,7 +4491,7 @@ impl<'a> Resolver<'a> {
                     *inner
                 } else {
                     // Cannot dereference non-reference type
-                    let _ = self.errors.error(TypeError::TypeMismatch {
+                    let _ = self.logger.error(TypeError::TypeMismatch {
                         expected: "reference type".to_string(),
                         found: self.type_table.borrow().type_name(expr.type_id),
                         span: unary.span,
@@ -4532,7 +4607,7 @@ impl<'a> Resolver<'a> {
 
             if let Some(is_mut) = is_mutable {
                 if !is_mut {
-                    let _ = self.errors.error(TypeError::CannotAssign {
+                    let _ = self.logger.error(TypeError::CannotAssign {
                         message: format!("cannot assign to immutable global variable '{name}'"),
                         span: assign.target.span(),
                     });
@@ -4564,7 +4639,7 @@ impl<'a> Resolver<'a> {
             } => {
                 let inner_type = self.type_table.borrow().get(expr.type_id).clone();
                 if matches!(inner_type, ResolvedType::Ref(_)) {
-                    let _ = self.errors.error(TypeError::CannotAssign {
+                    let _ = self.logger.error(TypeError::CannotAssign {
                         message: "cannot assign through immutable reference".to_string(),
                         span: assign.target.span(),
                     });
@@ -4578,7 +4653,7 @@ impl<'a> Resolver<'a> {
 
         if !is_valid_lvalue {
             // Report error for invalid assignment target
-            let _ = self.errors.error(TypeError::CannotAssign {
+            let _ = self.logger.error(TypeError::CannotAssign {
                 message: "expression is not assignable".to_string(),
                 span: assign.target.span(),
             });
@@ -4804,7 +4879,7 @@ impl<'a> Resolver<'a> {
                             let expected_args = usize::from(!payload_is_unit);
 
                             if args.len() != expected_args {
-                                let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                                let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                                     expected: expected_args,
                                     found: args.len(),
                                     span: call.span,
@@ -4837,7 +4912,7 @@ impl<'a> Resolver<'a> {
                             );
                         } else {
                             // Unknown case name
-                            let _ = self.errors.error(TypeError::UnknownFunction {
+                            let _ = self.logger.error(TypeError::UnknownFunction {
                                 name: format!("{prefix}::{suffix}"),
                                 span: call.span,
                             });
@@ -4911,7 +4986,7 @@ impl<'a> Resolver<'a> {
 
         // Report error for unknown functions
         if !is_known {
-            let _ = self.errors.error(TypeError::UnknownFunction {
+            let _ = self.logger.error(TypeError::UnknownFunction {
                 name: func_name.clone(),
                 span: call.span,
             });
@@ -5307,7 +5382,7 @@ impl<'a> Resolver<'a> {
             {
                 // Check if the literal can be an integer
                 if Self::is_float_only_literal(&num_lit.repr) {
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!(
                             "cannot use float literal '{}' as integer (has decimal point or negative exponent)",
                             num_lit.repr
@@ -5335,7 +5410,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        let _ = self.errors.error(TypeError::InvalidLiteral {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5360,7 +5435,7 @@ impl<'a> Resolver<'a> {
             {
                 // Check if the literal can be an integer
                 if Self::is_float_only_literal(&num_lit.repr) {
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!(
                             "cannot use float literal '-{}' as integer (has decimal point or negative exponent)",
                             num_lit.repr
@@ -5390,7 +5465,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        let _ = self.errors.error(TypeError::InvalidLiteral {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5423,7 +5498,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        let _ = self.errors.error(TypeError::InvalidLiteral {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5458,7 +5533,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        let _ = self.errors.error(TypeError::InvalidLiteral {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5549,7 +5624,7 @@ impl<'a> Resolver<'a> {
                                 lit.span,
                             );
                         }
-                        let _ = self.errors.error(TypeError::InvalidLiteral {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
                             message: format!("invalid u128 literal: {}", num_lit.repr),
                             span: lit.span,
                         });
@@ -5565,7 +5640,7 @@ impl<'a> Resolver<'a> {
                                 lit.span,
                             );
                         }
-                        let _ = self.errors.error(TypeError::InvalidLiteral {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
                             message: format!("invalid i128 literal: {}", num_lit.repr),
                             span: lit.span,
                         });
@@ -5601,7 +5676,7 @@ impl<'a> Resolver<'a> {
                             unary.span,
                         );
                     }
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!("invalid i128 literal: -{}", num_lit.repr),
                         span: unary.span,
                     });
@@ -5806,7 +5881,7 @@ impl<'a> Resolver<'a> {
             info
         } else {
             let type_name = self.type_table.borrow().type_name(base_type_id);
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: format!(
                     "type '{}' to have method '{}'",
                     type_name, method_call.method
@@ -5853,7 +5928,7 @@ impl<'a> Resolver<'a> {
             if let Some((expected_name, actual_name)) =
                 self.check_newtype_arg_mismatch(arg.type_id, expected_type)
             {
-                let _ = self.errors.error(TypeError::TypeMismatch {
+                let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: format!("argument {} to be {}", i + 1, expected_name),
                     found: actual_name,
                     span: method_call
@@ -6077,7 +6152,7 @@ impl<'a> Resolver<'a> {
                 "Some" => {
                     // Option::Some(value) - wrap in OptionSome
                     if args.len() != 1 {
-                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                             expected: 1,
                             found: args.len(),
                             span: static_call.span,
@@ -6097,7 +6172,7 @@ impl<'a> Resolver<'a> {
                 "None" => {
                     // Option::None - return null with Option<T> type
                     if !args.is_empty() {
-                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                             expected: 0,
                             found: args.len(),
                             span: static_call.span,
@@ -6137,7 +6212,7 @@ impl<'a> Resolver<'a> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: static_call.span,
@@ -6161,7 +6236,7 @@ impl<'a> Resolver<'a> {
                     );
                 } else {
                     // Unknown case name
-                    let _ = self.errors.error(TypeError::UnknownFunction {
+                    let _ = self.logger.error(TypeError::UnknownFunction {
                         name: format!("{}::{}", name, static_call.method),
                         span: static_call.span,
                     });
@@ -6169,7 +6244,7 @@ impl<'a> Resolver<'a> {
                 }
             } else {
                 // Variant not found in variant_cases (shouldn't happen)
-                let _ = self.errors.error(TypeError::UnknownType {
+                let _ = self.logger.error(TypeError::UnknownType {
                     name: name.clone(),
                     span: static_call.span,
                 });
@@ -6202,7 +6277,7 @@ impl<'a> Resolver<'a> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: static_call.span,
@@ -6226,7 +6301,7 @@ impl<'a> Resolver<'a> {
                     );
                 } else {
                     // Unknown case name
-                    let _ = self.errors.error(TypeError::UnknownFunction {
+                    let _ = self.logger.error(TypeError::UnknownFunction {
                         name: format!("{}::{}", name, static_call.method),
                         span: static_call.span,
                     });
@@ -8337,7 +8412,7 @@ impl<'a> Resolver<'a> {
                 for bound in &param.bounds {
                     if !self.type_implements_trait(type_arg, bound) {
                         let type_name = self.type_id_to_string(type_arg);
-                        let _ = self.errors.error(TypeError::TraitBoundNotSatisfied {
+                        let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                             type_name,
                             trait_name: bound.clone(),
                             param_name: param.name.clone(),
@@ -8978,7 +9053,7 @@ impl<'a> Resolver<'a> {
                     if index < elements.len() {
                         return (index as u32, elements[index]);
                     }
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!(
                             "tuple index {} out of bounds, tuple has {} elements",
                             index,
@@ -9161,7 +9236,7 @@ impl<'a> Resolver<'a> {
                         index.span,
                     );
                 } else {
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!(
                             "tuple index {} out of bounds, tuple has {} elements",
                             idx,
@@ -9174,7 +9249,7 @@ impl<'a> Resolver<'a> {
                 }
             }
             // Non-constant index on tuple
-            let _ = self.errors.error(TypeError::InvalidLiteral {
+            let _ = self.logger.error(TypeError::InvalidLiteral {
                 message: "tuple index must be a constant integer".to_string(),
                 span: index.span,
             });
@@ -9285,7 +9360,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Fallback: report error for unsupported indexing
-        let _ = self.errors.error(TypeError::TypeMismatch {
+        let _ = self.logger.error(TypeError::TypeMismatch {
             expected: "array or type implementing Index or IndexValue trait".to_string(),
             found: self.type_table.borrow().type_name(expr.type_id),
             span: index.span,
@@ -9353,7 +9428,7 @@ impl<'a> Resolver<'a> {
         let condition = match &if_expr.condition {
             ast::Condition::Expr(expr) => self.resolve_expr(expr, ctx),
             ast::Condition::Pattern { span, .. } => {
-                let _ = self.errors.error(TypeError::NotYetImplemented {
+                let _ = self.logger.error(TypeError::NotYetImplemented {
                     feature: "pattern matching in if expressions (use if statement instead)"
                         .to_string(),
                     span: *span,
@@ -9384,7 +9459,7 @@ impl<'a> Resolver<'a> {
                 // No else branch - require then branch to be unit
                 if then_type != TypeTable::UNIT {
                     let type_name = self.type_table.borrow().type_name(then_type);
-                    let _ = self.errors.error(TypeError::TypeMismatch {
+                    let _ = self.logger.error(TypeError::TypeMismatch {
                         expected: "()".to_string(),
                         found: type_name,
                         span: if_expr.then_block.span,
@@ -9395,7 +9470,7 @@ impl<'a> Resolver<'a> {
                 // Both branches exist but types don't match - report error
                 let then_name = self.type_table.borrow().type_name(then_type);
                 let else_name = self.type_table.borrow().type_name(else_type);
-                let _ = self.errors.error(TypeError::TypeMismatch {
+                let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: then_name,
                     found: else_name,
                     span: if_expr.else_block.as_ref().unwrap().span,
@@ -9406,7 +9481,7 @@ impl<'a> Resolver<'a> {
             // Types don't match
             let then_name = self.type_table.borrow().type_name(then_type);
             let else_name = self.type_table.borrow().type_name(else_type);
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: then_name,
                 found: else_name,
                 span: if_expr.else_block.as_ref().unwrap().span,
@@ -9452,7 +9527,7 @@ impl<'a> Resolver<'a> {
         let condition = match &if_expr.condition {
             ast::Condition::Expr(expr) => self.resolve_expr(expr, ctx),
             ast::Condition::Pattern { span, .. } => {
-                let _ = self.errors.error(TypeError::NotYetImplemented {
+                let _ = self.logger.error(TypeError::NotYetImplemented {
                     feature: "pattern matching in if expressions (use if statement instead)"
                         .to_string(),
                     span: *span,
@@ -10350,7 +10425,7 @@ impl<'a> Resolver<'a> {
                     let resolved = self.resolve_expr(elem, ctx);
                     // Type check: each element must match Array element type
                     if resolved.type_id != element_type && resolved.type_id != TypeTable::UNKNOWN {
-                        let _ = self.errors.error(TypeError::TypeMismatch {
+                        let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: self.type_table.borrow().type_name(element_type),
                             found: self.type_table.borrow().type_name(resolved.type_id),
                             span: elem.span(),
@@ -10441,7 +10516,7 @@ impl<'a> Resolver<'a> {
                             cast.span,
                         );
                     }
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!("invalid u128 literal: {}", num_lit.repr),
                         span: lit.span,
                     });
@@ -10451,7 +10526,7 @@ impl<'a> Resolver<'a> {
                         let (low, high) = Self::unpack_i128(value);
                         return self.build_from_pair_call(name, low, high, target_type, cast.span);
                     }
-                    let _ = self.errors.error(TypeError::InvalidLiteral {
+                    let _ = self.logger.error(TypeError::InvalidLiteral {
                         message: format!("invalid i128 literal: {}", num_lit.repr),
                         span: lit.span,
                     });
@@ -10472,7 +10547,7 @@ impl<'a> Resolver<'a> {
                     let (low, high) = Self::unpack_i128(value);
                     return self.build_from_pair_call(name, low, high, target_type, unary.span);
                 }
-                let _ = self.errors.error(TypeError::InvalidLiteral {
+                let _ = self.logger.error(TypeError::InvalidLiteral {
                     message: format!("invalid i128 literal: -{}", num_lit.repr),
                     span: unary.span,
                 });
@@ -10583,7 +10658,7 @@ impl<'a> Resolver<'a> {
         // Handle implicit struct literals (name is None)
         let Some(name) = &struct_lit.name else {
             // Implicit struct literal without type context - error
-            let _ = self.errors.error(TypeError::TypeMismatch {
+            let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: "named struct literal (e.g., Point { x: 1, y: 2 })".into(),
                 found: "implicit struct literal without type context".into(),
                 span: struct_lit.span,
@@ -11024,7 +11099,7 @@ impl<'a> Resolver<'a> {
                 return type_id;
             }
             // If not found, it's an unknown associated type
-            let _ = self.errors.error(TypeError::UnknownType {
+            let _ = self.logger.error(TypeError::UnknownType {
                 name: format!("Self::{}", namespaced.name),
                 span: namespaced.span,
             });
@@ -11034,7 +11109,7 @@ impl<'a> Resolver<'a> {
         if namespaced.namespace.as_str() == "builtin" {
             if namespaced.name.as_str() == "array" {
                 if namespaced.args.len() != 1 {
-                    let _ = self.errors.error(TypeError::ArgumentCountMismatch {
+                    let _ = self.logger.error(TypeError::ArgumentCountMismatch {
                         expected: 1,
                         found: namespaced.args.len(),
                         span: namespaced.span,
@@ -11046,14 +11121,14 @@ impl<'a> Resolver<'a> {
                     .borrow_mut()
                     .make_builtin_array(element_type)
             } else {
-                let _ = self.errors.error(TypeError::UnknownType {
+                let _ = self.logger.error(TypeError::UnknownType {
                     name: format!("builtin::{}", namespaced.name),
                     span: namespaced.span,
                 });
                 TypeTable::ERROR
             }
         } else {
-            let _ = self.errors.error(TypeError::UnknownType {
+            let _ = self.logger.error(TypeError::UnknownType {
                 name: format!("{}::{}", namespaced.namespace, namespaced.name),
                 span: namespaced.span,
             });
@@ -11143,7 +11218,7 @@ impl<'a> Resolver<'a> {
 
                 if !found_as_variant {
                     // Option not found as a variant - likely #![no_prelude] without explicit import
-                    let _ = self.errors.error(TypeError::UnknownType {
+                    let _ = self.logger.error(TypeError::UnknownType {
                         name: "Option".to_string(),
                         span,
                     });
@@ -11195,7 +11270,7 @@ impl<'a> Resolver<'a> {
                                         // Get the type name for the error message
                                         let type_name = self.type_id_to_string(type_arg);
                                         let _ =
-                                            self.errors.error(TypeError::TraitBoundNotSatisfied {
+                                            self.logger.error(TypeError::TraitBoundNotSatisfied {
                                                 type_name,
                                                 trait_name: bound.clone(),
                                                 param_name: param_name.clone(),
@@ -11276,15 +11351,16 @@ fn convert_unary_op(op: UnaryOp) -> TirUnaryOp {
 }
 
 /// Convenience function to resolve a module
-pub fn resolve_module(
+pub fn resolve_module<H: CompilerHost>(
     module: &Module,
     module_source: ModuleSource,
     symbols: &SymbolTable,
     loaded_modules: &HashMap<ModuleSource, Module>,
-) -> Result<TirModule, Vec<TypeError>> {
+    logger: &Logger<H>,
+) -> Result<TirModule, Bail> {
     let type_table = std::cell::RefCell::new(crate::tir::TypeTable::new());
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
-    let mut resolver = Resolver::new(symbols, loaded_modules, &builtin_registry);
+    let mut resolver = Resolver::new(symbols, loaded_modules, &builtin_registry, logger);
     resolver.resolve_module(module, module_source)
 }
 
@@ -11292,15 +11368,16 @@ pub fn resolve_module(
 ///
 /// This is the main entry point for the resolve phase. It resolves all modules
 /// to TIR and packages them into a Project struct.
-pub fn resolve_to_project(
+pub fn resolve_to_project<H: CompilerHost>(
     symbols: SymbolTable,
     modules: &HashMap<ModuleSource, Module>,
     entry_module_source: ModuleSource,
     implicit_modules: HashSet<ModuleSource>,
     module_name: String,
-) -> Result<Project, Vec<TypeError>> {
+    logger: &Logger<H>,
+) -> Result<Project, Bail> {
     let tir_modules =
-        Resolver::resolve_all_modules(&symbols, modules, entry_module_source.clone())?;
+        Resolver::resolve_all_modules(&symbols, modules, entry_module_source.clone(), logger)?;
 
     let (wasi_registry, world_registry) = crate::component_model::WasiRegistry::build_from_stdlib();
 

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -23,6 +23,7 @@ use crate::ast::{
     IfStmt, Item, LetStmt, Literal, LoopStmt, MatchArm, Module, Pattern, ReturnStmt, Stmt, Type,
     UnaryOp,
 };
+use crate::logger::ErrorLog;
 use crate::project::Project;
 use crate::symbol::{SymbolKind, SymbolTable};
 use crate::tir::{
@@ -484,7 +485,7 @@ pub struct Resolver<'a> {
     /// Imported function names for the current module
     imported_functions: HashSet<String>,
     /// Errors collected during resolution
-    errors: Vec<TypeError>,
+    errors: ErrorLog<TypeError>,
     /// Current module source being resolved (for struct type `module_source`)
     current_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
@@ -619,7 +620,7 @@ impl<'a> Resolver<'a> {
             all_resource_types: HashMap::new(),
             function_return_types: HashMap::new(),
             imported_functions: HashSet::new(),
-            errors: Vec::new(),
+            errors: ErrorLog::new(),
             current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
             current_module_items: Vec::new(),
             current_type_params: HashMap::new(),
@@ -893,10 +894,10 @@ impl<'a> Resolver<'a> {
             tir_module = tir_module.with_data_section(Some(data.to_string()));
         }
 
-        if self.errors.is_empty() {
-            Ok(tir_module)
+        if self.errors.has_errors() {
+            Err(self.errors.take())
         } else {
-            Err(std::mem::take(&mut self.errors))
+            Ok(tir_module)
         }
     }
 
@@ -911,7 +912,7 @@ impl<'a> Resolver<'a> {
         _entry_module_source: ModuleSource,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Vec<TypeError>> {
         let mut result = IndexMap::new();
-        let mut all_errors = Vec::new();
+        let mut all_errors = ErrorLog::new();
 
         // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
@@ -1269,7 +1270,7 @@ impl<'a> Resolver<'a> {
                 all_resource_types: all_resource_types.clone(),
                 function_return_types,
                 imported_functions,
-                errors: Vec::new(),
+                errors: ErrorLog::new(),
                 current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"), // Set in resolve_module
                 current_module_items: Vec::new(), // Set in resolve_module
                 current_type_params: HashMap::new(),
@@ -1293,18 +1294,15 @@ impl<'a> Resolver<'a> {
                     result.insert(module_source.clone(), tir_module);
                 }
                 Err(errors) => {
-                    all_errors.extend(errors);
+                    if all_errors.extend(errors).is_err() {
+                        // Too many errors across all modules - stop early
+                        return Err(all_errors.take());
+                    }
                 }
             }
         }
 
-        if all_errors.is_empty() {
-            // TypeTable is already shared across all modules via Rc<RefCell<>>
-            // No need to unify - all modules point to the same TypeTable
-            Ok(result)
-        } else {
-            Err(all_errors)
-        }
+        all_errors.into_result(result)
     }
 
     /// Build a module-specific flat map from per-module entries.
@@ -2114,7 +2112,7 @@ impl<'a> Resolver<'a> {
             && initializer.type_id != TypeTable::UNKNOWN
             && ty != TypeTable::UNKNOWN
         {
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: self.type_table.borrow().type_name(ty),
                 found: self.type_table.borrow().type_name(initializer.type_id),
                 span: global_decl.initializer.span(),
@@ -2658,7 +2656,7 @@ impl<'a> Resolver<'a> {
                             if resolved.type_id != element_type
                                 && resolved.type_id != TypeTable::UNKNOWN
                             {
-                                self.errors.push(TypeError::TypeMismatch {
+                                let _ = self.errors.error(TypeError::TypeMismatch {
                                     expected: self.type_table.borrow().type_name(element_type),
                                     found: self.type_table.borrow().type_name(resolved.type_id),
                                     span: elem.span(),
@@ -2690,7 +2688,7 @@ impl<'a> Resolver<'a> {
                                     && resolved.type_id != expected_type
                                     && resolved.type_id != TypeTable::UNKNOWN
                                 {
-                                    self.errors.push(TypeError::TypeMismatch {
+                                    let _ = self.errors.error(TypeError::TypeMismatch {
                                         expected: self.type_table.borrow().type_name(expected_type),
                                         found: self.type_table.borrow().type_name(resolved.type_id),
                                         span: elem.span(),
@@ -2702,7 +2700,7 @@ impl<'a> Resolver<'a> {
 
                         // Also check length mismatch
                         if tuple_lit.elements.len() != expected_elem_types.len() {
-                            self.errors.push(TypeError::TypeMismatch {
+                            let _ = self.errors.error(TypeError::TypeMismatch {
                                 expected: format!(
                                     "tuple with {} elements",
                                     expected_elem_types.len()
@@ -2758,7 +2756,7 @@ impl<'a> Resolver<'a> {
                         (value, target_type)
                     } else {
                         // Target type is not a struct - error
-                        self.errors.push(TypeError::TypeMismatch {
+                        let _ = self.errors.error(TypeError::TypeMismatch {
                             expected: self.type_table.borrow().type_name(target_type),
                             found: "implicit struct literal".into(),
                             span: struct_lit.span,
@@ -2797,7 +2795,7 @@ impl<'a> Resolver<'a> {
                 )
             };
             if !is_null_to_option {
-                self.errors.push(TypeError::TypeMismatch {
+                let _ = self.errors.error(TypeError::TypeMismatch {
                     expected: self.type_table.borrow().type_name(type_id),
                     found: self.type_table.borrow().type_name(value.type_id),
                     span: let_stmt.value.span(),
@@ -2846,7 +2844,7 @@ impl<'a> Resolver<'a> {
             }
             ast::Pattern::Literal(_) | ast::Pattern::Variant { .. } => {
                 // These patterns are not valid in let statements
-                self.errors.push(TypeError::InvalidPattern {
+                let _ = self.errors.error(TypeError::InvalidPattern {
                     message: "literal and variant patterns are not allowed in let statements"
                         .to_string(),
                     span: let_stmt.span,
@@ -2883,7 +2881,7 @@ impl<'a> Resolver<'a> {
                         elem_types.clone()
                     } else {
                         // Error: expected tuple type
-                        self.errors.push(TypeError::TypeMismatch {
+                        let _ = self.errors.error(TypeError::TypeMismatch {
                             expected: "tuple type".to_string(),
                             found: type_table.type_name(type_id),
                             span,
@@ -2894,7 +2892,7 @@ impl<'a> Resolver<'a> {
 
                 // Check length
                 if patterns.len() != elem_types.len() {
-                    self.errors.push(TypeError::TypeMismatch {
+                    let _ = self.errors.error(TypeError::TypeMismatch {
                         expected: format!("tuple with {} elements", elem_types.len()),
                         found: format!("pattern with {} elements", patterns.len()),
                         span,
@@ -2919,7 +2917,7 @@ impl<'a> Resolver<'a> {
             ast::Pattern::Wildcard => TirPattern::Wildcard,
             ast::Pattern::Literal(_) | ast::Pattern::Variant { .. } => {
                 // These patterns are not valid in let statements
-                self.errors.push(TypeError::InvalidPattern {
+                let _ = self.errors.error(TypeError::InvalidPattern {
                     message: "literal and variant patterns are not allowed in let statements"
                         .to_string(),
                     span,
@@ -3043,7 +3041,7 @@ impl<'a> Resolver<'a> {
                     Literal::Number(n) => {
                         // Float literals cannot be used in match patterns
                         if Self::is_float_only_literal(&n.repr) {
-                            self.errors.push(TypeError::InvalidPattern {
+                            let _ = self.errors.error(TypeError::InvalidPattern {
                                 message: "float literals cannot be used in match patterns"
                                     .to_string(),
                                 span,
@@ -3132,7 +3130,7 @@ impl<'a> Resolver<'a> {
                         if self.variant_cases.contains_key(name) {
                             self.get_variant_case_payload_type(name, variant_name, type_args, *span)
                         } else {
-                            self.errors.push(TypeError::TypeMismatch {
+                            let _ = self.errors.error(TypeError::TypeMismatch {
                                 expected: "variant type".to_string(),
                                 found: name.clone(),
                                 span: *span,
@@ -3141,7 +3139,7 @@ impl<'a> Resolver<'a> {
                         }
                     }
                     _ => {
-                        self.errors.push(TypeError::TypeMismatch {
+                        let _ = self.errors.error(TypeError::TypeMismatch {
                             expected: "variant type (Option or custom variant)".to_string(),
                             found: format!("{resolved_type:?}"),
                             span: *span,
@@ -3199,13 +3197,13 @@ impl<'a> Resolver<'a> {
 
         // Check if variant exists but case not found
         if self.variant_cases.contains_key(variant_name) {
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: format!("valid case of variant {variant_name}"),
                 found: case_name.to_string(),
                 span,
             });
         } else {
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: "known variant type".to_string(),
                 found: variant_name.to_string(),
                 span,
@@ -3227,7 +3225,7 @@ impl<'a> Resolver<'a> {
         if let Some(label) = &break_stmt.label
             && !ctx.active_labels.iter().any(|l| l == label)
         {
-            self.errors.push(TypeError::UnknownIdentifier {
+            let _ = self.errors.error(TypeError::UnknownIdentifier {
                 name: format!("labeled break target not found: {label}"),
                 span: break_stmt.span,
             });
@@ -3519,7 +3517,7 @@ impl<'a> Resolver<'a> {
                             TypeTable::F64,
                         ),
                         Err(message) => {
-                            self.errors.push(TypeError::InvalidLiteral {
+                            let _ = self.errors.error(TypeError::InvalidLiteral {
                                 message,
                                 span: lit.span,
                             });
@@ -3543,7 +3541,7 @@ impl<'a> Resolver<'a> {
                             TypeTable::I32,
                         ),
                         Err(message) => {
-                            self.errors.push(TypeError::InvalidLiteral {
+                            let _ = self.errors.error(TypeError::InvalidLiteral {
                                 message,
                                 span: lit.span,
                             });
@@ -3653,7 +3651,7 @@ impl<'a> Resolver<'a> {
                         ResolvedType::Unit
                     );
                     if !payload_is_unit {
-                        self.errors.push(TypeError::ArgumentCountMismatch {
+                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                             expected: 1,
                             found: 0,
                             span: ident.span,
@@ -3767,7 +3765,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Unknown variable - report error
-        self.errors.push(TypeError::UnknownIdentifier {
+        let _ = self.errors.error(TypeError::UnknownIdentifier {
             name: ident.name.clone(),
             span: ident.span,
         });
@@ -4170,7 +4168,7 @@ impl<'a> Resolver<'a> {
             if (left_is_newtype || right_is_newtype) && left.type_id != right.type_id {
                 let left_name = type_table.type_name(left.type_id);
                 let right_name = type_table.type_name(right.type_id);
-                self.errors.push(TypeError::TypeMismatch {
+                let _ = self.errors.error(TypeError::TypeMismatch {
                     expected: left_name,
                     found: right_name,
                     span: binary.span,
@@ -4220,7 +4218,7 @@ impl<'a> Resolver<'a> {
             && let Some(local) = ctx.lookup(name)
             && !local.is_mut
         {
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: "mutable variable".to_string(),
                 found: format!("immutable variable '{name}'"),
                 span: unary.span,
@@ -4246,7 +4244,7 @@ impl<'a> Resolver<'a> {
             if matches!(field_type, ResolvedType::Primitive(_))
                 || matches!(base_type, ResolvedType::Primitive(_))
             {
-                self.errors.push(TypeError::CannotAssign {
+                let _ = self.errors.error(TypeError::CannotAssign {
                     message: "cannot take mutable reference to primitive struct field; use the struct reference directly".to_string(),
                     span: unary.span,
                 });
@@ -4418,7 +4416,7 @@ impl<'a> Resolver<'a> {
                     *inner
                 } else {
                     // Cannot dereference non-reference type
-                    self.errors.push(TypeError::TypeMismatch {
+                    let _ = self.errors.error(TypeError::TypeMismatch {
                         expected: "reference type".to_string(),
                         found: self.type_table.borrow().type_name(expr.type_id),
                         span: unary.span,
@@ -4534,7 +4532,7 @@ impl<'a> Resolver<'a> {
 
             if let Some(is_mut) = is_mutable {
                 if !is_mut {
-                    self.errors.push(TypeError::CannotAssign {
+                    let _ = self.errors.error(TypeError::CannotAssign {
                         message: format!("cannot assign to immutable global variable '{name}'"),
                         span: assign.target.span(),
                     });
@@ -4566,7 +4564,7 @@ impl<'a> Resolver<'a> {
             } => {
                 let inner_type = self.type_table.borrow().get(expr.type_id).clone();
                 if matches!(inner_type, ResolvedType::Ref(_)) {
-                    self.errors.push(TypeError::CannotAssign {
+                    let _ = self.errors.error(TypeError::CannotAssign {
                         message: "cannot assign through immutable reference".to_string(),
                         span: assign.target.span(),
                     });
@@ -4580,7 +4578,7 @@ impl<'a> Resolver<'a> {
 
         if !is_valid_lvalue {
             // Report error for invalid assignment target
-            self.errors.push(TypeError::CannotAssign {
+            let _ = self.errors.error(TypeError::CannotAssign {
                 message: "expression is not assignable".to_string(),
                 span: assign.target.span(),
             });
@@ -4806,7 +4804,7 @@ impl<'a> Resolver<'a> {
                             let expected_args = usize::from(!payload_is_unit);
 
                             if args.len() != expected_args {
-                                self.errors.push(TypeError::ArgumentCountMismatch {
+                                let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                                     expected: expected_args,
                                     found: args.len(),
                                     span: call.span,
@@ -4839,7 +4837,7 @@ impl<'a> Resolver<'a> {
                             );
                         } else {
                             // Unknown case name
-                            self.errors.push(TypeError::UnknownFunction {
+                            let _ = self.errors.error(TypeError::UnknownFunction {
                                 name: format!("{prefix}::{suffix}"),
                                 span: call.span,
                             });
@@ -4913,7 +4911,7 @@ impl<'a> Resolver<'a> {
 
         // Report error for unknown functions
         if !is_known {
-            self.errors.push(TypeError::UnknownFunction {
+            let _ = self.errors.error(TypeError::UnknownFunction {
                 name: func_name.clone(),
                 span: call.span,
             });
@@ -5309,7 +5307,7 @@ impl<'a> Resolver<'a> {
             {
                 // Check if the literal can be an integer
                 if Self::is_float_only_literal(&num_lit.repr) {
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!(
                             "cannot use float literal '{}' as integer (has decimal point or negative exponent)",
                             num_lit.repr
@@ -5337,7 +5335,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        self.errors.push(TypeError::InvalidLiteral {
+                        let _ = self.errors.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5362,7 +5360,7 @@ impl<'a> Resolver<'a> {
             {
                 // Check if the literal can be an integer
                 if Self::is_float_only_literal(&num_lit.repr) {
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!(
                             "cannot use float literal '-{}' as integer (has decimal point or negative exponent)",
                             num_lit.repr
@@ -5392,7 +5390,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        self.errors.push(TypeError::InvalidLiteral {
+                        let _ = self.errors.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5425,7 +5423,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        self.errors.push(TypeError::InvalidLiteral {
+                        let _ = self.errors.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5460,7 +5458,7 @@ impl<'a> Resolver<'a> {
                         );
                     }
                     Err(message) => {
-                        self.errors.push(TypeError::InvalidLiteral {
+                        let _ = self.errors.error(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -5551,7 +5549,7 @@ impl<'a> Resolver<'a> {
                                 lit.span,
                             );
                         }
-                        self.errors.push(TypeError::InvalidLiteral {
+                        let _ = self.errors.error(TypeError::InvalidLiteral {
                             message: format!("invalid u128 literal: {}", num_lit.repr),
                             span: lit.span,
                         });
@@ -5567,7 +5565,7 @@ impl<'a> Resolver<'a> {
                                 lit.span,
                             );
                         }
-                        self.errors.push(TypeError::InvalidLiteral {
+                        let _ = self.errors.error(TypeError::InvalidLiteral {
                             message: format!("invalid i128 literal: {}", num_lit.repr),
                             span: lit.span,
                         });
@@ -5603,7 +5601,7 @@ impl<'a> Resolver<'a> {
                             unary.span,
                         );
                     }
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!("invalid i128 literal: -{}", num_lit.repr),
                         span: unary.span,
                     });
@@ -5808,7 +5806,7 @@ impl<'a> Resolver<'a> {
             info
         } else {
             let type_name = self.type_table.borrow().type_name(base_type_id);
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: format!(
                     "type '{}' to have method '{}'",
                     type_name, method_call.method
@@ -5855,7 +5853,7 @@ impl<'a> Resolver<'a> {
             if let Some((expected_name, actual_name)) =
                 self.check_newtype_arg_mismatch(arg.type_id, expected_type)
             {
-                self.errors.push(TypeError::TypeMismatch {
+                let _ = self.errors.error(TypeError::TypeMismatch {
                     expected: format!("argument {} to be {}", i + 1, expected_name),
                     found: actual_name,
                     span: method_call
@@ -6079,7 +6077,7 @@ impl<'a> Resolver<'a> {
                 "Some" => {
                     // Option::Some(value) - wrap in OptionSome
                     if args.len() != 1 {
-                        self.errors.push(TypeError::ArgumentCountMismatch {
+                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                             expected: 1,
                             found: args.len(),
                             span: static_call.span,
@@ -6099,7 +6097,7 @@ impl<'a> Resolver<'a> {
                 "None" => {
                     // Option::None - return null with Option<T> type
                     if !args.is_empty() {
-                        self.errors.push(TypeError::ArgumentCountMismatch {
+                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                             expected: 0,
                             found: args.len(),
                             span: static_call.span,
@@ -6139,7 +6137,7 @@ impl<'a> Resolver<'a> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        self.errors.push(TypeError::ArgumentCountMismatch {
+                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: static_call.span,
@@ -6163,7 +6161,7 @@ impl<'a> Resolver<'a> {
                     );
                 } else {
                     // Unknown case name
-                    self.errors.push(TypeError::UnknownFunction {
+                    let _ = self.errors.error(TypeError::UnknownFunction {
                         name: format!("{}::{}", name, static_call.method),
                         span: static_call.span,
                     });
@@ -6171,7 +6169,7 @@ impl<'a> Resolver<'a> {
                 }
             } else {
                 // Variant not found in variant_cases (shouldn't happen)
-                self.errors.push(TypeError::UnknownType {
+                let _ = self.errors.error(TypeError::UnknownType {
                     name: name.clone(),
                     span: static_call.span,
                 });
@@ -6204,7 +6202,7 @@ impl<'a> Resolver<'a> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        self.errors.push(TypeError::ArgumentCountMismatch {
+                        let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: static_call.span,
@@ -6228,7 +6226,7 @@ impl<'a> Resolver<'a> {
                     );
                 } else {
                     // Unknown case name
-                    self.errors.push(TypeError::UnknownFunction {
+                    let _ = self.errors.error(TypeError::UnknownFunction {
                         name: format!("{}::{}", name, static_call.method),
                         span: static_call.span,
                     });
@@ -8339,7 +8337,7 @@ impl<'a> Resolver<'a> {
                 for bound in &param.bounds {
                     if !self.type_implements_trait(type_arg, bound) {
                         let type_name = self.type_id_to_string(type_arg);
-                        self.errors.push(TypeError::TraitBoundNotSatisfied {
+                        let _ = self.errors.error(TypeError::TraitBoundNotSatisfied {
                             type_name,
                             trait_name: bound.clone(),
                             param_name: param.name.clone(),
@@ -8980,7 +8978,7 @@ impl<'a> Resolver<'a> {
                     if index < elements.len() {
                         return (index as u32, elements[index]);
                     }
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!(
                             "tuple index {} out of bounds, tuple has {} elements",
                             index,
@@ -9163,7 +9161,7 @@ impl<'a> Resolver<'a> {
                         index.span,
                     );
                 } else {
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!(
                             "tuple index {} out of bounds, tuple has {} elements",
                             idx,
@@ -9176,7 +9174,7 @@ impl<'a> Resolver<'a> {
                 }
             }
             // Non-constant index on tuple
-            self.errors.push(TypeError::InvalidLiteral {
+            let _ = self.errors.error(TypeError::InvalidLiteral {
                 message: "tuple index must be a constant integer".to_string(),
                 span: index.span,
             });
@@ -9287,7 +9285,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Fallback: report error for unsupported indexing
-        self.errors.push(TypeError::TypeMismatch {
+        let _ = self.errors.error(TypeError::TypeMismatch {
             expected: "array or type implementing Index or IndexValue trait".to_string(),
             found: self.type_table.borrow().type_name(expr.type_id),
             span: index.span,
@@ -9355,7 +9353,7 @@ impl<'a> Resolver<'a> {
         let condition = match &if_expr.condition {
             ast::Condition::Expr(expr) => self.resolve_expr(expr, ctx),
             ast::Condition::Pattern { span, .. } => {
-                self.errors.push(TypeError::NotYetImplemented {
+                let _ = self.errors.error(TypeError::NotYetImplemented {
                     feature: "pattern matching in if expressions (use if statement instead)"
                         .to_string(),
                     span: *span,
@@ -9386,7 +9384,7 @@ impl<'a> Resolver<'a> {
                 // No else branch - require then branch to be unit
                 if then_type != TypeTable::UNIT {
                     let type_name = self.type_table.borrow().type_name(then_type);
-                    self.errors.push(TypeError::TypeMismatch {
+                    let _ = self.errors.error(TypeError::TypeMismatch {
                         expected: "()".to_string(),
                         found: type_name,
                         span: if_expr.then_block.span,
@@ -9397,7 +9395,7 @@ impl<'a> Resolver<'a> {
                 // Both branches exist but types don't match - report error
                 let then_name = self.type_table.borrow().type_name(then_type);
                 let else_name = self.type_table.borrow().type_name(else_type);
-                self.errors.push(TypeError::TypeMismatch {
+                let _ = self.errors.error(TypeError::TypeMismatch {
                     expected: then_name,
                     found: else_name,
                     span: if_expr.else_block.as_ref().unwrap().span,
@@ -9408,7 +9406,7 @@ impl<'a> Resolver<'a> {
             // Types don't match
             let then_name = self.type_table.borrow().type_name(then_type);
             let else_name = self.type_table.borrow().type_name(else_type);
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: then_name,
                 found: else_name,
                 span: if_expr.else_block.as_ref().unwrap().span,
@@ -9454,7 +9452,7 @@ impl<'a> Resolver<'a> {
         let condition = match &if_expr.condition {
             ast::Condition::Expr(expr) => self.resolve_expr(expr, ctx),
             ast::Condition::Pattern { span, .. } => {
-                self.errors.push(TypeError::NotYetImplemented {
+                let _ = self.errors.error(TypeError::NotYetImplemented {
                     feature: "pattern matching in if expressions (use if statement instead)"
                         .to_string(),
                     span: *span,
@@ -10352,7 +10350,7 @@ impl<'a> Resolver<'a> {
                     let resolved = self.resolve_expr(elem, ctx);
                     // Type check: each element must match Array element type
                     if resolved.type_id != element_type && resolved.type_id != TypeTable::UNKNOWN {
-                        self.errors.push(TypeError::TypeMismatch {
+                        let _ = self.errors.error(TypeError::TypeMismatch {
                             expected: self.type_table.borrow().type_name(element_type),
                             found: self.type_table.borrow().type_name(resolved.type_id),
                             span: elem.span(),
@@ -10443,7 +10441,7 @@ impl<'a> Resolver<'a> {
                             cast.span,
                         );
                     }
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!("invalid u128 literal: {}", num_lit.repr),
                         span: lit.span,
                     });
@@ -10453,7 +10451,7 @@ impl<'a> Resolver<'a> {
                         let (low, high) = Self::unpack_i128(value);
                         return self.build_from_pair_call(name, low, high, target_type, cast.span);
                     }
-                    self.errors.push(TypeError::InvalidLiteral {
+                    let _ = self.errors.error(TypeError::InvalidLiteral {
                         message: format!("invalid i128 literal: {}", num_lit.repr),
                         span: lit.span,
                     });
@@ -10474,7 +10472,7 @@ impl<'a> Resolver<'a> {
                     let (low, high) = Self::unpack_i128(value);
                     return self.build_from_pair_call(name, low, high, target_type, unary.span);
                 }
-                self.errors.push(TypeError::InvalidLiteral {
+                let _ = self.errors.error(TypeError::InvalidLiteral {
                     message: format!("invalid i128 literal: -{}", num_lit.repr),
                     span: unary.span,
                 });
@@ -10585,7 +10583,7 @@ impl<'a> Resolver<'a> {
         // Handle implicit struct literals (name is None)
         let Some(name) = &struct_lit.name else {
             // Implicit struct literal without type context - error
-            self.errors.push(TypeError::TypeMismatch {
+            let _ = self.errors.error(TypeError::TypeMismatch {
                 expected: "named struct literal (e.g., Point { x: 1, y: 2 })".into(),
                 found: "implicit struct literal without type context".into(),
                 span: struct_lit.span,
@@ -11026,7 +11024,7 @@ impl<'a> Resolver<'a> {
                 return type_id;
             }
             // If not found, it's an unknown associated type
-            self.errors.push(TypeError::UnknownType {
+            let _ = self.errors.error(TypeError::UnknownType {
                 name: format!("Self::{}", namespaced.name),
                 span: namespaced.span,
             });
@@ -11036,7 +11034,7 @@ impl<'a> Resolver<'a> {
         if namespaced.namespace.as_str() == "builtin" {
             if namespaced.name.as_str() == "array" {
                 if namespaced.args.len() != 1 {
-                    self.errors.push(TypeError::ArgumentCountMismatch {
+                    let _ = self.errors.error(TypeError::ArgumentCountMismatch {
                         expected: 1,
                         found: namespaced.args.len(),
                         span: namespaced.span,
@@ -11048,14 +11046,14 @@ impl<'a> Resolver<'a> {
                     .borrow_mut()
                     .make_builtin_array(element_type)
             } else {
-                self.errors.push(TypeError::UnknownType {
+                let _ = self.errors.error(TypeError::UnknownType {
                     name: format!("builtin::{}", namespaced.name),
                     span: namespaced.span,
                 });
                 TypeTable::ERROR
             }
         } else {
-            self.errors.push(TypeError::UnknownType {
+            let _ = self.errors.error(TypeError::UnknownType {
                 name: format!("{}::{}", namespaced.namespace, namespaced.name),
                 span: namespaced.span,
             });
@@ -11145,7 +11143,7 @@ impl<'a> Resolver<'a> {
 
                 if !found_as_variant {
                     // Option not found as a variant - likely #![no_prelude] without explicit import
-                    self.errors.push(TypeError::UnknownType {
+                    let _ = self.errors.error(TypeError::UnknownType {
                         name: "Option".to_string(),
                         span,
                     });
@@ -11196,12 +11194,13 @@ impl<'a> Resolver<'a> {
                                     if !self.type_implements_trait(type_arg, bound) {
                                         // Get the type name for the error message
                                         let type_name = self.type_id_to_string(type_arg);
-                                        self.errors.push(TypeError::TraitBoundNotSatisfied {
-                                            type_name,
-                                            trait_name: bound.clone(),
-                                            param_name: param_name.clone(),
-                                            span,
-                                        });
+                                        let _ =
+                                            self.errors.error(TypeError::TraitBoundNotSatisfied {
+                                                type_name,
+                                                trait_name: bound.clone(),
+                                                param_name: param_name.clone(),
+                                                span,
+                                            });
                                     }
                                 }
                             }

--- a/wado-compiler/tests/common/mod.rs
+++ b/wado-compiler/tests/common/mod.rs
@@ -16,7 +16,7 @@ use wasmtime::component::{Linker, ResourceTable};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
-use wado_compiler::{CompileError, CompilerHost, Diagnostic, OptLevel, SourceError};
+use wado_compiler::{Bail, CompileError, CompilerHost, Diagnostic, OptLevel, SourceError};
 
 // ============================================================================
 // Compiler Hosts
@@ -61,7 +61,27 @@ impl CompilerHost for FilesystemHost {
 }
 
 /// An in-memory CompilerHost for tests that don't need file loading
-pub struct InMemoryHost;
+pub struct InMemoryHost {
+    diagnostics: Mutex<Vec<Diagnostic>>,
+}
+
+impl InMemoryHost {
+    pub fn new() -> Self {
+        Self {
+            diagnostics: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn diagnostics(&self) -> Vec<Diagnostic> {
+        self.diagnostics.lock().unwrap().clone()
+    }
+}
+
+impl Default for InMemoryHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl CompilerHost for InMemoryHost {
     fn load_source(
@@ -72,7 +92,64 @@ impl CompilerHost for InMemoryHost {
         async move { Err(SourceError::NotFound { path }) }
     }
 
-    fn emit_diagnostic(&self, _diagnostic: Diagnostic) {}
+    fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
+    }
+}
+
+/// Convert a `Bail` + host diagnostics into a `CompileError` for test backward compat
+pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>) -> CompileError {
+    if let Some(d) = diagnostics.first() {
+        let fname = filename.map(String::from).or_else(|| {
+            d.span.as_ref().and_then(|s| {
+                if s.file.is_empty() {
+                    None
+                } else {
+                    Some(s.file.clone())
+                }
+            })
+        });
+        let code = d.code;
+        let message = d.message.clone();
+        let line = d.span.as_ref().map_or(0, |s| s.line);
+        let column = d.span.as_ref().map_or(0, |s| s.column);
+
+        // Map diagnostic code to CompileError variant
+        use wado_compiler::Code;
+        if code == Code::InvalidSyntax && message.starts_with("lexer error:") {
+            CompileError::Lexer {
+                message: message
+                    .strip_prefix("lexer error: ")
+                    .unwrap_or(&message)
+                    .to_string(),
+                line,
+                column,
+                filename: fname,
+            }
+        } else if code == Code::InvalidSyntax && message.starts_with("parse error:") {
+            CompileError::Parser {
+                message: message
+                    .strip_prefix("parse error: ")
+                    .unwrap_or(&message)
+                    .to_string(),
+                line,
+                column,
+                filename: fname,
+            }
+        } else {
+            // All other errors
+            let all_messages: Vec<String> = diagnostics.iter().map(|d| d.message.clone()).collect();
+            CompileError::Analyzer {
+                message: all_messages.join("; "),
+                filename: fname,
+            }
+        }
+    } else {
+        CompileError::Analyzer {
+            message: "compilation failed".to_string(),
+            filename: filename.map(String::from),
+        }
+    }
 }
 
 // ============================================================================
@@ -204,13 +281,15 @@ pub fn cli_linker(engine: &Engine) -> anyhow::Result<Linker<CliWasiState>> {
 
 /// Compile source string using in-memory host
 pub fn compile_source(source: &str) -> Result<wado_compiler::CompileResult, CompileError> {
-    let host = InMemoryHost;
-    runtime().block_on(wado_compiler::compile_with_host(
-        source,
-        &host,
-        None,
-        OptLevel::default(),
-    ))
+    let host = InMemoryHost::new();
+    runtime()
+        .block_on(wado_compiler::compile_with_host(
+            source,
+            &host,
+            None,
+            OptLevel::default(),
+        ))
+        .map_err(|_: Bail| bail_to_compile_error(&host.diagnostics(), None))
 }
 
 /// Compile a file using filesystem host
@@ -239,13 +318,16 @@ pub fn compile_source_with_opts(
 ) -> Result<wado_compiler::CompileResult, CompileError> {
     let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let host = FilesystemHost::new(base_path);
+    let filename = path.to_string_lossy();
 
-    runtime().block_on(wado_compiler::compile_with_host(
-        source,
-        &host,
-        Some(&path.to_string_lossy()),
-        opt_level,
-    ))
+    runtime()
+        .block_on(wado_compiler::compile_with_host(
+            source,
+            &host,
+            Some(&filename),
+            opt_level,
+        ))
+        .map_err(|_: Bail| bail_to_compile_error(&host.diagnostics(), Some(&filename)))
 }
 
 /// Compile a file asynchronously (for use within async context)
@@ -260,8 +342,11 @@ pub async fn compile_file_async(
 
     let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let host = FilesystemHost::new(base_path);
+    let filename = path.to_string_lossy();
 
-    wado_compiler::compile_with_host(&source, &host, Some(&path.to_string_lossy()), opt_level).await
+    wado_compiler::compile_with_host(&source, &host, Some(&filename), opt_level)
+        .await
+        .map_err(|_: Bail| bail_to_compile_error(&host.diagnostics(), Some(&filename)))
 }
 
 // ============================================================================

--- a/wado-compiler/tests/http.rs
+++ b/wado-compiler/tests/http.rs
@@ -17,7 +17,7 @@ use wasmtime_wasi::{WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::p3::bindings::Service;
 use wasmtime_wasi_http::p3::{Request, WasiHttpCtx, WasiHttpCtxView, WasiHttpView};
 
-use wado_compiler::{CompileError, CompilerOptions, OptLevel};
+use wado_compiler::{Bail, CompileError, CompilerOptions, OptLevel};
 
 // ============================================================================
 // HTTP-specific WASI Context
@@ -64,15 +64,17 @@ async fn compile_http_service(path: &Path) -> Result<Vec<u8>, CompileError> {
 
     let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let host = common::FilesystemHost::new(base_path);
+    let filename = path.to_string_lossy();
 
     let options = CompilerOptions {
         opt_level: OptLevel::O2,
         target_world: Some("wasi:http/service".to_string()),
     };
 
-    wado_compiler::compile_with_options(&source, &host, Some(&path.to_string_lossy()), options)
+    wado_compiler::compile_with_options(&source, &host, Some(&filename), options)
         .await
         .map(|r| r.wasm)
+        .map_err(|_: Bail| common::bail_to_compile_error(&host.diagnostics(), Some(&filename)))
 }
 
 // ============================================================================


### PR DESCRIPTION
Replace Vec<E> error accumulation in all compiler phases (bind, analyze,
resolver, effect_check) with ErrorLog<E>, which tracks error count and
signals Bail when 100+ errors are reached. Add Severity::Fatal level
and ErrorLog::fatal() for immediate compilation abort.

https://claude.ai/code/session_017Yw988bA3efuSLXdSwsJEP