### PR TITLE
Fix WASI static function calls: CM ABI arg lowering for Option types

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -7617,8 +7617,49 @@ impl Codegen<'_> {
             } => {
                 let func_name = static_func.name();
 
-                // Generate arguments first
-                self.generate_args(func, args, type_table, ctx, builder);
+                // Check if this is a WASI static function to use CM ABI arg lowering.
+                // WASI functions need special argument handling (e.g., Option<T> is lowered
+                // to a (discriminant, payload) pair of i32 values instead of a GC nullref).
+                if let Some(func_info) = self.project.wasi_registry.get_function(&func_name) {
+                    for (i, arg) in args.iter().enumerate() {
+                        let param_type = &func_info.params[i].1;
+                        let resolved_type = self.project.wasi_registry.resolve_type(param_type);
+                        match &resolved_type {
+                            Type::Generic(g) if g.name == "Option" => {
+                                // Option<T> param: lower to (discriminant i32, payload i32)
+                                if matches!(arg.kind, TirExprKind::Null) {
+                                    // None: discriminant=0, payload=0
+                                    func.instruction(&Instruction::I32Const(0));
+                                    func.instruction(&Instruction::I32Const(0));
+                                } else {
+                                    // Some(value): discriminant=1, then the inner value
+                                    func.instruction(&Instruction::I32Const(1));
+                                    self.generate_expr(func, arg, type_table, ctx, builder);
+                                }
+                            }
+                            Type::Named(named) if named.name == "String" => {
+                                // String argument: lower to (ptr, len) pair
+                                self.generate_expr(func, arg, type_table, ctx, builder);
+                                let lower_idx = builder.func_idx("core/internal/cm_lower_string");
+                                func.instruction(&Instruction::Call(lower_idx));
+                                let temp = ctx.alloc_local("__cm_i64_temp", ValType::I64);
+                                func.instruction(&Instruction::LocalTee(temp));
+                                func.instruction(&Instruction::I32WrapI64);
+                                func.instruction(&Instruction::LocalGet(temp));
+                                func.instruction(&Instruction::I64Const(32));
+                                func.instruction(&Instruction::I64ShrU);
+                                func.instruction(&Instruction::I32WrapI64);
+                            }
+                            _ => {
+                                // Primitives, resource handles, Future<T>, Stream<T>, etc.
+                                self.generate_expr(func, arg, type_table, ctx, builder);
+                            }
+                        }
+                    }
+                } else {
+                    // Normal path: generate GC-level arguments
+                    self.generate_args(func, args, type_table, ctx, builder);
+                }
 
                 // Check if this is a monomorphized function using metadata
                 let base_struct_name = static_func.base_struct_name();

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -9567,7 +9567,7 @@ impl Codegen<'_> {
 
                             func.instruction(&Instruction::Else);
 
-                            // === Err case: extract ErrorCode discriminant and task-return Err ===
+                            // === Err case: extract ErrorCode and lower payload ===
                             let err_type_idx = result_info.cases[1].type_idx;
 
                             // Get ErrorCode type from Result's type_args[1]
@@ -9577,24 +9577,21 @@ impl Codegen<'_> {
                                     "expected GenericInstance for Result HTTP handler return"
                                 ),
                             };
-                            let (ec_name, ec_module_source) =
-                                match type_table.get(error_code_type_id) {
-                                    ResolvedType::Variant {
-                                        name,
-                                        module_source,
-                                    } => (name.clone(), module_source.clone()),
-                                    other => panic!(
-                                        "expected Variant for ErrorCode, got: {other:?}"
-                                    ),
-                                };
+                            let (ec_name, ec_module_source) = match type_table
+                                .get(error_code_type_id)
+                            {
+                                ResolvedType::Variant {
+                                    name,
+                                    module_source,
+                                } => (name.clone(), module_source.clone()),
+                                other => panic!("expected Variant for ErrorCode, got: {other:?}"),
+                            };
                             let ec_qualified_name = ec_module_source.qualify_name(&ec_name);
                             let ec_info = self
                                 .variant_types
                                 .get(&ec_qualified_name)
                                 .unwrap_or_else(|| {
-                                    panic!(
-                                        "ErrorCode variant not registered: {ec_qualified_name}"
-                                    )
+                                    panic!("ErrorCode variant not registered: {ec_qualified_name}")
                                 })
                                 .clone();
                             let ec_base_type_idx = ec_info.base_type_idx;
@@ -9609,7 +9606,12 @@ impl Codegen<'_> {
                                 field_index: 1, // ErrorCode payload
                             });
 
+                            // Save ErrorCode ref for payload extraction
+                            let ec_ref_local = ctx.alloc_local("_ec_ref", ValType::I32);
+                            func.instruction(&Instruction::LocalSet(ec_ref_local));
+
                             // Cast to ErrorCode base type and read discriminant
+                            func.instruction(&Instruction::LocalGet(ec_ref_local));
                             func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
                                 ec_base_type_idx,
                             )));
@@ -9617,21 +9619,208 @@ impl Codegen<'_> {
                                 struct_type_index: ec_base_type_idx,
                                 field_index: 0, // discriminant
                             });
-                            let ec_disc_local =
-                                ctx.alloc_local("_ec_disc", ValType::I32);
+                            let ec_disc_local = ctx.alloc_local("_ec_disc", ValType::I32);
                             func.instruction(&Instruction::LocalSet(ec_disc_local));
 
-                            // task-return Err(error-code) with discriminant only
-                            // (payload fields zeroed — correct for no-payload cases
-                            // and cases with None/null option payloads)
+                            // Pre-allocated payload locals (initialized to 0 by Wasm default)
+                            let p2 = ctx.alloc_local("_ec_p2", ValType::I32);
+                            let p3 = ctx.alloc_local("_ec_p3", ValType::I64);
+                            let p4 = ctx.alloc_local("_ec_p4", ValType::I32);
+                            let p5 = ctx.alloc_local("_ec_p5", ValType::I32);
+                            let p6 = ctx.alloc_local("_ec_p6", ValType::I32);
+                            let p7 = ctx.alloc_local("_ec_p7", ValType::I32);
+                            let payload_ref = ctx.alloc_local("_ec_payload_ref", ValType::I32);
+                            let field_ref = ctx.alloc_local("_ec_field_ref", ValType::I32);
+                            let i64_temp = ctx.alloc_local("_ec_i64_temp", ValType::I64);
+
+                            // Look up known payload struct types
+                            let string_type_idx = self
+                                .lookup_struct_type("String", &string_module_source())
+                                .map(|i| i.type_idx);
+                            let fsp_type_idx = self
+                                .lookup_struct_type("FieldSizePayload", &ec_module_source)
+                                .map(|i| i.type_idx);
+                            let dns_type_idx = self
+                                .lookup_struct_type("DnsErrorPayload", &ec_module_source)
+                                .map(|i| i.type_idx);
+                            let tls_type_idx = self
+                                .lookup_struct_type("TlsAlertReceivedPayload", &ec_module_source)
+                                .map(|i| i.type_idx);
+                            let box_u8_idx =
+                                self.get_box_struct_type_idx(&PrimitiveType::U8, type_table);
+                            let box_u16_idx =
+                                self.get_box_struct_type_idx(&PrimitiveType::U16, type_table);
+                            let box_u32_idx =
+                                self.get_box_struct_type_idx(&PrimitiveType::U32, type_table);
+                            let box_u64_idx =
+                                self.get_box_struct_type_idx(&PrimitiveType::U64, type_table);
+
+                            // Emit payload extraction for each non-unit ErrorCode case
+                            for case in &ec_info.cases {
+                                let Some(payload_vt) = &case.payload_type else {
+                                    continue; // unit case
+                                };
+                                let case_type_idx = case.type_idx;
+                                let case_index = case.name.clone(); // for debugging
+                                let _ = case_index;
+
+                                // Classify payload by ValType
+                                let (nullable, concrete_idx) = match payload_vt {
+                                    ValType::Ref(rt) => {
+                                        if let HeapType::Concrete(idx) = rt.heap_type {
+                                            (rt.nullable, Some(idx))
+                                        } else {
+                                            continue; // abstract ref, skip
+                                        }
+                                    }
+                                    _ => continue, // primitive, skip
+                                };
+
+                                // Emit: if (disc == case_index) { ... }
+                                func.instruction(&Instruction::LocalGet(ec_disc_local));
+                                func.instruction(&Instruction::I32Const(
+                                    ec_info
+                                        .cases
+                                        .iter()
+                                        .position(|c| c.type_idx == case_type_idx)
+                                        .unwrap() as i32,
+                                ));
+                                func.instruction(&Instruction::I32Eq);
+                                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+
+                                // Cast to case subtype and extract payload (field 1)
+                                func.instruction(&Instruction::LocalGet(ec_ref_local));
+                                func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                                    case_type_idx,
+                                )));
+                                func.instruction(&Instruction::StructGet {
+                                    struct_type_index: case_type_idx,
+                                    field_index: 1,
+                                });
+                                func.instruction(&Instruction::LocalSet(payload_ref));
+
+                                // Determine payload type and lower accordingly
+                                if nullable {
+                                    // Option type: nullable ref
+                                    if concrete_idx == string_type_idx {
+                                        // Option<String>: p2=disc, p3=ptr(i64), p4=len
+                                        Self::emit_option_string_lowering(
+                                            func,
+                                            payload_ref,
+                                            p2,
+                                            p3,
+                                            p4,
+                                            i64_temp,
+                                            string_type_idx.unwrap(),
+                                            builder,
+                                        );
+                                    } else if concrete_idx == box_u64_idx {
+                                        // Option<u64>: p2=disc, p3=value(i64)
+                                        Self::emit_option_box_u64_lowering(
+                                            func,
+                                            payload_ref,
+                                            p2,
+                                            p3,
+                                            concrete_idx.unwrap(),
+                                        );
+                                    } else if concrete_idx == box_u32_idx {
+                                        // Option<u32>: p2=disc, p3=value(i64)
+                                        Self::emit_option_box_i32_lowering(
+                                            func,
+                                            payload_ref,
+                                            p2,
+                                            p3,
+                                            concrete_idx.unwrap(),
+                                        );
+                                    } else if concrete_idx == fsp_type_idx {
+                                        // Option<FieldSizePayload>: p2=disc, p3-p7=fields
+                                        Self::emit_option_field_size_payload_lowering(
+                                            func,
+                                            payload_ref,
+                                            field_ref,
+                                            p2,
+                                            p3,
+                                            p4,
+                                            p5,
+                                            p6,
+                                            p7,
+                                            i64_temp,
+                                            concrete_idx.unwrap(),
+                                            box_u32_idx,
+                                            string_type_idx.unwrap(),
+                                            builder,
+                                        );
+                                    }
+                                    // else: unknown nullable payload, leave zeros
+                                } else {
+                                    // Direct struct payload (non-nullable)
+                                    if concrete_idx == fsp_type_idx {
+                                        // FieldSizePayload: p2-p6
+                                        Self::emit_field_size_payload_lowering(
+                                            func,
+                                            payload_ref,
+                                            field_ref,
+                                            p2,
+                                            p3,
+                                            p4,
+                                            p5,
+                                            p6,
+                                            i64_temp,
+                                            concrete_idx.unwrap(),
+                                            box_u32_idx,
+                                            string_type_idx.unwrap(),
+                                            builder,
+                                        );
+                                    } else if concrete_idx == dns_type_idx {
+                                        // DnsErrorPayload: p2-p6
+                                        Self::emit_dns_error_payload_lowering(
+                                            func,
+                                            payload_ref,
+                                            field_ref,
+                                            p2,
+                                            p3,
+                                            p4,
+                                            p5,
+                                            p6,
+                                            i64_temp,
+                                            concrete_idx.unwrap(),
+                                            box_u16_idx,
+                                            string_type_idx.unwrap(),
+                                            builder,
+                                        );
+                                    } else if concrete_idx == tls_type_idx {
+                                        // TlsAlertReceivedPayload: p2-p6
+                                        Self::emit_tls_alert_payload_lowering(
+                                            func,
+                                            payload_ref,
+                                            field_ref,
+                                            p2,
+                                            p3,
+                                            p4,
+                                            p5,
+                                            p6,
+                                            i64_temp,
+                                            concrete_idx.unwrap(),
+                                            box_u8_idx,
+                                            string_type_idx.unwrap(),
+                                            builder,
+                                        );
+                                    }
+                                    // else: unknown struct payload, leave zeros
+                                }
+
+                                func.instruction(&Instruction::End); // end if
+                            }
+
+                            // task-return Err(error-code) with lowered payload
                             func.instruction(&Instruction::I32Const(1)); // Err discriminant
                             func.instruction(&Instruction::LocalGet(ec_disc_local));
-                            func.instruction(&Instruction::I32Const(0)); // payload
-                            func.instruction(&Instruction::I64Const(0)); // payload
-                            func.instruction(&Instruction::I32Const(0)); // payload
-                            func.instruction(&Instruction::I32Const(0)); // payload
-                            func.instruction(&Instruction::I32Const(0)); // payload
-                            func.instruction(&Instruction::I32Const(0)); // payload
+                            func.instruction(&Instruction::LocalGet(p2));
+                            func.instruction(&Instruction::LocalGet(p3));
+                            func.instruction(&Instruction::LocalGet(p4));
+                            func.instruction(&Instruction::LocalGet(p5));
+                            func.instruction(&Instruction::LocalGet(p6));
+                            func.instruction(&Instruction::LocalGet(p7));
                             let task_ret_err = builder.func_idx("task-return");
                             func.instruction(&Instruction::Call(task_ret_err));
 
@@ -13263,6 +13452,419 @@ impl Codegen<'_> {
         }
 
         module.finish()
+    }
+
+    // ========================================================================
+    // ErrorCode payload lowering helpers
+    // ========================================================================
+    //
+    // These helpers emit Wasm instructions to lower ErrorCode variant payloads
+    // into flattened CM values for task-return. Each writes to pre-allocated
+    // locals (p2..p7) that map to task-return params 2..7.
+    //
+    // The CM ABI flattening of result<own<response>, error-code> is:
+    //   (i32, i32, i32, i64, i32, i32, i32, i32)
+    //    disc  ec   p2    p3   p4   p5   p6   p7
+    //
+    // Position p3 is i64 because it's the join of i32 (most cases) and i64
+    // (Option<u64> payload). When storing i32 values in p3, they must be
+    // extended to i64.
+
+    /// Emit lowering for Option<String> payload.
+    /// Layout: p2=disc, p3=ptr(i64), p4=len
+    fn emit_option_string_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        p2: u32,
+        p3: u32,
+        p4: u32,
+        i64_temp: u32,
+        string_type_idx: u32,
+        builder: &CoreModuleBuilder,
+    ) {
+        // payload_ref holds nullable String ref (stored in anyref local)
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefIsNull);
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        // Some: disc=1
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(p2));
+        // Lower string to linear memory (cast anyref → String for cm_lower_string)
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            string_type_idx,
+        )));
+        let lower_idx = builder.func_idx("core/internal/cm_lower_string");
+        func.instruction(&Instruction::Call(lower_idx));
+        func.instruction(&Instruction::LocalTee(i64_temp));
+        // Extract ptr (low 32 bits) → extend to i64
+        func.instruction(&Instruction::I32WrapI64);
+        func.instruction(&Instruction::I64ExtendI32U);
+        func.instruction(&Instruction::LocalSet(p3));
+        // Extract len (high 32 bits)
+        func.instruction(&Instruction::LocalGet(i64_temp));
+        func.instruction(&Instruction::I64Const(32));
+        func.instruction(&Instruction::I64ShrU);
+        func.instruction(&Instruction::I32WrapI64);
+        func.instruction(&Instruction::LocalSet(p4));
+        func.instruction(&Instruction::End);
+    }
+
+    /// Emit lowering for Option<u64> payload (nullable Box<u64>).
+    /// Layout: p2=disc, p3=value(i64)
+    fn emit_option_box_u64_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        p2: u32,
+        p3: u32,
+        box_type_idx: u32,
+    ) {
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefIsNull);
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(p2));
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            box_type_idx,
+        )));
+        func.instruction(&Instruction::StructGet {
+            struct_type_index: box_type_idx,
+            field_index: 0,
+        });
+        func.instruction(&Instruction::LocalSet(p3));
+        func.instruction(&Instruction::End);
+    }
+
+    /// Emit lowering for Option<u32> / Option<u16> / Option<u8> payload
+    /// (nullable Box with i32-valued field).
+    /// Layout: p2=disc, p3=value(i64, extended from i32)
+    fn emit_option_box_i32_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        p2: u32,
+        p3: u32,
+        box_type_idx: u32,
+    ) {
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefIsNull);
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(p2));
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            box_type_idx,
+        )));
+        func.instruction(&Instruction::StructGet {
+            struct_type_index: box_type_idx,
+            field_index: 0,
+        });
+        func.instruction(&Instruction::I64ExtendI32U);
+        func.instruction(&Instruction::LocalSet(p3));
+        func.instruction(&Instruction::End);
+    }
+
+    /// Emit lowering for `FieldSizePayload` struct.
+    /// {`field_name`: Option<String>, `field_size`: Option<u32>}
+    /// Layout: `p2=name_disc`, `p3=name_ptr(i64)`, `p4=name_len`, `p5=size_disc`, `p6=size_val`
+    #[allow(clippy::too_many_arguments)]
+    fn emit_field_size_payload_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        field_ref: u32,
+        p2: u32,
+        p3: u32,
+        p4: u32,
+        p5: u32,
+        p6: u32,
+        i64_temp: u32,
+        struct_type_idx: u32,
+        box_u32_idx: Option<u32>,
+        string_type_idx: u32,
+        builder: &CoreModuleBuilder,
+    ) {
+        // field_name (field 0): Option<String> = nullable String ref
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            struct_type_idx,
+        )));
+        func.instruction(&Instruction::StructGet {
+            struct_type_index: struct_type_idx,
+            field_index: 0,
+        });
+        func.instruction(&Instruction::LocalSet(field_ref));
+        Self::emit_option_string_lowering(
+            func,
+            field_ref,
+            p2,
+            p3,
+            p4,
+            i64_temp,
+            string_type_idx,
+            builder,
+        );
+
+        // field_size (field 1): Option<u32> = nullable Box<u32> ref
+        if let Some(box_idx) = box_u32_idx {
+            func.instruction(&Instruction::LocalGet(payload_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                struct_type_idx,
+            )));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: struct_type_idx,
+                field_index: 1,
+            });
+            func.instruction(&Instruction::LocalSet(field_ref));
+            // Inline option box lowering to p5/p6 (not p2/p3)
+            func.instruction(&Instruction::LocalGet(field_ref));
+            func.instruction(&Instruction::RefIsNull);
+            func.instruction(&Instruction::I32Eqz);
+            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::LocalSet(p5));
+            func.instruction(&Instruction::LocalGet(field_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(box_idx)));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: box_idx,
+                field_index: 0,
+            });
+            func.instruction(&Instruction::LocalSet(p6));
+            func.instruction(&Instruction::End);
+        }
+    }
+
+    /// Emit lowering for Option<FieldSizePayload>.
+    /// Layout: `p2=outer_disc`, `p3=name_disc(i64)`, `p4=name_ptr`, `p5=name_len`,
+    ///         `p6=size_disc`, `p7=size_val`
+    #[allow(clippy::too_many_arguments)]
+    fn emit_option_field_size_payload_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        field_ref: u32,
+        p2: u32,
+        p3: u32,
+        p4: u32,
+        p5: u32,
+        p6: u32,
+        p7: u32,
+        i64_temp: u32,
+        fsp_type_idx: u32,
+        box_u32_idx: Option<u32>,
+        string_type_idx: u32,
+        builder: &CoreModuleBuilder,
+    ) {
+        // payload_ref is nullable FieldSizePayload ref
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefIsNull);
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        // Some
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(p2));
+
+        // field_name (field 0): nullable String ref
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            fsp_type_idx,
+        )));
+        func.instruction(&Instruction::StructGet {
+            struct_type_index: fsp_type_idx,
+            field_index: 0,
+        });
+        func.instruction(&Instruction::LocalSet(field_ref));
+        // Check field_name is non-null
+        func.instruction(&Instruction::LocalGet(field_ref));
+        func.instruction(&Instruction::RefIsNull);
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        // name disc → p3 (as i64)
+        func.instruction(&Instruction::I64Const(1));
+        func.instruction(&Instruction::LocalSet(p3));
+        // Lower string (cast anyref → String for cm_lower_string)
+        func.instruction(&Instruction::LocalGet(field_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            string_type_idx,
+        )));
+        let lower_idx = builder.func_idx("core/internal/cm_lower_string");
+        func.instruction(&Instruction::Call(lower_idx));
+        func.instruction(&Instruction::LocalTee(i64_temp));
+        func.instruction(&Instruction::I32WrapI64);
+        func.instruction(&Instruction::LocalSet(p4));
+        func.instruction(&Instruction::LocalGet(i64_temp));
+        func.instruction(&Instruction::I64Const(32));
+        func.instruction(&Instruction::I64ShrU);
+        func.instruction(&Instruction::I32WrapI64);
+        func.instruction(&Instruction::LocalSet(p5));
+        func.instruction(&Instruction::End);
+
+        // field_size (field 1): nullable Box<u32> ref
+        if let Some(box_idx) = box_u32_idx {
+            func.instruction(&Instruction::LocalGet(payload_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                fsp_type_idx,
+            )));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: fsp_type_idx,
+                field_index: 1,
+            });
+            func.instruction(&Instruction::LocalSet(field_ref));
+            func.instruction(&Instruction::LocalGet(field_ref));
+            func.instruction(&Instruction::RefIsNull);
+            func.instruction(&Instruction::I32Eqz);
+            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::LocalSet(p6));
+            func.instruction(&Instruction::LocalGet(field_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(box_idx)));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: box_idx,
+                field_index: 0,
+            });
+            func.instruction(&Instruction::LocalSet(p7));
+            func.instruction(&Instruction::End);
+        }
+
+        func.instruction(&Instruction::End); // end outer Some
+    }
+
+    /// Emit lowering for `DnsErrorPayload` struct.
+    /// {rcode: Option<String>, `info_code`: Option<u16>}
+    /// Layout: `p2=rcode_disc`, `p3=rcode_ptr(i64)`, `p4=rcode_len`,
+    ///         `p5=info_disc`, `p6=info_val`
+    #[allow(clippy::too_many_arguments)]
+    fn emit_dns_error_payload_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        field_ref: u32,
+        p2: u32,
+        p3: u32,
+        p4: u32,
+        p5: u32,
+        p6: u32,
+        i64_temp: u32,
+        struct_type_idx: u32,
+        box_u16_idx: Option<u32>,
+        string_type_idx: u32,
+        builder: &CoreModuleBuilder,
+    ) {
+        // rcode (field 0): Option<String> = nullable String ref
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            struct_type_idx,
+        )));
+        func.instruction(&Instruction::StructGet {
+            struct_type_index: struct_type_idx,
+            field_index: 0,
+        });
+        func.instruction(&Instruction::LocalSet(field_ref));
+        Self::emit_option_string_lowering(
+            func,
+            field_ref,
+            p2,
+            p3,
+            p4,
+            i64_temp,
+            string_type_idx,
+            builder,
+        );
+
+        // info_code (field 1): Option<u16> = nullable Box<u16> ref
+        if let Some(box_idx) = box_u16_idx {
+            func.instruction(&Instruction::LocalGet(payload_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                struct_type_idx,
+            )));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: struct_type_idx,
+                field_index: 1,
+            });
+            func.instruction(&Instruction::LocalSet(field_ref));
+            func.instruction(&Instruction::LocalGet(field_ref));
+            func.instruction(&Instruction::RefIsNull);
+            func.instruction(&Instruction::I32Eqz);
+            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::LocalSet(p5));
+            func.instruction(&Instruction::LocalGet(field_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(box_idx)));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: box_idx,
+                field_index: 0,
+            });
+            func.instruction(&Instruction::LocalSet(p6));
+            func.instruction(&Instruction::End);
+        }
+    }
+
+    /// Emit lowering for `TlsAlertReceivedPayload` struct.
+    /// {`alert_id`: Option<u8>, `alert_message`: Option<String>}
+    /// Layout: `p2=id_disc`, `p3=id_val(i64)`, `p4=msg_disc`, `p5=msg_ptr`, `p6=msg_len`
+    #[allow(clippy::too_many_arguments)]
+    fn emit_tls_alert_payload_lowering(
+        func: &mut Function,
+        payload_ref: u32,
+        field_ref: u32,
+        p2: u32,
+        p3: u32,
+        p4: u32,
+        p5: u32,
+        p6: u32,
+        i64_temp: u32,
+        struct_type_idx: u32,
+        box_u8_idx: Option<u32>,
+        string_type_idx: u32,
+        builder: &CoreModuleBuilder,
+    ) {
+        // alert_id (field 0): Option<u8> = nullable Box<u8> ref
+        if let Some(box_idx) = box_u8_idx {
+            func.instruction(&Instruction::LocalGet(payload_ref));
+            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                struct_type_idx,
+            )));
+            func.instruction(&Instruction::StructGet {
+                struct_type_index: struct_type_idx,
+                field_index: 0,
+            });
+            func.instruction(&Instruction::LocalSet(field_ref));
+            Self::emit_option_box_i32_lowering(func, field_ref, p2, p3, box_idx);
+        }
+
+        // alert_message (field 1): Option<String> = nullable String ref
+        func.instruction(&Instruction::LocalGet(payload_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            struct_type_idx,
+        )));
+        func.instruction(&Instruction::StructGet {
+            struct_type_index: struct_type_idx,
+            field_index: 1,
+        });
+        func.instruction(&Instruction::LocalSet(field_ref));
+        // Lower to p4/p5/p6 instead of p2/p3/p4
+        func.instruction(&Instruction::LocalGet(field_ref));
+        func.instruction(&Instruction::RefIsNull);
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(p4));
+        // Cast anyref → String for cm_lower_string
+        func.instruction(&Instruction::LocalGet(field_ref));
+        func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            string_type_idx,
+        )));
+        let lower_idx = builder.func_idx("core/internal/cm_lower_string");
+        func.instruction(&Instruction::Call(lower_idx));
+        func.instruction(&Instruction::LocalTee(i64_temp));
+        func.instruction(&Instruction::I32WrapI64);
+        func.instruction(&Instruction::LocalSet(p5));
+        func.instruction(&Instruction::LocalGet(i64_temp));
+        func.instruction(&Instruction::I64Const(32));
+        func.instruction(&Instruction::I64ShrU);
+        func.instruction(&Instruction::I32WrapI64);
+        func.instruction(&Instruction::LocalSet(p6));
+        func.instruction(&Instruction::End);
     }
 }
 

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -9565,10 +9565,82 @@ impl Codegen<'_> {
 
                             func.instruction(&Instruction::Return);
 
-                            func.instruction(&Instruction::End); // end Ok if
+                            func.instruction(&Instruction::Else);
+
+                            // === Err case: extract ErrorCode discriminant and task-return Err ===
+                            let err_type_idx = result_info.cases[1].type_idx;
+
+                            // Get ErrorCode type from Result's type_args[1]
+                            let error_code_type_id = match type_table.get(result_type_id) {
+                                ResolvedType::GenericInstance { type_args, .. } => type_args[1],
+                                _ => panic!(
+                                    "expected GenericInstance for Result HTTP handler return"
+                                ),
+                            };
+                            let (ec_name, ec_module_source) =
+                                match type_table.get(error_code_type_id) {
+                                    ResolvedType::Variant {
+                                        name,
+                                        module_source,
+                                    } => (name.clone(), module_source.clone()),
+                                    other => panic!(
+                                        "expected Variant for ErrorCode, got: {other:?}"
+                                    ),
+                                };
+                            let ec_qualified_name = ec_module_source.qualify_name(&ec_name);
+                            let ec_info = self
+                                .variant_types
+                                .get(&ec_qualified_name)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "ErrorCode variant not registered: {ec_qualified_name}"
+                                    )
+                                })
+                                .clone();
+                            let ec_base_type_idx = ec_info.base_type_idx;
+
+                            // Load Result and extract ErrorCode from Err variant
+                            func.instruction(&Instruction::LocalGet(result_local));
+                            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                                err_type_idx,
+                            )));
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: err_type_idx,
+                                field_index: 1, // ErrorCode payload
+                            });
+
+                            // Cast to ErrorCode base type and read discriminant
+                            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                                ec_base_type_idx,
+                            )));
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: ec_base_type_idx,
+                                field_index: 0, // discriminant
+                            });
+                            let ec_disc_local =
+                                ctx.alloc_local("_ec_disc", ValType::I32);
+                            func.instruction(&Instruction::LocalSet(ec_disc_local));
+
+                            // task-return Err(error-code) with discriminant only
+                            // (payload fields zeroed — correct for no-payload cases
+                            // and cases with None/null option payloads)
+                            func.instruction(&Instruction::I32Const(1)); // Err discriminant
+                            func.instruction(&Instruction::LocalGet(ec_disc_local));
+                            func.instruction(&Instruction::I32Const(0)); // payload
+                            func.instruction(&Instruction::I64Const(0)); // payload
+                            func.instruction(&Instruction::I32Const(0)); // payload
+                            func.instruction(&Instruction::I32Const(0)); // payload
+                            func.instruction(&Instruction::I32Const(0)); // payload
+                            func.instruction(&Instruction::I32Const(0)); // payload
+                            let task_ret_err = builder.func_idx("task-return");
+                            func.instruction(&Instruction::Call(task_ret_err));
+
+                            func.instruction(&Instruction::Return);
+
+                            func.instruction(&Instruction::End); // end Ok/Err if
                         }
 
-                        // Fallback: Err case or no return value.
+                        // Fallback: no return value (function without explicit return).
                         // Create a hard-coded HTTP 200 response with empty body.
                         // 1. Create headers
                         // 2. Create trailers future (rx, tx)

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -9474,15 +9474,16 @@ impl Codegen<'_> {
                             let result_type_id = expr.type_id;
                             let mangled_name = type_table.mangle_type_name(result_type_id);
                             let result_module_source = match type_table.get(result_type_id) {
-                                ResolvedType::GenericInstance {
-                                    module_source, ..
-                                } => module_source.clone(),
+                                ResolvedType::GenericInstance { module_source, .. } => {
+                                    module_source.clone()
+                                }
                                 other => {
-                                    panic!("Expected GenericInstance (Result) for HTTP handler return, got: {other:?}")
+                                    panic!(
+                                        "Expected GenericInstance (Result) for HTTP handler return, got: {other:?}"
+                                    )
                                 }
                             };
-                            let qualified_name =
-                                result_module_source.qualify_name(&mangled_name);
+                            let qualified_name = result_module_source.qualify_name(&mangled_name);
                             let result_info = self
                                 .variant_types
                                 .get(&qualified_name)
@@ -9494,37 +9495,36 @@ impl Codegen<'_> {
                             let ok_type_idx = result_info.cases[0].type_idx;
 
                             // Save the Result value to a pre-allocated anyref local
-                            let result_local =
-                                ctx.alloc_local("_http_result", ValType::I32 /* unused, pre-allocated as anyref */);
+                            let result_local = ctx.alloc_local(
+                                "_http_result",
+                                ValType::I32, /* unused, pre-allocated as anyref */
+                            );
                             func.instruction(&Instruction::LocalSet(result_local));
 
                             // Read discriminant: 0 = Ok, non-zero = Err
                             // Cast from anyref to concrete Result base type first
                             func.instruction(&Instruction::LocalGet(result_local));
-                            func.instruction(&Instruction::RefCastNonNull(
-                                HeapType::Concrete(base_type_idx),
-                            ));
+                            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                                base_type_idx,
+                            )));
                             func.instruction(&Instruction::StructGet {
                                 struct_type_index: base_type_idx,
                                 field_index: 0,
                             });
                             func.instruction(&Instruction::I32Eqz); // true if Ok
 
-                            func.instruction(&Instruction::If(
-                                wasm_encoder::BlockType::Empty,
-                            ));
+                            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
 
                             // === Ok case: extract Response handle and task-return ===
                             func.instruction(&Instruction::LocalGet(result_local));
-                            func.instruction(&Instruction::RefCastNonNull(
-                                HeapType::Concrete(ok_type_idx),
-                            ));
+                            func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+                                ok_type_idx,
+                            )));
                             func.instruction(&Instruction::StructGet {
                                 struct_type_index: ok_type_idx,
                                 field_index: 1, // payload (Response handle)
                             });
-                            let user_response =
-                                ctx.alloc_local("_user_response", ValType::I32);
+                            let user_response = ctx.alloc_local("_user_response", ValType::I32);
                             func.instruction(&Instruction::LocalSet(user_response));
 
                             // task-return Ok(response)
@@ -9541,8 +9541,7 @@ impl Codegen<'_> {
 
                             // Post-return: resolve the user's trailers future by writing None.
                             // The tx handle was saved during Future::new() codegen.
-                            let user_tx =
-                                ctx.alloc_local("_user_trailers_tx", ValType::I32);
+                            let user_tx = ctx.alloc_local("_user_trailers_tx", ValType::I32);
                             // Write Result<Option<Trailers>, ErrorCode>::Ok(None) to memory
                             func.instruction(&Instruction::I32Const(256)); // offset for result disc
                             func.instruction(&Instruction::I32Const(0)); // Ok discriminant

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -9463,19 +9463,119 @@ impl Codegen<'_> {
                     // For async exports, call task-return with the result value
                     if ctx.has_http_handler_export {
                         // Service world: result<response, error-code>
-                        // TODO: Properly handle user's return value (deferred to future PR)
-                        // For now, drop the return value and create HTTP 200 response
+                        // Handle user's return value: extract Response from Ok,
+                        // fallback to hard-coded 200 for Err or missing return.
+
                         if let Some(expr) = value {
+                            // Generate the user's Result<Response, ErrorCode> expression
                             self.generate_expr(func, expr, type_table, ctx, builder);
+
+                            // Get Result variant type info for GC struct access
+                            let result_type_id = expr.type_id;
+                            let mangled_name = type_table.mangle_type_name(result_type_id);
+                            let result_module_source = match type_table.get(result_type_id) {
+                                ResolvedType::GenericInstance {
+                                    module_source, ..
+                                } => module_source.clone(),
+                                other => {
+                                    panic!("Expected GenericInstance (Result) for HTTP handler return, got: {other:?}")
+                                }
+                            };
+                            let qualified_name =
+                                result_module_source.qualify_name(&mangled_name);
+                            let result_info = self
+                                .variant_types
+                                .get(&qualified_name)
+                                .unwrap_or_else(|| {
+                                    panic!("Result type not registered: {qualified_name}")
+                                })
+                                .clone();
+                            let base_type_idx = result_info.base_type_idx;
+                            let ok_type_idx = result_info.cases[0].type_idx;
+
+                            // Save the Result value to a pre-allocated anyref local
+                            let result_local =
+                                ctx.alloc_local("_http_result", ValType::I32 /* unused, pre-allocated as anyref */);
+                            func.instruction(&Instruction::LocalSet(result_local));
+
+                            // Read discriminant: 0 = Ok, non-zero = Err
+                            // Cast from anyref to concrete Result base type first
+                            func.instruction(&Instruction::LocalGet(result_local));
+                            func.instruction(&Instruction::RefCastNonNull(
+                                HeapType::Concrete(base_type_idx),
+                            ));
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: base_type_idx,
+                                field_index: 0,
+                            });
+                            func.instruction(&Instruction::I32Eqz); // true if Ok
+
+                            func.instruction(&Instruction::If(
+                                wasm_encoder::BlockType::Empty,
+                            ));
+
+                            // === Ok case: extract Response handle and task-return ===
+                            func.instruction(&Instruction::LocalGet(result_local));
+                            func.instruction(&Instruction::RefCastNonNull(
+                                HeapType::Concrete(ok_type_idx),
+                            ));
+                            func.instruction(&Instruction::StructGet {
+                                struct_type_index: ok_type_idx,
+                                field_index: 1, // payload (Response handle)
+                            });
+                            let user_response =
+                                ctx.alloc_local("_user_response", ValType::I32);
+                            func.instruction(&Instruction::LocalSet(user_response));
+
+                            // task-return Ok(response)
+                            func.instruction(&Instruction::I32Const(0)); // Ok discriminant
+                            func.instruction(&Instruction::LocalGet(user_response));
+                            func.instruction(&Instruction::I32Const(0)); // padding
+                            func.instruction(&Instruction::I64Const(0)); // padding
+                            func.instruction(&Instruction::I32Const(0)); // padding
+                            func.instruction(&Instruction::I32Const(0)); // padding
+                            func.instruction(&Instruction::I32Const(0)); // padding
+                            func.instruction(&Instruction::I32Const(0)); // padding
+                            let task_ret = builder.func_idx("task-return");
+                            func.instruction(&Instruction::Call(task_ret));
+
+                            // Post-return: resolve the user's trailers future by writing None.
+                            // The tx handle was saved during Future::new() codegen.
+                            let user_tx =
+                                ctx.alloc_local("_user_trailers_tx", ValType::I32);
+                            // Write Result<Option<Trailers>, ErrorCode>::Ok(None) to memory
+                            func.instruction(&Instruction::I32Const(256)); // offset for result disc
+                            func.instruction(&Instruction::I32Const(0)); // Ok discriminant
+                            func.instruction(&Instruction::I32Store(MemArg {
+                                offset: 0,
+                                align: 2,
+                                memory_index: 0,
+                            }));
+                            func.instruction(&Instruction::I32Const(260)); // offset for option disc
+                            func.instruction(&Instruction::I32Const(0)); // None discriminant
+                            func.instruction(&Instruction::I32Store(MemArg {
+                                offset: 0,
+                                align: 2,
+                                memory_index: 0,
+                            }));
+                            func.instruction(&Instruction::LocalGet(user_tx));
+                            func.instruction(&Instruction::I32Const(256)); // payload ptr
+                            let future_write_idx = builder.func_idx("future-write");
+                            func.instruction(&Instruction::Call(future_write_idx));
                             func.instruction(&Instruction::Drop);
+
+                            func.instruction(&Instruction::Return);
+
+                            func.instruction(&Instruction::End); // end Ok if
                         }
 
-                        // Create HTTP 200 response:
+                        // Fallback: Err case or no return value.
+                        // Create a hard-coded HTTP 200 response with empty body.
                         // 1. Create headers
                         // 2. Create trailers future (rx, tx)
-                        // 3. Call response.new(rx) - this starts the reader!
-                        // 4. Write None to trailers future (reader should be ready now)
-                        // 5. Return Ok(response)
+                        // 3. Call response.new
+                        // 4. task-return Ok(response)
+                        // 5. Write None to trailers future (post-return)
 
                         // 1. Create headers
                         let fields_constructor_idx = builder.func_idx("http-fields-constructor");
@@ -9501,8 +9601,7 @@ impl Codegen<'_> {
                         let trailers_tx = ctx.alloc_local("_trailers_tx", ValType::I32);
                         func.instruction(&Instruction::LocalSet(trailers_tx));
 
-                        // 3. Call response.new FIRST (this starts the reader!)
-                        // response.new returns tuple: [response_handle, transmission_future]
+                        // 3. Call response.new
                         let response_new_idx = builder.func_idx("http-response-new");
                         func.instruction(&Instruction::LocalGet(headers_handle)); // headers
                         func.instruction(&Instruction::I32Const(0)); // body discriminant = None
@@ -9511,7 +9610,7 @@ impl Codegen<'_> {
                         func.instruction(&Instruction::I32Const(128)); // out_ptr
                         func.instruction(&Instruction::Call(response_new_idx));
 
-                        // 4. Read response handle from offset 128 (before task.return)
+                        // 4. Read response handle from offset 128
                         func.instruction(&Instruction::I32Const(128));
                         func.instruction(&Instruction::I32Load(MemArg {
                             offset: 0,
@@ -9521,7 +9620,7 @@ impl Codegen<'_> {
                         let response_handle = ctx.alloc_local("_response_handle", ValType::I32);
                         func.instruction(&Instruction::LocalSet(response_handle));
 
-                        // 5. Return Ok(response) via task-return
+                        // task-return Ok(response)
                         func.instruction(&Instruction::I32Const(0)); // Ok discriminant
                         func.instruction(&Instruction::LocalGet(response_handle));
                         func.instruction(&Instruction::I32Const(0)); // padding
@@ -9533,13 +9632,7 @@ impl Codegen<'_> {
                         let task_ret = builder.func_idx("task-return");
                         func.instruction(&Instruction::Call(task_ret));
 
-                        // 6. Write None (no trailers) to the trailers future
-                        // This is post-return execution - Component Model allows
-                        // code to run after task.return
-                        //
-                        // future-write payload: result<option<fields>, error-code>
-                        // - Ok(None) = 0 (result Ok), 0 (option None)
-                        // The payload is at memory offset, we'll use offset 256
+                        // 5. Write None to trailers future (post-return)
                         func.instruction(&Instruction::I32Const(256)); // offset for payload
                         func.instruction(&Instruction::I32Const(0)); // Ok discriminant
                         func.instruction(&Instruction::I32Store(MemArg {
@@ -9554,12 +9647,10 @@ impl Codegen<'_> {
                             align: 2,
                             memory_index: 0,
                         }));
-                        // Call future-write(tx, payload_ptr)
                         func.instruction(&Instruction::LocalGet(trailers_tx));
                         func.instruction(&Instruction::I32Const(256)); // payload ptr
                         let future_write_idx = builder.func_idx("future-write");
                         func.instruction(&Instruction::Call(future_write_idx));
-                        // Drop the return code (we don't check it)
                         func.instruction(&Instruction::Drop);
 
                         func.instruction(&Instruction::Return);
@@ -12641,6 +12732,15 @@ impl Codegen<'_> {
                 func.instruction(&Instruction::I64Const(32));
                 func.instruction(&Instruction::I64ShrU);
                 func.instruction(&Instruction::I32WrapI64);
+
+                // In HTTP handler, save the future tx handle so post-return code
+                // can resolve the trailers future after task-return.
+                if ctx.has_http_handler_export {
+                    let user_tx =
+                        ctx.alloc_local("_user_trailers_tx", ValType::I32);
+                    // Duplicate the tx value on the stack (tee saves and keeps)
+                    func.instruction(&Instruction::LocalTee(user_tx));
+                }
 
                 // Create tuple struct [rx, tx] unless skip_tuple_wrap is set
                 if !ctx.skip_tuple_wrap {

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -136,7 +136,13 @@ pub fn analyze_project(project: &mut Project) {
             }
         }
     }
-    if needs_cm_lower_string {
+    // HTTP handler exports need cm_lower_string for ErrorCode payload lowering
+    // (ErrorCode variant cases can contain Option<String> payloads)
+    let has_http_handler_export_early = project
+        .world_registry
+        .get(&project.target_world)
+        .is_some_and(super::world_registry::WorldInfo::has_http_handler_export);
+    if needs_cm_lower_string || has_http_handler_export_early {
         let func = core_internal("cm_lower_string");
         reachable.extend(compute_reachable(&call_graph, &func));
     }

--- a/wado-compiler/src/wasm_plan.rs
+++ b/wado-compiler/src/wasm_plan.rs
@@ -115,6 +115,18 @@ impl CmExportInfo {
                     name: "_response_handle".to_string(),
                     val_type: CmValType::I32,
                 },
+                CmScratchLocal {
+                    name: "_http_result".to_string(),
+                    val_type: CmValType::AnyRef,
+                },
+                CmScratchLocal {
+                    name: "_user_response".to_string(),
+                    val_type: CmValType::I32,
+                },
+                CmScratchLocal {
+                    name: "_user_trailers_tx".to_string(),
+                    val_type: CmValType::I32,
+                },
             ]);
         }
 

--- a/wado-compiler/src/wasm_plan.rs
+++ b/wado-compiler/src/wasm_plan.rs
@@ -131,6 +131,47 @@ impl CmExportInfo {
                     name: "_ec_disc".to_string(),
                     val_type: CmValType::I32,
                 },
+                // ErrorCode payload lowering scratch locals
+                CmScratchLocal {
+                    name: "_ec_ref".to_string(),
+                    val_type: CmValType::AnyRef,
+                },
+                CmScratchLocal {
+                    name: "_ec_p2".to_string(),
+                    val_type: CmValType::I32,
+                },
+                CmScratchLocal {
+                    name: "_ec_p3".to_string(),
+                    val_type: CmValType::I64,
+                },
+                CmScratchLocal {
+                    name: "_ec_p4".to_string(),
+                    val_type: CmValType::I32,
+                },
+                CmScratchLocal {
+                    name: "_ec_p5".to_string(),
+                    val_type: CmValType::I32,
+                },
+                CmScratchLocal {
+                    name: "_ec_p6".to_string(),
+                    val_type: CmValType::I32,
+                },
+                CmScratchLocal {
+                    name: "_ec_p7".to_string(),
+                    val_type: CmValType::I32,
+                },
+                CmScratchLocal {
+                    name: "_ec_payload_ref".to_string(),
+                    val_type: CmValType::AnyRef,
+                },
+                CmScratchLocal {
+                    name: "_ec_field_ref".to_string(),
+                    val_type: CmValType::AnyRef,
+                },
+                CmScratchLocal {
+                    name: "_ec_i64_temp".to_string(),
+                    val_type: CmValType::I64,
+                },
             ]);
         }
 

--- a/wado-compiler/src/wasm_plan.rs
+++ b/wado-compiler/src/wasm_plan.rs
@@ -127,6 +127,10 @@ impl CmExportInfo {
                     name: "_user_trailers_tx".to_string(),
                     val_type: CmValType::I32,
                 },
+                CmScratchLocal {
+                    name: "_ec_disc".to_string(),
+                    val_type: CmValType::I32,
+                },
             ]);
         }
 

--- a/wado-compiler/tests/fixtures.http/http-200.wado
+++ b/wado-compiler/tests/fixtures.http/http-200.wado
@@ -1,22 +1,20 @@
 // HTTP 200 response test
 // This test verifies the HTTP server returns 200 OK with empty body.
-//
-// Note: The current codegen ignores the user's return value and always
-// generates HTTP 200 response with empty body. The return statement below
-// is intentionally Err to demonstrate this behavior.
 
 use {
     Request,
     Response,
     ErrorCode,
+    Fields,
+    Trailers,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
-    // This return value is currently ignored by codegen.
-    // The handler always returns HTTP 200 with empty body.
-    return Result::<Response, ErrorCode>::Err(
-        ErrorCode::InternalError(null)
-    );
+    let [trailers_future, _trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, null, trailers_future);
+
+    return Result::<Response, ErrorCode>::Ok(response);
 }
 
 __DATA__

--- a/wado-compiler/tests/fixtures.http/http-400.wado
+++ b/wado-compiler/tests/fixtures.http/http-400.wado
@@ -1,26 +1,24 @@
 // HTTP 400 Bad Request response test
 // This test verifies the HTTP server can return 400 Bad Request.
-//
-// TODO: Current codegen ignores user's return value and always returns 200.
-// This test should pass once Response::set_status_code is implemented in codegen.
 
 use {
     Request,
     Response,
     ErrorCode,
+    Fields,
+    Trailers,
+    StatusCode,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
-    // TODO: Create response with 400 status code
-    // let response = Response::new(...);
-    // response.set_status_code(400);
-    // return Result::<Response, ErrorCode>::Ok(response);
+    let [trailers_future, _trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, null, trailers_future);
 
-    // For now, return Err which is also ignored
-    return Result::<Response, ErrorCode>::Err(
-        ErrorCode::HttpRequestDenied
-    );
+    response.set_status_code(400 as StatusCode);
+
+    return Result::<Response, ErrorCode>::Ok(response);
 }
 
 __DATA__
-{"TODO": true, "http_status": 400}
+{"http_status": 400}

--- a/wado-compiler/tests/fixtures.http/http-400.wado
+++ b/wado-compiler/tests/fixtures.http/http-400.wado
@@ -7,7 +7,6 @@ use {
     ErrorCode,
     Fields,
     Trailers,
-    StatusCode,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
@@ -15,7 +14,7 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
     let headers = Fields::new();
     let [response, _tx_future] = Response::new(headers, null, trailers_future);
 
-    response.set_status_code(400 as StatusCode);
+    response.set_status_code(400);
 
     return Result::<Response, ErrorCode>::Ok(response);
 }

--- a/wado-compiler/tests/fixtures.http/http-500.wado
+++ b/wado-compiler/tests/fixtures.http/http-500.wado
@@ -1,26 +1,24 @@
 // HTTP 500 Internal Server Error response test
 // This test verifies the HTTP server can return 500 Internal Server Error.
-//
-// TODO: Current codegen ignores user's return value and always returns 200.
-// This test should pass once Response::set_status_code is implemented in codegen.
 
 use {
     Request,
     Response,
     ErrorCode,
+    Fields,
+    Trailers,
+    StatusCode,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
-    // TODO: Create response with 500 status code
-    // let response = Response::new(...);
-    // response.set_status_code(500);
-    // return Result::<Response, ErrorCode>::Ok(response);
+    let [trailers_future, _trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, null, trailers_future);
 
-    // For now, return Err which is also ignored
-    return Result::<Response, ErrorCode>::Err(
-        ErrorCode::InternalError(Option::<String>::Some("Something went wrong"))
-    );
+    response.set_status_code(500 as StatusCode);
+
+    return Result::<Response, ErrorCode>::Ok(response);
 }
 
 __DATA__
-{"TODO": true, "http_status": 500}
+{"http_status": 500}

--- a/wado-compiler/tests/fixtures.http/http-500.wado
+++ b/wado-compiler/tests/fixtures.http/http-500.wado
@@ -7,7 +7,6 @@ use {
     ErrorCode,
     Fields,
     Trailers,
-    StatusCode,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
@@ -15,7 +14,7 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
     let headers = Fields::new();
     let [response, _tx_future] = Response::new(headers, null, trailers_future);
 
-    response.set_status_code(500 as StatusCode);
+    response.set_status_code(500);
 
     return Result::<Response, ErrorCode>::Ok(response);
 }

--- a/wado-compiler/tests/fixtures.http/http-error-code-payload.wado
+++ b/wado-compiler/tests/fixtures.http/http-error-code-payload.wado
@@ -1,0 +1,18 @@
+// HTTP ErrorCode payload lowering test
+// Tests that returning Err(ErrorCode::InternalError(Some("custom error")))
+// properly lowers the Option<String> payload through task-return.
+
+use {
+    Request,
+    Response,
+    ErrorCode,
+} from "wasi:http";
+
+export fn handle(request: Request) -> Result<Response, ErrorCode> {
+    return Result::<Response, ErrorCode>::Err(
+        ErrorCode::InternalError(Option::<String>::Some("custom error"))
+    );
+}
+
+__DATA__
+{"http_status": 500}

--- a/wado-compiler/tests/fixtures.http/http-error-code.wado
+++ b/wado-compiler/tests/fixtures.http/http-error-code.wado
@@ -1,0 +1,18 @@
+// HTTP ErrorCode return test
+// Tests that returning Err(ErrorCode::InternalError) from the handler
+// results in an HTTP 500 response.
+
+use {
+    Request,
+    Response,
+    ErrorCode,
+} from "wasi:http";
+
+export fn handle(request: Request) -> Result<Response, ErrorCode> {
+    return Result::<Response, ErrorCode>::Err(
+        ErrorCode::InternalError(null)
+    );
+}
+
+__DATA__
+{"http_status": 500}

--- a/wado-compiler/tests/fixtures.http/http-fields.wado
+++ b/wado-compiler/tests/fixtures.http/http-fields.wado
@@ -16,6 +16,7 @@ use {
     FieldName,
     FieldValue,
     HeaderError,
+    Trailers,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
@@ -57,10 +58,11 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
     let cloned_still_has = cloned.has("x-test" as FieldName);
     assert cloned_still_has;
 
-    // Return dummy (codegen always returns 200 with empty body)
-    return Result::<Response, ErrorCode>::Err(
-        ErrorCode::InternalError(null)
-    );
+    // Return 200 OK
+    let [trailers_future, _trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let response_headers = Fields::new();
+    let [response, _tx_future] = Response::new(response_headers, null, trailers_future);
+    return Result::<Response, ErrorCode>::Ok(response);
 }
 
 __DATA__

--- a/wado-compiler/tests/fixtures.http/http-future-new.wado
+++ b/wado-compiler/tests/fixtures.http/http-future-new.wado
@@ -10,6 +10,7 @@ use {
     Request,
     Response,
     ErrorCode,
+    Fields,
     Trailers,
 } from "wasi:http";
 
@@ -21,10 +22,11 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
     // The rx and tx handles are opaque i32 values managed by the runtime
     // We can't inspect them directly, but creating them should not trap
 
-    // Return dummy (codegen always returns 200 with empty body)
-    return Result::<Response, ErrorCode>::Err(
-        ErrorCode::InternalError(null)
-    );
+    // Return 200 OK
+    let [trailers_future, _trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, null, trailers_future);
+    return Result::<Response, ErrorCode>::Ok(response);
 }
 
 __DATA__

--- a/wado-compiler/tests/fixtures.http/http-response-ops.wado
+++ b/wado-compiler/tests/fixtures.http/http-response-ops.wado
@@ -7,6 +7,7 @@
 // - Response::new(headers, body, trailers) - construct a Response
 // - response.set_status_code(code) - set the status code
 // - response.get_status_code() - read the status code back
+// - Returning Ok(response) from the handler
 
 use {
     Request,
@@ -38,11 +39,9 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
     let new_status = response.get_status_code();
     assert new_status == 404 as StatusCode;
 
-    // Return dummy (codegen always returns 200 with empty body)
-    return Result::<Response, ErrorCode>::Err(
-        ErrorCode::InternalError(null)
-    );
+    // Return the response with status 404
+    return Result::<Response, ErrorCode>::Ok(response);
 }
 
 __DATA__
-{"http_status": 200}
+{"http_status": 404}

--- a/wado-compiler/tests/fixtures.http/http-response-ops.wado
+++ b/wado-compiler/tests/fixtures.http/http-response-ops.wado
@@ -15,7 +15,6 @@ use {
     ErrorCode,
     Fields,
     Trailers,
-    StatusCode,
 } from "wasi:http";
 
 export fn handle(request: Request) -> Result<Response, ErrorCode> {
@@ -30,14 +29,14 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
 
     // 4. Get default status code (should be 200)
     let default_status = response.get_status_code();
-    assert default_status == 200 as StatusCode;
+    assert default_status == 200;
 
     // 5. Set status code to 404
-    let set_result = response.set_status_code(404 as StatusCode);
+    let set_result = response.set_status_code(404);
 
     // 6. Read status code back (should be 404)
     let new_status = response.get_status_code();
-    assert new_status == 404 as StatusCode;
+    assert new_status == 404;
 
     // Return the response with status 404
     return Result::<Response, ErrorCode>::Ok(response);

--- a/wado-compiler/tests/fixtures.http/http-response-ops.wado
+++ b/wado-compiler/tests/fixtures.http/http-response-ops.wado
@@ -45,4 +45,4 @@ export fn handle(request: Request) -> Result<Response, ErrorCode> {
 }
 
 __DATA__
-{"TODO": true, "http_status": 200}
+{"http_status": 200}

--- a/wado-compiler/tests/http.rs
+++ b/wado-compiler/tests/http.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use bytes::Bytes;
-use futures::{FutureExt, try_join};
+use futures::FutureExt;
 use http_body_util::{BodyExt, Empty};
 use serde::Deserialize;
 use std::path::Path;
@@ -121,51 +121,44 @@ async fn run_http_request_async(wasm: Vec<u8>) -> anyhow::Result<HttpTestResult>
     // Add timeout wrapper
     let timeout_duration = Duration::from_secs(10);
 
-    // Run handler and response receiver in parallel
+    // Run handler, then receive response if Ok
     // Note: We don't await `io` because our handler doesn't consume request body
-    let result = tokio::time::timeout(timeout_duration, async {
-        let (handle_result, res) = try_join!(
-            async {
-                store
-                    .run_concurrent(async |store| {
-                        let (res, task) = match service.handle(store, req).await? {
-                            Ok(pair) => pair,
-                            Err(err) => return Ok(Err(Some(err))),
-                        };
-                        let _ =
-                            tx.send(store.with(|store| res.into_http(store, async { Ok(()) }))?);
-                        task.block(store).await;
-                        Ok(Ok(()))
-                    })
-                    .await?
-            },
-            async {
-                let res = rx.await?;
-                let (parts, body) = res.into_parts();
-                let body = body.collect().await?;
-                anyhow::Ok(http::Response::from_parts(parts, body))
-            }
-        )?;
-        // Drop io - we don't consume request body in our simple tests
-        drop(io);
-        anyhow::Ok((handle_result, res))
+    let handler_result = tokio::time::timeout(timeout_duration, async {
+        store
+            .run_concurrent(async |store| {
+                let (res, task) = match service.handle(store, req).await? {
+                    Ok(pair) => pair,
+                    Err(err) => return anyhow::Ok(Err(Some(err))),
+                };
+                let _ =
+                    tx.send(store.with(|store| res.into_http(store, async { Ok(()) }))?);
+                task.block(store).await;
+                Ok(Ok(()))
+            })
+            .await?
     })
     .await
     .map_err(|_| anyhow::anyhow!("HTTP handler timed out after {timeout_duration:?}"))??;
 
-    match result {
-        (Ok(()), res) => Ok(HttpTestResult {
-            status: res.status().as_u16(),
-            body: res.into_body().to_bytes().to_vec(),
-        }),
-        (Err(Some(error_code)), _) => {
+    drop(io);
+
+    match handler_result {
+        Ok(()) => {
+            let res = rx
+                .await
+                .map_err(|_| anyhow::anyhow!("response channel closed unexpectedly"))?;
+            let status = res.status().as_u16();
+            let body = res.into_body().collect().await?.to_bytes().to_vec();
+            Ok(HttpTestResult { status, body })
+        }
+        Err(Some(error_code)) => {
             // Handler returned error code - map to HTTP 500
             Ok(HttpTestResult {
                 status: 500,
                 body: format!("{error_code:?}").into_bytes(),
             })
         }
-        (Err(None), _) => Err(anyhow::anyhow!("Handler returned error without error code")),
+        Err(None) => Err(anyhow::anyhow!("Handler returned error without error code")),
     }
 }
 
@@ -337,6 +330,15 @@ async fn test_http_response_ops() {
     run_http_fixture_test(
         Path::new("tests/fixtures.http/http-response-ops.wado"),
         "http-response-ops.wado",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_http_error_code() {
+    run_http_fixture_test(
+        Path::new("tests/fixtures.http/http-error-code.wado"),
+        "http-error-code.wado",
     )
     .await;
 }

--- a/wado-compiler/tests/http.rs
+++ b/wado-compiler/tests/http.rs
@@ -130,8 +130,7 @@ async fn run_http_request_async(wasm: Vec<u8>) -> anyhow::Result<HttpTestResult>
                     Ok(pair) => pair,
                     Err(err) => return anyhow::Ok(Err(Some(err))),
                 };
-                let _ =
-                    tx.send(store.with(|store| res.into_http(store, async { Ok(()) }))?);
+                let _ = tx.send(store.with(|store| res.into_http(store, async { Ok(()) }))?);
                 task.block(store).await;
                 Ok(Ok(()))
             })
@@ -339,6 +338,15 @@ async fn test_http_error_code() {
     run_http_fixture_test(
         Path::new("tests/fixtures.http/http-error-code.wado"),
         "http-error-code.wado",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_http_error_code_payload() {
+    run_http_fixture_test(
+        Path::new("tests/fixtures.http/http-error-code-payload.wado"),
+        "http-error-code-payload.wado",
     )
     .await;
 }


### PR DESCRIPTION
Response::new(headers, null, trailers_future) was failing with Wasm
validation error "expected i32, found nullref" because StaticCall
generated GC-level args before looking up the WASI function. The null
argument for Option<Stream<u8>> became ref.null instead of the CM ABI
representation (i32 discriminant=0, i32 payload=0).

Now detects WASI static functions early in StaticCall handling and
generates CM ABI-lowered arguments (Option, String types) before the
normal function lookup. This enables Response::new(), get_status_code(),
and set_status_code() to work correctly in user HTTP handler code.

https://claude.ai/code/session_01Kjzf9fug65V4HhP6nnm6zC