### PR TITLE
Add compilation phase timing diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,40 @@ make benchmark-sieve       # use arrays
 make report-wasm-size
 ```
 
+## Compilation Log and Timing
+
+The compiler emits timestamped diagnostics to stderr. Use `--log-level` to control verbosity.
+
+### Log Levels
+
+```sh
+wado compile --log-level debug file.wado   # all messages including phase spans
+wado compile --log-level info file.wado    # info, warnings, errors (default)
+wado compile --log-level warn file.wado    # warnings and errors only
+wado compile --log-level error file.wado   # errors only
+wado compile --log-level off file.wado     # silent
+```
+
+`--log-level` is available on `compile`, `run`, and `serve` subcommands.
+
+### Reading the Output
+
+At `debug` level, the compiler logs phase spans with timestamps:
+
+```
+[00:00:00.0012] >> load <entry>       # phase start
+[00:00:00.0034] << load <entry>       # phase end
+[00:00:00.0035] >> load core:prelude
+[00:00:00.0051] << load core:prelude
+[00:00:00.0100] >> type_check
+[00:00:00.0250] << type_check
+```
+
+- `>>` marks the start of a phase, `<<` marks the end
+- Timestamps are `[hh:mm:ss.mmmm]` (0.1ms precision) from compilation start
+- Duration of a phase = its `<<` timestamp minus its `>>` timestamp
+- Errors and warnings include source location: `[timestamp] file:line:col: severity: message`
+
 ## Development Workflow
 
 ### When Starting a Task

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,24 +355,6 @@ wado compile --log-level off file.wado     # silent
 
 `--log-level` is available on `compile`, `run`, and `serve` subcommands.
 
-### Reading the Output
-
-At `debug` level, the compiler logs phase spans with timestamps:
-
-```
-[00:00:00.0012] >> load <entry>       # phase start
-[00:00:00.0034] << load <entry>       # phase end
-[00:00:00.0035] >> load core:prelude
-[00:00:00.0051] << load core:prelude
-[00:00:00.0100] >> type_check
-[00:00:00.0250] << type_check
-```
-
-- `>>` marks the start of a phase, `<<` marks the end
-- Timestamps are `[hh:mm:ss.mmmm]` (0.1ms precision) from compilation start
-- Duration of a phase = its `<<` timestamp minus its `>>` timestamp
-- Errors and warnings include source location: `[timestamp] file:line:col: severity: message`
-
 ## Development Workflow
 
 ### When Starting a Task

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -99,12 +99,23 @@ impl FilesystemCompilerHost {
         }
     }
 
-    /// Format diagnostic with timestamp for span tracking
+    /// Format elapsed time as `hh:mm:ss.mmmm` (fixed-width under 100 minutes).
     ///
     /// Time tracking is done here in the CLI to keep the compiler syscall-free.
-    fn format_diagnostic(&self, diagnostic: &Diagnostic) -> String {
+    fn format_timestamp(&self) -> String {
         let elapsed = self.start_time.elapsed();
-        let timestamp = format!("[{:>6.3}s]", elapsed.as_secs_f64());
+        let total_secs = elapsed.as_secs();
+        let hours = total_secs / 3600;
+        let minutes = (total_secs % 3600) / 60;
+        let seconds = total_secs % 60;
+        // 4 decimal places = 0.1ms precision
+        let frac = elapsed.subsec_micros() / 100;
+        format!("[{hours:02}:{minutes:02}:{seconds:02}.{frac:04}]")
+    }
+
+    /// Format diagnostic with timestamp for span tracking
+    fn format_diagnostic(&self, diagnostic: &Diagnostic) -> String {
+        let timestamp = self.format_timestamp();
 
         match diagnostic.code {
             Code::SpanStart => {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -271,11 +271,6 @@ pub async fn compile_with_options<H: CompilerHost>(
     // Loader performs: lex → parse → bind → desugar for each module
     // Also preserves the original (non-desugared) entry AST for tooling
     let load_result = {
-        let span_name = match filename {
-            Some(ref f) => format!("load {f}"),
-            None => "load".to_string(),
-        };
-        let _span = logger.span(&span_name);
         let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
             .load_all(source, filename.as_deref())
@@ -429,22 +424,12 @@ pub async fn dump_with_host<H: CompilerHost>(
 
     // === Phase 5: Load all modules ===
     let load_result = {
-        let span_name = match filename {
-            Some(ref f) => format!("load {f}"),
-            None => "load".to_string(),
-        };
-        let _span = logger.span(&span_name);
         let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
             .load_all(source, filename.as_deref())
             .await
             .map_err(|e| {
-                let _ = logger.error(compiler_host::Diagnostic {
-                    severity: compiler_host::Severity::Error,
-                    code: compiler_host::Code::ModuleNotFound,
-                    message: e.to_string(),
-                    span: None,
-                });
+                let _ = logger.error(e);
                 Bail
             })?
     };

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -267,70 +267,63 @@ pub async fn compile_with_options<H: CompilerHost>(
         logger.set_file(f);
     }
 
-    // === Phase 1: Lexer (for original AST) ===
-    let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| {
-        let _ = logger.error(e);
-        Bail
-    })?;
-    let (data_section, _comments, shebang) = lexer.into_parts();
-
-    // === Phase 2: Parser (for original AST) ===
-    // Note: The AST is parsed here for early error detection, but the Loader
-    // will re-parse the entry module along with all dependencies.
-    let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-    let ast = parser.parse().map_err(|e| {
-        let _ = logger.error(e);
-        Bail
-    })?;
-
-    // Note: Bind phase moved to Loader for all modules (including entry module)
-
-    // === Phase 3: Load all modules upfront ===
-    // Loader performs: parse → bind → desugar for each module
+    // === Phase 1: Load all modules ===
+    // Loader performs: lex → parse → bind → desugar for each module
+    // Also preserves the original (non-desugared) entry AST for tooling
     let load_result = {
+        let span_name = match filename {
+            Some(ref f) => format!("load {f}"),
+            None => "load".to_string(),
+        };
+        let _span = logger.span(&span_name);
         let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
             .load_all(source, filename.as_deref())
             .await
             .map_err(|e| {
-                let _ = logger.error(compiler_host::Diagnostic {
-                    severity: compiler_host::Severity::Error,
-                    code: compiler_host::Code::ModuleNotFound,
-                    message: e.to_string(),
-                    span: None,
-                });
+                let _ = logger.error(e);
                 Bail
             })?
     };
 
-    // === Phase 5: Analyze all modules ===
-    let mut analyzer = Analyzer::new(&logger);
-    analyzer.analyze_loaded_modules(
-        &load_result.modules,
-        &load_result.entry_module_source,
-        load_result.implicit_modules.clone(),
-    )?;
-
-    let symbols = analyzer.into_symbols();
+    // === Phase 2: Analyze all modules ===
+    let symbols = {
+        let _span = logger.span("analyze");
+        let mut analyzer = Analyzer::new(&logger);
+        analyzer.analyze_loaded_modules(
+            &load_result.modules,
+            &load_result.entry_module_source,
+            load_result.implicit_modules.clone(),
+        )?;
+        analyzer.into_symbols()
+    };
 
     let module_name = filename.clone().unwrap_or_else(|| "module".to_string());
 
     // === Phase 6: Resolve all modules to Project ===
-    let project = resolve_to_project(
-        symbols,
-        &load_result.modules,
-        load_result.entry_module_source.clone(),
-        load_result.implicit_modules.clone(),
-        module_name,
-        &logger,
-    )?;
+    let project = {
+        let _span = logger.span("resolve");
+        resolve_to_project(
+            symbols,
+            &load_result.modules,
+            load_result.entry_module_source.clone(),
+            load_result.implicit_modules.clone(),
+            module_name,
+            &logger,
+        )?
+    };
 
     // === Phase 7: Effect Check ===
-    check_effects(&project.tir_modules, &logger)?;
+    {
+        let _span = logger.span("effect-check");
+        check_effects(&project.tir_modules, &logger)?;
+    }
 
     // === Phase 8: Monomorphize (Project -> Project) ===
-    let mut project = monomorphize_project(project);
+    let mut project = {
+        let _span = logger.span("monomorphize");
+        monomorphize_project(project)
+    };
 
     // Apply target world from options
     // Convert WIT-style world specifier (e.g., "wasi:http/service") to internal name (e.g., "Service")
@@ -339,27 +332,42 @@ pub async fn compile_with_options<H: CompilerHost>(
     }
 
     // === Phase 9: Lower (Project -> Project) ===
-    let project = lower_project(project);
+    let project = {
+        let _span = logger.span("lower");
+        lower_project(project)
+    };
 
     // === Phase 10: Optimize (Project -> Project) ===
-    let project = optimize(project, options.opt_level);
+    let project = {
+        let _span = logger.span("optimize");
+        optimize(project, options.opt_level)
+    };
 
     // === Phase 11: Wasm Plan (Project -> Project) ===
-    let project = wasm_plan(project).map_err(|message| {
-        let _ = logger.error(compiler_host::Diagnostic {
-            severity: compiler_host::Severity::Error,
-            code: compiler_host::Code::UnsupportedFeature,
-            message,
-            span: None,
-        });
-        Bail
-    })?;
+    let project = {
+        let _span = logger.span("wasm-plan");
+        wasm_plan(project).map_err(|message| {
+            let _ = logger.error(compiler_host::Diagnostic {
+                severity: compiler_host::Severity::Error,
+                code: compiler_host::Code::UnsupportedFeature,
+                message,
+                span: None,
+            });
+            Bail
+        })?
+    };
 
     // === Phase 12: Codegen ===
-    let wasm = Codegen::generate_wasm(&project);
+    let wasm = {
+        let _span = logger.span("codegen");
+        Codegen::generate_wasm(&project)
+    };
 
-    // Return the original (non-desugared) AST for tooling
-    Ok(CompileResult { wasm, module: ast })
+    // Return the original (non-desugared) entry AST for tooling
+    Ok(CompileResult {
+        wasm,
+        module: load_result.entry_ast,
+    })
 }
 
 /// Dump compiler internal state (async version).
@@ -381,33 +389,51 @@ pub async fn dump_with_host<H: CompilerHost>(
     }
 
     // === Phase 1: Lexer ===
-    let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| {
-        let _ = logger.error(e);
-        Bail
-    })?;
-    let (data_section, comments, shebang) = lexer.into_parts();
+    let (tokens, tokens_for_dump, comments, data_section, shebang) = {
+        let _span = logger.span("lex");
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().map_err(|e| {
+            let _ = logger.error(e);
+            Bail
+        })?;
+        let (data_section, comments, shebang) = lexer.into_parts();
+        let tokens_for_dump = tokens.clone();
+        (tokens, tokens_for_dump, comments, data_section, shebang)
+    };
 
     // Build comment map
     let comment_map = comment::CommentMap::from_comments(comments, source);
 
     // === Phase 2: Parser ===
-    let tokens_for_dump = tokens.clone();
-    let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-    let ast = parser.parse().map_err(|e| {
-        let _ = logger.error(e);
-        Bail
-    })?;
+    let ast = {
+        let _span = logger.span("parse");
+        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        parser.parse().map_err(|e| {
+            let _ = logger.error(e);
+            Bail
+        })?
+    };
 
     // === Phase 3: Bind ===
-    let mut binder = Binder::new(&logger);
-    binder.bind_module(&ast)?;
+    {
+        let _span = logger.span("bind");
+        let mut binder = Binder::new(&logger);
+        binder.bind_module(&ast)?;
+    }
 
     // === Phase 4: Desugar ===
-    let desugared_ast = desugar::desugar_module(&ast);
+    let desugared_ast = {
+        let _span = logger.span("desugar");
+        desugar::desugar_module(&ast)
+    };
 
     // === Phase 5: Load all modules ===
     let load_result = {
+        let span_name = match filename {
+            Some(ref f) => format!("load {f}"),
+            None => "load".to_string(),
+        };
+        let _span = logger.span(&span_name);
         let module_loader = loader::ModuleLoader::new(host, compiler_host::LogLevel::default());
         module_loader
             .load_all(source, filename.as_deref())
@@ -424,72 +450,84 @@ pub async fn dump_with_host<H: CompilerHost>(
     };
 
     // === Phase 6: Analyze all modules ===
-    let mut analyzer = Analyzer::new(&logger);
-    analyzer.analyze_loaded_modules(
-        &load_result.modules,
-        &load_result.entry_module_source,
-        load_result.implicit_modules.clone(),
-    )?;
-
-    let symbols = analyzer.into_symbols();
+    let symbols = {
+        let _span = logger.span("analyze");
+        let mut analyzer = Analyzer::new(&logger);
+        analyzer.analyze_loaded_modules(
+            &load_result.modules,
+            &load_result.entry_module_source,
+            load_result.implicit_modules.clone(),
+        )?;
+        analyzer.into_symbols()
+    };
 
     // === Phase 7: Resolve all modules to TIR ===
-    let tir_modules = Resolver::resolve_all_modules(
-        &symbols,
-        &load_result.modules,
-        load_result.entry_module_source.clone(),
-        &logger,
-    )
-    .ok();
+    let tir_modules = {
+        let _span = logger.span("resolve");
+        Resolver::resolve_all_modules(
+            &symbols,
+            &load_result.modules,
+            load_result.entry_module_source.clone(),
+            &logger,
+        )
+        .ok()
+    };
 
     // TIR modules already use ModuleSource keys
     let tir_modules_by_source: Option<IndexMap<ModuleSource, tir::TirModule>> = tir_modules.clone();
 
     // === Phase 8: Monomorphize all modules ===
     // Use monomorphize_modules_indexed for cross-module generic function support
-    let monomorphized_tir_modules_by_source: Option<IndexMap<ModuleSource, tir::TirModule>> =
+    let monomorphized_tir_modules_by_source: Option<IndexMap<ModuleSource, tir::TirModule>> = {
+        let _span = logger.span("monomorphize");
         tir_modules_by_source
             .clone()
-            .map(monomorphize_modules_indexed);
+            .map(monomorphize_modules_indexed)
+    };
 
     // === Phase 9: Lower all modules ===
     // Apply string literal collection to monomorphized modules
     let entry_source = &load_result.entry_module_source;
-    let lowered_tir_modules_by_source: Option<IndexMap<ModuleSource, tir::TirModule>> =
+    let lowered_tir_modules_by_source: Option<IndexMap<ModuleSource, tir::TirModule>> = {
+        let _span = logger.span("lower");
         monomorphized_tir_modules_by_source
             .clone()
-            .map(|m| lower_modules_indexed(m, entry_source));
+            .map(|m| lower_modules_indexed(m, entry_source))
+    };
 
     // === Phase 10: Optimize ===
     // Build a Project from lowered modules if available
-    let optimized_project = lowered_tir_modules_by_source
-        .clone()
-        .and_then(|modules_by_source| {
-            let module_name = filename.clone().unwrap_or_else(|| "module".to_string());
+    let optimized_project = {
+        let _span = logger.span("optimize");
+        lowered_tir_modules_by_source
+            .clone()
+            .and_then(|modules_by_source| {
+                let module_name = filename.clone().unwrap_or_else(|| "module".to_string());
 
-            let implicit_modules_by_source = load_result.implicit_modules.clone();
+                let implicit_modules_by_source = load_result.implicit_modules.clone();
 
-            let (wasi_registry, world_registry) =
-                component_model::WasiRegistry::build_from_stdlib();
+                let (wasi_registry, world_registry) =
+                    component_model::WasiRegistry::build_from_stdlib();
 
-            // Build builtin registry (uses a temporary type table for type resolution)
-            let temp_type_table = std::cell::RefCell::new(tir::TypeTable::new());
-            let builtin_registry =
-                builtin_registry::BuiltinRegistry::build_from_stdlib(&temp_type_table);
+                // Build builtin registry (uses a temporary type table for type resolution)
+                let temp_type_table = std::cell::RefCell::new(tir::TypeTable::new());
+                let builtin_registry =
+                    builtin_registry::BuiltinRegistry::build_from_stdlib(&temp_type_table);
 
-            let project = Project::new(
-                load_result.entry_module_source.clone(),
-                modules_by_source,
-                symbols.clone(),
-                implicit_modules_by_source,
-                module_name,
-                wasi_registry,
-                world_registry,
-                builtin_registry,
-            );
-            let project = optimize(project, opt_level);
-            wasm_plan(project).ok()
-        });
+                let project = Project::new(
+                    load_result.entry_module_source.clone(),
+                    modules_by_source,
+                    symbols.clone(),
+                    implicit_modules_by_source,
+                    module_name,
+                    wasi_registry,
+                    world_registry,
+                    builtin_registry,
+                );
+                let project = optimize(project, opt_level);
+                wasm_plan(project).ok()
+            })
+    };
 
     Ok(DumpResult {
         source: source.to_string(),

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -28,11 +28,15 @@ pub enum LoadError {
     ParseError {
         module_source: ModuleSource,
         message: String,
+        line: usize,
+        column: usize,
     },
     /// Lexer error
     LexError {
         module_source: ModuleSource,
         message: String,
+        line: usize,
+        column: usize,
     },
     /// Bind error (scope checking)
     BindError {
@@ -56,14 +60,24 @@ impl std::fmt::Display for LoadError {
             LoadError::ParseError {
                 module_source,
                 message,
+                line,
+                column,
             } => {
-                write!(f, "parse error in {module_source}: {message}")
+                write!(
+                    f,
+                    "parse error in {module_source}: line {line}, column {column}: {message}"
+                )
             }
             LoadError::LexError {
                 module_source,
                 message,
+                line,
+                column,
             } => {
-                write!(f, "lex error in {module_source}: {message}")
+                write!(
+                    f,
+                    "lex error in {module_source}: line {line}, column {column}: {message}"
+                )
             }
             LoadError::BindError {
                 module_source,
@@ -92,6 +106,63 @@ impl std::fmt::Display for LoadError {
 
 impl std::error::Error for LoadError {}
 
+impl From<LoadError> for crate::compiler_host::Diagnostic {
+    fn from(e: LoadError) -> Self {
+        use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        match e {
+            LoadError::LexError {
+                message,
+                line,
+                column,
+                ..
+            } => Self {
+                severity: Severity::Error,
+                code: Code::InvalidSyntax,
+                message: format!("lexer error: {message}"),
+                span: Some(DiagnosticSpan {
+                    file: String::new(),
+                    line,
+                    column,
+                    end_line: None,
+                    end_column: None,
+                }),
+            },
+            LoadError::ParseError {
+                message,
+                line,
+                column,
+                ..
+            } => Self {
+                severity: Severity::Error,
+                code: Code::InvalidSyntax,
+                message: format!("parse error: {message}"),
+                span: Some(DiagnosticSpan {
+                    file: String::new(),
+                    line,
+                    column,
+                    end_line: None,
+                    end_column: None,
+                }),
+            },
+            LoadError::BindError {
+                module_source,
+                message,
+            } => Self {
+                severity: Severity::Error,
+                code: Code::DuplicateDefinition,
+                message: format!("bind error in {module_source}: {message}"),
+                span: None,
+            },
+            ref other => Self {
+                severity: Severity::Error,
+                code: Code::ModuleNotFound,
+                message: other.to_string(),
+                span: None,
+            },
+        }
+    }
+}
+
 impl From<SourceError> for LoadError {
     fn from(err: SourceError) -> Self {
         match err {
@@ -110,6 +181,8 @@ pub struct LoadResult {
     pub modules: IndexMap<ModuleSource, Module>,
     /// The entry module source
     pub entry_module_source: ModuleSource,
+    /// Original (non-desugared) entry module AST, for tooling
+    pub entry_ast: Module,
     /// Modules that were implicitly loaded (not from user imports)
     pub implicit_modules: IndexSet<ModuleSource>,
 }
@@ -203,11 +276,6 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         }
     }
 
-    /// Create a logger for emitting diagnostics
-    fn logger(&self) -> Logger<'_, H> {
-        Logger::new(self.host, self.log_level)
-    }
-
     /// Load all modules starting from the entry source
     ///
     /// This loads the entry module and all its transitive dependencies.
@@ -221,8 +289,6 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         entry_source: &str,
         entry_filename: Option<&str>,
     ) -> Result<LoadResult, LoadError> {
-        self.logger().span_start("load");
-
         // Parse, bind, and desugar entry module
         // Use "<stdin>" as synthetic filename when no filename is provided (e.g., REPL, embedded code)
         let entry_module_source =
@@ -234,11 +300,12 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         let mut pending: VecDeque<(ModuleSource, ModuleSource)> = VecDeque::new();
         self.collect_imports(&entry_ast, &entry_module_source, &mut pending)?;
 
-        // Bind and desugar, then store
+        // Bind and desugar, then store (keep original AST for tooling)
         self.bind_module(&entry_ast, &entry_module_source)?;
         let desugared_entry = desugar_module(&entry_ast);
         self.loaded
             .insert(entry_module_source.clone(), desugared_entry);
+        let entry_ast_original = entry_ast;
 
         // Load all dependencies iteratively
         let core_cache = cached_core_stdlib();
@@ -280,11 +347,10 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Load implicit modules (for compiler-generated code)
         self.load_implicit_modules()?;
 
-        self.logger().span_end("load");
-
         Ok(LoadResult {
             modules: self.loaded,
             entry_module_source,
+            entry_ast: entry_ast_original,
             implicit_modules: self.implicit_modules,
         })
     }
@@ -472,20 +538,18 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         let mut lexer = Lexer::new(source);
         let tokens = lexer.tokenize().map_err(|e| LoadError::LexError {
             module_source: module_source.clone(),
-            message: format!(
-                "line {}, column {}: {}",
-                e.span.line, e.span.column, e.message
-            ),
+            message: e.message,
+            line: e.span.line,
+            column: e.span.column,
         })?;
         let (data_section, _comments, shebang) = lexer.into_parts();
 
         let mut parser = Parser::with_metadata(tokens, shebang, data_section);
         parser.parse().map_err(|e| LoadError::ParseError {
             module_source: module_source.clone(),
-            message: format!(
-                "line {}, column {}: {}",
-                e.span.line, e.span.column, e.message
-            ),
+            message: e.message,
+            line: e.span.line,
+            column: e.span.column,
         })
     }
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -256,6 +256,8 @@ pub struct ModuleLoader<'a, H: CompilerHost> {
     host: &'a H,
     /// Log level for filtering messages
     log_level: LogLevel,
+    /// Logger for timing spans and diagnostics
+    logger: Logger<'a, H>,
     /// Cache of already parsed modules
     loaded: IndexMap<ModuleSource, Module>,
     /// Set of modules currently being loaded (for cycle detection during collection)
@@ -270,6 +272,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         Self {
             host,
             log_level,
+            logger: Logger::new(host, log_level),
             loaded: IndexMap::new(),
             loading: IndexSet::new(),
             implicit_modules: IndexSet::new(),
@@ -293,19 +296,34 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Use "<stdin>" as synthetic filename when no filename is provided (e.g., REPL, embedded code)
         let entry_module_source =
             ModuleSource::entry_point_with_filename(entry_filename.unwrap_or("<stdin>"));
+
+        let entry_name = entry_module_source.to_string();
+        self.logger.span_start(&format!("load {entry_name}"));
+
         // Parse first to collect imports before binding
-        let entry_ast = self.parse_source(entry_source, &entry_module_source)?;
+        let entry_ast = {
+            let _span = self.logger.span(&format!("parse {entry_name}"));
+            self.parse_source(entry_source, &entry_module_source)?
+        };
 
         // Collect imports from entry module (before bind/desugar)
         let mut pending: VecDeque<(ModuleSource, ModuleSource)> = VecDeque::new();
         self.collect_imports(&entry_ast, &entry_module_source, &mut pending)?;
 
         // Bind and desugar, then store (keep original AST for tooling)
-        self.bind_module(&entry_ast, &entry_module_source)?;
-        let desugared_entry = desugar_module(&entry_ast);
+        {
+            let _span = self.logger.span(&format!("bind {entry_name}"));
+            self.bind_module(&entry_ast, &entry_module_source)?;
+        }
+        let desugared_entry = {
+            let _span = self.logger.span(&format!("desugar {entry_name}"));
+            desugar_module(&entry_ast)
+        };
         self.loaded
             .insert(entry_module_source.clone(), desugared_entry);
         let entry_ast_original = entry_ast;
+
+        self.logger.span_end(&format!("load {entry_name}"));
 
         // Load all dependencies iteratively
         let core_cache = cached_core_stdlib();
@@ -320,8 +338,11 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 continue;
             }
 
+            let mod_name = module_source.to_string();
+
             // Use cached desugared module for core stdlib
             if let Some(cached) = core_cache.get(&module_source) {
+                let _span = self.logger.span(&format!("load {mod_name} (cached)"));
                 self.collect_imports(cached, &module_source, &mut pending)?;
                 self.loaded.insert(module_source, cached.clone());
                 continue;
@@ -330,18 +351,31 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             // Mark as loading
             self.loading.insert(module_source.clone());
 
+            self.logger.span_start(&format!("load {mod_name}"));
+
             // Load and parse the module
             let source = self.get_source(&module_source, &from_module_source).await?;
-            let ast = self.parse_source(&source, &module_source)?;
+            let ast = {
+                let _span = self.logger.span(&format!("parse {mod_name}"));
+                self.parse_source(&source, &module_source)?
+            };
 
             // Collect its imports (before bind/desugar)
             self.collect_imports(&ast, &module_source, &mut pending)?;
 
             // Bind, desugar, and store
-            self.bind_module(&ast, &module_source)?;
-            let desugared = desugar_module(&ast);
+            {
+                let _span = self.logger.span(&format!("bind {mod_name}"));
+                self.bind_module(&ast, &module_source)?;
+            }
+            let desugared = {
+                let _span = self.logger.span(&format!("desugar {mod_name}"));
+                desugar_module(&ast)
+            };
             self.loaded.insert(module_source.clone(), desugared);
             self.loading.swap_remove(&module_source);
+
+            self.logger.span_end(&format!("load {mod_name}"));
         }
 
         // Load implicit modules (for compiler-generated code)

--- a/wado-compiler/tests/common/mod.rs
+++ b/wado-compiler/tests/common/mod.rs
@@ -99,7 +99,15 @@ impl CompilerHost for InMemoryHost {
 
 /// Convert a `Bail` + host diagnostics into a `CompileError` for test backward compat
 pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>) -> CompileError {
-    if let Some(d) = diagnostics.first() {
+    use wado_compiler::{Code, Severity};
+
+    // Filter to only error/fatal diagnostics (skip span tracking and debug messages)
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| matches!(d.severity, Severity::Error | Severity::Fatal))
+        .collect();
+
+    if let Some(d) = errors.first() {
         let fname = filename.map(String::from).or_else(|| {
             d.span.as_ref().and_then(|s| {
                 if s.file.is_empty() {
@@ -115,7 +123,6 @@ pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>)
         let column = d.span.as_ref().map_or(0, |s| s.column);
 
         // Map diagnostic code to CompileError variant
-        use wado_compiler::Code;
         if code == Code::InvalidSyntax && message.starts_with("lexer error:") {
             CompileError::Lexer {
                 message: message
@@ -138,7 +145,7 @@ pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>)
             }
         } else {
             // All other errors
-            let all_messages: Vec<String> = diagnostics.iter().map(|d| d.message.clone()).collect();
+            let all_messages: Vec<String> = errors.iter().map(|d| d.message.clone()).collect();
             CompileError::Analyzer {
                 message: all_messages.join("; "),
                 filename: fname,


### PR DESCRIPTION
Change diagnostic timestamp format from seconds to hh:mm:ss.mmmm for
fixed-width display. Add span tracking around each compiler phase in
both compile_with_options and dump_with_host, emitting debug-level
diagnostics that show phase boundaries when --log-level debug is used.
Timing is handled entirely in wado-cli, keeping wado-compiler wasm32-safe.

https://claude.ai/code/session_01BUHQcKgzYefg1QTWFyUoBX