### PR TITLE
Introduce WIR (Wasm IR) interposition layer between codegen and wasm_encoder

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -7,7 +7,7 @@ This document describes the Wado compiler architecture and implementation status
 The compiler follows a multi-phase pipeline:
 
 ```
-Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve → Effect Check → Monomorphize → Lower → Optimize → Wasm Plan → Codegen
+Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve → Effect Check → Monomorphize → Lower → Optimize → Wasm Plan → Codegen → Emit
 ```
 
 ### Compilation Pipeline
@@ -25,7 +25,8 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 | Lower        | Project       | Project         | Closure, i128 match, global init, string literal lowering |
 | Optimize     | Project       | Project         | DCE, usage analysis, feature flags                        |
 | Wasm Plan    | Project       | Project         | Wasm pre-codegen planning, CM boundary analysis           |
-| Codegen      | Project       | Wasm bytes      | Generate Component Model Wasm                             |
+| Codegen      | Project       | WirModule       | Build WIR module (types, imports, globals, function bodies) |
+| Emit         | WirModule     | Wasm bytes      | Mechanical conversion of WirModule to Wasm binary         |
 
 **Note:** The Desugar phase is integrated into the Load phase. Each module goes through the same frontend pipeline: `lexer → parser → bind → desugar`.
 
@@ -64,8 +65,10 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 | WasiRegistry     | `wasi_registry.rs`      | WASI import registry, WASI type resolution            |
 | BuiltinRegistry  | `builtin_registry.rs`   | Builtin function registry from `core:builtin`         |
 | WorldRegistry    | `world_registry.rs`     | World definitions registry for export signatures      |
-| WasmBuilder      | `wasm_builder.rs`       | Wasm index tracking utilities                         |
-| Codegen          | `codegen.rs`            | Generates Component Model Wasm via wasm-encoder       |
+| WIR              | `wir.rs`                | WIR (Wasm IR) data structures: WirModule, WirInstr    |
+| WirEmit          | `wir_emit.rs`           | Emits WirModule to Wasm binary via wasm-encoder       |
+| WasmBuilder      | `wasm_builder.rs`       | Collects WIR types and tracks Wasm indices            |
+| Codegen          | `codegen.rs`            | Builds WirModule for Component Model Wasm             |
 | Bundled          | `bundled.rs`            | Loads pre-compiled Wasm builtins (wado-bundled)       |
 | Postproc         | `wasm_postprocess.rs`   | Wasm binary transformations                           |
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -12,21 +12,21 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 
 ### Compilation Pipeline
 
-| Phase        | Input         | Output          | Description                                               |
-| ------------ | ------------- | --------------- | --------------------------------------------------------- |
-| Lexer        | Source        | Tokens          | Tokenize, extract `__DATA__` section                      |
-| Parser       | Tokens        | AST             | Build abstract syntax tree                                |
-| Bind         | AST           | AST (validated) | Local name resolution, scope/mutability checking          |
-| Load         | AST           | All modules     | Load dependencies; each module: parse → bind → desugar    |
-| Analyze      | All modules   | Symbol table    | Build symbol table, validate imports                      |
-| Resolve      | AST + Symbols | Project         | Type resolution, produce Project                          |
-| Effect Check | Project       | Errors          | Validate function effect requirements                     |
-| Monomorphize | Project       | Project         | Instantiate generics with concrete types                  |
-| Lower        | Project       | Project         | Closure, i128 match, global init, string literal lowering |
-| Optimize     | Project       | Project         | DCE, usage analysis, feature flags                        |
-| Wasm Plan    | Project       | Project         | Wasm pre-codegen planning, CM boundary analysis           |
+| Phase        | Input         | Output          | Description                                                 |
+| ------------ | ------------- | --------------- | ----------------------------------------------------------- |
+| Lexer        | Source        | Tokens          | Tokenize, extract `__DATA__` section                        |
+| Parser       | Tokens        | AST             | Build abstract syntax tree                                  |
+| Bind         | AST           | AST (validated) | Local name resolution, scope/mutability checking            |
+| Load         | AST           | All modules     | Load dependencies; each module: parse → bind → desugar      |
+| Analyze      | All modules   | Symbol table    | Build symbol table, validate imports                        |
+| Resolve      | AST + Symbols | Project         | Type resolution, produce Project                            |
+| Effect Check | Project       | Errors          | Validate function effect requirements                       |
+| Monomorphize | Project       | Project         | Instantiate generics with concrete types                    |
+| Lower        | Project       | Project         | Closure, i128 match, global init, string literal lowering   |
+| Optimize     | Project       | Project         | DCE, usage analysis, feature flags                          |
+| Wasm Plan    | Project       | Project         | Wasm pre-codegen planning, CM boundary analysis             |
 | Codegen      | Project       | WirModule       | Build WIR module (types, imports, globals, function bodies) |
-| Emit         | WirModule     | Wasm bytes      | Mechanical conversion of WirModule to Wasm binary         |
+| Emit         | WirModule     | Wasm bytes      | Mechanical conversion of WirModule to Wasm binary           |
 
 **Note:** The Desugar phase is integrated into the Load phase. Each module goes through the same frontend pipeline: `lexer → parser → bind → desugar`.
 

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -31,6 +31,7 @@ use crate::wasm_plan::{
     sort_types_topologically,
 };
 use crate::wasm_postprocess;
+use crate::wir::WirFunction;
 use crate::world_registry::WorldExportInfo;
 use heck::ToKebabCase;
 use indexmap::IndexMap;
@@ -4474,7 +4475,7 @@ impl Codegen<'_> {
     /// Assumes the source value is on the stack. Leaves the copied value on the stack.
     fn generate_value_copy(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         type_id: TypeId,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -4596,7 +4597,7 @@ impl Codegen<'_> {
     /// Leaves the copied struct reference on the stack.
     fn generate_struct_copy(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         type_idx: u32,
         field_count: usize,
         ctx: &mut FunctionContext,
@@ -4640,7 +4641,7 @@ impl Codegen<'_> {
     /// 4. Create a new instance of the same case type
     fn generate_variant_copy(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         base_type_idx: u32,
         cases: &[VariantCaseInfo],
         ctx: &mut FunctionContext,
@@ -4760,7 +4761,7 @@ impl Codegen<'_> {
     /// `is_packed` should be true for arrays with packed storage (e.g., i8/i16 for strings).
     fn generate_array_copy(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         array_type_idx: u32,
         is_packed: bool,
         ctx: &mut FunctionContext,
@@ -4894,7 +4895,7 @@ impl Codegen<'_> {
     /// Leaves the copied option value on the stack.
     fn generate_option_copy(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         inner_type_id: TypeId,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -6086,7 +6087,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR expression
     fn generate_expr(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         expr: &TirExpr,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -8580,7 +8581,7 @@ impl Codegen<'_> {
     /// Generate code for multiple arguments (convenience wrapper)
     fn generate_args(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         args: &[TirExpr],
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -8625,7 +8626,7 @@ impl Codegen<'_> {
     /// This optimizes assignment expressions to avoid the drop-tee pattern.
     fn generate_expr_as_stmt(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         expr: &TirExpr,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -8648,7 +8649,7 @@ impl Codegen<'_> {
     /// This avoids the drop-tee pattern where we use local.tee then immediately drop.
     fn generate_assignment_as_stmt(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         target: &TirExpr,
         value: &TirExpr,
         type_table: &TypeTable,
@@ -8754,7 +8755,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR binary operation
     fn generate_binary_op(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         op: TirBinaryOp,
         operand_type: TypeId,
         type_table: &TypeTable,
@@ -8970,7 +8971,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR unary operation
     fn generate_unary_op(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         op: TirUnaryOp,
         operand_type: TypeId,
         type_table: &TypeTable,
@@ -9032,7 +9033,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR type cast
     fn generate_cast(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         from_type: TypeId,
         to_type: TypeId,
         type_table: &TypeTable,
@@ -9263,7 +9264,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR block
     fn generate_block(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         block: &TirBlock,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -9277,7 +9278,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR block as an expression (keeps last expression value on stack)
     fn generate_block_as_expr(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         block: &TirBlock,
         result_type: TypeId,
         type_table: &TypeTable,
@@ -9351,7 +9352,7 @@ impl Codegen<'_> {
     /// Generate code for a TIR statement
     fn generate_stmt(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         stmt: &TirStmt,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
@@ -10110,7 +10111,7 @@ impl Codegen<'_> {
     /// The tuple value should already be on the stack
     fn generate_let_pattern_binding(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         pattern: &TirPattern,
         tuple_type_id: TypeId,
         type_table: &TypeTable,
@@ -10247,7 +10248,7 @@ impl Codegen<'_> {
     /// Returns `true` if the optimization was applied, `false` otherwise.
     fn try_generate_multivalue_builtin_destructure(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         pattern: &TirPattern,
         value: &TirExpr,
         type_table: &TypeTable,
@@ -10487,7 +10488,7 @@ impl Codegen<'_> {
     #[allow(clippy::too_many_arguments, clippy::cast_sign_loss)]
     fn generate_match_br_table(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         scrutinee_local: u32,
         arms: &[TirMatchArm],
         analysis: BrTableAnalysis,
@@ -10629,7 +10630,7 @@ impl Codegen<'_> {
     #[allow(clippy::too_many_arguments)]
     fn generate_match_expr(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         scrutinee: &TirExpr,
         arms: &[TirMatchArm],
         result_type_id: TypeId,
@@ -10684,7 +10685,7 @@ impl Codegen<'_> {
     #[allow(clippy::too_many_arguments)]
     fn generate_match_arms(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         scrutinee_local: u32,
         scrutinee_type_id: TypeId,
         arms: &[TirMatchArm],
@@ -10860,7 +10861,7 @@ impl Codegen<'_> {
     /// Returns true if condition was generated, false if pattern is unsupported
     fn generate_match_pattern_check(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         scrutinee_type: &ResolvedType,
         pattern: &TirPattern,
         _type_table: &TypeTable,
@@ -11079,7 +11080,7 @@ impl Codegen<'_> {
     #[allow(clippy::too_many_arguments)]
     fn generate_match_pattern_binding(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         scrutinee_local: u32,
         scrutinee_type_id: TypeId,
         pattern: &TirPattern,
@@ -11334,7 +11335,7 @@ impl Codegen<'_> {
         }
 
         // Generate the function code
-        let mut wasm_func = Function::new(func_ctx.get_local_decls());
+        let mut wasm_func = WirFunction::new(func_ctx.get_local_decls());
 
         // Generate body
         if let Some(body) = &tir_func.body {
@@ -11354,7 +11355,7 @@ impl Codegen<'_> {
 
         // Return function and collected branch hints
         let branch_hints = func_ctx.branch_hints;
-        (wasm_func, branch_hints)
+        (wasm_func.emit(), branch_hints)
     }
 
     /// Generate the 'run' function for TIR with task.return wrapper
@@ -11419,7 +11420,7 @@ impl Codegen<'_> {
             self.preallocate_scalarized_locals(body, type_table, &mut func_ctx, builder);
         }
 
-        let mut wasm_func = Function::new(func_ctx.get_local_decls());
+        let mut wasm_func = WirFunction::new(func_ctx.get_local_decls());
 
         // Generate body
         if let Some(body) = &tir_func.body {
@@ -11449,7 +11450,7 @@ impl Codegen<'_> {
         }
         wasm_func.instruction(&Instruction::End);
 
-        wasm_func
+        wasm_func.emit()
     }
 
     // ========================================================================
@@ -12060,7 +12061,7 @@ impl Codegen<'_> {
     #[allow(clippy::too_many_arguments)]
     fn generate_cm_effect_call(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         ctx: &mut FunctionContext,
         builder: &CoreModuleBuilder,
         type_table: &TypeTable,
@@ -12221,7 +12222,7 @@ impl Codegen<'_> {
     #[allow(clippy::too_many_arguments)]
     fn generate_cm_resource_method_call(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         ctx: &mut FunctionContext,
         builder: &CoreModuleBuilder,
         type_table: &TypeTable,
@@ -12473,7 +12474,7 @@ impl Codegen<'_> {
     /// It waits for the subtask started by write-via-stream to complete.
     fn generate_effect_wait(
         &self,
-        func: &mut Function,
+        func: &mut WirFunction,
         ctx: &FunctionContext,
         builder: &CoreModuleBuilder,
     ) {
@@ -12529,7 +12530,7 @@ impl Codegen<'_> {
         builtin_name: &str,
         args: &[TirExpr],
         expr: &TirExpr,
-        func: &mut Function,
+        func: &mut WirFunction,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
         builder: &CoreModuleBuilder,
@@ -13027,7 +13028,7 @@ impl Codegen<'_> {
         &self,
         func_name: &str,
         args: &[TirExpr],
-        func: &mut Function,
+        func: &mut WirFunction,
         type_table: &TypeTable,
         ctx: &mut FunctionContext,
         builder: &CoreModuleBuilder,
@@ -13473,7 +13474,7 @@ impl Codegen<'_> {
     /// Emit lowering for Option<String> payload.
     /// Layout: p2=disc, p3=ptr(i64), p4=len
     fn emit_option_string_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         p2: u32,
         p3: u32,
@@ -13514,7 +13515,7 @@ impl Codegen<'_> {
     /// Emit lowering for Option<u64> payload (nullable Box<u64>).
     /// Layout: p2=disc, p3=value(i64)
     fn emit_option_box_u64_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         p2: u32,
         p3: u32,
@@ -13542,7 +13543,7 @@ impl Codegen<'_> {
     /// (nullable Box with i32-valued field).
     /// Layout: p2=disc, p3=value(i64, extended from i32)
     fn emit_option_box_i32_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         p2: u32,
         p3: u32,
@@ -13572,7 +13573,7 @@ impl Codegen<'_> {
     /// Layout: `p2=name_disc`, `p3=name_ptr(i64)`, `p4=name_len`, `p5=size_disc`, `p6=size_val`
     #[allow(clippy::too_many_arguments)]
     fn emit_field_size_payload_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         field_ref: u32,
         p2: u32,
@@ -13641,7 +13642,7 @@ impl Codegen<'_> {
     ///         `p6=size_disc`, `p7=size_val`
     #[allow(clippy::too_many_arguments)]
     fn emit_option_field_size_payload_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         field_ref: u32,
         p2: u32,
@@ -13736,7 +13737,7 @@ impl Codegen<'_> {
     ///         `p5=info_disc`, `p6=info_val`
     #[allow(clippy::too_many_arguments)]
     fn emit_dns_error_payload_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         field_ref: u32,
         p2: u32,
@@ -13804,7 +13805,7 @@ impl Codegen<'_> {
     /// Layout: `p2=id_disc`, `p3=id_val(i64)`, `p4=msg_disc`, `p5=msg_ptr`, `p6=msg_len`
     #[allow(clippy::too_many_arguments)]
     fn emit_tls_alert_payload_lowering(
-        func: &mut Function,
+        func: &mut WirFunction,
         payload_ref: u32,
         field_ref: u32,
         p2: u32,

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -25,13 +25,15 @@ use crate::tir::{
     TirLiteralPattern, TirMatchArm, TirModule, TirPattern, TirStmt, TirStmtKind, TirUnaryOp,
     TypeId, TypeTable,
 };
-use crate::wasm_builder::{ComponentModelContext, CoreModuleBuilder, RecTypeKind};
+use crate::wasm_builder::{ComponentModelContext, CoreModuleBuilder};
 use crate::wasm_plan::{
     CmValType, TypeDecl, get_self_referential_field_types, get_type_dependencies,
     sort_types_topologically,
 };
 use crate::wasm_postprocess;
-use crate::wir::{WirBranchHintEntry, WirConstExpr, WirFunction, WirFunctionBody, WirModule};
+use crate::wir::{
+    WirBranchHintEntry, WirConstExpr, WirFunction, WirFunctionBody, WirModule, WirRecGroupKind,
+};
 use crate::world_registry::WorldExportInfo;
 use heck::ToKebabCase;
 use indexmap::IndexMap;
@@ -3841,7 +3843,7 @@ impl Codegen<'_> {
         // Plus the main struct type itself
 
         let base_idx = builder.peek_next_type_idx();
-        let mut rec_types: Vec<(String, RecTypeKind)> = Vec::new();
+        let mut rec_types: Vec<(String, WirRecGroupKind)> = Vec::new();
         let mut array_type_mappings: Vec<(TypeId, u32, u32)> = Vec::new(); // (element_type_id, raw_array_idx, array_struct_idx)
 
         // First, add the raw GC array types and Array struct types for self-referential fields
@@ -3876,7 +3878,7 @@ impl Codegen<'_> {
                 }));
                 rec_types.push((
                     raw_array_name.clone(),
-                    RecTypeKind::Array(FieldType {
+                    WirRecGroupKind::Array(FieldType {
                         element_type: element_storage,
                         mutable: true,
                     }),
@@ -3898,7 +3900,10 @@ impl Codegen<'_> {
                         mutable: true,
                     },
                 ];
-                rec_types.push((array_struct_name, RecTypeKind::Struct(array_struct_fields)));
+                rec_types.push((
+                    array_struct_name,
+                    WirRecGroupKind::Struct(array_struct_fields),
+                ));
 
                 array_type_mappings.push((element_type_id, raw_array_idx, array_struct_idx));
             }
@@ -3958,7 +3963,10 @@ impl Codegen<'_> {
             });
         }
 
-        rec_types.push((struct_name.name.clone(), RecTypeKind::Struct(struct_fields)));
+        rec_types.push((
+            struct_name.name.clone(),
+            WirRecGroupKind::Struct(struct_fields),
+        ));
 
         // Define the rec group
         let indices = builder.define_rec_group(&rec_types);

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -31,18 +31,17 @@ use crate::wasm_plan::{
     sort_types_topologically,
 };
 use crate::wasm_postprocess;
-use crate::wir::WirFunction;
+use crate::wir::{WirBranchHintEntry, WirConstExpr, WirFunction, WirFunctionBody, WirModule};
 use crate::world_registry::WorldExportInfo;
 use heck::ToKebabCase;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use wasm_encoder::{
-    AbstractHeapType, Alias, BlockType, BranchHint, BranchHints, CanonicalOption, CodeSection,
-    ComponentBuilder, ComponentExportKind, ComponentOuterAliasKind, ComponentValType, ConstExpr,
-    DataCountSection, DataSection, ElementSection, Elements, ExportKind, ExportSection, FieldType,
-    Function, FunctionSection, GlobalSection, GlobalType, HeapType, InstanceType, Instruction,
-    MemArg, MemorySection, MemoryType, Module, ModuleArg, NameMap, NameSection, PrimitiveValType,
-    RefType, StorageType, TypeBounds, TypeSection, ValType,
+    AbstractHeapType, Alias, BlockType, CanonicalOption, CodeSection, ComponentBuilder,
+    ComponentExportKind, ComponentOuterAliasKind, ComponentValType, ExportKind, ExportSection,
+    FieldType, Function, FunctionSection, GlobalSection, GlobalType, HeapType, InstanceType,
+    Instruction, MemArg, MemorySection, MemoryType, Module, ModuleArg, NameMap, NameSection,
+    PrimitiveValType, RefType, StorageType, TypeBounds, TypeSection, ValType,
 };
 use wasmparser::{Validator, WasmFeatures};
 
@@ -520,7 +519,7 @@ impl Codegen<'_> {
     }
 
     /// Build the main core Wasm module containing user-defined functions.
-    fn build_main_module(&mut self, params: BuildMainModuleParams<'_>) -> Vec<u8> {
+    fn build_main_module(&mut self, params: BuildMainModuleParams<'_>) -> WirModule {
         let BuildMainModuleParams {
             entry_tir,
             all_tir_modules,
@@ -532,7 +531,6 @@ impl Codegen<'_> {
         } = params;
         let strip_names = project.strip_names;
 
-        let mut module = Module::new();
         let mut builder = CoreModuleBuilder::new();
         let type_table = &*entry_tir.type_table.borrow();
         let entry_module_source = &entry_tir.module_source;
@@ -1363,8 +1361,7 @@ impl Codegen<'_> {
             }
         }
 
-        // Add types section to module
-        module.section(builder.types());
+        // Types are accumulated in builder — no section assembly here.
 
         // ========================================
         // Import section
@@ -1389,7 +1386,7 @@ impl Codegen<'_> {
         }
 
         builder.import_memory("mem", "memory", 1);
-        module.section(builder.imports());
+        // Imports are accumulated in builder — no section assembly here.
 
         // ========================================
         // Function section
@@ -1539,7 +1536,7 @@ impl Codegen<'_> {
             }
         }
 
-        module.section(builder.functions());
+        // Functions are accumulated in builder — no section assembly here.
 
         // ========================================
         // Global section
@@ -1578,10 +1575,7 @@ impl Codegen<'_> {
                 );
             }
         }
-        // Add globals section only if there are globals
-        if builder.has_globals() {
-            module.section(builder.globals());
-        }
+        // Globals are accumulated in builder — no section assembly here.
 
         // ========================================
         // Export section
@@ -1599,29 +1593,13 @@ impl Codegen<'_> {
         for test in &entry_tir.tests {
             builder.export_func(&test.function_name, &test.function_name);
         }
-        module.section(builder.exports());
+        // Exports are accumulated in builder — no section assembly here.
 
         // ========================================
-        // Element section (required for ref.func in closures)
+        // Generate function bodies
         // ========================================
-        if !closure_call_func_indices.is_empty() {
-            let mut elements = ElementSection::new();
-            // Create declarative element segment for ref.func usage
-            elements.declared(Elements::Functions(std::borrow::Cow::Borrowed(
-                &closure_call_func_indices,
-            )));
-            module.section(&elements);
-        }
-
-        // Data count section (required for array.new_data with GC)
-        let data_count = u32::from(!string_data.is_empty());
-        module.section(&DataCountSection { count: data_count });
-
-        // ========================================
-        // Code section
-        // ========================================
-        let mut code = CodeSection::new();
-        let mut all_branch_hints: Vec<(u32, Vec<(u32, bool)>)> = Vec::new();
+        let mut bodies: Vec<WirFunctionBody> = Vec::new();
+        let mut all_branch_hints: Vec<WirBranchHintEntry> = Vec::new();
         let mut func_idx = builder.import_func_count;
         // Generate user-defined functions from entry TIR (excluding world exports which are handled specially)
         for tir_func_rc in &entry_tir.functions {
@@ -1640,14 +1618,18 @@ impl Codegen<'_> {
             }
             // Test functions need task.return wrapper like run
             if tir_func.name.starts_with("__test_") {
-                let wasm_func = self.generate_run_function(&tir_func, type_table, &builder);
-                code.function(&wasm_func);
+                let body = self.generate_run_function_body(&tir_func, type_table, &builder);
+                bodies.push(body);
             } else {
-                let (wasm_func, hints) =
-                    self.generate_function(&tir_func, type_table, &builder, entry_module_source);
-                code.function(&wasm_func);
+                let (body, hints) = self.generate_function_body(
+                    &tir_func,
+                    type_table,
+                    &builder,
+                    entry_module_source,
+                );
+                bodies.push(body);
                 if !hints.is_empty() {
-                    all_branch_hints.push((func_idx, hints));
+                    all_branch_hints.push(WirBranchHintEntry { func_idx, hints });
                 }
             }
             func_idx += 1;
@@ -1664,11 +1646,11 @@ impl Codegen<'_> {
                 continue;
             }
 
-            let (wasm_func, hints) =
-                self.generate_function(&tir_func, func_type_table, &builder, module_source);
-            code.function(&wasm_func);
+            let (body, hints) =
+                self.generate_function_body(&tir_func, func_type_table, &builder, module_source);
+            bodies.push(body);
             if !hints.is_empty() {
-                all_branch_hints.push((func_idx, hints));
+                all_branch_hints.push(WirBranchHintEntry { func_idx, hints });
             }
             func_idx += 1;
         }
@@ -1686,11 +1668,15 @@ impl Codegen<'_> {
                 continue;
             }
 
-            let (wasm_func, hints) =
-                self.generate_function(&tir_method, method_type_table, &builder, module_source);
-            code.function(&wasm_func);
+            let (body, hints) = self.generate_function_body(
+                &tir_method,
+                method_type_table,
+                &builder,
+                module_source,
+            );
+            bodies.push(body);
             if !hints.is_empty() {
-                all_branch_hints.push((func_idx, hints));
+                all_branch_hints.push(WirBranchHintEntry { func_idx, hints });
             }
             func_idx += 1;
         }
@@ -1702,35 +1688,35 @@ impl Codegen<'_> {
                 .iter()
                 .find(|f| f.borrow().name == *export_name);
 
-            let export_wasm_func = if let Some(tir_rc) = export_tir_rc {
+            let body = if let Some(tir_rc) = export_tir_rc {
                 // Generate function body using the TIR function body generation
                 let tir_func = tir_rc.borrow();
-                self.generate_run_function(&tir_func, type_table, &builder)
+                self.generate_run_function_body(&tir_func, type_table, &builder)
             } else {
                 // No matching function - create empty entry point
-                let mut func = Function::new(vec![]);
+                let mut wir_func = WirFunction::new(vec![]);
                 let task_return_idx = builder.func_idx("task-return");
                 if self.project.has_http_handler_export {
                     // Service world: result<own<response>, error-code> with complex payloads
                     // Flattens to: (i32, i32, i32, i64, i32, i32, i32, i32)
-                    func.instruction(&Instruction::I32Const(1)); // Err discriminant
-                    func.instruction(&Instruction::I32Const(38)); // internal-error
-                    func.instruction(&Instruction::I32Const(1)); // option<string> has Some
-                    func.instruction(&Instruction::I64Const(0)); // u64 padding
-                    func.instruction(&Instruction::I32Const(0)); // string ptr
-                    func.instruction(&Instruction::I32Const(37)); // string len
-                    func.instruction(&Instruction::I32Const(0)); // padding
-                    func.instruction(&Instruction::I32Const(0)); // padding
+                    wir_func.instruction(&Instruction::I32Const(1)); // Err discriminant
+                    wir_func.instruction(&Instruction::I32Const(38)); // internal-error
+                    wir_func.instruction(&Instruction::I32Const(1)); // option<string> has Some
+                    wir_func.instruction(&Instruction::I64Const(0)); // u64 padding
+                    wir_func.instruction(&Instruction::I32Const(0)); // string ptr
+                    wir_func.instruction(&Instruction::I32Const(37)); // string len
+                    wir_func.instruction(&Instruction::I32Const(0)); // padding
+                    wir_func.instruction(&Instruction::I32Const(0)); // padding
                 } else {
                     // Command world: result<_, _> needs just (i32)
-                    func.instruction(&Instruction::I32Const(0)); // Ok discriminant
+                    wir_func.instruction(&Instruction::I32Const(0)); // Ok discriminant
                 }
-                func.instruction(&Instruction::Call(task_return_idx));
-                func.instruction(&Instruction::End);
-                func
+                wir_func.instruction(&Instruction::Call(task_return_idx));
+                wir_func.instruction(&Instruction::End);
+                wir_func.into_body()
             };
 
-            code.function(&export_wasm_func);
+            bodies.push(body);
         }
 
         // Generate canonical wrapper function bodies for closure __call methods
@@ -1744,63 +1730,45 @@ impl Codegen<'_> {
                 continue;
             }
 
-            let mut wrapper_func = Function::new(vec![]);
+            let mut wir_func = WirFunction::new(vec![]);
 
             // Cast first param (ref struct) to specific functor type
-            wrapper_func.instruction(&Instruction::LocalGet(0)); // env param
-            wrapper_func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
+            wir_func.instruction(&Instruction::LocalGet(0)); // env param
+            wir_func.instruction(&Instruction::RefCastNonNull(HeapType::Concrete(
                 wrapper_info.functor_type_idx,
             )));
 
             // Pass through all other params
             for i in 0..wrapper_info.param_type_ids.len() {
-                wrapper_func.instruction(&Instruction::LocalGet((i + 1) as u32));
+                wir_func.instruction(&Instruction::LocalGet((i + 1) as u32));
             }
 
             // Call the original __call method
-            wrapper_func.instruction(&Instruction::Call(wrapper_info.call_func_idx));
+            wir_func.instruction(&Instruction::Call(wrapper_info.call_func_idx));
 
-            wrapper_func.instruction(&Instruction::End);
-            code.function(&wrapper_func);
+            wir_func.instruction(&Instruction::End);
+            bodies.push(wir_func.into_body());
         }
 
-        // Branch hints section (emit before code section for proper placement)
-        if !all_branch_hints.is_empty() {
-            let mut hints = BranchHints::new();
-            for (func_idx, func_hints) in all_branch_hints {
-                hints.function_hints(
-                    func_idx,
-                    func_hints.into_iter().map(|(offset, taken)| BranchHint {
-                        branch_func_offset: offset,
-                        branch_hint_value: u32::from(taken),
-                    }),
-                );
-            }
-            module.section(&hints);
+        // ========================================
+        // Assemble WirModule
+        // ========================================
+        let parts = builder.into_parts();
+        WirModule {
+            types: parts.types,
+            imports: parts.imports,
+            func_type_indices: parts.func_type_indices,
+            globals: parts.globals,
+            exports: parts.exports,
+            element_func_indices: closure_call_func_indices,
+            data: string_data.to_vec(),
+            bodies,
+            branch_hints: all_branch_hints,
+            import_func_count: parts.import_func_count,
+            names: if strip_names { None } else { Some(parts.names) },
+            module_name: module_name.to_string(),
+            has_memory: parts.has_memory,
         }
-
-        module.section(&code);
-
-        // Data section
-        if !string_data.is_empty() {
-            let mut data = DataSection::new();
-            data.passive(string_data.iter().copied());
-            module.section(&data);
-        }
-
-        // Name section (skip in size-optimized builds)
-        if !strip_names {
-            let names = builder.build_name_section(module_name);
-            module.section(&names);
-        }
-
-        // Producers section (skip in size-optimized builds)
-        if !strip_names {
-            let producers = CoreModuleBuilder::build_producers_section();
-            module.section(&producers);
-        }
-
-        module.finish()
     }
 
     /// Generate component from TIR for WASI P3
@@ -2135,7 +2103,7 @@ impl Codegen<'_> {
         // ========================================
         // Main core module
         // ========================================
-        let main_module = self.build_main_module(BuildMainModuleParams {
+        let wir_module = self.build_main_module(BuildMainModuleParams {
             entry_tir,
             all_tir_modules,
             symbols,
@@ -2144,6 +2112,7 @@ impl Codegen<'_> {
             module_name,
             available_wasi_funcs: &available_wasi_funcs,
         });
+        let main_module = crate::wir_emit::emit_module(&wir_module);
         // Validate main module before embedding
         {
             let mut validator = Validator::new_with_features(WasmFeatures::all());
@@ -5691,9 +5660,7 @@ impl Codegen<'_> {
 
     /// Convert a global variable initializer to a Wasm constant expression
     /// Only supports constant expressions (literals, null)
-    fn global_init_to_const_expr(init: &TirExpr, type_table: &TypeTable) -> ConstExpr {
-        use wasm_encoder::{Ieee32, Ieee64};
-
+    fn global_init_to_const_expr(init: &TirExpr, type_table: &TypeTable) -> WirConstExpr {
         match &init.kind {
             TirExprKind::IntLiteral { value, .. } => {
                 // Determine the right type of constant based on the expression type
@@ -5706,16 +5673,14 @@ impl Codegen<'_> {
                         | PrimitiveType::I32
                         | PrimitiveType::U8
                         | PrimitiveType::U16
-                        | PrimitiveType::U32 => ConstExpr::i32_const(*value as i32),
-                        PrimitiveType::I64 | PrimitiveType::U64 => {
-                            ConstExpr::i64_const(*value as i64)
-                        }
+                        | PrimitiveType::U32 => WirConstExpr::I32(*value as i32),
+                        PrimitiveType::I64 | PrimitiveType::U64 => WirConstExpr::I64(*value as i64),
                         _ => panic!(
                             "unexpected primitive type for int literal: {:?}",
                             type_table.get(init.type_id)
                         ),
                     },
-                    _ => ConstExpr::i32_const(*value as i32), // Default to i32
+                    _ => WirConstExpr::I32(*value as i32), // Default to i32
                 }
             }
             TirExprKind::FloatLiteral { value, .. } => {
@@ -5723,26 +5688,26 @@ impl Codegen<'_> {
                 let base_type = type_table.get_ultimate_base_type(init.type_id);
                 match type_table.get(base_type) {
                     ResolvedType::Primitive(PrimitiveType::F32) => {
-                        ConstExpr::f32_const(Ieee32::from(*value as f32))
+                        WirConstExpr::F32((*value as f32).to_bits())
                     }
                     ResolvedType::Primitive(PrimitiveType::F64) => {
-                        ConstExpr::f64_const(Ieee64::from(*value))
+                        WirConstExpr::F64(value.to_bits())
                     }
-                    _ => ConstExpr::f64_const(Ieee64::from(*value)), // Default to f64
+                    _ => WirConstExpr::F64(value.to_bits()), // Default to f64
                 }
             }
-            TirExprKind::BoolLiteral(b) => ConstExpr::i32_const(i32::from(*b)),
+            TirExprKind::BoolLiteral(b) => WirConstExpr::I32(i32::from(*b)),
             TirExprKind::Null => {
                 // For null, we need a ref.null of the appropriate type
                 // For Option<T>, null means None
-                ConstExpr::ref_null(HeapType::Abstract {
+                WirConstExpr::RefNull(HeapType::Abstract {
                     shared: false,
                     ty: AbstractHeapType::None,
                 })
             }
             TirExprKind::Unit => {
                 // Unit type - use 0
-                ConstExpr::i32_const(0)
+                WirConstExpr::I32(0)
             }
             TirExprKind::Cast { expr: inner, .. } => {
                 // For casts, evaluate the inner expression with the cast's target type
@@ -5753,7 +5718,7 @@ impl Codegen<'_> {
             _ => {
                 // For non-constant initializers, use null as placeholder
                 // The actual initialization happens in __initialize_globals
-                ConstExpr::ref_null(HeapType::Abstract {
+                WirConstExpr::RefNull(HeapType::Abstract {
                     shared: false,
                     ty: AbstractHeapType::None,
                 })
@@ -11276,13 +11241,13 @@ impl Codegen<'_> {
     /// Generate a Wasm function from TIR function
     ///
     /// Returns the generated function and any branch hints collected during generation.
-    fn generate_function(
+    fn generate_function_body(
         &self,
         tir_func: &TirFunction,
         type_table: &TypeTable,
         builder: &CoreModuleBuilder,
         module_source: &ModuleSource,
-    ) -> (Function, Vec<(u32, bool)>) {
+    ) -> (WirFunctionBody, Vec<(u32, bool)>) {
         // Create function context - TIR already has local count and types
         let mut func_ctx = FunctionContext::with_module_source(
             tir_func.params.len() as u32,
@@ -11353,21 +11318,21 @@ impl Codegen<'_> {
         }
         wasm_func.instruction(&Instruction::End);
 
-        // Return function and collected branch hints
+        // Return function body and collected branch hints
         let branch_hints = func_ctx.branch_hints;
-        (wasm_func.emit(), branch_hints)
+        (wasm_func.into_body(), branch_hints)
     }
 
-    /// Generate the 'run' function for TIR with task.return wrapper
+    /// Generate the 'run' function body for TIR with task.return wrapper
     ///
     /// This is a special case of function generation for the WASI CLI entry point.
     /// It generates the function body and appends task.return before End.
-    fn generate_run_function(
+    fn generate_run_function_body(
         &self,
         tir_func: &TirFunction,
         type_table: &TypeTable,
         builder: &CoreModuleBuilder,
-    ) -> Function {
+    ) -> WirFunctionBody {
         // Create function context
         let mut func_ctx = FunctionContext::new(tir_func.params.len() as u32);
 
@@ -11450,7 +11415,7 @@ impl Codegen<'_> {
         }
         wasm_func.instruction(&Instruction::End);
 
-        wasm_func.emit()
+        wasm_func.into_body()
     }
 
     // ========================================================================
@@ -13398,7 +13363,7 @@ impl Codegen<'_> {
                 mutable: true,
                 shared: false,
             },
-            &ConstExpr::i32_const(1024),
+            &wasm_encoder::ConstExpr::i32_const(1024),
         );
         module.section(&globals);
 

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -31,9 +31,7 @@ use crate::wasm_plan::{
     sort_types_topologically,
 };
 use crate::wasm_postprocess;
-use crate::wir::{
-    WirBranchHintEntry, WirConstExpr, WirFunction, WirFunctionBody, WirModule, WirRecGroupKind,
-};
+use crate::wir::{WirConstExpr, WirFunction, WirFunctionBody, WirModule, WirRecGroupKind};
 use crate::world_registry::WorldExportInfo;
 use heck::ToKebabCase;
 use indexmap::IndexMap;
@@ -186,8 +184,6 @@ struct FunctionContext {
     /// Pending branch hint from `builtin::likely()` or `builtin::unlikely()`
     /// None = no hint, Some(true) = likely taken, Some(false) = unlikely taken
     pending_branch_hint: Option<bool>,
-    /// Collected branch hints for this function (offset, taken)
-    branch_hints: Vec<(u32, bool)>,
     /// Module source of the current function (for access control checks)
     current_module_source: ModuleSource,
     /// Stack of break targets for loops and labeled blocks.
@@ -237,7 +233,6 @@ impl FunctionContext {
             local_types: Vec::new(),
             return_type: None,
             pending_branch_hint: None,
-            branch_hints: Vec::new(),
             current_module_source: ModuleSource::entry_point_with_filename("<unknown>"),
             loop_info: Vec::new(),
             local_index_offset: 0,
@@ -263,7 +258,6 @@ impl FunctionContext {
             local_types: Vec::new(),
             return_type: None,
             pending_branch_hint: None,
-            branch_hints: Vec::new(),
             current_module_source: module_source,
             loop_info: Vec::new(),
             local_index_offset: 0,
@@ -316,10 +310,10 @@ impl FunctionContext {
         self.pending_branch_hint = Some(taken);
     }
 
-    /// Consume pending branch hint and record it at the given offset
-    fn consume_branch_hint(&mut self, offset: u32) {
+    /// Consume pending branch hint and emit it into the WIR instruction stream.
+    fn consume_branch_hint(&mut self, func: &mut WirFunction) {
         if let Some(taken) = self.pending_branch_hint.take() {
-            self.branch_hints.push((offset, taken));
+            func.branch_hint(taken);
         }
     }
 
@@ -1601,8 +1595,6 @@ impl Codegen<'_> {
         // Generate function bodies
         // ========================================
         let mut bodies: Vec<WirFunctionBody> = Vec::new();
-        let mut all_branch_hints: Vec<WirBranchHintEntry> = Vec::new();
-        let mut func_idx = builder.import_func_count;
         // Generate user-defined functions from entry TIR (excluding world exports which are handled specially)
         for tir_func_rc in &entry_tir.functions {
             let tir_func = tir_func_rc.borrow();
@@ -1623,18 +1615,14 @@ impl Codegen<'_> {
                 let body = self.generate_run_function_body(&tir_func, type_table, &builder);
                 bodies.push(body);
             } else {
-                let (body, hints) = self.generate_function_body(
+                let body = self.generate_function_body(
                     &tir_func,
                     type_table,
                     &builder,
                     entry_module_source,
                 );
                 bodies.push(body);
-                if !hints.is_empty() {
-                    all_branch_hints.push(WirBranchHintEntry { func_idx, hints });
-                }
             }
-            func_idx += 1;
         }
 
         // Generate loaded module functions (TIR path)
@@ -1648,13 +1636,9 @@ impl Codegen<'_> {
                 continue;
             }
 
-            let (body, hints) =
+            let body =
                 self.generate_function_body(&tir_func, func_type_table, &builder, module_source);
             bodies.push(body);
-            if !hints.is_empty() {
-                all_branch_hints.push(WirBranchHintEntry { func_idx, hints });
-            }
-            func_idx += 1;
         }
 
         // Generate impl methods from loaded modules (TIR path)
@@ -1670,17 +1654,13 @@ impl Codegen<'_> {
                 continue;
             }
 
-            let (body, hints) = self.generate_function_body(
+            let body = self.generate_function_body(
                 &tir_method,
                 method_type_table,
                 &builder,
                 module_source,
             );
             bodies.push(body);
-            if !hints.is_empty() {
-                all_branch_hints.push(WirBranchHintEntry { func_idx, hints });
-            }
-            func_idx += 1;
         }
 
         // Generate world export functions (entry points with task.return wrapper)
@@ -1765,7 +1745,6 @@ impl Codegen<'_> {
             element_func_indices: closure_call_func_indices,
             data: string_data.to_vec(),
             bodies,
-            branch_hints: all_branch_hints,
             import_func_count: parts.import_func_count,
             names: if strip_names { None } else { Some(parts.names) },
             module_name: module_name.to_string(),
@@ -9940,8 +9919,8 @@ impl Codegen<'_> {
                 else_block,
             } => {
                 self.generate_expr(func, condition, type_table, ctx, builder);
-                // Record branch hint at the current offset (before emitting the if instruction)
-                ctx.consume_branch_hint(func.byte_len() as u32);
+                // Emit branch hint if pending (before the if instruction)
+                ctx.consume_branch_hint(func);
                 func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
                 // If creates a block level - increment extra depth if we're inside a loop
                 if let Some((_, extra, _, _, _)) = ctx.loop_info.last_mut() {
@@ -11255,7 +11234,7 @@ impl Codegen<'_> {
         type_table: &TypeTable,
         builder: &CoreModuleBuilder,
         module_source: &ModuleSource,
-    ) -> (WirFunctionBody, Vec<(u32, bool)>) {
+    ) -> WirFunctionBody {
         // Create function context - TIR already has local count and types
         let mut func_ctx = FunctionContext::with_module_source(
             tir_func.params.len() as u32,
@@ -11326,9 +11305,7 @@ impl Codegen<'_> {
         }
         wasm_func.instruction(&Instruction::End);
 
-        // Return function body and collected branch hints
-        let branch_hints = func_ctx.branch_hints;
-        (wasm_func.into_body(), branch_hints)
+        wasm_func.into_body()
     }
 
     /// Generate the 'run' function body for TIR with task.return wrapper

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -107,6 +107,8 @@ pub mod unparse;
 pub mod wasm_builder;
 pub mod wasm_plan;
 pub mod wasm_postprocess;
+pub mod wir;
+pub mod wir_emit;
 pub mod world_registry;
 
 pub use analyze::Analyzer;

--- a/wado-compiler/src/wasm_builder.rs
+++ b/wado-compiler/src/wasm_builder.rs
@@ -1,18 +1,21 @@
-//! Wasm building utilities for code generation
+//! Wasm building utilities for code generation.
 //!
-//! This module provides index-tracking wrappers around wasm-encoder types,
-//! eliminating hardcoded magic numbers in codegen.
+//! `CoreModuleBuilder` collects WIR types (not `wasm_encoder` sections) and
+//! provides name→index mapping during code generation. After planning and
+//! codegen, call `into_parts()` to extract accumulated WIR data for
+//! `WirModule` construction.
 
 use indexmap::{IndexMap, IndexSet};
 
-use wasm_encoder::{
-    ArrayType, CompositeInnerType, CompositeType, ConstExpr, EntityType, ExportKind, ExportSection,
-    FieldType, FunctionSection, GlobalSection, GlobalType, ImportSection, MemoryType, NameMap,
-    NameSection, ProducersField, ProducersSection, StorageType, SubType, TypeSection, ValType,
+use wasm_encoder::{ExportKind, FieldType, StorageType, ValType};
+
+use crate::wir::{
+    WirConstExpr, WirExport, WirGlobal, WirImport, WirNames, WirRecGroupEntry, WirRecGroupKind,
+    WirTypeDef,
 };
 
 // ============================================================================
-// Rec Group Types
+// Rec Group Types (used by codegen to specify rec group entries)
 // ============================================================================
 
 /// Kind of type within a rec group (for mutually recursive types)
@@ -25,26 +28,42 @@ pub enum RecTypeKind {
 }
 
 // ============================================================================
-// CoreModuleBuilder - Builder for Wasm core modules with dynamic index allocation
+// WirModuleParts — extracted data from CoreModuleBuilder
+// ============================================================================
+
+/// Accumulated WIR data extracted from `CoreModuleBuilder` for `WirModule` construction.
+pub struct WirModuleParts {
+    pub types: Vec<WirTypeDef>,
+    pub imports: Vec<WirImport>,
+    pub func_type_indices: Vec<u32>,
+    pub globals: Vec<WirGlobal>,
+    pub exports: Vec<WirExport>,
+    pub import_func_count: u32,
+    pub has_memory: bool,
+    pub names: WirNames,
+}
+
+// ============================================================================
+// CoreModuleBuilder — collects WIR types with name→index mapping
 // ============================================================================
 
 /// Builder for Wasm core modules with dynamic index allocation.
-/// Eliminates hardcoded type/function indices by tracking them by name.
+///
+/// Collects WIR types and provides name→index mapping during code generation.
+/// Does not touch `wasm_encoder` sections — that's `emit_module`'s job.
 pub struct CoreModuleBuilder {
-    // Wasm sections
-    types: TypeSection,
-    imports: ImportSection,
-    functions: FunctionSection,
-    globals: GlobalSection,
-    exports: ExportSection,
-    #[allow(dead_code)]
-    names: NameSection,
+    // Accumulated WIR data
+    types: Vec<WirTypeDef>,
+    imports: Vec<WirImport>,
+    func_type_indices: Vec<u32>,
+    globals: Vec<WirGlobal>,
+    exports: Vec<WirExport>,
 
-    // Type tracking
+    // Type tracking (name → index)
     type_names: IndexMap<String, u32>,
     next_type_idx: u32,
 
-    // Function tracking
+    // Function tracking (name → index)
     func_names: IndexMap<String, u32>,
     func_type_names: IndexMap<String, String>,
     type_has_return: IndexMap<String, bool>,
@@ -53,7 +72,7 @@ pub struct CoreModuleBuilder {
     /// Number of imported functions (for branch hint calculation)
     pub import_func_count: u32,
 
-    // Global tracking
+    // Global tracking (name → index)
     global_names: IndexMap<String, u32>,
     next_global_idx: u32,
     /// Globals that are initialized with null (need `ref.as_non_null` on access)
@@ -70,12 +89,11 @@ impl CoreModuleBuilder {
     /// Create a new builder with all indices starting at 0
     pub fn new() -> Self {
         Self {
-            types: TypeSection::new(),
-            imports: ImportSection::new(),
-            functions: FunctionSection::new(),
-            globals: GlobalSection::new(),
-            exports: ExportSection::new(),
-            names: NameSection::new(),
+            types: Vec::new(),
+            imports: Vec::new(),
+            func_type_indices: Vec::new(),
+            globals: Vec::new(),
+            exports: Vec::new(),
             type_names: IndexMap::new(),
             next_type_idx: 0,
             func_names: IndexMap::new(),
@@ -100,9 +118,10 @@ impl CoreModuleBuilder {
     /// Define a function type and return its index
     pub fn define_func_type(&mut self, name: &str, params: &[ValType], results: &[ValType]) -> u32 {
         let idx = self.next_type_idx;
-        self.types
-            .ty()
-            .function(params.iter().copied(), results.iter().copied());
+        self.types.push(WirTypeDef::Func {
+            params: params.to_vec(),
+            results: results.to_vec(),
+        });
         self.type_names.insert(name.to_string(), idx);
         self.type_has_return
             .insert(name.to_string(), !results.is_empty());
@@ -116,67 +135,39 @@ impl CoreModuleBuilder {
     /// Define a GC array type and return its index
     pub fn define_gc_array_type(&mut self, name: &str, element: StorageType, mutable: bool) -> u32 {
         let idx = self.next_type_idx;
-        self.types.ty().subtype(&SubType {
-            is_final: true,
-            supertype_idx: None,
-            composite_type: CompositeType {
-                inner: CompositeInnerType::Array(ArrayType(FieldType {
-                    element_type: element,
-                    mutable,
-                })),
-                shared: false,
-                descriptor: None,
-                describes: None,
-            },
-        });
+        self.types.push(WirTypeDef::GcArray { element, mutable });
         self.type_names.insert(name.to_string(), idx);
         self.next_type_idx += 1;
         idx
     }
 
-    /// Define a GC struct type and return its index
-    /// Uses `is_final`: false to allow more flexible subtyping with exact types
+    /// Define a GC struct type and return its index.
+    /// Uses `is_final: false` to allow more flexible subtyping with exact types.
     pub fn define_gc_struct_type(&mut self, name: &str, fields: &[FieldType]) -> u32 {
-        use wasm_encoder::StructType;
         let idx = self.next_type_idx;
-        self.types.ty().subtype(&SubType {
+        self.types.push(WirTypeDef::GcStruct {
+            fields: fields.to_vec(),
             is_final: false, // Non-final allows (ref (exact $T)) to be subtype of (ref $T)
             supertype_idx: None,
-            composite_type: CompositeType {
-                inner: CompositeInnerType::Struct(StructType {
-                    fields: fields.to_vec().into_boxed_slice(),
-                }),
-                shared: false,
-                descriptor: None,
-                describes: None,
-            },
         });
         self.type_names.insert(name.to_string(), idx);
         self.next_type_idx += 1;
         idx
     }
 
-    /// Define a GC struct subtype (with a supertype) and return its index
-    /// The subtype must include all fields from the supertype as a prefix
+    /// Define a GC struct subtype (with a supertype) and return its index.
+    /// The subtype must include all fields from the supertype as a prefix.
     pub fn define_gc_struct_subtype(
         &mut self,
         name: &str,
         supertype_idx: u32,
         fields: &[FieldType],
     ) -> u32 {
-        use wasm_encoder::StructType;
         let idx = self.next_type_idx;
-        self.types.ty().subtype(&SubType {
+        self.types.push(WirTypeDef::GcStruct {
+            fields: fields.to_vec(),
             is_final: true, // Subtypes are final (no further subtyping)
             supertype_idx: Some(supertype_idx),
-            composite_type: CompositeType {
-                inner: CompositeInnerType::Struct(StructType {
-                    fields: fields.to_vec().into_boxed_slice(),
-                }),
-                shared: false,
-                descriptor: None,
-                describes: None,
-            },
         });
         self.type_names.insert(name.to_string(), idx);
         self.next_type_idx += 1;
@@ -196,8 +187,6 @@ impl CoreModuleBuilder {
     /// Each element in `types` is (name, `RecTypeKind`) where `RecTypeKind` specifies
     /// whether it's a struct or array type.
     pub fn define_rec_group(&mut self, types: &[(String, RecTypeKind)]) -> Vec<u32> {
-        use wasm_encoder::StructType;
-
         let base_idx = self.next_type_idx;
         let mut indices = Vec::with_capacity(types.len());
 
@@ -208,38 +197,18 @@ impl CoreModuleBuilder {
             indices.push(idx);
         }
 
-        // Build SubType list for rec group
-        let subtypes: Vec<SubType> = types
+        // Build WIR rec group entries
+        let entries: Vec<WirRecGroupEntry> = types
             .iter()
-            .map(|(_, kind)| match kind {
-                RecTypeKind::Struct(fields) => SubType {
-                    is_final: false,
-                    supertype_idx: None,
-                    composite_type: CompositeType {
-                        inner: CompositeInnerType::Struct(StructType {
-                            fields: fields.clone().into_boxed_slice(),
-                        }),
-                        shared: false,
-                        descriptor: None,
-                        describes: None,
-                    },
-                },
-                RecTypeKind::Array(field_type) => SubType {
-                    is_final: true,
-                    supertype_idx: None,
-                    composite_type: CompositeType {
-                        inner: CompositeInnerType::Array(ArrayType(*field_type)),
-                        shared: false,
-                        descriptor: None,
-                        describes: None,
-                    },
+            .map(|(_, kind)| WirRecGroupEntry {
+                kind: match kind {
+                    RecTypeKind::Struct(fields) => WirRecGroupKind::Struct(fields.clone()),
+                    RecTypeKind::Array(field_type) => WirRecGroupKind::Array(*field_type),
                 },
             })
             .collect();
 
-        // Emit the rec group
-        self.types.ty().rec(subtypes);
-
+        self.types.push(WirTypeDef::RecGroup(entries));
         self.next_type_idx += types.len() as u32;
         indices
     }
@@ -253,8 +222,11 @@ impl CoreModuleBuilder {
     /// The function type is looked up by name (import name == type name).
     pub fn import_func(&mut self, module: &str, name: &str) -> u32 {
         let type_idx = self.type_idx(name);
-        self.imports
-            .import(module, name, EntityType::Function(type_idx));
+        self.imports.push(WirImport::Func {
+            module: module.to_string(),
+            name: name.to_string(),
+            type_idx,
+        });
         let func_idx = self.next_func_idx;
         self.func_names.insert(name.to_string(), func_idx);
         self.func_type_names
@@ -266,24 +238,18 @@ impl CoreModuleBuilder {
 
     /// Import memory
     pub fn import_memory(&mut self, module: &str, name: &str, min: u64) {
-        self.imports.import(
-            module,
-            name,
-            EntityType::Memory(MemoryType {
-                minimum: min,
-                maximum: None,
-                memory64: false,
-                shared: false,
-                page_size_log2: None,
-            }),
-        );
+        self.imports.push(WirImport::Memory {
+            module: module.to_string(),
+            name: name.to_string(),
+            min,
+        });
         self.has_memory = true;
     }
 
     /// Define a function (adds to function section) and return its index
     pub fn define_func(&mut self, name: &str, type_name: &str) -> u32 {
         let type_idx = self.type_idx(type_name);
-        self.functions.function(type_idx);
+        self.func_type_indices.push(type_idx);
         let func_idx = self.next_func_idx;
         self.func_names.insert(name.to_string(), func_idx);
         self.func_type_names
@@ -300,7 +266,11 @@ impl CoreModuleBuilder {
     /// Export a function
     pub fn export_func(&mut self, export_name: &str, func_name: &str) {
         let func_idx = self.func_idx(func_name);
-        self.exports.export(export_name, ExportKind::Func, func_idx);
+        self.exports.push(WirExport {
+            name: export_name.to_string(),
+            kind: ExportKind::Func,
+            index: func_idx,
+        });
     }
 
     /// Get type index by name
@@ -338,16 +308,16 @@ impl CoreModuleBuilder {
         name: &str,
         val_type: ValType,
         mutable: bool,
-        init: ConstExpr,
+        init: WirConstExpr,
         is_nullable: bool,
     ) -> u32 {
         let idx = self.next_global_idx;
-        let global_type = GlobalType {
+        self.globals.push(WirGlobal {
+            name: name.to_string(),
             val_type,
             mutable,
-            shared: false,
-        };
-        self.globals.global(global_type, &init);
+            init,
+        });
         self.global_names.insert(name.to_string(), idx);
         if is_nullable {
             self.nullable_globals.insert(name.to_string());
@@ -374,77 +344,53 @@ impl CoreModuleBuilder {
         self.global_names.get(name).copied()
     }
 
-    /// Get the types section (for module building)
-    pub fn types(&self) -> &TypeSection {
-        &self.types
-    }
-
-    /// Get the imports section (for module building)
-    pub fn imports(&self) -> &ImportSection {
-        &self.imports
-    }
-
-    /// Get the functions section (for module building)
-    pub fn functions(&self) -> &FunctionSection {
-        &self.functions
-    }
-
-    /// Get the globals section (for module building)
-    pub fn globals(&self) -> &GlobalSection {
-        &self.globals
-    }
-
     /// Check if any globals have been defined
     pub fn has_globals(&self) -> bool {
         self.next_global_idx > 0
     }
 
-    /// Get the exports section (for module building)
-    pub fn exports(&self) -> &ExportSection {
-        &self.exports
+    /// Check if a function type has a return value
+    pub fn type_has_return(&self, type_name: &str) -> Option<bool> {
+        self.type_has_return.get(type_name).copied()
     }
 
-    /// Build the name section from tracked type and function names
-    pub fn build_name_section(&self, module_name: &str) -> NameSection {
-        let mut names = NameSection::new();
-
-        // Module name (must come first according to spec)
-        names.module(module_name);
-
-        // Function names
-        let mut func_names = NameMap::new();
-        for (name, &idx) in &self.func_names {
-            func_names.append(idx, name);
-        }
-        names.functions(&func_names);
-
-        // Type names (must come after functions according to spec)
-        let mut type_names = NameMap::new();
-        for (name, &idx) in &self.type_names {
-            type_names.append(idx, name);
-        }
-        names.types(&type_names);
-
-        names
+    /// Get the return type of a function type
+    pub fn type_return_type(&self, type_name: &str) -> Option<ValType> {
+        self.type_return_type.get(type_name).copied()
     }
 
-    /// Build the producers section with language and compiler metadata
+    /// Get the type name for a function
+    pub fn func_type_name(&self, func_name: &str) -> Option<&str> {
+        self.func_type_names.get(func_name).map(String::as_str)
+    }
+
+    /// Extract accumulated WIR data for `WirModule` construction.
     ///
-    /// This is a standard custom section that records toolchain information.
-    /// See: <https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md>
-    #[must_use]
-    pub fn build_producers_section() -> ProducersSection {
-        let mut language = ProducersField::new();
-        language.value("Wado", "");
-
-        let mut processed_by = ProducersField::new();
-        processed_by.value(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-
-        let mut producers = ProducersSection::new();
-        producers.field("language", &language);
-        producers.field("processed-by", &processed_by);
-
-        producers
+    /// Consumes the builder. After this call, use the returned `WirModuleParts`
+    /// to construct a `WirModule` together with function bodies.
+    pub fn into_parts(self) -> WirModuleParts {
+        let names = WirNames {
+            func_names: self
+                .func_names
+                .into_iter()
+                .map(|(name, idx)| (idx, name))
+                .collect(),
+            type_names: self
+                .type_names
+                .into_iter()
+                .map(|(name, idx)| (idx, name))
+                .collect(),
+        };
+        WirModuleParts {
+            types: self.types,
+            imports: self.imports,
+            func_type_indices: self.func_type_indices,
+            globals: self.globals,
+            exports: self.exports,
+            import_func_count: self.import_func_count,
+            has_memory: self.has_memory,
+            names,
+        }
     }
 }
 

--- a/wado-compiler/src/wasm_builder.rs
+++ b/wado-compiler/src/wasm_builder.rs
@@ -15,19 +15,6 @@ use crate::wir::{
 };
 
 // ============================================================================
-// Rec Group Types (used by codegen to specify rec group entries)
-// ============================================================================
-
-/// Kind of type within a rec group (for mutually recursive types)
-#[derive(Debug, Clone)]
-pub enum RecTypeKind {
-    /// Struct type with fields
-    Struct(Vec<FieldType>),
-    /// Array type with element type
-    Array(FieldType),
-}
-
-// ============================================================================
 // WirModuleParts — extracted data from CoreModuleBuilder
 // ============================================================================
 
@@ -183,10 +170,7 @@ impl CoreModuleBuilder {
 
     /// Define a rec group containing multiple mutually recursive types.
     /// Types within the rec group can forward-reference each other.
-    ///
-    /// Each element in `types` is (name, `RecTypeKind`) where `RecTypeKind` specifies
-    /// whether it's a struct or array type.
-    pub fn define_rec_group(&mut self, types: &[(String, RecTypeKind)]) -> Vec<u32> {
+    pub fn define_rec_group(&mut self, types: &[(String, WirRecGroupKind)]) -> Vec<u32> {
         let base_idx = self.next_type_idx;
         let mut indices = Vec::with_capacity(types.len());
 
@@ -200,12 +184,7 @@ impl CoreModuleBuilder {
         // Build WIR rec group entries
         let entries: Vec<WirRecGroupEntry> = types
             .iter()
-            .map(|(_, kind)| WirRecGroupEntry {
-                kind: match kind {
-                    RecTypeKind::Struct(fields) => WirRecGroupKind::Struct(fields.clone()),
-                    RecTypeKind::Array(field_type) => WirRecGroupKind::Array(*field_type),
-                },
-            })
+            .map(|(_, kind)| WirRecGroupEntry { kind: kind.clone() })
             .collect();
 
         self.types.push(WirTypeDef::RecGroup(entries));

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -9,10 +9,8 @@
 // stream as a flat list. Tree-structured IR is a future step (see WEP).
 
 use wasm_encoder::{
-    BlockType, ExportKind, FieldType, HeapType, Instruction, MemArg, StorageType, ValType,
+    BlockType, Encode, ExportKind, FieldType, HeapType, Instruction, MemArg, StorageType, ValType,
 };
-
-use crate::wir_emit;
 
 // ============================================================================
 // Module-level WIR types
@@ -77,6 +75,7 @@ pub struct WirRecGroupEntry {
 }
 
 /// Kind of type within a rec group.
+#[derive(Debug, Clone)]
 pub enum WirRecGroupKind {
     Struct(Vec<FieldType>),
     Array(FieldType),
@@ -631,38 +630,38 @@ impl WirInstr {
 pub struct WirFunction {
     local_decls: Vec<(u32, ValType)>,
     instrs: Vec<WirInstr>,
-    /// Scratch function used only for `byte_len()` (branch-hint offsets).
-    scratch: wasm_encoder::Function,
+    /// Cumulative encoded byte length (locals + instructions), used for
+    /// branch-hint offset computation without maintaining a full scratch encoder.
+    byte_offset: usize,
+    /// Reusable buffer for computing per-instruction encoded sizes.
+    encode_buf: Vec<u8>,
 }
 
 impl WirFunction {
     pub fn new(locals: Vec<(u32, ValType)>) -> Self {
-        let scratch = wasm_encoder::Function::new(locals.clone());
+        // Compute initial byte_offset from locals encoding
+        let tmp = wasm_encoder::Function::new(locals.clone());
+        let byte_offset = tmp.byte_len();
         Self {
             local_decls: locals,
             instrs: Vec::new(),
-            scratch,
+            byte_offset,
+            encode_buf: Vec::new(),
         }
     }
 
     /// Record one instruction.  Same signature as `wasm_encoder::Function::instruction`.
     pub fn instruction(&mut self, instr: &Instruction<'_>) -> &mut Self {
         self.instrs.push(WirInstr::from_instruction(instr));
-        self.scratch.instruction(instr);
+        self.encode_buf.clear();
+        instr.encode(&mut self.encode_buf);
+        self.byte_offset += self.encode_buf.len();
         self
     }
 
     /// Current encoded byte length (used for branch-hint offset recording).
     pub fn byte_len(&self) -> usize {
-        self.scratch.byte_len()
-    }
-
-    /// Consume self and produce a `wasm_encoder::Function` by replaying the
-    /// `WirInstr` stream through `wir_emit`.
-    pub fn emit(self) -> wasm_encoder::Function {
-        let mut func = wasm_encoder::Function::new(self.local_decls);
-        wir_emit::emit(&self.instrs, &mut func);
-        func
+        self.byte_offset
     }
 
     /// Consume self and produce a `WirFunctionBody` for inclusion in a `WirModule`.

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -9,7 +9,7 @@
 // stream as a flat list. Tree-structured IR is a future step (see WEP).
 
 use wasm_encoder::{
-    BlockType, Encode, ExportKind, FieldType, HeapType, Instruction, MemArg, StorageType, ValType,
+    BlockType, ExportKind, FieldType, HeapType, Instruction, MemArg, StorageType, ValType,
 };
 
 // ============================================================================
@@ -33,9 +33,7 @@ pub struct WirModule {
     pub data: Vec<u8>,
     /// One body per defined function (same order as `func_type_indices`).
     pub bodies: Vec<WirFunctionBody>,
-    /// Per-function branch hints.
-    pub branch_hints: Vec<WirBranchHintEntry>,
-    /// Number of imported functions (offset for branch hint func indices).
+    /// Number of imported functions (used to compute branch hint func indices).
     pub import_func_count: u32,
     /// Module name and debug names. `None` in strip-names mode.
     pub names: Option<WirNames>,
@@ -117,12 +115,6 @@ pub struct WirExport {
     pub name: String,
     pub kind: ExportKind,
     pub index: u32,
-}
-
-/// Branch hints for a single function.
-pub struct WirBranchHintEntry {
-    pub func_idx: u32,
-    pub hints: Vec<(u32, bool)>,
 }
 
 /// Debug names for the name section.
@@ -382,6 +374,12 @@ pub enum WirInstr {
     // ── Misc ───────────────────────────────────────────────────────────
     Drop,
     TypedSelect(ValType),
+
+    // ── Pseudo-instructions (not emitted as Wasm bytes) ────────────────
+    /// Branch hint for the next branch instruction.
+    /// `true` = likely taken, `false` = unlikely taken.
+    /// Emitter records the byte offset here and emits it in the branch hints section.
+    BranchHint(bool),
 }
 
 impl WirInstr {
@@ -630,38 +628,25 @@ impl WirInstr {
 pub struct WirFunction {
     local_decls: Vec<(u32, ValType)>,
     instrs: Vec<WirInstr>,
-    /// Cumulative encoded byte length (locals + instructions), used for
-    /// branch-hint offset computation without maintaining a full scratch encoder.
-    byte_offset: usize,
-    /// Reusable buffer for computing per-instruction encoded sizes.
-    encode_buf: Vec<u8>,
 }
 
 impl WirFunction {
     pub fn new(locals: Vec<(u32, ValType)>) -> Self {
-        // Compute initial byte_offset from locals encoding
-        let tmp = wasm_encoder::Function::new(locals.clone());
-        let byte_offset = tmp.byte_len();
         Self {
             local_decls: locals,
             instrs: Vec::new(),
-            byte_offset,
-            encode_buf: Vec::new(),
         }
     }
 
     /// Record one instruction.  Same signature as `wasm_encoder::Function::instruction`.
     pub fn instruction(&mut self, instr: &Instruction<'_>) -> &mut Self {
         self.instrs.push(WirInstr::from_instruction(instr));
-        self.encode_buf.clear();
-        instr.encode(&mut self.encode_buf);
-        self.byte_offset += self.encode_buf.len();
         self
     }
 
-    /// Current encoded byte length (used for branch-hint offset recording).
-    pub fn byte_len(&self) -> usize {
-        self.byte_offset
+    /// Record a branch hint for the next branch instruction.
+    pub fn branch_hint(&mut self, taken: bool) {
+        self.instrs.push(WirInstr::BranchHint(taken));
     }
 
     /// Consume self and produce a `WirFunctionBody` for inclusion in a `WirModule`.

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1,0 +1,539 @@
+// WIR (Wasm IR) — an interposition layer between codegen and wasm_encoder.
+//
+// WirFunction captures the instruction stream as WirInstr values, then
+// emits them to a wasm_encoder::Function via wir_emit.  This proves the
+// WIR representation can round-trip every instruction the codegen produces.
+
+use wasm_encoder::{BlockType, HeapType, Instruction, MemArg, ValType};
+
+use crate::wir_emit;
+
+/// Owned memory-access argument (mirrors `wasm_encoder::MemArg`).
+#[derive(Clone, Copy, Debug)]
+pub struct WirMemArg {
+    pub offset: u64,
+    pub align: u32,
+    pub memory_index: u32,
+}
+
+impl From<MemArg> for WirMemArg {
+    fn from(m: MemArg) -> Self {
+        Self {
+            offset: m.offset,
+            align: m.align,
+            memory_index: m.memory_index,
+        }
+    }
+}
+
+impl From<WirMemArg> for MemArg {
+    fn from(m: WirMemArg) -> Self {
+        Self {
+            offset: m.offset,
+            align: m.align,
+            memory_index: m.memory_index,
+        }
+    }
+}
+
+/// Owned Wasm instruction — lifetime-free mirror of `wasm_encoder::Instruction`.
+///
+/// Only the variants actually used by codegen are included.
+#[derive(Clone, Debug)]
+pub enum WirInstr {
+    // ── Constants ───────────────────────────────────────────────────────
+    I32Const(i32),
+    I64Const(i64),
+    /// Stored as raw IEEE-754 bits to avoid NaN canonicalization.
+    F32Const(u32),
+    /// Stored as raw IEEE-754 bits to avoid NaN canonicalization.
+    F64Const(u64),
+
+    // ── Locals / Globals ───────────────────────────────────────────────
+    LocalGet(u32),
+    LocalSet(u32),
+    LocalTee(u32),
+    GlobalGet(u32),
+    GlobalSet(u32),
+
+    // ── i32 arithmetic & comparison ────────────────────────────────────
+    I32Add,
+    I32Sub,
+    I32Mul,
+    I32DivS,
+    I32DivU,
+    I32RemS,
+    I32RemU,
+    I32And,
+    I32Or,
+    I32Xor,
+    I32Shl,
+    I32ShrS,
+    I32ShrU,
+    I32Clz,
+    I32Eq,
+    I32Ne,
+    I32Eqz,
+    I32LtS,
+    I32LtU,
+    I32GtS,
+    I32GtU,
+    I32LeS,
+    I32LeU,
+    I32GeS,
+    I32GeU,
+
+    // ── i64 arithmetic & comparison ────────────────────────────────────
+    I64Add,
+    I64Sub,
+    I64Mul,
+    I64DivS,
+    I64DivU,
+    I64RemS,
+    I64RemU,
+    I64And,
+    I64Or,
+    I64Xor,
+    I64Shl,
+    I64ShrS,
+    I64ShrU,
+    I64Clz,
+    I64Eq,
+    I64Ne,
+    I64LtS,
+    I64LtU,
+    I64GtS,
+    I64GtU,
+    I64LeS,
+    I64LeU,
+    I64GeS,
+    I64GeU,
+
+    // ── Wide-integer instructions (Wasm 3.0) ───────────────────────────
+    I64Add128,
+    I64Sub128,
+    I64MulWideS,
+    I64MulWideU,
+
+    // ── f32 arithmetic & comparison ────────────────────────────────────
+    F32Add,
+    F32Sub,
+    F32Mul,
+    F32Div,
+    F32Eq,
+    F32Ne,
+    F32Lt,
+    F32Gt,
+    F32Le,
+    F32Ge,
+    F32Abs,
+    F32Neg,
+    F32Ceil,
+    F32Floor,
+    F32Trunc,
+    F32Nearest,
+    F32Sqrt,
+    F32Min,
+    F32Max,
+    F32Copysign,
+
+    // ── f64 arithmetic & comparison ────────────────────────────────────
+    F64Add,
+    F64Sub,
+    F64Mul,
+    F64Div,
+    F64Eq,
+    F64Ne,
+    F64Lt,
+    F64Gt,
+    F64Le,
+    F64Ge,
+    F64Abs,
+    F64Neg,
+    F64Ceil,
+    F64Floor,
+    F64Trunc,
+    F64Nearest,
+    F64Sqrt,
+    F64Min,
+    F64Max,
+    F64Copysign,
+
+    // ── Conversions / reinterpret ──────────────────────────────────────
+    I32WrapI64,
+    I64ExtendI32S,
+    I64ExtendI32U,
+    I32TruncF32S,
+    I32TruncF64S,
+    I64TruncF32S,
+    I64TruncF32U,
+    I64TruncF64S,
+    I64TruncF64U,
+    F32ConvertI32S,
+    F32ConvertI64S,
+    F32ConvertI64U,
+    F64ConvertI32S,
+    F64ConvertI64S,
+    F64ConvertI64U,
+    F32DemoteF64,
+    F64PromoteF32,
+    I32ReinterpretF32,
+    I64ReinterpretF64,
+    F32ReinterpretI32,
+    F64ReinterpretI64,
+
+    // ── Memory ─────────────────────────────────────────────────────────
+    I32Load(WirMemArg),
+    I64Load(WirMemArg),
+    F32Load(WirMemArg),
+    F64Load(WirMemArg),
+    I32Load8U(WirMemArg),
+    I32Store(WirMemArg),
+    I32Store8(WirMemArg),
+
+    // ── Control flow ───────────────────────────────────────────────────
+    Block(BlockType),
+    Loop(BlockType),
+    If(BlockType),
+    Else,
+    End,
+    Br(u32),
+    BrIf(u32),
+    BrTable {
+        targets: Vec<u32>,
+        default: u32,
+    },
+    Return,
+    Unreachable,
+
+    // ── Call ────────────────────────────────────────────────────────────
+    Call(u32),
+    CallRef(u32),
+
+    // ── GC: struct ─────────────────────────────────────────────────────
+    StructNew(u32),
+    StructGet {
+        struct_type_index: u32,
+        field_index: u32,
+    },
+    StructSet {
+        struct_type_index: u32,
+        field_index: u32,
+    },
+
+    // ── GC: array ──────────────────────────────────────────────────────
+    ArrayNew(u32),
+    ArrayNewDefault(u32),
+    ArrayNewData {
+        array_type_index: u32,
+        array_data_index: u32,
+    },
+    ArrayNewFixed {
+        array_type_index: u32,
+        array_size: u32,
+    },
+    ArrayGet(u32),
+    ArrayGetS(u32),
+    ArrayGetU(u32),
+    ArraySet(u32),
+    ArrayLen,
+    ArrayCopy {
+        array_type_index_dst: u32,
+        array_type_index_src: u32,
+    },
+    ArrayFill(u32),
+
+    // ── GC: ref ────────────────────────────────────────────────────────
+    RefNull(HeapType),
+    RefIsNull,
+    RefAsNonNull,
+    RefEq,
+    RefFunc(u32),
+    RefCastNonNull(HeapType),
+    RefTestNonNull(HeapType),
+
+    // ── Misc ───────────────────────────────────────────────────────────
+    Drop,
+    TypedSelect(ValType),
+}
+
+impl WirInstr {
+    /// Convert a borrowed `wasm_encoder::Instruction` to an owned `WirInstr`.
+    ///
+    /// Panics on instruction variants that codegen never emits.
+    pub fn from_instruction(instr: &Instruction<'_>) -> Self {
+        match *instr {
+            // Constants
+            Instruction::I32Const(v) => Self::I32Const(v),
+            Instruction::I64Const(v) => Self::I64Const(v),
+            Instruction::F32Const(ieee) => Self::F32Const(ieee.bits()),
+            Instruction::F64Const(ieee) => Self::F64Const(ieee.bits()),
+
+            // Locals / Globals
+            Instruction::LocalGet(i) => Self::LocalGet(i),
+            Instruction::LocalSet(i) => Self::LocalSet(i),
+            Instruction::LocalTee(i) => Self::LocalTee(i),
+            Instruction::GlobalGet(i) => Self::GlobalGet(i),
+            Instruction::GlobalSet(i) => Self::GlobalSet(i),
+
+            // i32 arithmetic
+            Instruction::I32Add => Self::I32Add,
+            Instruction::I32Sub => Self::I32Sub,
+            Instruction::I32Mul => Self::I32Mul,
+            Instruction::I32DivS => Self::I32DivS,
+            Instruction::I32DivU => Self::I32DivU,
+            Instruction::I32RemS => Self::I32RemS,
+            Instruction::I32RemU => Self::I32RemU,
+            Instruction::I32And => Self::I32And,
+            Instruction::I32Or => Self::I32Or,
+            Instruction::I32Xor => Self::I32Xor,
+            Instruction::I32Shl => Self::I32Shl,
+            Instruction::I32ShrS => Self::I32ShrS,
+            Instruction::I32ShrU => Self::I32ShrU,
+            Instruction::I32Clz => Self::I32Clz,
+            Instruction::I32Eq => Self::I32Eq,
+            Instruction::I32Ne => Self::I32Ne,
+            Instruction::I32Eqz => Self::I32Eqz,
+            Instruction::I32LtS => Self::I32LtS,
+            Instruction::I32LtU => Self::I32LtU,
+            Instruction::I32GtS => Self::I32GtS,
+            Instruction::I32GtU => Self::I32GtU,
+            Instruction::I32LeS => Self::I32LeS,
+            Instruction::I32LeU => Self::I32LeU,
+            Instruction::I32GeS => Self::I32GeS,
+            Instruction::I32GeU => Self::I32GeU,
+
+            // i64 arithmetic
+            Instruction::I64Add => Self::I64Add,
+            Instruction::I64Sub => Self::I64Sub,
+            Instruction::I64Mul => Self::I64Mul,
+            Instruction::I64DivS => Self::I64DivS,
+            Instruction::I64DivU => Self::I64DivU,
+            Instruction::I64RemS => Self::I64RemS,
+            Instruction::I64RemU => Self::I64RemU,
+            Instruction::I64And => Self::I64And,
+            Instruction::I64Or => Self::I64Or,
+            Instruction::I64Xor => Self::I64Xor,
+            Instruction::I64Shl => Self::I64Shl,
+            Instruction::I64ShrS => Self::I64ShrS,
+            Instruction::I64ShrU => Self::I64ShrU,
+            Instruction::I64Clz => Self::I64Clz,
+            Instruction::I64Eq => Self::I64Eq,
+            Instruction::I64Ne => Self::I64Ne,
+            Instruction::I64LtS => Self::I64LtS,
+            Instruction::I64LtU => Self::I64LtU,
+            Instruction::I64GtS => Self::I64GtS,
+            Instruction::I64GtU => Self::I64GtU,
+            Instruction::I64LeS => Self::I64LeS,
+            Instruction::I64LeU => Self::I64LeU,
+            Instruction::I64GeS => Self::I64GeS,
+            Instruction::I64GeU => Self::I64GeU,
+
+            // Wide integer
+            Instruction::I64Add128 => Self::I64Add128,
+            Instruction::I64Sub128 => Self::I64Sub128,
+            Instruction::I64MulWideS => Self::I64MulWideS,
+            Instruction::I64MulWideU => Self::I64MulWideU,
+
+            // f32 arithmetic
+            Instruction::F32Add => Self::F32Add,
+            Instruction::F32Sub => Self::F32Sub,
+            Instruction::F32Mul => Self::F32Mul,
+            Instruction::F32Div => Self::F32Div,
+            Instruction::F32Eq => Self::F32Eq,
+            Instruction::F32Ne => Self::F32Ne,
+            Instruction::F32Lt => Self::F32Lt,
+            Instruction::F32Gt => Self::F32Gt,
+            Instruction::F32Le => Self::F32Le,
+            Instruction::F32Ge => Self::F32Ge,
+            Instruction::F32Abs => Self::F32Abs,
+            Instruction::F32Neg => Self::F32Neg,
+            Instruction::F32Ceil => Self::F32Ceil,
+            Instruction::F32Floor => Self::F32Floor,
+            Instruction::F32Trunc => Self::F32Trunc,
+            Instruction::F32Nearest => Self::F32Nearest,
+            Instruction::F32Sqrt => Self::F32Sqrt,
+            Instruction::F32Min => Self::F32Min,
+            Instruction::F32Max => Self::F32Max,
+            Instruction::F32Copysign => Self::F32Copysign,
+
+            // f64 arithmetic
+            Instruction::F64Add => Self::F64Add,
+            Instruction::F64Sub => Self::F64Sub,
+            Instruction::F64Mul => Self::F64Mul,
+            Instruction::F64Div => Self::F64Div,
+            Instruction::F64Eq => Self::F64Eq,
+            Instruction::F64Ne => Self::F64Ne,
+            Instruction::F64Lt => Self::F64Lt,
+            Instruction::F64Gt => Self::F64Gt,
+            Instruction::F64Le => Self::F64Le,
+            Instruction::F64Ge => Self::F64Ge,
+            Instruction::F64Abs => Self::F64Abs,
+            Instruction::F64Neg => Self::F64Neg,
+            Instruction::F64Ceil => Self::F64Ceil,
+            Instruction::F64Floor => Self::F64Floor,
+            Instruction::F64Trunc => Self::F64Trunc,
+            Instruction::F64Nearest => Self::F64Nearest,
+            Instruction::F64Sqrt => Self::F64Sqrt,
+            Instruction::F64Min => Self::F64Min,
+            Instruction::F64Max => Self::F64Max,
+            Instruction::F64Copysign => Self::F64Copysign,
+
+            // Conversions
+            Instruction::I32WrapI64 => Self::I32WrapI64,
+            Instruction::I64ExtendI32S => Self::I64ExtendI32S,
+            Instruction::I64ExtendI32U => Self::I64ExtendI32U,
+            Instruction::I32TruncF32S => Self::I32TruncF32S,
+            Instruction::I32TruncF64S => Self::I32TruncF64S,
+            Instruction::I64TruncF32S => Self::I64TruncF32S,
+            Instruction::I64TruncF32U => Self::I64TruncF32U,
+            Instruction::I64TruncF64S => Self::I64TruncF64S,
+            Instruction::I64TruncF64U => Self::I64TruncF64U,
+            Instruction::F32ConvertI32S => Self::F32ConvertI32S,
+            Instruction::F32ConvertI64S => Self::F32ConvertI64S,
+            Instruction::F32ConvertI64U => Self::F32ConvertI64U,
+            Instruction::F64ConvertI32S => Self::F64ConvertI32S,
+            Instruction::F64ConvertI64S => Self::F64ConvertI64S,
+            Instruction::F64ConvertI64U => Self::F64ConvertI64U,
+            Instruction::F32DemoteF64 => Self::F32DemoteF64,
+            Instruction::F64PromoteF32 => Self::F64PromoteF32,
+            Instruction::I32ReinterpretF32 => Self::I32ReinterpretF32,
+            Instruction::I64ReinterpretF64 => Self::I64ReinterpretF64,
+            Instruction::F32ReinterpretI32 => Self::F32ReinterpretI32,
+            Instruction::F64ReinterpretI64 => Self::F64ReinterpretI64,
+
+            // Memory
+            Instruction::I32Load(m) => Self::I32Load(m.into()),
+            Instruction::I64Load(m) => Self::I64Load(m.into()),
+            Instruction::F32Load(m) => Self::F32Load(m.into()),
+            Instruction::F64Load(m) => Self::F64Load(m.into()),
+            Instruction::I32Load8U(m) => Self::I32Load8U(m.into()),
+            Instruction::I32Store(m) => Self::I32Store(m.into()),
+            Instruction::I32Store8(m) => Self::I32Store8(m.into()),
+
+            // Control
+            Instruction::Block(bt) => Self::Block(bt),
+            Instruction::Loop(bt) => Self::Loop(bt),
+            Instruction::If(bt) => Self::If(bt),
+            Instruction::Else => Self::Else,
+            Instruction::End => Self::End,
+            Instruction::Br(d) => Self::Br(d),
+            Instruction::BrIf(d) => Self::BrIf(d),
+            Instruction::BrTable(ref targets, default) => Self::BrTable {
+                targets: targets.to_vec(),
+                default,
+            },
+            Instruction::Return => Self::Return,
+            Instruction::Unreachable => Self::Unreachable,
+
+            // Call
+            Instruction::Call(i) => Self::Call(i),
+            Instruction::CallRef(i) => Self::CallRef(i),
+
+            // GC: struct
+            Instruction::StructNew(i) => Self::StructNew(i),
+            Instruction::StructGet {
+                struct_type_index,
+                field_index,
+            } => Self::StructGet {
+                struct_type_index,
+                field_index,
+            },
+            Instruction::StructSet {
+                struct_type_index,
+                field_index,
+            } => Self::StructSet {
+                struct_type_index,
+                field_index,
+            },
+
+            // GC: array
+            Instruction::ArrayNew(i) => Self::ArrayNew(i),
+            Instruction::ArrayNewDefault(i) => Self::ArrayNewDefault(i),
+            Instruction::ArrayNewData {
+                array_type_index,
+                array_data_index,
+            } => Self::ArrayNewData {
+                array_type_index,
+                array_data_index,
+            },
+            Instruction::ArrayNewFixed {
+                array_type_index,
+                array_size,
+            } => Self::ArrayNewFixed {
+                array_type_index,
+                array_size,
+            },
+            Instruction::ArrayGet(i) => Self::ArrayGet(i),
+            Instruction::ArrayGetS(i) => Self::ArrayGetS(i),
+            Instruction::ArrayGetU(i) => Self::ArrayGetU(i),
+            Instruction::ArraySet(i) => Self::ArraySet(i),
+            Instruction::ArrayLen => Self::ArrayLen,
+            Instruction::ArrayCopy {
+                array_type_index_dst,
+                array_type_index_src,
+            } => Self::ArrayCopy {
+                array_type_index_dst,
+                array_type_index_src,
+            },
+            Instruction::ArrayFill(i) => Self::ArrayFill(i),
+
+            // GC: ref
+            Instruction::RefNull(ht) => Self::RefNull(ht),
+            Instruction::RefIsNull => Self::RefIsNull,
+            Instruction::RefAsNonNull => Self::RefAsNonNull,
+            Instruction::RefEq => Self::RefEq,
+            Instruction::RefFunc(i) => Self::RefFunc(i),
+            Instruction::RefCastNonNull(ht) => Self::RefCastNonNull(ht),
+            Instruction::RefTestNonNull(ht) => Self::RefTestNonNull(ht),
+
+            // Misc
+            Instruction::Drop => Self::Drop,
+            Instruction::TypedSelect(vt) => Self::TypedSelect(vt),
+
+            _ => panic!("WirInstr: unsupported instruction"),
+        }
+    }
+}
+
+/// A function body represented as a `WirInstr` stream.
+///
+/// Provides the same `instruction(&Instruction)` API as `wasm_encoder::Function`
+/// so that codegen can switch types with minimal changes.
+pub struct WirFunction {
+    local_decls: Vec<(u32, ValType)>,
+    instrs: Vec<WirInstr>,
+    /// Scratch function used only for `byte_len()` (branch-hint offsets).
+    scratch: wasm_encoder::Function,
+}
+
+impl WirFunction {
+    pub fn new(locals: Vec<(u32, ValType)>) -> Self {
+        let scratch = wasm_encoder::Function::new(locals.clone());
+        Self {
+            local_decls: locals,
+            instrs: Vec::new(),
+            scratch,
+        }
+    }
+
+    /// Record one instruction.  Same signature as `wasm_encoder::Function::instruction`.
+    pub fn instruction(&mut self, instr: &Instruction<'_>) -> &mut Self {
+        self.instrs.push(WirInstr::from_instruction(instr));
+        self.scratch.instruction(instr);
+        self
+    }
+
+    /// Current encoded byte length (used for branch-hint offset recording).
+    pub fn byte_len(&self) -> usize {
+        self.scratch.byte_len()
+    }
+
+    /// Consume self and produce a `wasm_encoder::Function` by replaying the
+    /// `WirInstr` stream through `wir_emit`.
+    pub fn emit(self) -> wasm_encoder::Function {
+        let mut func = wasm_encoder::Function::new(self.local_decls);
+        wir_emit::emit(&self.instrs, &mut func);
+        func
+    }
+}

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1,12 +1,140 @@
 // WIR (Wasm IR) — an interposition layer between codegen and wasm_encoder.
 //
-// WirFunction captures the instruction stream as WirInstr values, then
-// emits them to a wasm_encoder::Function via wir_emit.  This proves the
-// WIR representation can round-trip every instruction the codegen produces.
+// Module-level types (`WirModule`, `WirTypeDef`, etc.) capture the complete
+// core Wasm module in inspectable form. The `emit_module` function in
+// `wir_emit.rs` converts a `WirModule` to Wasm bytes — the only place
+// that touches `wasm_encoder` sections.
+//
+// Function-level types (`WirFunction`, `WirInstr`) capture the instruction
+// stream as a flat list. Tree-structured IR is a future step (see WEP).
 
-use wasm_encoder::{BlockType, HeapType, Instruction, MemArg, ValType};
+use wasm_encoder::{
+    BlockType, ExportKind, FieldType, HeapType, Instruction, MemArg, StorageType, ValType,
+};
 
 use crate::wir_emit;
+
+// ============================================================================
+// Module-level WIR types
+// ============================================================================
+
+/// Complete core Wasm module in inspectable form.
+///
+/// All indices are resolved. `emit_module` converts this to `Vec<u8>` purely
+/// mechanically — no decisions, no lookups.
+pub struct WirModule {
+    pub types: Vec<WirTypeDef>,
+    pub imports: Vec<WirImport>,
+    /// Function section: one type index per defined function.
+    pub func_type_indices: Vec<u32>,
+    pub globals: Vec<WirGlobal>,
+    pub exports: Vec<WirExport>,
+    /// Function indices for the declarative element segment (required for `ref.func`).
+    pub element_func_indices: Vec<u32>,
+    /// Passive data segment bytes (concatenated string literals).
+    pub data: Vec<u8>,
+    /// One body per defined function (same order as `func_type_indices`).
+    pub bodies: Vec<WirFunctionBody>,
+    /// Per-function branch hints.
+    pub branch_hints: Vec<WirBranchHintEntry>,
+    /// Number of imported functions (offset for branch hint func indices).
+    pub import_func_count: u32,
+    /// Module name and debug names. `None` in strip-names mode.
+    pub names: Option<WirNames>,
+    pub module_name: String,
+    /// Whether a memory import exists (used to emit the memory import flag).
+    pub has_memory: bool,
+}
+
+/// A single function body: local declarations + flat instruction stream.
+pub struct WirFunctionBody {
+    pub locals: Vec<(u32, ValType)>,
+    pub instrs: Vec<WirInstr>,
+}
+
+/// Type definition in the type section.
+pub enum WirTypeDef {
+    /// `(func (param ...) (result ...))`.
+    Func {
+        params: Vec<ValType>,
+        results: Vec<ValType>,
+    },
+    /// `(array (field ...))`.
+    GcArray { element: StorageType, mutable: bool },
+    /// `(struct (field ...) ...)`.
+    GcStruct {
+        fields: Vec<FieldType>,
+        is_final: bool,
+        supertype_idx: Option<u32>,
+    },
+    /// `(rec ...)` containing mutually recursive types.
+    RecGroup(Vec<WirRecGroupEntry>),
+}
+
+/// One entry inside a `WirTypeDef::RecGroup`.
+pub struct WirRecGroupEntry {
+    pub kind: WirRecGroupKind,
+}
+
+/// Kind of type within a rec group.
+pub enum WirRecGroupKind {
+    Struct(Vec<FieldType>),
+    Array(FieldType),
+}
+
+/// Import entry.
+pub enum WirImport {
+    Func {
+        module: String,
+        name: String,
+        type_idx: u32,
+    },
+    Memory {
+        module: String,
+        name: String,
+        min: u64,
+    },
+}
+
+/// Global variable definition.
+pub struct WirGlobal {
+    pub name: String,
+    pub val_type: ValType,
+    pub mutable: bool,
+    pub init: WirConstExpr,
+}
+
+/// Constant expression for global initializers.
+pub enum WirConstExpr {
+    I32(i32),
+    I64(i64),
+    F32(u32),
+    F64(u64),
+    RefNull(HeapType),
+}
+
+/// Export entry.
+pub struct WirExport {
+    pub name: String,
+    pub kind: ExportKind,
+    pub index: u32,
+}
+
+/// Branch hints for a single function.
+pub struct WirBranchHintEntry {
+    pub func_idx: u32,
+    pub hints: Vec<(u32, bool)>,
+}
+
+/// Debug names for the name section.
+pub struct WirNames {
+    pub func_names: Vec<(u32, String)>,
+    pub type_names: Vec<(u32, String)>,
+}
+
+// ============================================================================
+// Instruction-level WIR types
+// ============================================================================
 
 /// Owned memory-access argument (mirrors `wasm_encoder::MemArg`).
 #[derive(Clone, Copy, Debug)]
@@ -535,5 +663,13 @@ impl WirFunction {
         let mut func = wasm_encoder::Function::new(self.local_decls);
         wir_emit::emit(&self.instrs, &mut func);
         func
+    }
+
+    /// Consume self and produce a `WirFunctionBody` for inclusion in a `WirModule`.
+    pub fn into_body(self) -> WirFunctionBody {
+        WirFunctionBody {
+            locals: self.local_decls,
+            instrs: self.instrs,
+        }
     }
 }

--- a/wado-compiler/src/wir_emit.rs
+++ b/wado-compiler/src/wir_emit.rs
@@ -1,0 +1,578 @@
+// WIR emitter — converts a WirInstr stream into wasm_encoder::Function instructions.
+
+use wasm_encoder::{Function, Instruction};
+
+use crate::wir::{WirInstr, WirMemArg};
+
+/// Emit a slice of `WirInstr` into a `wasm_encoder::Function`.
+pub fn emit(instrs: &[WirInstr], func: &mut Function) {
+    for instr in instrs {
+        emit_instr(instr, func);
+    }
+}
+
+fn mem(m: &WirMemArg) -> wasm_encoder::MemArg {
+    (*m).into()
+}
+
+fn emit_instr(instr: &WirInstr, func: &mut Function) {
+    match *instr {
+        // Constants
+        WirInstr::I32Const(v) => {
+            func.instruction(&Instruction::I32Const(v));
+        }
+        WirInstr::I64Const(v) => {
+            func.instruction(&Instruction::I64Const(v));
+        }
+        WirInstr::F32Const(bits) => {
+            func.instruction(&Instruction::F32Const(wasm_encoder::Ieee32::new(bits)));
+        }
+        WirInstr::F64Const(bits) => {
+            func.instruction(&Instruction::F64Const(wasm_encoder::Ieee64::new(bits)));
+        }
+
+        // Locals / Globals
+        WirInstr::LocalGet(i) => {
+            func.instruction(&Instruction::LocalGet(i));
+        }
+        WirInstr::LocalSet(i) => {
+            func.instruction(&Instruction::LocalSet(i));
+        }
+        WirInstr::LocalTee(i) => {
+            func.instruction(&Instruction::LocalTee(i));
+        }
+        WirInstr::GlobalGet(i) => {
+            func.instruction(&Instruction::GlobalGet(i));
+        }
+        WirInstr::GlobalSet(i) => {
+            func.instruction(&Instruction::GlobalSet(i));
+        }
+
+        // i32 arithmetic
+        WirInstr::I32Add => {
+            func.instruction(&Instruction::I32Add);
+        }
+        WirInstr::I32Sub => {
+            func.instruction(&Instruction::I32Sub);
+        }
+        WirInstr::I32Mul => {
+            func.instruction(&Instruction::I32Mul);
+        }
+        WirInstr::I32DivS => {
+            func.instruction(&Instruction::I32DivS);
+        }
+        WirInstr::I32DivU => {
+            func.instruction(&Instruction::I32DivU);
+        }
+        WirInstr::I32RemS => {
+            func.instruction(&Instruction::I32RemS);
+        }
+        WirInstr::I32RemU => {
+            func.instruction(&Instruction::I32RemU);
+        }
+        WirInstr::I32And => {
+            func.instruction(&Instruction::I32And);
+        }
+        WirInstr::I32Or => {
+            func.instruction(&Instruction::I32Or);
+        }
+        WirInstr::I32Xor => {
+            func.instruction(&Instruction::I32Xor);
+        }
+        WirInstr::I32Shl => {
+            func.instruction(&Instruction::I32Shl);
+        }
+        WirInstr::I32ShrS => {
+            func.instruction(&Instruction::I32ShrS);
+        }
+        WirInstr::I32ShrU => {
+            func.instruction(&Instruction::I32ShrU);
+        }
+        WirInstr::I32Clz => {
+            func.instruction(&Instruction::I32Clz);
+        }
+        WirInstr::I32Eq => {
+            func.instruction(&Instruction::I32Eq);
+        }
+        WirInstr::I32Ne => {
+            func.instruction(&Instruction::I32Ne);
+        }
+        WirInstr::I32Eqz => {
+            func.instruction(&Instruction::I32Eqz);
+        }
+        WirInstr::I32LtS => {
+            func.instruction(&Instruction::I32LtS);
+        }
+        WirInstr::I32LtU => {
+            func.instruction(&Instruction::I32LtU);
+        }
+        WirInstr::I32GtS => {
+            func.instruction(&Instruction::I32GtS);
+        }
+        WirInstr::I32GtU => {
+            func.instruction(&Instruction::I32GtU);
+        }
+        WirInstr::I32LeS => {
+            func.instruction(&Instruction::I32LeS);
+        }
+        WirInstr::I32LeU => {
+            func.instruction(&Instruction::I32LeU);
+        }
+        WirInstr::I32GeS => {
+            func.instruction(&Instruction::I32GeS);
+        }
+        WirInstr::I32GeU => {
+            func.instruction(&Instruction::I32GeU);
+        }
+
+        // i64 arithmetic
+        WirInstr::I64Add => {
+            func.instruction(&Instruction::I64Add);
+        }
+        WirInstr::I64Sub => {
+            func.instruction(&Instruction::I64Sub);
+        }
+        WirInstr::I64Mul => {
+            func.instruction(&Instruction::I64Mul);
+        }
+        WirInstr::I64DivS => {
+            func.instruction(&Instruction::I64DivS);
+        }
+        WirInstr::I64DivU => {
+            func.instruction(&Instruction::I64DivU);
+        }
+        WirInstr::I64RemS => {
+            func.instruction(&Instruction::I64RemS);
+        }
+        WirInstr::I64RemU => {
+            func.instruction(&Instruction::I64RemU);
+        }
+        WirInstr::I64And => {
+            func.instruction(&Instruction::I64And);
+        }
+        WirInstr::I64Or => {
+            func.instruction(&Instruction::I64Or);
+        }
+        WirInstr::I64Xor => {
+            func.instruction(&Instruction::I64Xor);
+        }
+        WirInstr::I64Shl => {
+            func.instruction(&Instruction::I64Shl);
+        }
+        WirInstr::I64ShrS => {
+            func.instruction(&Instruction::I64ShrS);
+        }
+        WirInstr::I64ShrU => {
+            func.instruction(&Instruction::I64ShrU);
+        }
+        WirInstr::I64Clz => {
+            func.instruction(&Instruction::I64Clz);
+        }
+        WirInstr::I64Eq => {
+            func.instruction(&Instruction::I64Eq);
+        }
+        WirInstr::I64Ne => {
+            func.instruction(&Instruction::I64Ne);
+        }
+        WirInstr::I64LtS => {
+            func.instruction(&Instruction::I64LtS);
+        }
+        WirInstr::I64LtU => {
+            func.instruction(&Instruction::I64LtU);
+        }
+        WirInstr::I64GtS => {
+            func.instruction(&Instruction::I64GtS);
+        }
+        WirInstr::I64GtU => {
+            func.instruction(&Instruction::I64GtU);
+        }
+        WirInstr::I64LeS => {
+            func.instruction(&Instruction::I64LeS);
+        }
+        WirInstr::I64LeU => {
+            func.instruction(&Instruction::I64LeU);
+        }
+        WirInstr::I64GeS => {
+            func.instruction(&Instruction::I64GeS);
+        }
+        WirInstr::I64GeU => {
+            func.instruction(&Instruction::I64GeU);
+        }
+
+        // Wide integer
+        WirInstr::I64Add128 => {
+            func.instruction(&Instruction::I64Add128);
+        }
+        WirInstr::I64Sub128 => {
+            func.instruction(&Instruction::I64Sub128);
+        }
+        WirInstr::I64MulWideS => {
+            func.instruction(&Instruction::I64MulWideS);
+        }
+        WirInstr::I64MulWideU => {
+            func.instruction(&Instruction::I64MulWideU);
+        }
+
+        // f32 arithmetic
+        WirInstr::F32Add => {
+            func.instruction(&Instruction::F32Add);
+        }
+        WirInstr::F32Sub => {
+            func.instruction(&Instruction::F32Sub);
+        }
+        WirInstr::F32Mul => {
+            func.instruction(&Instruction::F32Mul);
+        }
+        WirInstr::F32Div => {
+            func.instruction(&Instruction::F32Div);
+        }
+        WirInstr::F32Eq => {
+            func.instruction(&Instruction::F32Eq);
+        }
+        WirInstr::F32Ne => {
+            func.instruction(&Instruction::F32Ne);
+        }
+        WirInstr::F32Lt => {
+            func.instruction(&Instruction::F32Lt);
+        }
+        WirInstr::F32Gt => {
+            func.instruction(&Instruction::F32Gt);
+        }
+        WirInstr::F32Le => {
+            func.instruction(&Instruction::F32Le);
+        }
+        WirInstr::F32Ge => {
+            func.instruction(&Instruction::F32Ge);
+        }
+        WirInstr::F32Abs => {
+            func.instruction(&Instruction::F32Abs);
+        }
+        WirInstr::F32Neg => {
+            func.instruction(&Instruction::F32Neg);
+        }
+        WirInstr::F32Ceil => {
+            func.instruction(&Instruction::F32Ceil);
+        }
+        WirInstr::F32Floor => {
+            func.instruction(&Instruction::F32Floor);
+        }
+        WirInstr::F32Trunc => {
+            func.instruction(&Instruction::F32Trunc);
+        }
+        WirInstr::F32Nearest => {
+            func.instruction(&Instruction::F32Nearest);
+        }
+        WirInstr::F32Sqrt => {
+            func.instruction(&Instruction::F32Sqrt);
+        }
+        WirInstr::F32Min => {
+            func.instruction(&Instruction::F32Min);
+        }
+        WirInstr::F32Max => {
+            func.instruction(&Instruction::F32Max);
+        }
+        WirInstr::F32Copysign => {
+            func.instruction(&Instruction::F32Copysign);
+        }
+
+        // f64 arithmetic
+        WirInstr::F64Add => {
+            func.instruction(&Instruction::F64Add);
+        }
+        WirInstr::F64Sub => {
+            func.instruction(&Instruction::F64Sub);
+        }
+        WirInstr::F64Mul => {
+            func.instruction(&Instruction::F64Mul);
+        }
+        WirInstr::F64Div => {
+            func.instruction(&Instruction::F64Div);
+        }
+        WirInstr::F64Eq => {
+            func.instruction(&Instruction::F64Eq);
+        }
+        WirInstr::F64Ne => {
+            func.instruction(&Instruction::F64Ne);
+        }
+        WirInstr::F64Lt => {
+            func.instruction(&Instruction::F64Lt);
+        }
+        WirInstr::F64Gt => {
+            func.instruction(&Instruction::F64Gt);
+        }
+        WirInstr::F64Le => {
+            func.instruction(&Instruction::F64Le);
+        }
+        WirInstr::F64Ge => {
+            func.instruction(&Instruction::F64Ge);
+        }
+        WirInstr::F64Abs => {
+            func.instruction(&Instruction::F64Abs);
+        }
+        WirInstr::F64Neg => {
+            func.instruction(&Instruction::F64Neg);
+        }
+        WirInstr::F64Ceil => {
+            func.instruction(&Instruction::F64Ceil);
+        }
+        WirInstr::F64Floor => {
+            func.instruction(&Instruction::F64Floor);
+        }
+        WirInstr::F64Trunc => {
+            func.instruction(&Instruction::F64Trunc);
+        }
+        WirInstr::F64Nearest => {
+            func.instruction(&Instruction::F64Nearest);
+        }
+        WirInstr::F64Sqrt => {
+            func.instruction(&Instruction::F64Sqrt);
+        }
+        WirInstr::F64Min => {
+            func.instruction(&Instruction::F64Min);
+        }
+        WirInstr::F64Max => {
+            func.instruction(&Instruction::F64Max);
+        }
+        WirInstr::F64Copysign => {
+            func.instruction(&Instruction::F64Copysign);
+        }
+
+        // Conversions
+        WirInstr::I32WrapI64 => {
+            func.instruction(&Instruction::I32WrapI64);
+        }
+        WirInstr::I64ExtendI32S => {
+            func.instruction(&Instruction::I64ExtendI32S);
+        }
+        WirInstr::I64ExtendI32U => {
+            func.instruction(&Instruction::I64ExtendI32U);
+        }
+        WirInstr::I32TruncF32S => {
+            func.instruction(&Instruction::I32TruncF32S);
+        }
+        WirInstr::I32TruncF64S => {
+            func.instruction(&Instruction::I32TruncF64S);
+        }
+        WirInstr::I64TruncF32S => {
+            func.instruction(&Instruction::I64TruncF32S);
+        }
+        WirInstr::I64TruncF32U => {
+            func.instruction(&Instruction::I64TruncF32U);
+        }
+        WirInstr::I64TruncF64S => {
+            func.instruction(&Instruction::I64TruncF64S);
+        }
+        WirInstr::I64TruncF64U => {
+            func.instruction(&Instruction::I64TruncF64U);
+        }
+        WirInstr::F32ConvertI32S => {
+            func.instruction(&Instruction::F32ConvertI32S);
+        }
+        WirInstr::F32ConvertI64S => {
+            func.instruction(&Instruction::F32ConvertI64S);
+        }
+        WirInstr::F32ConvertI64U => {
+            func.instruction(&Instruction::F32ConvertI64U);
+        }
+        WirInstr::F64ConvertI32S => {
+            func.instruction(&Instruction::F64ConvertI32S);
+        }
+        WirInstr::F64ConvertI64S => {
+            func.instruction(&Instruction::F64ConvertI64S);
+        }
+        WirInstr::F64ConvertI64U => {
+            func.instruction(&Instruction::F64ConvertI64U);
+        }
+        WirInstr::F32DemoteF64 => {
+            func.instruction(&Instruction::F32DemoteF64);
+        }
+        WirInstr::F64PromoteF32 => {
+            func.instruction(&Instruction::F64PromoteF32);
+        }
+        WirInstr::I32ReinterpretF32 => {
+            func.instruction(&Instruction::I32ReinterpretF32);
+        }
+        WirInstr::I64ReinterpretF64 => {
+            func.instruction(&Instruction::I64ReinterpretF64);
+        }
+        WirInstr::F32ReinterpretI32 => {
+            func.instruction(&Instruction::F32ReinterpretI32);
+        }
+        WirInstr::F64ReinterpretI64 => {
+            func.instruction(&Instruction::F64ReinterpretI64);
+        }
+
+        // Memory
+        WirInstr::I32Load(ref m) => {
+            func.instruction(&Instruction::I32Load(mem(m)));
+        }
+        WirInstr::I64Load(ref m) => {
+            func.instruction(&Instruction::I64Load(mem(m)));
+        }
+        WirInstr::F32Load(ref m) => {
+            func.instruction(&Instruction::F32Load(mem(m)));
+        }
+        WirInstr::F64Load(ref m) => {
+            func.instruction(&Instruction::F64Load(mem(m)));
+        }
+        WirInstr::I32Load8U(ref m) => {
+            func.instruction(&Instruction::I32Load8U(mem(m)));
+        }
+        WirInstr::I32Store(ref m) => {
+            func.instruction(&Instruction::I32Store(mem(m)));
+        }
+        WirInstr::I32Store8(ref m) => {
+            func.instruction(&Instruction::I32Store8(mem(m)));
+        }
+
+        // Control
+        WirInstr::Block(bt) => {
+            func.instruction(&Instruction::Block(bt));
+        }
+        WirInstr::Loop(bt) => {
+            func.instruction(&Instruction::Loop(bt));
+        }
+        WirInstr::If(bt) => {
+            func.instruction(&Instruction::If(bt));
+        }
+        WirInstr::Else => {
+            func.instruction(&Instruction::Else);
+        }
+        WirInstr::End => {
+            func.instruction(&Instruction::End);
+        }
+        WirInstr::Br(d) => {
+            func.instruction(&Instruction::Br(d));
+        }
+        WirInstr::BrIf(d) => {
+            func.instruction(&Instruction::BrIf(d));
+        }
+        WirInstr::BrTable {
+            ref targets,
+            default,
+        } => {
+            func.instruction(&Instruction::BrTable(targets.as_slice().into(), default));
+        }
+        WirInstr::Return => {
+            func.instruction(&Instruction::Return);
+        }
+        WirInstr::Unreachable => {
+            func.instruction(&Instruction::Unreachable);
+        }
+
+        // Call
+        WirInstr::Call(i) => {
+            func.instruction(&Instruction::Call(i));
+        }
+        WirInstr::CallRef(i) => {
+            func.instruction(&Instruction::CallRef(i));
+        }
+
+        // GC: struct
+        WirInstr::StructNew(i) => {
+            func.instruction(&Instruction::StructNew(i));
+        }
+        WirInstr::StructGet {
+            struct_type_index,
+            field_index,
+        } => {
+            func.instruction(&Instruction::StructGet {
+                struct_type_index,
+                field_index,
+            });
+        }
+        WirInstr::StructSet {
+            struct_type_index,
+            field_index,
+        } => {
+            func.instruction(&Instruction::StructSet {
+                struct_type_index,
+                field_index,
+            });
+        }
+
+        // GC: array
+        WirInstr::ArrayNew(i) => {
+            func.instruction(&Instruction::ArrayNew(i));
+        }
+        WirInstr::ArrayNewDefault(i) => {
+            func.instruction(&Instruction::ArrayNewDefault(i));
+        }
+        WirInstr::ArrayNewData {
+            array_type_index,
+            array_data_index,
+        } => {
+            func.instruction(&Instruction::ArrayNewData {
+                array_type_index,
+                array_data_index,
+            });
+        }
+        WirInstr::ArrayNewFixed {
+            array_type_index,
+            array_size,
+        } => {
+            func.instruction(&Instruction::ArrayNewFixed {
+                array_type_index,
+                array_size,
+            });
+        }
+        WirInstr::ArrayGet(i) => {
+            func.instruction(&Instruction::ArrayGet(i));
+        }
+        WirInstr::ArrayGetS(i) => {
+            func.instruction(&Instruction::ArrayGetS(i));
+        }
+        WirInstr::ArrayGetU(i) => {
+            func.instruction(&Instruction::ArrayGetU(i));
+        }
+        WirInstr::ArraySet(i) => {
+            func.instruction(&Instruction::ArraySet(i));
+        }
+        WirInstr::ArrayLen => {
+            func.instruction(&Instruction::ArrayLen);
+        }
+        WirInstr::ArrayCopy {
+            array_type_index_dst,
+            array_type_index_src,
+        } => {
+            func.instruction(&Instruction::ArrayCopy {
+                array_type_index_dst,
+                array_type_index_src,
+            });
+        }
+        WirInstr::ArrayFill(i) => {
+            func.instruction(&Instruction::ArrayFill(i));
+        }
+
+        // GC: ref
+        WirInstr::RefNull(ht) => {
+            func.instruction(&Instruction::RefNull(ht));
+        }
+        WirInstr::RefIsNull => {
+            func.instruction(&Instruction::RefIsNull);
+        }
+        WirInstr::RefAsNonNull => {
+            func.instruction(&Instruction::RefAsNonNull);
+        }
+        WirInstr::RefEq => {
+            func.instruction(&Instruction::RefEq);
+        }
+        WirInstr::RefFunc(i) => {
+            func.instruction(&Instruction::RefFunc(i));
+        }
+        WirInstr::RefCastNonNull(ht) => {
+            func.instruction(&Instruction::RefCastNonNull(ht));
+        }
+        WirInstr::RefTestNonNull(ht) => {
+            func.instruction(&Instruction::RefTestNonNull(ht));
+        }
+
+        // Misc
+        WirInstr::Drop => {
+            func.instruction(&Instruction::Drop);
+        }
+        WirInstr::TypedSelect(vt) => {
+            func.instruction(&Instruction::TypedSelect(vt));
+        }
+    }
+}

--- a/wado-compiler/src/wir_emit.rs
+++ b/wado-compiler/src/wir_emit.rs
@@ -1,8 +1,272 @@
-// WIR emitter — converts a WirInstr stream into wasm_encoder::Function instructions.
+// WIR emitter — converts WIR to wasm_encoder types.
+//
+// `emit_module` converts a `WirModule` to Wasm bytes. This is the ONLY place
+// that creates `wasm_encoder` sections — codegen never touches them directly.
+//
+// `emit` (function-level) replays a `WirInstr` stream into a
+// `wasm_encoder::Function`.
 
-use wasm_encoder::{Function, Instruction};
+use wasm_encoder::{
+    ArrayType, BranchHint, BranchHints, CodeSection, CompositeInnerType, CompositeType, ConstExpr,
+    DataCountSection, DataSection, ElementSection, Elements, ExportSection, FieldType, Function,
+    FunctionSection, GlobalSection, GlobalType, ImportSection, Instruction, MemoryType, Module,
+    NameMap, NameSection, ProducersField, ProducersSection, SubType, TypeSection,
+};
 
-use crate::wir::{WirInstr, WirMemArg};
+use crate::wir::{
+    WirConstExpr, WirImport, WirInstr, WirMemArg, WirModule, WirRecGroupKind, WirTypeDef,
+};
+
+// ============================================================================
+// Module-level emission
+// ============================================================================
+
+/// Convert a `WirModule` to Wasm binary bytes.
+///
+/// This is purely mechanical — no decisions, no lookups, no TIR access.
+pub fn emit_module(wir: &WirModule) -> Vec<u8> {
+    let mut module = Module::new();
+
+    // Type section
+    let mut types = TypeSection::new();
+    for typedef in &wir.types {
+        emit_typedef(&mut types, typedef);
+    }
+    module.section(&types);
+
+    // Import section
+    if !wir.imports.is_empty() {
+        let mut imports = ImportSection::new();
+        for import in &wir.imports {
+            match import {
+                WirImport::Func {
+                    module: m,
+                    name,
+                    type_idx,
+                } => {
+                    imports.import(m, name, wasm_encoder::EntityType::Function(*type_idx));
+                }
+                WirImport::Memory {
+                    module: m,
+                    name,
+                    min,
+                } => {
+                    imports.import(
+                        m,
+                        name,
+                        wasm_encoder::EntityType::Memory(MemoryType {
+                            minimum: *min,
+                            maximum: None,
+                            memory64: false,
+                            shared: false,
+                            page_size_log2: None,
+                        }),
+                    );
+                }
+            }
+        }
+        module.section(&imports);
+    }
+
+    // Function section
+    if !wir.func_type_indices.is_empty() {
+        let mut functions = FunctionSection::new();
+        for &type_idx in &wir.func_type_indices {
+            functions.function(type_idx);
+        }
+        module.section(&functions);
+    }
+
+    // Global section
+    if !wir.globals.is_empty() {
+        let mut globals = GlobalSection::new();
+        for global in &wir.globals {
+            let global_type = GlobalType {
+                val_type: global.val_type,
+                mutable: global.mutable,
+                shared: false,
+            };
+            globals.global(global_type, &emit_const_expr(&global.init));
+        }
+        module.section(&globals);
+    }
+
+    // Export section
+    if !wir.exports.is_empty() {
+        let mut exports = ExportSection::new();
+        for export in &wir.exports {
+            exports.export(&export.name, export.kind, export.index);
+        }
+        module.section(&exports);
+    }
+
+    // Element section (declarative, for ref.func)
+    if !wir.element_func_indices.is_empty() {
+        let mut elements = ElementSection::new();
+        elements.declared(Elements::Functions(std::borrow::Cow::Borrowed(
+            &wir.element_func_indices,
+        )));
+        module.section(&elements);
+    }
+
+    // Data count section (required for array.new_data with GC)
+    let data_count = u32::from(!wir.data.is_empty());
+    module.section(&DataCountSection { count: data_count });
+
+    // Branch hints section (must come before code section)
+    if !wir.branch_hints.is_empty() {
+        let mut hints = BranchHints::new();
+        for entry in &wir.branch_hints {
+            hints.function_hints(
+                entry.func_idx,
+                entry.hints.iter().map(|&(offset, taken)| BranchHint {
+                    branch_func_offset: offset,
+                    branch_hint_value: u32::from(taken),
+                }),
+            );
+        }
+        module.section(&hints);
+    }
+
+    // Code section
+    let mut code = CodeSection::new();
+    for body in &wir.bodies {
+        let mut func = Function::new(body.locals.clone());
+        emit(&body.instrs, &mut func);
+        code.function(&func);
+    }
+    module.section(&code);
+
+    // Data section
+    if !wir.data.is_empty() {
+        let mut data = DataSection::new();
+        data.passive(wir.data.iter().copied());
+        module.section(&data);
+    }
+
+    // Name section
+    if let Some(names) = &wir.names {
+        let mut name_section = NameSection::new();
+        name_section.module(&wir.module_name);
+
+        let mut func_names = NameMap::new();
+        for (idx, name) in &names.func_names {
+            func_names.append(*idx, name);
+        }
+        name_section.functions(&func_names);
+
+        let mut type_names = NameMap::new();
+        for (idx, name) in &names.type_names {
+            type_names.append(*idx, name);
+        }
+        name_section.types(&type_names);
+
+        module.section(&name_section);
+    }
+
+    // Producers section
+    if wir.names.is_some() {
+        let mut language = ProducersField::new();
+        language.value("Wado", "");
+        let mut processed_by = ProducersField::new();
+        processed_by.value(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        let mut producers = ProducersSection::new();
+        producers.field("language", &language);
+        producers.field("processed-by", &processed_by);
+        module.section(&producers);
+    }
+
+    module.finish()
+}
+
+/// Emit a single type definition into the type section.
+fn emit_typedef(types: &mut TypeSection, typedef: &WirTypeDef) {
+    match typedef {
+        WirTypeDef::Func { params, results } => {
+            types
+                .ty()
+                .function(params.iter().copied(), results.iter().copied());
+        }
+        WirTypeDef::GcArray { element, mutable } => {
+            types.ty().subtype(&SubType {
+                is_final: true,
+                supertype_idx: None,
+                composite_type: CompositeType {
+                    inner: CompositeInnerType::Array(ArrayType(FieldType {
+                        element_type: *element,
+                        mutable: *mutable,
+                    })),
+                    shared: false,
+                    descriptor: None,
+                    describes: None,
+                },
+            });
+        }
+        WirTypeDef::GcStruct {
+            fields,
+            is_final,
+            supertype_idx,
+        } => {
+            types.ty().subtype(&SubType {
+                is_final: *is_final,
+                supertype_idx: *supertype_idx,
+                composite_type: CompositeType {
+                    inner: CompositeInnerType::Struct(wasm_encoder::StructType {
+                        fields: fields.clone().into_boxed_slice(),
+                    }),
+                    shared: false,
+                    descriptor: None,
+                    describes: None,
+                },
+            });
+        }
+        WirTypeDef::RecGroup(entries) => {
+            let subtypes: Vec<SubType> = entries
+                .iter()
+                .map(|entry| match &entry.kind {
+                    WirRecGroupKind::Struct(fields) => SubType {
+                        is_final: false,
+                        supertype_idx: None,
+                        composite_type: CompositeType {
+                            inner: CompositeInnerType::Struct(wasm_encoder::StructType {
+                                fields: fields.clone().into_boxed_slice(),
+                            }),
+                            shared: false,
+                            descriptor: None,
+                            describes: None,
+                        },
+                    },
+                    WirRecGroupKind::Array(field_type) => SubType {
+                        is_final: true,
+                        supertype_idx: None,
+                        composite_type: CompositeType {
+                            inner: CompositeInnerType::Array(ArrayType(*field_type)),
+                            shared: false,
+                            descriptor: None,
+                            describes: None,
+                        },
+                    },
+                })
+                .collect();
+            types.ty().rec(subtypes);
+        }
+    }
+}
+
+/// Convert a `WirConstExpr` to a `wasm_encoder::ConstExpr`.
+fn emit_const_expr(expr: &WirConstExpr) -> ConstExpr {
+    match *expr {
+        WirConstExpr::I32(v) => ConstExpr::i32_const(v),
+        WirConstExpr::I64(v) => ConstExpr::i64_const(v),
+        WirConstExpr::F32(bits) => ConstExpr::f32_const(wasm_encoder::Ieee32::new(bits)),
+        WirConstExpr::F64(bits) => ConstExpr::f64_const(wasm_encoder::Ieee64::new(bits)),
+        WirConstExpr::RefNull(ht) => ConstExpr::ref_null(ht),
+    }
+}
+
+// ============================================================================
+// Function-level emission
+// ============================================================================
 
 /// Emit a slice of `WirInstr` into a `wasm_encoder::Function`.
 pub fn emit(instrs: &[WirInstr], func: &mut Function) {

--- a/wado-compiler/src/wir_emit.rs
+++ b/wado-compiler/src/wir_emit.rs
@@ -113,27 +113,39 @@ pub fn emit_module(wir: &WirModule) -> Vec<u8> {
     let data_count = u32::from(!wir.data.is_empty());
     module.section(&DataCountSection { count: data_count });
 
-    // Branch hints section (must come before code section)
-    if !wir.branch_hints.is_empty() {
-        let mut hints = BranchHints::new();
-        for entry in &wir.branch_hints {
-            hints.function_hints(
-                entry.func_idx,
-                entry.hints.iter().map(|&(offset, taken)| BranchHint {
+    // Pre-emit function bodies and collect branch hints from BranchHint
+    // pseudo-instructions.  Branch hints section must come before code section,
+    // so we emit bodies first, gather hints, write the hints section, then write
+    // the code section.
+    let mut emitted_funcs: Vec<Function> = Vec::with_capacity(wir.bodies.len());
+    let mut all_hints = BranchHints::new();
+    let mut has_hints = false;
+    for (i, body) in wir.bodies.iter().enumerate() {
+        let mut func = Function::new(body.locals.clone());
+        let hints = emit_with_hints(&body.instrs, &mut func);
+        if !hints.is_empty() {
+            has_hints = true;
+            let func_idx = wir.import_func_count + i as u32;
+            all_hints.function_hints(
+                func_idx,
+                hints.into_iter().map(|(offset, taken)| BranchHint {
                     branch_func_offset: offset,
                     branch_hint_value: u32::from(taken),
                 }),
             );
         }
-        module.section(&hints);
+        emitted_funcs.push(func);
+    }
+
+    // Branch hints section (must come before code section)
+    if has_hints {
+        module.section(&all_hints);
     }
 
     // Code section
     let mut code = CodeSection::new();
-    for body in &wir.bodies {
-        let mut func = Function::new(body.locals.clone());
-        emit(&body.instrs, &mut func);
-        code.function(&func);
+    for func in &emitted_funcs {
+        code.function(func);
     }
     module.section(&code);
 
@@ -268,11 +280,18 @@ fn emit_const_expr(expr: &WirConstExpr) -> ConstExpr {
 // Function-level emission
 // ============================================================================
 
-/// Emit a slice of `WirInstr` into a `wasm_encoder::Function`.
-pub fn emit(instrs: &[WirInstr], func: &mut Function) {
+/// Emit a slice of `WirInstr` into a `wasm_encoder::Function`,
+/// extracting branch hints (byte offset, taken) from `BranchHint` pseudo-instructions.
+fn emit_with_hints(instrs: &[WirInstr], func: &mut Function) -> Vec<(u32, bool)> {
+    let mut hints = Vec::new();
     for instr in instrs {
-        emit_instr(instr, func);
+        if let WirInstr::BranchHint(taken) = *instr {
+            hints.push((func.byte_len() as u32, taken));
+        } else {
+            emit_instr(instr, func);
+        }
     }
+    hints
 }
 
 fn mem(m: &WirMemArg) -> wasm_encoder::MemArg {
@@ -838,5 +857,8 @@ fn emit_instr(instr: &WirInstr, func: &mut Function) {
         WirInstr::TypedSelect(vt) => {
             func.instruction(&Instruction::TypedSelect(vt));
         }
+
+        // Pseudo-instructions — handled by emit_with_hints, not here.
+        WirInstr::BranchHint(_) => {}
     }
 }


### PR DESCRIPTION
All function bodies now flow through WirFunction which captures a WirInstr
stream, then emits to wasm_encoder::Function via wir_emit. This validates
the WIR representation can round-trip every instruction codegen produces.

https://claude.ai/code/session_01L8Lh9nP3jDGwLrkcW79mK1