### PR TITLE
Upgrade datatest-mini to 0.2.0 and use async harness for HTTP tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,9 +525,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datatest-mini"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0f402f318551d3866eaf4d6f2351fbfd5a82a3924b554ec041d1dd3d6564d"
+checksum = "4d062a9cc8c06b78557d11246945ebe0ad619f88bc2c5527663fd75c77b3e79c"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 rust-version = "1.92"
 
 [workspace.dependencies]
-datatest-mini = { version = "0.1" }
+datatest-mini = { version = "0.2" }
 anyhow = { version = "1" }
 fluent-uri = { version = "0.4" }
 glob = { version = "0.3" }

--- a/wado-compiler/tests/http.rs
+++ b/wado-compiler/tests/http.rs
@@ -186,13 +186,20 @@ struct HttpTestSpec {
 // ============================================================================
 
 /// Run an HTTP fixture test, handling TODO tests properly
-async fn run_http_fixture_test(fixture_path: &Path, fixture_name: &str) {
-    // Read source and spec
-    let source = std::fs::read_to_string(fixture_path)
-        .unwrap_or_else(|e| panic!("[{fixture_name}] failed to read: {e}"));
-    let data_section = common::extract_data_section(&source)
+async fn run_http_fixture_test(
+    fixture_path: &Path,
+    content: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let fixture_name = fixture_path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Parse spec from content
+    let data_section = common::extract_data_section(content)
         .unwrap_or_else(|| panic!("[{fixture_name}] missing __DATA__ section"));
-    let spec: HttpTestSpec = common::parse_data_section(data_section, fixture_name);
+    let spec: HttpTestSpec = common::parse_data_section(data_section, &fixture_name);
 
     // Handle TODO tests - they must fail
     if spec.todo {
@@ -200,7 +207,7 @@ async fn run_http_fixture_test(fixture_path: &Path, fixture_name: &str) {
 
         // Use catch_unwind to recover from panics (e.g., codegen validation failures)
         let test_result =
-            std::panic::AssertUnwindSafe(run_http_test_inner(fixture_path, fixture_name, &spec))
+            std::panic::AssertUnwindSafe(run_http_test_inner(fixture_path, &fixture_name, &spec))
                 .catch_unwind()
                 .await;
 
@@ -231,10 +238,12 @@ async fn run_http_fixture_test(fixture_path: &Path, fixture_name: &str) {
         }
     } else {
         // Normal test - run and expect success
-        run_http_test_inner(fixture_path, fixture_name, &spec)
+        run_http_test_inner(fixture_path, &fixture_name, &spec)
             .await
             .unwrap_or_else(|e| panic!("{e}"));
     }
+
+    Ok(())
 }
 
 /// Inner test logic that returns Result for TODO handling
@@ -279,74 +288,6 @@ async fn run_http_test_inner(
 // Tests
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_200_response() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-200.wado"),
-        "http-200.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_400_response() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-400.wado"),
-        "http-400.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_500_response() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-500.wado"),
-        "http-500.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_fields() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-fields.wado"),
-        "http-fields.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_future_new() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-future-new.wado"),
-        "http-future-new.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_response_ops() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-response-ops.wado"),
-        "http-response-ops.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_error_code() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-error-code.wado"),
-        "http-error-code.wado",
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_http_error_code_payload() {
-    run_http_fixture_test(
-        Path::new("tests/fixtures.http/http-error-code-payload.wado"),
-        "http-error-code-payload.wado",
-    )
-    .await;
+datatest_mini::harness! {
+    { test = run_http_fixture_test, root = "tests/fixtures.http", pattern = r"\.wado$", async, attr = r#"tokio::test(flavor = "multi_thread")"# },
 }


### PR DESCRIPTION
Replace manually listed #[tokio::test] functions in tests/http.rs with
datatest_mini::harness! async support, auto-discovering fixtures from
tests/fixtures.http/.

https://claude.ai/code/session_01PeHsn8s5mP1AW9aWZYafkC