### PR TITLE
Update wasm-size report: Wado pi_approx drops from 15,354 to 6,533 bytes

### DIFF
--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -26,7 +26,7 @@ struct OptConfig {
 }
 use crate::optimize_licm::apply_licm;
 use crate::optimize_ref_elim::eliminate_unnecessary_refs;
-use crate::optimize_rewrite::{collect_value_copy_types, insert_moves};
+use crate::optimize_rewrite::{collect_value_copy_types, insert_moves, simplify_labeled_blocks};
 use crate::optimize_sroa::scalar_replace_aggregates;
 use crate::project::Project;
 
@@ -122,6 +122,10 @@ pub fn optimize(mut project: Project, opt_level: OptLevel) -> Project {
             remove_unreachable_types(&mut project);
         }
     }
+
+    // Simplify trivial labeled blocks left by inlining (e.g., `L: { break L: expr; }` → `expr`).
+    // Runs after the main optimization loop to avoid interfering with SROA/copy propagation.
+    simplify_labeled_blocks(&mut project);
 
     // Insert move optimization for all optimization levels (after inlining)
     // This eliminates unnecessary copies for fresh values

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -26,7 +26,7 @@ struct OptConfig {
 }
 use crate::optimize_licm::apply_licm;
 use crate::optimize_ref_elim::eliminate_unnecessary_refs;
-use crate::optimize_rewrite::{collect_value_copy_types, insert_moves, simplify_labeled_blocks};
+use crate::optimize_rewrite;
 use crate::optimize_sroa::scalar_replace_aggregates;
 use crate::project::Project;
 
@@ -123,22 +123,9 @@ pub fn optimize(mut project: Project, opt_level: OptLevel) -> Project {
         }
     }
 
-    // Simplify trivial labeled blocks left by inlining (e.g., `L: { break L: expr; }` → `expr`).
-    // Runs after the main optimization loop to avoid interfering with SROA/copy propagation.
-    simplify_labeled_blocks(&mut project);
-
-    // Insert move optimization for all optimization levels (after inlining)
-    // This eliminates unnecessary copies for fresh values
-    insert_moves(&mut project);
-
-    // Collect value copy types for all functions
-    // This populates needed_copy_types for codegen to pre-allocate scratch locals
-    collect_value_copy_types(&mut project);
-
-    // Expand copy source types for all functions
-    // This creates the expanded set of types that need copy source locals,
-    // including nested types (e.g., Option<Variant> expands to include the Variant type)
-    expand_copy_source_types(&mut project);
+    // Post-optimization rewrites: simplify labeled blocks, insert moves,
+    // collect value copy types, and expand copy source types in a single pass.
+    optimize_rewrite::rewrite(&mut project);
 
     // Analyze scratch local requirements for all functions
     // This must run AFTER inlining since the function body may change.
@@ -175,22 +162,3 @@ fn run_optimization_passes(project: &mut Project, config: &OptConfig) {
     }
 }
 
-/// Expand copy source types for all functions in the project.
-///
-/// This takes the `needed_copy_types` set (computed by `collect_value_copy_types`)
-/// and expands it to include all nested types that also need copy source locals.
-/// For example, `Option<Variant>` expands to include both Option and Variant types.
-fn expand_copy_source_types(project: &mut Project) {
-    use crate::copy_context::CopyContext;
-
-    for module in project.tir_modules.values() {
-        let type_table = module.type_table.borrow();
-        for func_rc in &module.functions {
-            let mut func = func_rc.borrow_mut();
-            if !func.needed_copy_types.is_empty() {
-                func.copy_source_types =
-                    CopyContext::expand_copy_types(&func.needed_copy_types, &type_table);
-            }
-        }
-    }
-}

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -161,4 +161,3 @@ fn run_optimization_passes(project: &mut Project, config: &OptConfig) {
         }
     }
 }
-

--- a/wado-compiler/src/optimize_rewrite.rs
+++ b/wado-compiler/src/optimize_rewrite.rs
@@ -21,8 +21,8 @@
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{
-    FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirStmt,
-    TirStmtKind, TypeId, TypeTable,
+    FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind,
+    TypeId, TypeTable,
 };
 use indexmap::IndexSet;
 
@@ -921,4 +921,3 @@ fn collect_value_copy_types_in_expr(
         | TirExprKind::EnumConstruct { .. } => {}
     }
 }
-

--- a/wado-compiler/src/optimize_rewrite.rs
+++ b/wado-compiler/src/optimize_rewrite.rs
@@ -21,7 +21,7 @@
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{
-    FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt,
+    FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirStmt,
     TirStmtKind, TypeId, TypeTable,
 };
 use indexmap::IndexSet;
@@ -30,26 +30,45 @@ use indexmap::IndexSet;
 // Labeled Block Simplification
 // =============================================================================
 
-/// Simplify trivial labeled block expressions in all functions.
+/// Run all post-optimization TIR rewrites in a single pass over all functions.
 ///
-/// After inlining, patterns like `label: { break label: expr; }` are common.
-/// This rewrites them to just `expr`, eliminating the redundant block+break.
-pub fn simplify_labeled_blocks(project: &mut Project) -> bool {
-    let mut changed = false;
+/// For each function, this performs (in order):
+/// 1. Labeled block simplification (`L: { break L: expr; }` -> `expr`)
+/// 2. Move insertion (wrap fresh values in `Move` to avoid copies)
+/// 3. Value copy type collection (populate `needed_copy_types` for codegen)
+/// 4. Copy source type expansion (expand nested types for scratch locals)
+pub fn rewrite(project: &mut Project) {
+    use crate::copy_context::CopyContext;
+
     for module in project.tir_modules.values_mut() {
+        let type_table = module.type_table.borrow();
         for func_rc in &module.functions {
             let mut func = func_rc.borrow_mut();
-            changed |= simplify_labeled_blocks_in_function(&mut func);
+
+            // 1. Simplify trivial labeled blocks
+            if let Some(ref mut body) = func.body {
+                simplify_labeled_blocks_in_block(body);
+            }
+
+            // 2. Insert moves for fresh values
+            if let Some(ref mut body) = func.body {
+                insert_moves_in_block(body, &type_table);
+            }
+
+            // 3. Collect value copy types
+            let mut copy_types = IndexSet::new();
+            if let Some(ref body) = func.body {
+                collect_value_copy_types_in_block(body, &type_table, &mut copy_types);
+            }
+            func.needed_copy_types.extend(copy_types);
+
+            // 4. Expand copy source types
+            if !func.needed_copy_types.is_empty() {
+                func.copy_source_types =
+                    CopyContext::expand_copy_types(&func.needed_copy_types, &type_table);
+            }
         }
     }
-    changed
-}
-
-fn simplify_labeled_blocks_in_function(func: &mut TirFunction) -> bool {
-    let Some(body) = &mut func.body else {
-        return false;
-    };
-    simplify_labeled_blocks_in_block(body)
 }
 
 fn simplify_labeled_blocks_in_block(block: &mut TirBlock) -> bool {
@@ -660,19 +679,6 @@ fn insert_moves_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
     }
 }
 
-/// Insert move optimization for all functions in the project.
-pub fn insert_moves(project: &mut Project) {
-    for module in project.tir_modules.values_mut() {
-        let type_table = module.type_table.borrow();
-        for func_rc in &module.functions {
-            let mut func = func_rc.borrow_mut();
-            if let Some(ref mut body) = func.body {
-                insert_moves_in_block(body, &type_table);
-            }
-        }
-    }
-}
-
 // =============================================================================
 // Value Copy Type Collection
 // =============================================================================
@@ -916,19 +922,3 @@ fn collect_value_copy_types_in_expr(
     }
 }
 
-/// Collect value copy types for all functions in the project.
-/// This populates `needed_copy_types` which codegen uses to pre-allocate scratch locals.
-pub fn collect_value_copy_types(project: &mut Project) {
-    for module in project.tir_modules.values_mut() {
-        let type_table = module.type_table.borrow();
-        for func_rc in &module.functions {
-            let mut func = func_rc.borrow_mut();
-            // Collect into a temporary set first to avoid borrow conflicts
-            let mut copy_types = IndexSet::new();
-            if let Some(ref body) = func.body {
-                collect_value_copy_types_in_block(body, &type_table, &mut copy_types);
-            }
-            func.needed_copy_types.extend(copy_types);
-        }
-    }
-}

--- a/wado-compiler/src/optimize_rewrite.rs
+++ b/wado-compiler/src/optimize_rewrite.rs
@@ -1,27 +1,258 @@
-//! Move insertion optimization, select lowering, and value copy type collection for Wado TIR
+//! TIR rewrite optimizations for Wado
 //!
-//! This module provides three optimizations:
+//! This module provides lightweight TIR rewrites that don't warrant their own module:
 //!
-//! 1. **Select Lowering**: Converts simple `if cond { a } else { b }` expressions to
+//! 1. **Labeled Block Simplification**: Eliminates trivial `label: { break label: expr; }`
+//!    patterns (common after inlining) by replacing them with just `expr`.
+//!
+//! 2. **Select Lowering**: Converts simple `if cond { a } else { b }` expressions to
 //!    `builtin::select(cond, a, b)` which emits the branchless Wasm `select` instruction.
 //!    Both branches must be pure (no side effects, no traps) since `select` evaluates
 //!    both operands eagerly.
 //!
-//! 2. **Move Insertion**: Wraps fresh values in `Move` nodes to avoid unnecessary copies.
+//! 3. **Move Insertion**: Wraps fresh values in `Move` nodes to avoid unnecessary copies.
 //!    Fresh values (literals, call results, etc.) can be moved directly without copying
 //!    since they are newly created and owned by the current expression.
 //!
-//! 3. **Value Copy Type Collection**: Collects types that require value copying in each
+//! 4. **Value Copy Type Collection**: Collects types that require value copying in each
 //!    function body. This information is used by codegen to pre-allocate scratch locals
 //!    for copy operations.
 
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{
-    FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind,
-    TypeId, TypeTable,
+    FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt,
+    TirStmtKind, TypeId, TypeTable,
 };
 use indexmap::IndexSet;
+
+// =============================================================================
+// Labeled Block Simplification
+// =============================================================================
+
+/// Simplify trivial labeled block expressions in all functions.
+///
+/// After inlining, patterns like `label: { break label: expr; }` are common.
+/// This rewrites them to just `expr`, eliminating the redundant block+break.
+pub fn simplify_labeled_blocks(project: &mut Project) -> bool {
+    let mut changed = false;
+    for module in project.tir_modules.values_mut() {
+        for func_rc in &module.functions {
+            let mut func = func_rc.borrow_mut();
+            changed |= simplify_labeled_blocks_in_function(&mut func);
+        }
+    }
+    changed
+}
+
+fn simplify_labeled_blocks_in_function(func: &mut TirFunction) -> bool {
+    let Some(body) = &mut func.body else {
+        return false;
+    };
+    simplify_labeled_blocks_in_block(body)
+}
+
+fn simplify_labeled_blocks_in_block(block: &mut TirBlock) -> bool {
+    let mut changed = false;
+    for stmt in &mut block.stmts {
+        changed |= simplify_labeled_blocks_in_stmt(stmt);
+    }
+    changed
+}
+
+fn simplify_labeled_blocks_in_stmt(stmt: &mut TirStmt) -> bool {
+    match &mut stmt.kind {
+        TirStmtKind::Let { value, .. } => simplify_labeled_blocks_in_expr(value),
+        TirStmtKind::Expr(expr) => simplify_labeled_blocks_in_expr(expr),
+        TirStmtKind::Return { value } => {
+            value.as_mut().is_some_and(simplify_labeled_blocks_in_expr)
+        }
+        TirStmtKind::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            let mut changed = simplify_labeled_blocks_in_expr(condition);
+            changed |= simplify_labeled_blocks_in_block(then_block);
+            if let Some(eb) = else_block {
+                changed |= simplify_labeled_blocks_in_block(eb);
+            }
+            changed
+        }
+        TirStmtKind::Loop { body } => simplify_labeled_blocks_in_block(body),
+        TirStmtKind::LabeledBlock { block, .. } => simplify_labeled_blocks_in_block(block),
+        TirStmtKind::IfPattern {
+            scrutinee,
+            then_block,
+            else_block,
+            ..
+        } => {
+            let mut changed = simplify_labeled_blocks_in_expr(scrutinee);
+            changed |= simplify_labeled_blocks_in_block(then_block);
+            if let Some(eb) = else_block {
+                changed |= simplify_labeled_blocks_in_block(eb);
+            }
+            changed
+        }
+        TirStmtKind::Break { value, .. } => {
+            value.as_mut().is_some_and(simplify_labeled_blocks_in_expr)
+        }
+        TirStmtKind::Continue => false,
+        TirStmtKind::LetPattern { value, .. } => simplify_labeled_blocks_in_expr(value),
+    }
+}
+
+fn simplify_labeled_blocks_in_expr(expr: &mut TirExpr) -> bool {
+    let mut changed = false;
+
+    // First, recurse into sub-expressions
+    match &mut expr.kind {
+        TirExprKind::Binary { left, right, .. } => {
+            changed |= simplify_labeled_blocks_in_expr(left);
+            changed |= simplify_labeled_blocks_in_expr(right);
+        }
+        TirExprKind::Unary { expr: inner, .. }
+        | TirExprKind::FieldAccess { expr: inner, .. }
+        | TirExprKind::Cast { expr: inner, .. }
+        | TirExprKind::Move { expr: inner }
+        | TirExprKind::IsNotNull { expr: inner }
+        | TirExprKind::UnwrapOption { expr: inner, .. }
+        | TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. } => {
+            changed |= simplify_labeled_blocks_in_expr(inner);
+        }
+        TirExprKind::Assign { target, value } => {
+            changed |= simplify_labeled_blocks_in_expr(target);
+            changed |= simplify_labeled_blocks_in_expr(value);
+        }
+        TirExprKind::Index { expr: inner, index } => {
+            changed |= simplify_labeled_blocks_in_expr(inner);
+            changed |= simplify_labeled_blocks_in_expr(index);
+        }
+        TirExprKind::Call { args, .. }
+        | TirExprKind::StaticCall { args, .. }
+        | TirExprKind::EffectCall { args, .. } => {
+            for arg in args {
+                changed |= simplify_labeled_blocks_in_expr(arg);
+            }
+        }
+        TirExprKind::MethodCall { receiver, args, .. } => {
+            changed |= simplify_labeled_blocks_in_expr(receiver);
+            for arg in args {
+                changed |= simplify_labeled_blocks_in_expr(arg);
+            }
+        }
+        TirExprKind::IndirectCall { callee, args } => {
+            changed |= simplify_labeled_blocks_in_expr(callee);
+            for arg in args {
+                changed |= simplify_labeled_blocks_in_expr(arg);
+            }
+        }
+        TirExprKind::ClosureToCanonical { functor, .. } => {
+            changed |= simplify_labeled_blocks_in_expr(functor);
+        }
+        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
+            changed |= simplify_labeled_blocks_in_block(block);
+        }
+        TirExprKind::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            changed |= simplify_labeled_blocks_in_expr(condition);
+            changed |= simplify_labeled_blocks_in_block(then_branch);
+            if let Some(eb) = else_branch {
+                changed |= simplify_labeled_blocks_in_block(eb);
+            }
+        }
+        TirExprKind::Match { expr: inner, arms } => {
+            changed |= simplify_labeled_blocks_in_expr(inner);
+            for arm in arms {
+                if let Some(guard) = &mut arm.guard {
+                    changed |= simplify_labeled_blocks_in_expr(guard);
+                }
+                changed |= simplify_labeled_blocks_in_expr(&mut arm.body);
+            }
+        }
+        TirExprKind::StructLiteral { fields, .. } => {
+            for field in fields {
+                changed |= simplify_labeled_blocks_in_expr(&mut field.value);
+            }
+        }
+        TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                changed |= simplify_labeled_blocks_in_expr(elem);
+            }
+        }
+        TirExprKind::OptionSome { value } => {
+            changed |= simplify_labeled_blocks_in_expr(value);
+        }
+        TirExprKind::VariantConstruct { payload, .. } => {
+            if let Some(p) = payload {
+                changed |= simplify_labeled_blocks_in_expr(p);
+            }
+        }
+        TirExprKind::Closure { body, .. } => {
+            changed |= simplify_labeled_blocks_in_expr(body);
+        }
+        TirExprKind::GlobalVarSet { value, .. } => {
+            changed |= simplify_labeled_blocks_in_expr(value);
+        }
+        TirExprKind::Switch {
+            scrutinee,
+            arms,
+            default,
+            ..
+        } => {
+            changed |= simplify_labeled_blocks_in_expr(scrutinee);
+            for arm in arms {
+                changed |= simplify_labeled_blocks_in_block(arm);
+            }
+            changed |= simplify_labeled_blocks_in_block(default);
+        }
+        // Leaf nodes
+        TirExprKind::Local { .. }
+        | TirExprKind::Global { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => {}
+    }
+
+    // Simplify: `label: { break label: expr; }` → `expr`
+    if let TirExprKind::LabeledBlock { label, block, .. } = &expr.kind
+        && block.stmts.len() == 1
+        && let TirStmtKind::Break {
+            label: Some(break_label),
+            value: Some(_),
+        } = &block.stmts[0].kind
+        && break_label == label
+    {
+        let TirExprKind::LabeledBlock { block, .. } =
+            std::mem::replace(&mut expr.kind, TirExprKind::Unit)
+        else {
+            unreachable!();
+        };
+        let mut stmts = block.stmts;
+        let TirStmtKind::Break {
+            value: Some(inner), ..
+        } = stmts.remove(0).kind
+        else {
+            unreachable!();
+        };
+        *expr = inner;
+        changed = true;
+    }
+
+    changed
+}
 
 // =============================================================================
 // Select Lowering (If → builtin::select)

--- a/wado-compiler/tests/fixtures.golden/array-sort.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array-sort.lowered.wado
@@ -33,9 +33,7 @@ fn print_array(arr: &Array<i32>) with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = arr.used;
         loop {
-            if !(i < __inline_Array_i32___len_0: {
-                break __inline_Array_i32___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -43,9 +41,7 @@ fn print_array(arr: &Array<i32>) with Stdout {
                     core::cli::print(move " ");
                 }
                 core::cli::print(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -90,18 +86,14 @@ fn run() with Stdout {
         self."Array<i32>::sort_by$__Closure_4"(&__Closure_4 {  });
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "empty len: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_5: {
-                break __inline_Array_i32___len_5: empty.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: empty.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/array_append.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_append.lowered.wado
@@ -19,27 +19,21 @@ fn run() with Stdout {
     arr."Array<i32>::append"(20);
     arr."Array<i32>::append"(30);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "len=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_3: {
-                break __inline_Array_i32___len_3: arr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -75,27 +69,21 @@ fn run() with Stdout {
     arr."Array<i32>::append"(50);
     arr."Array<i32>::append"(60);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "after_growth_len=");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_12: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_13: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_14: {
-                break __inline_Array_i32___len_14: arr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_16: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let mut arr: Array<i32> = move [10, 20, 30];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -52,9 +50,7 @@ fn run() with Stdout {
     });
     arr."Array<i32>^IndexAssign::index_assign"(1, 99);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_8: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_get.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_get.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_0) {
         let v: i32 = __unwrap_option(__pattern_temp_0).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(25), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
             __r.String::append(move "get(0) = ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -35,9 +33,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_1) {
         let v: i32 = __unwrap_option(__pattern_temp_1).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_3: {
-                break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(25), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
             __r.String::append(move "get(2) = ");
             let mut __f: Formatter = __inline_Formatter__new_4: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/array_explicit_cast.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_explicit_cast.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let a: Array<i32> = move [1, 2, 3];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_f64.lowered.wado
@@ -17,9 +17,7 @@
 fn run() with Stdout {
     let a: Array<f64> = move [1.5, 2.5, 3.5];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_index_inline.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     let second: i32 = arr."Array<i32>^IndexValue::index_value"(1);
     arr."Array<i32>^IndexAssign::index_assign"(2, 100);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_btree.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_btree.lowered.wado
@@ -27,9 +27,7 @@ fn run() with Stdout {
     let tree: Tree<String> = move Tree<String> { root: Node<String> { keys: ["apple", "banana", "cherry", "date"], deleted: [false, true, false, false] }, max_keys: 5 };
     let result: i32 = tree."Tree<String>::check"();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -59,9 +57,7 @@ fn "Node<String>::find_index"(self: &Node<String>, key: &String) -> i32 {
     let _licm_keys: Array<String> = self.keys;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (_licm_keys."Array<String>^IndexValue::index_value"(i)."String^Ord::cmp"(&*key) == Ordering::Less)) {
+        if !((i < _licm_used) && (_licm_keys."Array<String>^IndexValue::index_value"(i)."String^Ord::cmp"(&*key) == Ordering::Less)) {
             break;
         }
         i = (i + 1);
@@ -84,9 +80,7 @@ fn "Node<String>::is_full"(self: &Node<String>, max_keys: i32) -> bool {
         let _licm_deleted: Array<bool> = self.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -115,9 +109,7 @@ fn "Node<String>::count_active"(self: &Node<String>) -> i32 {
         let _licm_deleted: Array<bool> = self.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_compare.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_compare.lowered.wado
@@ -17,9 +17,7 @@ fn find_key_index(keys: &Array<String>, key: &String) -> i32 {
     let mut i: i32 = 0;
     let _licm_used: i32 = keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (keys."Array<String>^IndexValue::index_value"(i)."String^Ord::cmp"(&*key) == Ordering::Less)) {
+        if !((i < _licm_used) && (keys."Array<String>^IndexValue::index_value"(i)."String^Ord::cmp"(&*key) == Ordering::Less)) {
             break;
         }
         i = (i + 1);
@@ -31,9 +29,7 @@ fn run() with Stdout {
     let keys: Array<String> = move ["apple", "banana", "cherry", "date"];
     let result: i32 = find_key_index(&keys, &"cherry");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "index: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_generic.lowered.wado
@@ -23,9 +23,7 @@ fn run() with Stdout {
     let second: i32 = __sroa_c_items."Array<i32>^IndexValue::index_value"(1);
     let third: i32 = __sroa_c_items."Array<i32>^IndexValue::index_value"(2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_loop.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = arr.used;
         loop {
-            if !(i < __inline_Array_i32___len_0: {
-                break __inline_Array_i32___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -32,9 +30,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -61,9 +57,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_method.lowered.wado
@@ -24,9 +24,7 @@ fn run() with Stdout {
     let idx: i32 = c."Container<String,i32>::find_key_index"(&"cherry");
     let full: bool = c."Container<String,i32>::is_full"(5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(47), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(47), used: 0 };
         __r.String::append(move "index: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -63,9 +61,7 @@ fn "Container<String,i32>::is_full"(self: &Container<String,i32>, max_keys: i32)
         let _licm_deleted: Array<bool> = self.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -91,9 +87,7 @@ fn "Container<String,i32>::find_key_index"(self: &Container<String,i32>, key: &S
     let _licm_keys: Array<String> = self.keys;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (_licm_keys."Array<String>^IndexValue::index_value"(i)."String^Ord::cmp"(&*key) == Ordering::Less)) {
+        if !((i < _licm_used) && (_licm_keys."Array<String>^IndexValue::index_value"(i)."String^Ord::cmp"(&*key) == Ordering::Less)) {
             break;
         }
         i = (i + 1);

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_multi.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_multi.lowered.wado
@@ -20,26 +20,14 @@ struct "Container<String>" {
 
 fn run() with Stdout {
     let c: Container<String> = move Container<String> { items: ["apple", "banana", "cherry"], markers: [true, false, true] };
-    let item0: String = __inline_Container_String___get_item_0: {
-        break __inline_Container_String___get_item_0: c.items."Array<String>^IndexValue::index_value"(0);
-    };
-    let item1: String = __inline_Container_String___get_item_1: {
-        break __inline_Container_String___get_item_1: c.items."Array<String>^IndexValue::index_value"(1);
-    };
-    let item2: String = __inline_Container_String___get_item_2: {
-        break __inline_Container_String___get_item_2: c.items."Array<String>^IndexValue::index_value"(2);
-    };
-    let flag0: bool = __inline_Container_String___is_flagged_3: {
-        break __inline_Container_String___is_flagged_3: c.markers."Array<bool>^IndexValue::index_value"(0);
-    };
-    let flag1: bool = __inline_Container_String___is_flagged_4: {
-        break __inline_Container_String___is_flagged_4: c.markers."Array<bool>^IndexValue::index_value"(1);
-    };
+    let item0: String = move c.items."Array<String>^IndexValue::index_value"(0);
+    let item1: String = move c.items."Array<String>^IndexValue::index_value"(1);
+    let item2: String = move c.items."Array<String>^IndexValue::index_value"(2);
+    let flag0: bool = c.markers."Array<bool>^IndexValue::index_value"(0);
+    let flag1: bool = c.markers."Array<bool>^IndexValue::index_value"(1);
     let count: i32 = c."Container<String>::count_flagged"();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(59), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(59), used: 0 };
         __r.String::append(move "items: ");
         __r.String::append(item0);
         __r.String::append(move ", ");
@@ -49,9 +37,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "flags: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -83,9 +69,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "count: ");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
@@ -107,9 +91,7 @@ fn "Container<String>::count_flagged"(self: &Container<String>) -> i32 {
         let _licm_markers: Array<bool> = self.markers;
         let _licm_used: i32 = _licm_markers.used;
         loop {
-            if !(i < __inline_Array_bool___len_0: {
-                break __inline_Array_bool___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_nested.lowered.wado
@@ -28,9 +28,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = __sroa_node_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -42,9 +40,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "sum (excluding deleted): ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -58,9 +54,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "first key: ");
         __r.String::append(move __sroa_node_keys."Array<String>^IndexValue::index_value"(0));
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.lowered.wado
@@ -21,9 +21,7 @@ struct "Node<String>" {
 
 fn print_depth(depth: i32) with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "depth: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/array_of_generic_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_of_generic_struct.lowered.wado
@@ -24,17 +24,13 @@ struct "Box<i32>" {
 
 fn __test_0_container_of_boxes() {
     let mut c: Container<Box<i32>> = move "Container<Box<i32>>::new"();
-    c."Container<Box<i32>>::add"(__inline_Box_i32___new_0: {
-        break __inline_Box_i32___new_0: Box<i32> { value: 42 };
-    });
+    c."Container<Box<i32>>::add"(move Box<i32> { value: 42 });
     __assert_0: {
         let __v0: i32 = c.size;
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(122), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(122), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_0_container_of_boxes");
                 __r.String::append(move " at ");
@@ -70,9 +66,7 @@ fn __test_0_container_of_boxes() {
         let __cond: bool = (__v0 == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(143), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(143), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_0_container_of_boxes");
                 __r.String::append(move " at ");
@@ -107,20 +101,14 @@ fn __test_0_container_of_boxes() {
 
 fn __test_1_array_of_boxes() {
     let mut arr: Array<Box<i32>> = move [];
-    arr."Array<Box<i32>>::append"(__inline_Box_i32___new_0: {
-        break __inline_Box_i32___new_0: Box<i32> { value: 10 };
-    });
-    arr."Array<Box<i32>>::append"(__inline_Box_i32___new_1: {
-        break __inline_Box_i32___new_1: Box<i32> { value: 20 };
-    });
+    arr."Array<Box<i32>>::append"(move Box<i32> { value: 10 });
+    arr."Array<Box<i32>>::append"(move Box<i32> { value: 20 });
     __assert_2: {
         let __v0: i32 = arr."Array<Box<i32>>::len"();
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_1_array_of_boxes");
                 __r.String::append(move " at ");
@@ -156,9 +144,7 @@ fn __test_1_array_of_boxes() {
         let __cond: bool = (__v0 == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(135), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(135), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_1_array_of_boxes");
                 __r.String::append(move " at ");
@@ -194,9 +180,7 @@ fn __test_1_array_of_boxes() {
         let __cond: bool = (__v0 == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(135), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(135), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_1_array_of_boxes");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/array_param_coercion.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_param_coercion.lowered.wado
@@ -20,9 +20,7 @@ fn sum_array(arr: Array<i32>) -> i32 {
 fn run() with Stdout {
     let result: i32 = sum_array(move [10, 20, 30]);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_return.lowered.wado
@@ -14,13 +14,9 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: Array<i32> = __inline_get_numbers_0: {
-        break __inline_get_numbers_0: [1, 2, 3];
-    };
+    let a: Array<i32> = move [1, 2, 3];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_bool.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_bool.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<bool>::append"(false);
     arr."Array<bool>::append"(true);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<bool> = __inline_Array_bool__IntoIterator__into_iter_0: {
-            break __inline_Array_bool__IntoIterator__into_iter_0: ArrayIter<bool> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<bool> = move ArrayIter<bool> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<bool> = __iter_0."ArrayIter<bool>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: bool = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_char.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_char.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<char>::append"('B');
     arr."Array<char>::append"('C');
     __for_of_0: {
-        let mut __iter_0: ArrayIter<char> = __inline_Array_char__IntoIterator__into_iter_0: {
-            break __inline_Array_char__IntoIterator__into_iter_0: ArrayIter<char> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<char> = move ArrayIter<char> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<char> = __iter_0."ArrayIter<char>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: char = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_f32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_f32.lowered.wado
@@ -22,17 +22,13 @@ fn run() with Stdout {
     arr."Array<f32>::append"(2.5 as f32);
     arr."Array<f32>::append"(3.5 as f32);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<f32> = __inline_Array_f32__IntoIterator__into_iter_0: {
-            break __inline_Array_f32__IntoIterator__into_iter_0: ArrayIter<f32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<f32> = move ArrayIter<f32> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<f32> = __iter_0."ArrayIter<f32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: f32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_f64.lowered.wado
@@ -22,17 +22,13 @@ fn run() with Stdout {
     arr."Array<f64>::append"(2.5);
     arr."Array<f64>::append"(3.5);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<f64> = __inline_Array_f64__IntoIterator__into_iter_0: {
-            break __inline_Array_f64__IntoIterator__into_iter_0: ArrayIter<f64> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<f64> = move ArrayIter<f64> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<f64> = __iter_0."ArrayIter<f64>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: f64 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i16.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i16.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<i16>::append"(-2000);
     arr."Array<i16>::append"(3000);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i16> = __inline_Array_i16__IntoIterator__into_iter_0: {
-            break __inline_Array_i16__IntoIterator__into_iter_0: ArrayIter<i16> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i16> = move ArrayIter<i16> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i16> = __iter_0."ArrayIter<i16>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i16 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i32.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<i32>::append"(-200000);
     arr."Array<i32>::append"(300000);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i64.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<i64>::append"(-20000000000);
     arr."Array<i64>::append"(30000000000);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i64> = __inline_Array_i64__IntoIterator__into_iter_0: {
-            break __inline_Array_i64__IntoIterator__into_iter_0: ArrayIter<i64> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i64> = move ArrayIter<i64> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i64> = __iter_0."ArrayIter<i64>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i64 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i8.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<i8>::append"(-2);
     arr."Array<i8>::append"(3);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i8> = __inline_Array_i8__IntoIterator__into_iter_0: {
-            break __inline_Array_i8__IntoIterator__into_iter_0: ArrayIter<i8> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i8> = move ArrayIter<i8> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i8> = __iter_0."ArrayIter<i8>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i8 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_string.lowered.wado
@@ -21,9 +21,7 @@ fn run() with Stdout {
     arr."Array<String>::append"(move "world");
     arr."Array<String>::append"(move "!");
     __for_of_0: {
-        let mut __iter_0: ArrayIter<String> = __inline_Array_String__IntoIterator__into_iter_0: {
-            break __inline_Array_String__IntoIterator__into_iter_0: ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<String> = move ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<String> = move __iter_0."ArrayIter<String>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {

--- a/wado-compiler/tests/fixtures.golden/array_specialized_tuple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_tuple.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<Tuple<bool,i32,String>>::append"(move [false, 2, "two"]);
     arr."Array<Tuple<bool,i32,String>>::append"(move [true, 3, "three"]);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<Tuple<bool,i32,String>> = __inline_Array_Tuple_bool_i32_String___IntoIterator__into_iter_0: {
-            break __inline_Array_Tuple_bool_i32_String___IntoIterator__into_iter_0: ArrayIter<Tuple<bool,i32,String>> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<Tuple<bool,i32,String>> = move ArrayIter<Tuple<bool,i32,String>> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<[bool, i32, String]> = move __iter_0."ArrayIter<Tuple<bool,i32,String>>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: [bool, i32, String] = __unwrap_option(__pattern_temp_0);
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(50), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u16.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u16.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<u16>::append"(2000);
     arr."Array<u16>::append"(3000);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<u16> = __inline_Array_u16__IntoIterator__into_iter_0: {
-            break __inline_Array_u16__IntoIterator__into_iter_0: ArrayIter<u16> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<u16> = move ArrayIter<u16> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<u16> = __iter_0."ArrayIter<u16>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: u16 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u32.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<u32>::append"(200000);
     arr."Array<u32>::append"(300000);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<u32> = __inline_Array_u32__IntoIterator__into_iter_0: {
-            break __inline_Array_u32__IntoIterator__into_iter_0: ArrayIter<u32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<u32> = move ArrayIter<u32> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<u32> = __iter_0."ArrayIter<u32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: u32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u64.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<u64>::append"(20000000000);
     arr."Array<u64>::append"(30000000000);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<u64> = __inline_Array_u64__IntoIterator__into_iter_0: {
-            break __inline_Array_u64__IntoIterator__into_iter_0: ArrayIter<u64> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<u64> = move ArrayIter<u64> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<u64> = __iter_0."ArrayIter<u64>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: u64 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u8.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
     arr."Array<u8>::append"(2);
     arr."Array<u8>::append"(3);
     __for_of_0: {
-        let mut __iter_0: ArrayIter<u8> = __inline_Array_u8__IntoIterator__into_iter_0: {
-            break __inline_Array_u8__IntoIterator__into_iter_0: ArrayIter<u8> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<u8> = move ArrayIter<u8> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<u8> = __iter_0."ArrayIter<u8>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: u8 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/array_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let names: Array<String> = move ["Alice", "Bob", "Charlie"];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         __r.String::append(move names."Array<String>^IndexValue::index_value"(0));
         __r.String::append(move ", ");
         __r.String::append(move names."Array<String>^IndexValue::index_value"(1));

--- a/wado-compiler/tests/fixtures.golden/array_string_cast.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string_cast.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let names: Array<String> = move ["Hello", "World"];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move names."Array<String>^IndexValue::index_value"(0));
         __r.String::append(move " ");
         __r.String::append(move names."Array<String>^IndexValue::index_value"(1));

--- a/wado-compiler/tests/fixtures.golden/array_string_param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string_param.lowered.wado
@@ -15,9 +15,7 @@
 
 fn join_names(names: Array<String>) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move names."Array<String>^IndexValue::index_value"(0));
         __r.String::append(move " and ");
         __r.String::append(move names."Array<String>^IndexValue::index_value"(1));

--- a/wado-compiler/tests/fixtures.golden/array_type_annotation.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_type_annotation.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let a: Array<i32> = move [1, 2, 3];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/assert_fail_intermediate.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_intermediate.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (7 > 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(160), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(160), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/assert_fail_side_effect.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_side_effect.lowered.wado
@@ -24,9 +24,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (__v0 > 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/assert_fail_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_simple.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (5 > 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/assert_fail_with_message.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_with_message.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (-5 > 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/assert_power.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_power.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (5 > 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(111), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(111), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -55,9 +53,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (8 == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(160), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(160), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -114,9 +110,7 @@ fn run() with Stdout, Stderr {
         let __cond: bool = (5 != 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_14: {
-                    break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(150), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(150), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/associated_const_integers.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_const_integers.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i8::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i8::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u8::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u8::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i16::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -91,9 +81,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i16::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -107,9 +95,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u16::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -123,9 +109,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u16::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
@@ -139,9 +123,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i32::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -155,9 +137,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i32::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_28: {
             let buf: &mut String = &mut __r;
@@ -171,9 +151,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_30: {
-            break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u32::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_31: {
             let buf: &mut String = &mut __r;
@@ -187,9 +165,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u32::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_34: {
             let buf: &mut String = &mut __r;
@@ -203,9 +179,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i64::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -219,9 +193,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_39: {
-            break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i64::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_40: {
             let buf: &mut String = &mut __r;
@@ -235,9 +207,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_42: {
-            break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u64::MAX = ");
         let mut __f: Formatter = __inline_Formatter__new_43: {
             let buf: &mut String = &mut __r;
@@ -251,9 +221,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_45: {
-            break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u64::MIN = ");
         let mut __f: Formatter = __inline_Formatter__new_46: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/associated_const_user_defined.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_const_user_defined.lowered.wado
@@ -17,9 +17,7 @@ struct Color {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(57), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(57), used: 0 };
         __r.String::append(move "red: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -53,9 +51,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(59), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(59), used: 0 };
         __r.String::append(move "white: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/associated_type_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_basic.lowered.wado
@@ -14,13 +14,9 @@ struct IntBox {
 }
 
 fn run() with Stdout {
-    let val: i32 = __inline_IntBox_Container__get_0: {
-        break __inline_IntBox_Container__get_0: 42;
-    };
+    let val: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/associated_type_index_assign.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_index_assign.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
         __sroa_box_value = 42;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/associated_type_index_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_index_mut.lowered.wado
@@ -20,21 +20,15 @@ struct Container {
 fn run() with Stdout {
     let mut __sroa_c_item: Counter = move Counter { value: 0 };
     __inline_Counter__increment_0: {
-        let self: &mut Counter = __inline_Container_IndexMut__index_mut_1: {
-            break __inline_Container_IndexMut__index_mut_1: &mut __sroa_c_item;
-        };
+        let self: &mut Counter = &mut __sroa_c_item;
         self.value = (self.value + 1);
     };
     __inline_Counter__increment_2: {
-        let self: &mut Counter = __inline_Container_IndexMut__index_mut_3: {
-            break __inline_Container_IndexMut__index_mut_3: &mut __sroa_c_item;
-        };
+        let self: &mut Counter = &mut __sroa_c_item;
         self.value = (self.value + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/associated_type_index_trait.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_index_trait.lowered.wado
@@ -14,14 +14,10 @@ struct MyContainer {
 }
 
 fn run() with Stdout {
-    let val_ref: Box<i32> = __inline_MyContainer_Index__index_0: {
-        break __inline_MyContainer_Index__index_0: Box<i32> { value: 42 };
-    };
+    let val_ref: Box<i32> = move Box<i32> { value: 42 };
     let val: i32 = val_ref.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/auto_deref_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref_method.lowered.wado
@@ -28,15 +28,11 @@ struct "Box<i32>" {
 
 fn run() with Stdout {
     __assert_0: {
-        let __v0: i32 = __inline_Point__sum_0: {
-            break __inline_Point__sum_0: 30;
-        };
+        let __v0: i32 = 30;
         let __cond: bool = (__v0 == 30);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -68,15 +64,11 @@ fn run() with Stdout {
         }
     }
     __assert_1: {
-        let __v0: i32 = __inline_Point__scale_6: {
-            break __inline_Point__scale_6: 60;
-        };
+        let __v0: i32 = 60;
         let __cond: bool = (__v0 == 60);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(139), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(139), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -108,15 +100,11 @@ fn run() with Stdout {
         }
     }
     __assert_2: {
-        let __v0: i32 = __inline_Point__sum_12: {
-            break __inline_Point__sum_12: 30;
-        };
+        let __v0: i32 = 30;
         let __cond: bool = (__v0 == 30);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(135), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(135), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -148,15 +136,11 @@ fn run() with Stdout {
         }
     }
     __assert_3: {
-        let __v0: i32 = __inline_Box_i32___get_18: {
-            break __inline_Box_i32___get_18: 42;
-        };
+        let __v0: i32 = 42;
         let __cond: bool = (__v0 == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_19: {
-                    break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(137), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(137), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -188,19 +172,13 @@ fn run() with Stdout {
         }
     }
     let __sroa_box_str_value: String = move "hello";
-    let inner: String = __inline_Box_String___get_24: {
-        break __inline_Box_String___get_24: __sroa_box_str_value;
-    };
+    let inner: String = __sroa_box_str_value;
     __assert_4: {
-        let __v0: i32 = __inline_String__len_25: {
-            break __inline_String__len_25: inner.used;
-        };
+        let __v0: i32 = inner.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -233,15 +211,11 @@ fn run() with Stdout {
     }
     let s: String = move "hello";
     __assert_5: {
-        let __v0: i32 = __inline_String__len_31: {
-            break __inline_String__len_31: s.used;
-        };
+        let __v0: i32 = s.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -272,9 +246,7 @@ fn run() with Stdout {
             });
         }
     }
-    let mut bytes_iter: StrUtf8ByteIter = __inline_String__bytes_37: {
-        break __inline_String__bytes_37: StrUtf8ByteIter { repr: s.repr, used: s.used, index: 0 };
-    };
+    let mut bytes_iter: StrUtf8ByteIter = move StrUtf8ByteIter { repr: s.repr, used: s.used, index: 0 };
     let __pattern_temp_0: Option<u8> = bytes_iter."StrUtf8ByteIter^Iterator::next"();
     if __is_not_null(__pattern_temp_0) {
         let b: u8 = __unwrap_option(__pattern_temp_0).value;
@@ -282,9 +254,7 @@ fn run() with Stdout {
             let __cond: bool = (b == 'h' as u8);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_38: {
-                        break __inline_String__with_capacity_38: String { repr: "array_new<u8>"(120), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(120), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -317,15 +287,11 @@ fn run() with Stdout {
         }
     }
     __assert_7: {
-        let __v0: i32 = __inline_Point__sum_43: {
-            break __inline_Point__sum_43: 15;
-        };
+        let __v0: i32 = 15;
         let __cond: bool = (__v0 == 15);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_44: {
-                    break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(143), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(143), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -357,15 +323,11 @@ fn run() with Stdout {
         }
     }
     __assert_8: {
-        let __v0: i32 = __inline_Point__sum_49: {
-            break __inline_Point__sum_49: 30;
-        };
+        let __v0: i32 = 30;
         let __cond: bool = (__v0 == 30);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_50: {
-                    break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(135), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(135), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/bitwise_and.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/bitwise_and.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (result == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(122), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(122), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/bitwise_combined.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/bitwise_combined.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (result == 7);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(122), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(122), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/bitwise_not.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/bitwise_not.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (result == -1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/bitwise_or.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/bitwise_or.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (result == 14);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(123), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(123), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/bitwise_shift.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/bitwise_shift.lowered.wado
@@ -20,9 +20,7 @@ fn run() {
         let __cond: bool = (left_shift == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -57,9 +55,7 @@ fn run() {
         let __cond: bool = (right_shift == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/bitwise_xor.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/bitwise_xor.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (result == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(122), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(122), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/builtin_clz_reinterpret.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/builtin_clz_reinterpret.lowered.wado
@@ -14,9 +14,7 @@
 fn run() with Stdout {
     let clz32_1: i32 = core::builtin::i32_clz(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "i32_clz(0) = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -31,9 +29,7 @@ fn run() with Stdout {
     });
     let clz32_2: i32 = core::builtin::i32_clz(1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "i32_clz(1) = ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -48,9 +44,7 @@ fn run() with Stdout {
     });
     let clz32_3: i32 = core::builtin::i32_clz(-2147483648);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "i32_clz(0x80000000) = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -65,9 +59,7 @@ fn run() with Stdout {
     });
     let clz32_4: i32 = core::builtin::i32_clz(65536);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "i32_clz(0x00010000) = ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -82,9 +74,7 @@ fn run() with Stdout {
     });
     let clz64_1: i64 = core::builtin::i64_clz(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "i64_clz(0) = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -99,9 +89,7 @@ fn run() with Stdout {
     });
     let clz64_2: i64 = core::builtin::i64_clz(1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "i64_clz(1) = ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -116,9 +104,7 @@ fn run() with Stdout {
     });
     let clz64_3: i64 = core::builtin::i64_clz(-9223372036854775808);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(46), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(46), used: 0 };
         __r.String::append(move "i64_clz(0x8000000000000000) = ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -133,9 +119,7 @@ fn run() with Stdout {
     });
     let pi_bits: i64 = core::builtin::i64_reinterpret_f64(3.141592653589793);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "f64 pi bits = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
@@ -150,9 +134,7 @@ fn run() with Stdout {
     });
     let back_to_pi: f64 = core::builtin::f64_reinterpret_i64(pi_bits);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "back to pi = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -167,9 +149,7 @@ fn run() with Stdout {
     });
     let zero_bits: i64 = core::builtin::i64_reinterpret_f64(0.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "f64 0.0 bits = ");
         let mut __f: Formatter = __inline_Formatter__new_28: {
             let buf: &mut String = &mut __r;
@@ -184,9 +164,7 @@ fn run() with Stdout {
     });
     let neg_zero_bits: i64 = core::builtin::i64_reinterpret_f64(-0.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_30: {
-            break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f64 -0.0 bits = ");
         let mut __f: Formatter = __inline_Formatter__new_31: {
             let buf: &mut String = &mut __r;
@@ -202,9 +180,7 @@ fn run() with Stdout {
     let pi32: f32 = 3.14159265 as f32;
     let pi32_bits: i32 = core::builtin::i32_reinterpret_f32(pi32);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "f32 pi bits = ");
         let mut __f: Formatter = __inline_Formatter__new_34: {
             let buf: &mut String = &mut __r;
@@ -219,9 +195,7 @@ fn run() with Stdout {
     });
     let back_to_pi32: f32 = core::builtin::f32_reinterpret_i32(pi32_bits);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "back to f32 pi = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -236,9 +210,7 @@ fn run() with Stdout {
     });
     let zero32_bits: i32 = core::builtin::i32_reinterpret_f32(0.0 as f32);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_39: {
-            break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "f32 0.0 bits = ");
         let mut __f: Formatter = __inline_Formatter__new_40: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/char_cast_from_u32_fn.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/char_cast_from_u32_fn.lowered.wado
@@ -21,9 +21,7 @@ fn run() with Stdout {
             let __cond: bool = (c == 'A');
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_0: {
-                        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -60,9 +58,7 @@ fn run() with Stdout {
             let __cond: bool = (c as i32 == 0x1F600);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_4: {
-                        break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(105), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -92,9 +88,7 @@ fn run() with Stdout {
             let __cond: bool = (c == 'A');
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_7: {
-                        break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -151,9 +145,7 @@ fn run() with Stdout {
             let __cond: bool = (c as i32 == 0);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_11: {
-                        break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(99), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(99), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -183,9 +175,7 @@ fn run() with Stdout {
             let __cond: bool = (c as i32 == 0xD7FF);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_14: {
-                        break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(104), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -215,9 +205,7 @@ fn run() with Stdout {
             let __cond: bool = (c as i32 == 0xE000);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_17: {
-                        break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(104), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -247,9 +235,7 @@ fn run() with Stdout {
             let __cond: bool = (c as i32 == 0x10FFFF);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_20: {
-                        break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(106), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -272,16 +258,12 @@ fn run() with Stdout {
     } else {
         core::internal::panic(move "expected Some for U+10FFFF");
     }
-    let uc: char = __inline_char__from_u32_unchecked_23: {
-        break __inline_char__from_u32_unchecked_23: core::builtin::i32_as_char(65);
-    };
+    let uc: char = core::builtin::i32_as_char(65);
     __assert_7: {
         let __cond: bool = (uc == 'A');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_24: {
-                    break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -308,16 +290,12 @@ fn run() with Stdout {
             });
         }
     }
-    let uc2: char = __inline_char__from_u32_unchecked_28: {
-        break __inline_char__from_u32_unchecked_28: core::builtin::i32_as_char(128512);
-    };
+    let uc2: char = core::builtin::i32_as_char(128512);
     __assert_8: {
         let __cond: bool = (uc2 as i32 == 0x1F600);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_29: {
-                    break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(107), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(107), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/char_cast_from_u8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/char_cast_from_u8.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
         let __cond: bool = (c == 'A');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(114), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -53,9 +51,7 @@ fn run() with Stdout {
         let __cond: bool = (c2 as i32 == 255);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_4: {
-                    break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -80,9 +76,7 @@ fn run() with Stdout {
         let __cond: bool = (c3 as i32 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/char_cast_valid.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/char_cast_valid.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
         let __cond: bool = (code_i32 == 65);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(127), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(127), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -57,9 +55,7 @@ fn run() with Stdout {
         let __cond: bool = (code_u32 as i32 == 65);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(107), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(107), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -84,9 +80,7 @@ fn run() with Stdout {
         let __cond: bool = (emoji_code == 0x1F600);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_8: {
-                    break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(136), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(136), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/cli_args.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/cli_args.lowered.wado
@@ -12,18 +12,14 @@
 fn run() with Stdout, Environment {
     let arguments: Array<String> = move core::cli::args();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "args.len = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_String___len_3: {
-                break __inline_Array_String___len_3: arguments.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arguments.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/closure-in-generic-method-delegation.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure-in-generic-method-delegation.lowered.wado
@@ -24,9 +24,7 @@ fn run() with Stdout {
         break __inline_Pair_i32___pick_smaller_0: self."Pair<i32>::pick_by$__Closure_0"(&__Closure_0 {  });
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_block_body.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_body.lowered.wado
@@ -14,51 +14,39 @@ struct __Closure_0 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline___Closure_0____call_3: {
-                break __inline___Closure_0____call_3: 15;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 15 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline___Closure_0____call_7: {
-                break __inline___Closure_0____call_7: 20;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 20 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_10: {
-            let self: Box<i32> = move Box<i32> { value: __inline___Closure_0____call_11: {
-                break __inline___Closure_0____call_11: 25;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 25 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/closure_block_for.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_for.lowered.wado
@@ -15,9 +15,7 @@ struct __Closure_0 {
 fn run() with Stdout {
     let factorial: &__Closure_0 = &__Closure_0 {  };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -45,9 +41,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_block_if.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_if.lowered.wado
@@ -15,9 +15,7 @@ struct __Closure_0 {
 fn run() with Stdout {
     let max_of_three: &__Closure_0 = &__Closure_0 {  };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -45,9 +41,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_block_multi_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_multi_types.lowered.wado
@@ -15,9 +15,7 @@ struct __Closure_0 {
 fn run() with Stdout {
     let mixed: &__Closure_0 = &__Closure_0 {  };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -45,9 +41,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_block_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_nested.lowered.wado
@@ -15,9 +15,7 @@ struct __Closure_0 {
 fn run() with Stdout {
     let compute: &__Closure_0 = &__Closure_0 {  };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_block_while.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_while.lowered.wado
@@ -15,9 +15,7 @@ struct __Closure_0 {
 fn run() with Stdout {
     let sum_to_n: &__Closure_0 = &__Closure_0 {  };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -45,9 +41,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_call_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_call_basic.lowered.wado
@@ -13,13 +13,9 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let result: i32 = __inline___Closure_0____call_0: {
-        break __inline___Closure_0____call_0: 6;
-    };
+    let result: i32 = 6;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_call_multi_args.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_call_multi_args.lowered.wado
@@ -17,18 +17,12 @@ struct __Closure_1 {
 
 fn run() with Stdout {
     let result: i32 = __inline___Closure_0____call_0: {
-        let a: i32 = __inline___Closure_1____call_1: {
-            break __inline___Closure_1____call_1: 6;
-        };
-        let b: i32 = __inline___Closure_1____call_2: {
-            break __inline___Closure_1____call_2: 20;
-        };
+        let a: i32 = 6;
+        let b: i32 = 20;
         break __inline___Closure_0____call_0: (a + b);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_call_multiple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_call_multiple.lowered.wado
@@ -13,19 +13,11 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let a: i32 = __inline___Closure_0____call_0: {
-        break __inline___Closure_0____call_0: 6;
-    };
-    let b: i32 = __inline___Closure_0____call_1: {
-        break __inline___Closure_0____call_1: 10;
-    };
-    let c: i32 = __inline___Closure_0____call_2: {
-        break __inline___Closure_0____call_2: 14;
-    };
+    let a: i32 = 6;
+    let b: i32 = 10;
+    let c: i32 = 14;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param.lowered.wado
@@ -17,15 +17,9 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let result: i32 = __inline_Box_i32___apply___Closure_0_0: {
-        break __inline_Box_i32___apply___Closure_0_0: __inline___Closure_0____call_1: {
-            break __inline___Closure_0____call_1: 10;
-        };
-    };
+    let result: i32 = 10;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_capture.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_capture.lowered.wado
@@ -18,15 +18,9 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let result: i32 = __inline_Box_i32___apply___Closure_0_0: {
-        break __inline_Box_i32___apply___Closure_0_0: __inline___Closure_0____call_1: {
-            break __inline___Closure_0____call_1: 15;
-        };
-    };
+    let result: i32 = 15;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_multiple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_multiple.lowered.wado
@@ -16,18 +16,12 @@ struct __Closure_1 {
 }
 
 fn run() with Stdout {
-    let result: i32 = __inline_combine___Closure_0___Closure_1_0: {
-        break __inline_combine___Closure_0___Closure_1_0: __inline___Closure_1____call_2: {
-            let x: i32 = __inline___Closure_0____call_1: {
-                break __inline___Closure_0____call_1: 6;
-            };
-            break __inline___Closure_1____call_2: (x * 2);
-        };
+    let result: i32 = __inline___Closure_1____call_2: {
+        let x: i32 = 6;
+        break __inline___Closure_1____call_2: (x * 2);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_static.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_static.lowered.wado
@@ -13,15 +13,9 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let result: i32 = __inline_Transform__apply___Closure_0_0: {
-        break __inline_Transform__apply___Closure_0_0: __inline___Closure_0____call_0: {
-            break __inline___Closure_0____call_0: 15;
-        };
-    };
+    let result: i32 = 15;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/closure_in_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_in_loop.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
                 break __for_0;
             }
             __for_0_body: {
-                sum = (sum + __inline___Closure_0____call_0: {
-                    break __inline___Closure_0____call_0: (i * 2);
-                });
+                sum = (sum + (i * 2));
             }
             i = (i + 1);
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.lowered.wado
@@ -53,9 +53,7 @@ fn run() with Stdout {
         break __inline_call_fn_4: f(0);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(84), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(84), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.lowered.wado
@@ -27,9 +27,7 @@ fn run() with Stdout {
     let items: Array<i32> = move [10, 20, 30, 40, 50];
     let mut closures: Array<fn(i32) -> i32> = move [];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
@@ -62,9 +60,7 @@ fn run() with Stdout {
         break __inline_call_fn_5: f(0);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(84), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(84), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_no_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_no_params.lowered.wado
@@ -21,37 +21,27 @@ struct __Closure_2 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline___Closure_0____call_3: {
-                break __inline___Closure_0____call_3: 42;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 42 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    core::cli::println(__inline___Closure_1____call_4: {
-        break __inline___Closure_1____call_4: "hello";
-    });
+    core::cli::println(move "hello");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline___Closure_2____call_8: {
-                break __inline___Closure_2____call_8: 10;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 10 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -59,9 +49,7 @@ fn run() with Stdout {
     });
     let a: bool = (false || true);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -77,13 +65,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c: bool = (false || (__inline___Closure_0____call_12: {
-        break __inline___Closure_0____call_12: 42;
-    } > 0));
+    let c: bool = (false || (42 > 0));
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_14: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_return_bool.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_return_bool.lowered.wado
@@ -13,16 +13,10 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let a: bool = __inline___Closure_0____call_0: {
-        break __inline___Closure_0____call_0: (0 == 0);
-    };
-    let b: bool = __inline___Closure_0____call_1: {
-        break __inline___Closure_0____call_1: (1 == 0);
-    };
+    let a: bool = (0 == 0);
+    let b: bool = (1 == 0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_return_i64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_return_i64.lowered.wado
@@ -13,13 +13,9 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let big: i64 = __inline___Closure_0____call_0: {
-        break __inline___Closure_0____call_0: 5000000000;
-    };
+    let big: i64 = 5000000000;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/closure_struct_literal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_struct_literal.lowered.wado
@@ -18,13 +18,9 @@ struct __Closure_0 {
 }
 
 fn run() with Stdout {
-    let p: Point = __inline___Closure_0____call_0: {
-        break __inline___Closure_0____call_0: Point { x: 10, y: 20 };
-    };
+    let p: Point = move Point { x: 10, y: 20 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_args.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_args.lowered.wado
@@ -12,16 +12,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: f32 = __inline_take_f32_0: {
-        break __inline_take_f32_0: 3.14;
-    };
-    let b: f64 = __inline_take_f64_1: {
-        break __inline_take_f64_1: 2.718;
-    };
+    let a: f32 = 3.14;
+    let b: f64 = 2.718;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f32: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -35,9 +29,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_f32_binary.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_f32_binary.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     let inf: f32 = (1.0 / 0.0);
     let neg_inf: f32 = (-1.0 / 0.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -29,9 +27,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_f32_const.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_f32_const.lowered.wado
@@ -12,9 +12,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "f32 PI: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_let.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_let.lowered.wado
@@ -13,9 +13,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f32: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -29,9 +27,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_return.lowered.wado
@@ -13,36 +13,28 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f32: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f32_Display__fmt_2: {
-            let self: Box<f32> = move Box<f32> { value: __inline_get_f32_3: {
-                break __inline_get_f32_3: 3.14;
-            } };
+            let self: Box<f32> = move Box<f32> { value: 3.14 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f32"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_6: {
-            let self: Box<f64> = move Box<f64> { value: __inline_get_f64_7: {
-                break __inline_get_f64_7: 2.718;
-            } };
+            let self: Box<f64> = move Box<f64> { value: 2.718 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/coerce_i128_u128.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_i128_u128.lowered.wado
@@ -19,17 +19,9 @@ struct BigInts {
 }
 
 fn run() with Stdout {
-    let b: BigInts = __inline_get_big_0: {
-        break __inline_get_big_0: BigInts { a: __inline_u128__from_u64_1: {
-            break __inline_u128__from_u64_1: u128 { low: 42, high: 0 };
-        }, b: __inline_i128__from_pair_2: {
-            break __inline_i128__from_pair_2: i128 { low: 18446744073709551516, high: -1 };
-        } };
-    };
+    let b: BigInts = move BigInts { a: u128 { low: 42, high: 0 }, b: i128 { low: 18446744073709551516, high: -1 } };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "a=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -45,9 +37,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "b=");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -62,16 +52,10 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let x: u128 = __inline_u128__from_u64_11: {
-        break __inline_u128__from_u64_11: u128 { low: 12345, high: 0 };
-    };
-    let y: i128 = __inline_i128__from_pair_12: {
-        break __inline_i128__from_pair_12: i128 { low: 18446744073709483726, high: -1 };
-    };
+    let x: u128 = move u128 { low: 12345, high: 0 };
+    let y: i128 = move i128 { low: 18446744073709483726, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "x=");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -87,9 +71,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_17: {
-            break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "y=");
         let mut __f: Formatter = __inline_Formatter__new_18: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_args.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_args.lowered.wado
@@ -10,22 +10,12 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i64 = __inline_take_i64_0: {
-        break __inline_take_i64_0: 42;
-    };
-    let b: u64 = __inline_take_u64_1: {
-        break __inline_take_u64_1: 100;
-    };
-    let c: i8 = __inline_take_i8_2: {
-        break __inline_take_i8_2: 10;
-    };
-    let d: u8 = __inline_take_u8_3: {
-        break __inline_take_u8_3: 200;
-    };
+    let a: i64 = 42;
+    let b: u64 = 100;
+    let c: i8 = 10;
+    let d: u8 = 200;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -39,9 +29,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "u64: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -55,9 +43,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "i8: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -71,9 +57,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "u8: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_binary.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_binary.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
         let __cond: bool = (1000000000042 == 1000000000042);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -55,9 +53,7 @@ fn run() with Stdout {
         let __cond: bool = (1553255926290448384 == 1553255926290448384);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(137), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(137), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -92,9 +88,7 @@ fn run() with Stdout {
         let __cond: bool = (1000000000100 == 1000000000100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -129,9 +123,7 @@ fn run() with Stdout {
         let __cond: bool = (11553255926290448384 == 11553255926290448384);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -163,9 +155,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i64 + 42: ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
@@ -179,9 +169,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_23: {
-            break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "u64 * 2: ");
         let mut __f: Formatter = __inline_Formatter__new_24: {
             let buf: &mut String = &mut __r;
@@ -195,9 +183,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_26: {
-            break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "100 + i64: ");
         let mut __f: Formatter = __inline_Formatter__new_27: {
             let buf: &mut String = &mut __r;
@@ -211,9 +197,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_29: {
-            break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "3 * u64: ");
         let mut __f: Formatter = __inline_Formatter__new_30: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_const_i64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_const_i64.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "i64 MAX: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "i64 MIN: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "u64 MAX: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "u64 MIN: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_if_branch.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_if_branch.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "true: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "false: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_instance_method_arg.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_instance_method_arg.lowered.wado
@@ -14,25 +14,17 @@ struct Counter {
 }
 
 fn run() with Stdout {
-    let c: Counter = __inline_Counter__new_0: {
-        break __inline_Counter__new_0: Counter { value: 0 };
-    };
-    let c2: Counter = __inline_Counter__add_1: {
-        break __inline_Counter__add_1: Counter { value: (c.value + 10) };
-    };
+    let c: Counter = move Counter { value: 0 };
+    let c2: Counter = move Counter { value: (c.value + 10) };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_u64_Display__fmt_4: {
-            let self: Box<u64> = move Box<u64> { value: __inline_Counter__get_5: {
-                break __inline_Counter__get_5: c2.value;
-            } };
+            let self: Box<u64> = move Box<u64> { value: c2.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_u64_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_let.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_let.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "i8: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i16: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i32: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "u8: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -91,9 +81,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "u16: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -107,9 +95,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "u32: ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -123,9 +109,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "u64: ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_method_arg.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_method_arg.lowered.wado
@@ -14,43 +14,31 @@ struct Counter {
 }
 
 fn run() with Stdout {
-    let counter: Counter = __inline_Counter__new_0: {
-        break __inline_Counter__new_0: Counter { value: 0 };
-    };
+    let counter: Counter = move Counter { value: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_u64_Display__fmt_3: {
-            let self: Box<u64> = move Box<u64> { value: __inline_Counter__get_4: {
-                break __inline_Counter__get_4: counter.value;
-            } };
+            let self: Box<u64> = move Box<u64> { value: counter.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_u64_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    let counter2: Counter = __inline_Counter__new_5: {
-        break __inline_Counter__new_5: Counter { value: 42 };
-    };
+    let counter2: Counter = move Counter { value: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_u64_Display__fmt_8: {
-            let self: Box<u64> = move Box<u64> { value: __inline_Counter__get_9: {
-                break __inline_Counter__get_9: counter2.value;
-            } };
+            let self: Box<u64> = move Box<u64> { value: counter2.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_u64_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_return.lowered.wado
@@ -11,72 +11,56 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i64_Display__fmt_2: {
-            let self: Box<i64> = move Box<i64> { value: __inline_get_i64_3: {
-                break __inline_get_i64_3: 42;
-            } };
+            let self: Box<i64> = move Box<i64> { value: 42 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i64_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "u64: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_u64_Display__fmt_6: {
-            let self: Box<u64> = move Box<u64> { value: __inline_get_u64_7: {
-                break __inline_get_u64_7: 100;
-            } };
+            let self: Box<u64> = move Box<u64> { value: 100 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_u64_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "i8: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i8_Display__fmt_10: {
-            let self: Box<i8> = move Box<i8> { value: __inline_get_i8_11: {
-                break __inline_get_i8_11: 10;
-            } };
+            let self: Box<i8> = move Box<i8> { value: 10 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value as i32, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "u8: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_u8_Display__fmt_14: {
-            let self: Box<u8> = move Box<u8> { value: __inline_get_u8_15: {
-                break __inline_get_u8_15: 200;
-            } };
+            let self: Box<u8> = move Box<u8> { value: 200 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value as i32, f);
         };

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_u64_comparison.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_u64_comparison.lowered.wado
@@ -11,18 +11,14 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "0 is zero: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_bool_Display__fmt_2: {
-            let self: Box<bool> = move Box<bool> { value: __inline_is_zero_3: {
-                break __inline_is_zero_3: (0 == 0);
-            } };
+            let self: Box<bool> = move Box<bool> { value: (0 == 0) };
             let f: &mut Formatter = &mut __f;
             f.Formatter::pad(if self.value {
                 "true";
@@ -33,18 +29,14 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "1 is zero: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_bool_Display__fmt_6: {
-            let self: Box<bool> = move Box<bool> { value: __inline_is_zero_7: {
-                break __inline_is_zero_7: (1 == 0);
-            } };
+            let self: Box<bool> = move Box<bool> { value: (1 == 0) };
             let f: &mut Formatter = &mut __f;
             f.Formatter::pad(if self.value {
                 "true";

--- a/wado-compiler/tests/fixtures.golden/coerce_match_arm.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_match_arm.lowered.wado
@@ -10,24 +10,18 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let u64_0: u64 = __inline_get_u64_0: {
-        break __inline_get_u64_0: match 0 {
-            0 => 1,
-            1 => 10,
-            _ => 0,
-        };
+    let u64_0: u64 = match 0 {
+        0 => 1,
+        1 => 10,
+        _ => 0,
     };
-    let u64_1: u64 = __inline_get_u64_1: {
-        break __inline_get_u64_1: match 1 {
-            0 => 1,
-            1 => 10,
-            _ => 0,
-        };
+    let u64_1: u64 = match 1 {
+        0 => 1,
+        1 => 10,
+        _ => 0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(39), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
         __r.String::append(move "u64: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -50,24 +44,18 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let i64_0: i64 = __inline_get_i64_7: {
-        break __inline_get_i64_7: match 0 {
-            0 => -1,
-            1 => -100,
-            _ => 0,
-        };
+    let i64_0: i64 = match 0 {
+        0 => -1,
+        1 => -100,
+        _ => 0,
     };
-    let i64_1: i64 = __inline_get_i64_8: {
-        break __inline_get_i64_8: match 1 {
-            0 => -1,
-            1 => -100,
-            _ => 0,
-        };
+    let i64_1: i64 = match 1 {
+        0 => -1,
+        1 => -100,
+        _ => 0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(39), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -90,24 +78,18 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let u8_0: u8 = __inline_get_u8_14: {
-        break __inline_get_u8_14: match 0 {
-            0 => 1,
-            1 => 255,
-            _ => 0,
-        };
+    let u8_0: u8 = match 0 {
+        0 => 1,
+        1 => 255,
+        _ => 0,
     };
-    let u8_1: u8 = __inline_get_u8_15: {
-        break __inline_get_u8_15: match 1 {
-            0 => 1,
-            1 => 255,
-            _ => 0,
-        };
+    let u8_1: u8 = match 1 {
+        0 => 1,
+        1 => 255,
+        _ => 0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "u8: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
@@ -130,24 +112,18 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let i8_0: i8 = __inline_get_i8_21: {
-        break __inline_get_i8_21: match 0 {
-            0 => -1,
-            1 => -128,
-            _ => 0,
-        };
+    let i8_0: i8 = match 0 {
+        0 => -1,
+        1 => -128,
+        _ => 0,
     };
-    let i8_1: i8 = __inline_get_i8_22: {
-        break __inline_get_i8_22: match 1 {
-            0 => -1,
-            1 => -128,
-            _ => 0,
-        };
+    let i8_1: i8 = match 1 {
+        0 => -1,
+        1 => -128,
+        _ => 0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_23: {
-            break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "i8: ");
         let mut __f: Formatter = __inline_Formatter__new_24: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/coerce_struct_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_struct_field.lowered.wado
@@ -27,13 +27,9 @@ struct SmallInts {
 }
 
 fn run() with Stdout {
-    let pm: PmHiLo = __inline_get_pm_0: {
-        break __inline_get_pm_0: PmHiLo { hi: 0xfa8fd5a0081c0289, lo: 0xe8cd3796329f1bac };
-    };
+    let pm: PmHiLo = move PmHiLo { hi: 0xfa8fd5a0081c0289, lo: 0xe8cd3796329f1bac };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "hi=");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -47,9 +43,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "lo=");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -62,13 +56,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let p: Point64 = __inline_get_point_7: {
-        break __inline_get_point_7: Point64 { x: -100, y: 200 };
-    };
+    let p: Point64 = move Point64 { x: -100, y: 200 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "x=");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -82,9 +72,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "y=");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
@@ -97,13 +85,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let s: SmallInts = __inline_get_small_14: {
-        break __inline_get_small_14: SmallInts { a: 255, b: -128, c: 0, d: 127 };
-    };
+    let s: SmallInts = move SmallInts { a: 255, b: -128, c: 0, d: 127 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(78), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(78), used: 0 };
         __r.String::append(move "a=");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/compound_assign_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/compound_assign_basic.lowered.wado
@@ -13,9 +13,7 @@ fn run() with Stdout {
     let mut x: i32 = 10;
     x = (x + 5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "+= : ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn run() with Stdout {
     });
     x = (x - 3);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "-= : ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -47,9 +43,7 @@ fn run() with Stdout {
     });
     x = (x * 2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "*= : ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -64,9 +58,7 @@ fn run() with Stdout {
     });
     x = (x / 4);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "/= : ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -81,9 +73,7 @@ fn run() with Stdout {
     });
     x = (x % 4);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "%= : ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/const_fold_int_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/const_fold_int_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "a=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "b=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "c=");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "d=");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "e=");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -91,9 +81,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "f=");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -107,9 +95,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "g=");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/const_fold_int_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/const_fold_int_types.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "a=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "b=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "c=");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "d=");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "e=");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -91,9 +81,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "f=");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/contextual_keyword.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/contextual_keyword.lowered.wado
@@ -17,9 +17,7 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "flags + type = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -32,13 +30,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let result: i32 = __inline_test_param_3: {
-        break __inline_test_param_3: 30;
-    };
+    let result: i32 = 30;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "test_param result = ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -53,17 +47,13 @@ fn run() with Stdout {
     });
     let arr: Array<i32> = move [1, 2, 3];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_7: {
-            break __inline_Array_i32__IntoIterator__into_iter_7: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let flags: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_8: {
-                        break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(31), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
                     __r.String::append(move "for-of flags = ");
                     let mut __f: Formatter = __inline_Formatter__new_9: {
                         let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/cross_module_generic_deep.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_generic_deep.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_wrap_i32__0: {
-        break __inline_wrap_i32__0: 42;
-    };
+    let x: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "wrap(42) = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -30,17 +26,11 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     let y: i32 = __inline_apply_twice_i32__4: {
-        let first: i32 = __inline_wrap_i32__5: {
-            break __inline_wrap_i32__5: 10;
-        };
-        break __inline_apply_twice_i32__4: __inline_wrap_i32__6: {
-            break __inline_wrap_i32__6: first;
-        };
+        let first: i32 = 10;
+        break __inline_apply_twice_i32__4: first;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "apply_twice(10) = ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -54,21 +44,11 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     let pair: [i32, i32] = __inline_wrap_and_double_i32__10: {
-        let wrapped: i32 = __inline_wrap_i32__11: {
-            break __inline_wrap_i32__11: 5;
-        };
-        break __inline_wrap_and_double_i32__10: __inline_pair_i32__12: {
-            break __inline_pair_i32__12: [__inline_wrap_i32__0: {
-                break __inline_wrap_i32__0: wrapped;
-            }, __inline_wrap_i32__1: {
-                break __inline_wrap_i32__1: wrapped;
-            }];
-        };
+        let wrapped: i32 = 5;
+        break __inline_wrap_and_double_i32__10: [wrapped, wrapped];
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(57), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(57), used: 0 };
         __r.String::append(move "wrap_and_double(5) = [");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -94,26 +74,16 @@ fn run() with Stdout {
     });
     let quad: i32 = __inline_quad_wrap_i32__18: {
         let first: i32 = __inline_apply_twice_i32__19: {
-            let first: i32 = __inline_wrap_i32__20: {
-                break __inline_wrap_i32__20: 7;
-            };
-            break __inline_apply_twice_i32__19: __inline_wrap_i32__21: {
-                break __inline_wrap_i32__21: first;
-            };
+            let first: i32 = 7;
+            break __inline_apply_twice_i32__19: first;
         };
         break __inline_quad_wrap_i32__18: __inline_apply_twice_i32__22: {
-            let first: i32 = __inline_wrap_i32__2: {
-                break __inline_wrap_i32__2: first;
-            };
-            break __inline_apply_twice_i32__22: __inline_wrap_i32__3: {
-                break __inline_wrap_i32__3: first;
-            };
+            let first: i32 = first;
+            break __inline_apply_twice_i32__22: first;
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_23: {
-            break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "quad_wrap(7) = ");
         let mut __f: Formatter = __inline_Formatter__new_24: {
             let buf: &mut String = &mut __r;
@@ -131,9 +101,7 @@ fn run() with Stdout {
         break __inline_wrap_String__26: value;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "wrap(hello) = ");
         __r.String::append(s);
         break __tmpl: __r;
@@ -141,26 +109,16 @@ fn run() with Stdout {
     let s2: String = __inline_quad_wrap_String__28: {
         let value: String = move "world";
         let first: String = __inline_apply_twice_String__29: {
-            let first: String = __inline_wrap_String__30: {
-                break __inline_wrap_String__30: value;
-            };
-            break __inline_apply_twice_String__29: __inline_wrap_String__31: {
-                break __inline_wrap_String__31: first;
-            };
+            let first: String = value;
+            break __inline_apply_twice_String__29: first;
         };
         break __inline_quad_wrap_String__28: __inline_apply_twice_String__32: {
-            let first: String = __inline_wrap_String__4: {
-                break __inline_wrap_String__4: first;
-            };
-            break __inline_apply_twice_String__32: __inline_wrap_String__5: {
-                break __inline_wrap_String__5: first;
-            };
+            let first: String = first;
+            break __inline_apply_twice_String__32: first;
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "quad_wrap(world) = ");
         __r.String::append(s2);
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/cross_module_generic_helper.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_generic_helper.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_identity_i32__0: {
-        break __inline_identity_i32__0: 100;
-    };
+    let x: i32 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "identity(100) = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/cross_module_generic_import.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_generic_import.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_identity_i32__0: {
-        break __inline_identity_i32__0: 42;
-    };
+    let x: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "identity<i32>(42) = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -34,9 +30,7 @@ fn run() with Stdout {
         break __inline_identity_String__4: value;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "identity<String>(hello) = ");
         __r.String::append(s);
         break __tmpl: __r;
@@ -46,9 +40,7 @@ fn run() with Stdout {
         break __inline_make_pair_i32_String__6: [10, second];
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(48), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(48), used: 0 };
         __r.String::append(move "make_pair = (");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/default_type_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/default_type_params.lowered.wado
@@ -15,18 +15,14 @@ struct IntBox {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_IntBox_Container__value_3: {
-                break __inline_IntBox_Container__value_3: 42;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 42 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/dict_mini.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/dict_mini.lowered.wado
@@ -18,9 +18,7 @@ struct "MiniDict<String,String>" {
 }
 
 fn run() with Stdout {
-    let mut dict: MiniDict<String,String> = __inline_MiniDict_String_String___new_0: {
-        break __inline_MiniDict_String_String___new_0: MiniDict<String,String> { entries: [] };
-    };
+    let mut dict: MiniDict<String,String> = move MiniDict<String,String> { entries: [] };
     dict."MiniDict<String,String>::set"(move "name", move "Wado");
     dict."MiniDict<String,String>::set"(move "type", move "language");
     dict."MiniDict<String,String>::set"(move "target", move "WebAssembly");
@@ -28,9 +26,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_0) {
         let name_val: String = __unwrap_option(__pattern_temp_0);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_1: {
-                break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(22), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
             __r.String::append(move "name: ");
             __r.String::append(name_val);
             break __tmpl: __r;
@@ -40,9 +36,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_1) {
         let type_val: String = __unwrap_option(__pattern_temp_1);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_2: {
-                break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(22), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
             __r.String::append(move "type: ");
             __r.String::append(type_val);
             break __tmpl: __r;
@@ -53,18 +47,14 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_2) {
         let updated_val: String = __unwrap_option(__pattern_temp_2);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_3: {
-                break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(30), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
             __r.String::append(move "updated name: ");
             __r.String::append(updated_val);
             break __tmpl: __r;
         });
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "has 'target': ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -82,9 +72,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "has 'version': ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -102,20 +90,16 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "size: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_11: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_12: {
-            let self: Box<i32> = move Box<i32> { value: __inline_MiniDict_String_String___size_13: {
-                break __inline_MiniDict_String_String___size_13: __inline_Array_Tuple_String_String____len_0: {
-                    let self: &Array<[String, String]> = &dict.entries;
-                    break __inline_Array_Tuple_String_String____len_0: self.used;
-                };
+            let self: Box<i32> = move Box<i32> { value: __inline_Array_Tuple_String_String____len_0: {
+                let self: &Array<[String, String]> = &dict.entries;
+                break __inline_Array_Tuple_String_String____len_0: self.used;
             } };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
@@ -134,9 +118,7 @@ fn "MiniDict<String,String>::has"(self: &MiniDict<String,String>, key: String) -
         let _licm_entries: Array<[String, String]> = self.entries;
         let _licm_used: i32 = _licm_entries.used;
         loop {
-            if !(i < __inline_Array_Tuple_String_String____len_0: {
-                break __inline_Array_Tuple_String_String____len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_2;
             }
             __for_2_body: {
@@ -163,9 +145,7 @@ fn "MiniDict<String,String>::get"(self: &MiniDict<String,String>, key: String) -
         let _licm_entries: Array<[String, String]> = self.entries;
         let _licm_used: i32 = _licm_entries.used;
         loop {
-            if !(i < __inline_Array_Tuple_String_String____len_0: {
-                break __inline_Array_Tuple_String_String____len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {

--- a/wado-compiler/tests/fixtures.golden/display_all_primitives.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_all_primitives.lowered.wado
@@ -17,25 +17,19 @@
 
 fn run() with Stdout {
     __assert_0: {
-        let __v0: String = __inline_i8__to_string_0: {
-            break __inline_i8__to_string_0: __inline_i32__to_string_0: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(127, &mut f);
-                break __inline_i32__to_string_0: buf;
+        let __v0: String = __inline_i32__to_string_0: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(127, &mut f);
+            break __inline_i32__to_string_0: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"127");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -59,25 +53,19 @@ fn run() with Stdout {
         }
     }
     __assert_1: {
-        let __v0: String = __inline_i8__to_string_4: {
-            break __inline_i8__to_string_4: __inline_i32__to_string_1: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(-128, &mut f);
-                break __inline_i32__to_string_1: buf;
+        let __v0: String = __inline_i32__to_string_1: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(-128, &mut f);
+            break __inline_i32__to_string_1: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"-128");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(159), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(159), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -101,25 +89,19 @@ fn run() with Stdout {
         }
     }
     __assert_2: {
-        let __v0: String = __inline_u8__to_string_8: {
-            break __inline_u8__to_string_8: __inline_i32__to_string_2: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(255, &mut f);
-                break __inline_i32__to_string_2: buf;
+        let __v0: String = __inline_i32__to_string_2: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(255, &mut f);
+            break __inline_i32__to_string_2: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"255");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -143,25 +125,19 @@ fn run() with Stdout {
         }
     }
     __assert_3: {
-        let __v0: String = __inline_u8__to_string_12: {
-            break __inline_u8__to_string_12: __inline_i32__to_string_3: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(0, &mut f);
-                break __inline_i32__to_string_3: buf;
+        let __v0: String = __inline_i32__to_string_3: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(0, &mut f);
+            break __inline_i32__to_string_3: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(150), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(150), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -185,25 +161,19 @@ fn run() with Stdout {
         }
     }
     __assert_4: {
-        let __v0: String = __inline_i16__to_string_16: {
-            break __inline_i16__to_string_16: __inline_i32__to_string_4: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(32767, &mut f);
-                break __inline_i32__to_string_4: buf;
+        let __v0: String = __inline_i32__to_string_4: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(32767, &mut f);
+            break __inline_i32__to_string_4: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"32767");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -227,25 +197,19 @@ fn run() with Stdout {
         }
     }
     __assert_5: {
-        let __v0: String = __inline_i16__to_string_20: {
-            break __inline_i16__to_string_20: __inline_i32__to_string_5: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(-32768, &mut f);
-                break __inline_i32__to_string_5: buf;
+        let __v0: String = __inline_i32__to_string_5: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(-32768, &mut f);
+            break __inline_i32__to_string_5: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"-32768");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(167), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(167), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -269,25 +233,19 @@ fn run() with Stdout {
         }
     }
     __assert_6: {
-        let __v0: String = __inline_u16__to_string_24: {
-            break __inline_u16__to_string_24: __inline_i32__to_string_6: {
-                let mut buf: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-                };
-                let mut f: Formatter = __inline_Formatter__new_1: {
-                    let buf: &mut String = &mut buf;
-                    break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-                };
-                "core::prelude/primitives.wado::fmt_i32_decimal"(65535, &mut f);
-                break __inline_i32__to_string_6: buf;
+        let __v0: String = __inline_i32__to_string_6: {
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
+            let mut f: Formatter = __inline_Formatter__new_1: {
+                let buf: &mut String = &mut buf;
+                break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
+            "core::prelude/primitives.wado::fmt_i32_decimal"(65535, &mut f);
+            break __inline_i32__to_string_6: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"65535");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -312,9 +270,7 @@ fn run() with Stdout {
     }
     __assert_7: {
         let __v0: String = __inline_i32__to_string_7: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -325,9 +281,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"2147483647");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_28: {
-                    break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(165), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(165), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -352,9 +306,7 @@ fn run() with Stdout {
     }
     __assert_8: {
         let __v0: String = __inline_i32__to_string_8: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -365,9 +317,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"-2147483648");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_31: {
-                    break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(168), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(168), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -392,9 +342,7 @@ fn run() with Stdout {
     }
     __assert_9: {
         let __v0: String = __inline_i32__to_string_9: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -405,9 +353,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -432,9 +378,7 @@ fn run() with Stdout {
     }
     __assert_10: {
         let __v0: String = __inline_u32__to_string_10: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(11), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(11), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -445,9 +389,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"4294967295");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -472,9 +414,7 @@ fn run() with Stdout {
     }
     __assert_11: {
         let __v0: String = __inline_i64__to_string_11: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(21), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -485,9 +425,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"9223372036854775807");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -512,9 +450,7 @@ fn run() with Stdout {
     }
     __assert_12: {
         let __v0: String = __inline_i64__to_string_12: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(21), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -525,9 +461,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"-9223372036854775808");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(157), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(157), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -552,9 +486,7 @@ fn run() with Stdout {
     }
     __assert_13: {
         let __v0: String = __inline_u64__to_string_13: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(21), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -565,9 +497,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"18446744073709551615");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_46: {
-                    break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(157), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(157), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -592,9 +522,7 @@ fn run() with Stdout {
     }
     __assert_14: {
         let __v0: String = __inline_f32__to_string_14: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -605,9 +533,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"3.14");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_49: {
-                    break __inline_String__with_capacity_49: String { repr: "array_new<u8>"(141), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(141), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -632,9 +558,7 @@ fn run() with Stdout {
     }
     __assert_15: {
         let __v0: String = __inline_f64__to_string_15: {
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(24), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -645,9 +569,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"3.141592653589793");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_52: {
-                    break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(154), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(154), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -675,9 +597,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"true");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -705,9 +625,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"false");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_58: {
-                    break __inline_String__with_capacity_58: String { repr: "array_new<u8>"(150), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(150), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -732,18 +650,14 @@ fn run() with Stdout {
     }
     __assert_18: {
         let __v0: String = __inline_char__to_string_61: {
-            let mut buf: String = __inline_String__with_capacity_62: {
-                break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(4), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(4), used: 0 };
             buf.String::append_char('Z');
             break __inline_char__to_string_61: buf;
         };
         let __cond: bool = __v0."String^Eq::eq"(&"Z");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_63: {
-                    break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/display_custom.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_custom.lowered.wado
@@ -21,9 +21,7 @@ pub fn "Point^Display::fmt"(self: &Point, f: &mut Formatter) {
     __inline_Formatter__write_str_1: {
         let s: String = __inline_i32__to_string_0: {
             let self: i32 = self.x;
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -40,9 +38,7 @@ pub fn "Point^Display::fmt"(self: &Point, f: &mut Formatter) {
     __inline_Formatter__write_str_3: {
         let s: String = __inline_i32__to_string_1: {
             let self: i32 = self.y;
-            let mut buf: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-            };
+            let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
             let mut f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut buf;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -59,9 +55,7 @@ pub fn "Point^Display::fmt"(self: &Point, f: &mut Formatter) {
 
 fn run() with Stdout {
     let p: Point = move Point { x: 10, y: 20 };
-    let mut buf: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let mut f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -69,9 +63,7 @@ fn run() with Stdout {
     p."Point^Display::fmt"(&mut f);
     core::cli::println(buf);
     let o: Point = move Point { x: 0, y: 0 };
-    buf = __inline_String__with_capacity_2: {
-        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    buf = move String { repr: "array_new<u8>"(64), used: 0 };
     f = __inline_Formatter__new_3: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/display_format_base.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_format_base.lowered.wado
@@ -14,9 +14,7 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn fmt_with(value: Box<i32>, sign_plus: bool, zero_pad: bool, width: i32, align: Alignment) -> String {
-    let mut buf: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let fill: char = core::builtin::select::<char>(zero_pad, '0', ' ');
     let mut f: Formatter = move Formatter { fill: fill, align: align, sign_plus: sign_plus, alternate: false, zero_pad: zero_pad, width: width, precision: -1, buf: &mut buf };
     __inline_i32_Display__fmt_1: {
@@ -34,9 +32,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"+42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(208), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(208), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -64,9 +60,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"-42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(212), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(212), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -94,9 +88,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"+0000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(209), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(209), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -124,9 +116,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"-0000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(215), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(215), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -154,9 +144,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"       +42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(215), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(215), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -184,9 +172,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"-42       ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(219), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(219), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/display_format_padding.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_format_padding.lowered.wado
@@ -14,9 +14,7 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn fmt_int(value: Box<i32>, fill: char, align: Alignment, sign_plus: bool, zero_pad: bool, width: i32) -> String {
-    let mut buf: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let mut f: Formatter = move Formatter { fill: fill, align: align, sign_plus: sign_plus, alternate: false, zero_pad: zero_pad, width: width, precision: -1, buf: &mut buf };
     __inline_i32_Display__fmt_1: {
         let f: &mut Formatter = &mut f;
@@ -34,9 +32,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"        42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(225), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(225), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -64,9 +60,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"42        ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(223), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(223), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -94,9 +88,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"    42    ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(227), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(227), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -124,9 +116,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"00000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(219), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(219), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -154,9 +144,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"-0000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(223), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(223), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -184,9 +172,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"+42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(216), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(216), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -214,9 +200,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"****42****");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_18: {
-                    break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(227), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(227), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -239,9 +223,7 @@ fn run() with Stdout {
             });
         }
     }
-    let mut buf: String = __inline_String__with_capacity_21: {
-        break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let mut f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 8, precision: -1, buf: &mut buf };
     __inline_bool_Display__fmt_22: {
         let f: &mut Formatter = &mut f;
@@ -256,9 +238,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"true    ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_23: {
-                    break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(125), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(125), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -286,9 +266,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"12345");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(222), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(222), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/display_formatter_methods.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_formatter_methods.lowered.wado
@@ -10,62 +10,48 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let mut buf: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "width: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Formatter__width_5: {
-                break __inline_Formatter__width_5: f.width;
-            } };
+            let self: Box<i32> = move Box<i32> { value: f.width };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "precision: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Formatter__precision_9: {
-                break __inline_Formatter__precision_9: f.precision;
-            } };
+            let self: Box<i32> = move Box<i32> { value: f.precision };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "alternate: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_11: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_bool_Display__fmt_12: {
-            let self: Box<bool> = move Box<bool> { value: __inline_Formatter__alternate_13: {
-                break __inline_Formatter__alternate_13: f.alternate;
-            } };
+            let self: Box<bool> = move Box<bool> { value: f.alternate };
             let f: &mut Formatter = &mut __f;
             f.Formatter::pad(if self.value {
                 "true";
@@ -76,18 +62,14 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "sign_plus: ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_15: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_bool_Display__fmt_16: {
-            let self: Box<bool> = move Box<bool> { value: __inline_Formatter__sign_plus_17: {
-                break __inline_Formatter__sign_plus_17: f.sign_plus;
-            } };
+            let self: Box<bool> = move Box<bool> { value: f.sign_plus };
             let f: &mut Formatter = &mut __f;
             f.Formatter::pad(if self.value {
                 "true";

--- a/wado-compiler/tests/fixtures.golden/display_primitives.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_primitives.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let mut buf: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let mut f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -22,9 +20,7 @@ fn run() with Stdout {
         "core::prelude/primitives.wado::fmt_i32_decimal"(42, f);
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_3: {
-        break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    buf = move String { repr: "array_new<u8>"(64), used: 0 };
     f = __inline_Formatter__new_4: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -38,9 +34,7 @@ fn run() with Stdout {
         });
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_6: {
-        break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    buf = move String { repr: "array_new<u8>"(64), used: 0 };
     f = __inline_Formatter__new_7: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -54,18 +48,14 @@ fn run() with Stdout {
         });
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_9: {
-        break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    buf = move String { repr: "array_new<u8>"(64), used: 0 };
     f = __inline_Formatter__new_10: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
     };
     Box<char> { value: 'A' }."char^Display::fmt"(&mut f);
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_11: {
-        break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    buf = move String { repr: "array_new<u8>"(64), used: 0 };
     f = __inline_Formatter__new_12: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_12: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/display_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_string.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let mut buf: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    let mut buf: String = move String { repr: "array_new<u8>"(64), used: 0 };
     let mut f: Formatter = __inline_Formatter__new_1: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -24,9 +22,7 @@ fn run() with Stdout {
         f.Formatter::pad(*self);
     };
     core::cli::println(buf);
-    buf = __inline_String__with_capacity_3: {
-        break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(64), used: 0 };
-    };
+    buf = move String { repr: "array_new<u8>"(64), used: 0 };
     f = __inline_Formatter__new_4: {
         let buf: &mut String = &mut buf;
         break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -38,9 +34,7 @@ fn run() with Stdout {
         f.Formatter::pad(*self);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
         __r.String::append(buf);
         __r.String::append(move "]");

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     __assert_0: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -32,9 +30,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -56,9 +52,7 @@ fn run() with Stdout {
     }
     __assert_1: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_6: {
-                break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_7: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -72,9 +66,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -99,9 +91,7 @@ fn run() with Stdout {
         let __cond: bool = s."String^Eq::eq"(&"hello");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -123,9 +113,7 @@ fn run() with Stdout {
     }
     __assert_3: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_15: {
-                break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_16: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -136,9 +124,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"        42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -160,9 +146,7 @@ fn run() with Stdout {
     }
     __assert_4: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_20: {
-                break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_21: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -173,9 +157,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"42        ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -197,9 +179,7 @@ fn run() with Stdout {
     }
     __assert_5: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_25: {
-                break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_26: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -210,9 +190,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"    42    ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -234,9 +212,7 @@ fn run() with Stdout {
     }
     __assert_6: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_30: {
-                break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '*', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_31: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -247,9 +223,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"****42****");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -271,9 +245,7 @@ fn run() with Stdout {
     }
     __assert_7: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_35: {
-                break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 8, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_36: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -284,9 +256,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"00000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -308,9 +278,7 @@ fn run() with Stdout {
     }
     __assert_8: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_40: {
-                break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '-', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 8, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_41: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -321,9 +289,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"42------");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_42: {
-                    break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -345,9 +311,7 @@ fn run() with Stdout {
     }
     __assert_9: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_45: {
-                break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: true, alternate: false, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_46: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -358,9 +322,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"+42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -382,9 +344,7 @@ fn run() with Stdout {
     }
     __assert_10: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_50: {
-                break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: true, alternate: false, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_51: {
                 let self: Box<i32> = move Box<i32> { value: -42 };
@@ -395,9 +355,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_52: {
-                    break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -419,9 +377,7 @@ fn run() with Stdout {
     }
     __assert_11: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_55: {
-                break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_56: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_56: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -435,9 +391,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-42");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_58: {
-                    break __inline_String__with_capacity_58: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -459,9 +413,7 @@ fn run() with Stdout {
     }
     __assert_12: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_61: {
-                break __inline_String__with_capacity_61: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: true, width: 8, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_62: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -472,9 +424,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"00000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_63: {
-                    break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -496,9 +446,7 @@ fn run() with Stdout {
     }
     __assert_13: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_66: {
-                break __inline_String__with_capacity_66: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: true, width: 8, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_67: {
                 let self: Box<i32> = move Box<i32> { value: -42 };
@@ -509,9 +457,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-0000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_68: {
-                    break __inline_String__with_capacity_68: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -533,9 +479,7 @@ fn run() with Stdout {
     }
     __assert_14: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_71: {
-                break __inline_String__with_capacity_71: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: true, alternate: false, zero_pad: true, width: 8, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_72: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -546,9 +490,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"+0000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_73: {
-                    break __inline_String__with_capacity_73: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -570,9 +512,7 @@ fn run() with Stdout {
     }
     __assert_15: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_76: {
-                break __inline_String__with_capacity_76: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_77: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_77: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -582,9 +522,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"101010");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_78: {
-                    break __inline_String__with_capacity_78: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -606,9 +544,7 @@ fn run() with Stdout {
     }
     __assert_16: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_81: {
-                break __inline_String__with_capacity_81: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_82: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_82: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -622,9 +558,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"11111111");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_84: {
-                    break __inline_String__with_capacity_84: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -646,9 +580,7 @@ fn run() with Stdout {
     }
     __assert_17: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_87: {
-                break __inline_String__with_capacity_87: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             __inline_u8_Binary__fmt_88: {
                 let self: Box<u8> = move Box<u8> { value: 255 };
@@ -659,9 +591,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"0b11111111");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_89: {
-                    break __inline_String__with_capacity_89: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -683,18 +613,14 @@ fn run() with Stdout {
     }
     __assert_18: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_92: {
-                break __inline_String__with_capacity_92: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: true, width: 8, precision: -1, buf: &mut __r };
             Box<i32> { value: 42 }."i32^Binary::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"00101010");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_93: {
-                    break __inline_String__with_capacity_93: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -716,18 +642,14 @@ fn run() with Stdout {
     }
     __assert_19: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_96: {
-                break __inline_String__with_capacity_96: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: true, width: 10, precision: -1, buf: &mut __r };
             Box<i32> { value: 42 }."i32^Binary::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0b00101010");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_97: {
-                    break __inline_String__with_capacity_97: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -749,9 +671,7 @@ fn run() with Stdout {
     }
     __assert_20: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_100: {
-                break __inline_String__with_capacity_100: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_101: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_101: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -761,9 +681,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"52");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_102: {
-                    break __inline_String__with_capacity_102: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -785,9 +703,7 @@ fn run() with Stdout {
     }
     __assert_21: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_105: {
-                break __inline_String__with_capacity_105: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_106: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_106: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -797,9 +713,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"777");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_107: {
-                    break __inline_String__with_capacity_107: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -821,18 +735,14 @@ fn run() with Stdout {
     }
     __assert_22: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_110: {
-                break __inline_String__with_capacity_110: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             Box<i32> { value: 511 }."i32^Octal::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0o777");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_111: {
-                    break __inline_String__with_capacity_111: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -854,9 +764,7 @@ fn run() with Stdout {
     }
     __assert_23: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_114: {
-                break __inline_String__with_capacity_114: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_115: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_115: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -866,9 +774,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"2a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_116: {
-                    break __inline_String__with_capacity_116: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -890,9 +796,7 @@ fn run() with Stdout {
     }
     __assert_24: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_119: {
-                break __inline_String__with_capacity_119: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_120: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_120: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -902,9 +806,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"2A");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_121: {
-                    break __inline_String__with_capacity_121: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -926,9 +828,7 @@ fn run() with Stdout {
     }
     __assert_25: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_124: {
-                break __inline_String__with_capacity_124: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_125: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_125: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -938,9 +838,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"ff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_126: {
-                    break __inline_String__with_capacity_126: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -962,9 +860,7 @@ fn run() with Stdout {
     }
     __assert_26: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_129: {
-                break __inline_String__with_capacity_129: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_130: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_130: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -974,9 +870,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"FF");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_131: {
-                    break __inline_String__with_capacity_131: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -998,18 +892,14 @@ fn run() with Stdout {
     }
     __assert_27: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_134: {
-                break __inline_String__with_capacity_134: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             Box<i32> { value: 255 }."i32^LowerHex::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0xff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_135: {
-                    break __inline_String__with_capacity_135: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1031,18 +921,14 @@ fn run() with Stdout {
     }
     __assert_28: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_138: {
-                break __inline_String__with_capacity_138: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             Box<i32> { value: 255 }."i32^UpperHex::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0XFF");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_139: {
-                    break __inline_String__with_capacity_139: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1064,18 +950,14 @@ fn run() with Stdout {
     }
     __assert_29: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_142: {
-                break __inline_String__with_capacity_142: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: true, width: 10, precision: -1, buf: &mut __r };
             Box<i32> { value: 255 }."i32^LowerHex::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0x000000ff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_143: {
-                    break __inline_String__with_capacity_143: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1097,9 +979,7 @@ fn run() with Stdout {
     }
     __assert_30: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_146: {
-                break __inline_String__with_capacity_146: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_147: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_147: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1109,9 +989,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"ffffffff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_148: {
-                    break __inline_String__with_capacity_148: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1133,9 +1011,7 @@ fn run() with Stdout {
     }
     __assert_31: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_151: {
-                break __inline_String__with_capacity_151: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_152: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_152: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1145,9 +1021,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"11111111111111111111111111111111");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_153: {
-                    break __inline_String__with_capacity_153: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1169,9 +1043,7 @@ fn run() with Stdout {
     }
     __assert_32: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_156: {
-                break __inline_String__with_capacity_156: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_157: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_157: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1181,9 +1053,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"7fffffffffffffff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_158: {
-                    break __inline_String__with_capacity_158: String { repr: "array_new<u8>"(114), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1205,9 +1075,7 @@ fn run() with Stdout {
     }
     __assert_33: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_161: {
-                break __inline_String__with_capacity_161: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_162: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_162: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1221,9 +1089,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_164: {
-                    break __inline_String__with_capacity_164: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1245,9 +1111,7 @@ fn run() with Stdout {
     }
     __assert_34: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_167: {
-                break __inline_String__with_capacity_167: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_168: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_168: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1257,9 +1121,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_169: {
-                    break __inline_String__with_capacity_169: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1281,9 +1143,7 @@ fn run() with Stdout {
     }
     __assert_35: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_172: {
-                break __inline_String__with_capacity_172: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_173: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_173: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1297,9 +1157,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"ffffffffffffffff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_175: {
-                    break __inline_String__with_capacity_175: String { repr: "array_new<u8>"(114), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1321,9 +1179,7 @@ fn run() with Stdout {
     }
     __assert_36: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_178: {
-                break __inline_String__with_capacity_178: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_179: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_179: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1337,9 +1193,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"FFFFFFFFFFFFFFFF");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_181: {
-                    break __inline_String__with_capacity_181: String { repr: "array_new<u8>"(114), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1361,9 +1215,7 @@ fn run() with Stdout {
     }
     __assert_37: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_184: {
-                break __inline_String__with_capacity_184: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_185: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_185: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1377,9 +1229,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"1777777777777777777777");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_187: {
-                    break __inline_String__with_capacity_187: String { repr: "array_new<u8>"(120), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(120), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1401,9 +1251,7 @@ fn run() with Stdout {
     }
     __assert_38: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_190: {
-                break __inline_String__with_capacity_190: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_191: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_191: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1417,9 +1265,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_193: {
-                    break __inline_String__with_capacity_193: String { repr: "array_new<u8>"(99), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(99), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1441,9 +1287,7 @@ fn run() with Stdout {
     }
     __assert_39: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_196: {
-                break __inline_String__with_capacity_196: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             __inline_u64_LowerHex__fmt_197: {
                 let self: Box<u64> = move Box<u64> { value: 1 };
@@ -1454,9 +1298,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"0x1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_198: {
-                    break __inline_String__with_capacity_198: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1479,9 +1321,7 @@ fn run() with Stdout {
     let i128_val: i128 = move i128::from_i64(255);
     __assert_40: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_201: {
-                break __inline_String__with_capacity_201: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_202: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_202: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1495,9 +1335,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"ff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_204: {
-                    break __inline_String__with_capacity_204: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1519,9 +1357,7 @@ fn run() with Stdout {
     }
     __assert_41: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_207: {
-                break __inline_String__with_capacity_207: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_208: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_208: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1535,9 +1371,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"FF");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_210: {
-                    break __inline_String__with_capacity_210: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1559,9 +1393,7 @@ fn run() with Stdout {
     }
     __assert_42: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_213: {
-                break __inline_String__with_capacity_213: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_214: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_214: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1575,9 +1407,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"11111111");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_216: {
-                    break __inline_String__with_capacity_216: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1599,9 +1429,7 @@ fn run() with Stdout {
     }
     __assert_43: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_219: {
-                break __inline_String__with_capacity_219: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_220: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_220: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1615,9 +1443,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"377");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_222: {
-                    break __inline_String__with_capacity_222: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1639,9 +1465,7 @@ fn run() with Stdout {
     }
     __assert_44: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_225: {
-                break __inline_String__with_capacity_225: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             __inline_i128_LowerHex__fmt_226: {
                 let self: &i128 = &i128_val;
@@ -1652,9 +1476,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"0xff");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_227: {
-                    break __inline_String__with_capacity_227: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1674,14 +1496,10 @@ fn run() with Stdout {
             });
         }
     }
-    let neg_i128: i128 = __inline_i128__from_pair_230: {
-        break __inline_i128__from_pair_230: i128 { low: 18446744073709551615, high: -1 };
-    };
+    let neg_i128: i128 = move i128 { low: 18446744073709551615, high: -1 };
     __assert_45: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_231: {
-                break __inline_String__with_capacity_231: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_232: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_232: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1695,9 +1513,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_234: {
-                    break __inline_String__with_capacity_234: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1719,9 +1535,7 @@ fn run() with Stdout {
     }
     __assert_46: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_237: {
-                break __inline_String__with_capacity_237: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_238: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_238: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1735,9 +1549,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_240: {
-                    break __inline_String__with_capacity_240: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1757,14 +1569,10 @@ fn run() with Stdout {
             });
         }
     }
-    let u128_val: u128 = __inline_u128__from_u64_243: {
-        break __inline_u128__from_u64_243: u128 { low: 256, high: 0 };
-    };
+    let u128_val: u128 = move u128 { low: 256, high: 0 };
     __assert_47: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_244: {
-                break __inline_String__with_capacity_244: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_245: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_245: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1778,9 +1586,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"100");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_247: {
-                    break __inline_String__with_capacity_247: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1802,9 +1608,7 @@ fn run() with Stdout {
     }
     __assert_48: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_250: {
-                break __inline_String__with_capacity_250: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_251: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_251: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1818,9 +1622,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"100000000");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_253: {
-                    break __inline_String__with_capacity_253: String { repr: "array_new<u8>"(107), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(107), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1842,9 +1644,7 @@ fn run() with Stdout {
     }
     __assert_49: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_256: {
-                break __inline_String__with_capacity_256: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_257: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_257: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1858,9 +1658,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"400");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_259: {
-                    break __inline_String__with_capacity_259: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1882,9 +1680,7 @@ fn run() with Stdout {
     }
     __assert_50: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_262: {
-                break __inline_String__with_capacity_262: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             __inline_u128_UpperHex__fmt_263: {
                 let self: &u128 = &u128_val;
@@ -1895,9 +1691,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"0X100");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_264: {
-                    break __inline_String__with_capacity_264: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1919,9 +1713,7 @@ fn run() with Stdout {
     }
     __assert_51: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_267: {
-                break __inline_String__with_capacity_267: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: true, alternate: false, zero_pad: true, width: 10, precision: -1, buf: &mut __r };
             __inline_i32_Display__fmt_268: {
                 let self: Box<i32> = move Box<i32> { value: 42 };
@@ -1932,9 +1724,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"+000000042");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_269: {
-                    break __inline_String__with_capacity_269: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1956,18 +1746,14 @@ fn run() with Stdout {
     }
     __assert_52: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_272: {
-                break __inline_String__with_capacity_272: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '0', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: true, width: 10, precision: -1, buf: &mut __r };
             Box<i32> { value: 42 }."i32^LowerHex::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0x0000002a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_273: {
-                    break __inline_String__with_capacity_273: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1989,18 +1775,14 @@ fn run() with Stdout {
     }
     __assert_53: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_276: {
-                break __inline_String__with_capacity_276: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             Box<i32> { value: 42 }."i32^LowerHex::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"2a        ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_277: {
-                    break __inline_String__with_capacity_277: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2022,9 +1804,7 @@ fn run() with Stdout {
     }
     __assert_54: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_280: {
-                break __inline_String__with_capacity_280: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_String_Display__fmt_281: {
                 let self: &String = &s;
@@ -2035,9 +1815,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"     hello");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_282: {
-                    break __inline_String__with_capacity_282: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2059,9 +1837,7 @@ fn run() with Stdout {
     }
     __assert_55: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_285: {
-                break __inline_String__with_capacity_285: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_String_Display__fmt_286: {
                 let self: &String = &s;
@@ -2072,9 +1848,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"hello     ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_287: {
-                    break __inline_String__with_capacity_287: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2096,9 +1870,7 @@ fn run() with Stdout {
     }
     __assert_56: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_290: {
-                break __inline_String__with_capacity_290: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: -1, buf: &mut __r };
             __inline_String_Display__fmt_291: {
                 let self: &String = &s;
@@ -2109,9 +1881,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"  hello   ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_292: {
-                    break __inline_String__with_capacity_292: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2133,9 +1903,7 @@ fn run() with Stdout {
     }
     __assert_57: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_295: {
-                break __inline_String__with_capacity_295: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_296: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_296: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2153,9 +1921,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"true");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_298: {
-                    break __inline_String__with_capacity_298: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2177,9 +1943,7 @@ fn run() with Stdout {
     }
     __assert_58: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_301: {
-                break __inline_String__with_capacity_301: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_302: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_302: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2197,9 +1961,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"false");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_304: {
-                    break __inline_String__with_capacity_304: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2221,9 +1983,7 @@ fn run() with Stdout {
     }
     __assert_59: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_307: {
-                break __inline_String__with_capacity_307: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_308: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_308: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2233,9 +1993,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-101010");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_309: {
-                    break __inline_String__with_capacity_309: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2257,9 +2015,7 @@ fn run() with Stdout {
     }
     __assert_60: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_312: {
-                break __inline_String__with_capacity_312: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_313: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_313: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2269,9 +2025,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-52");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_314: {
-                    break __inline_String__with_capacity_314: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2293,9 +2047,7 @@ fn run() with Stdout {
     }
     __assert_61: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_317: {
-                break __inline_String__with_capacity_317: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_318: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_318: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2305,9 +2057,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-2a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_319: {
-                    break __inline_String__with_capacity_319: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2329,18 +2079,14 @@ fn run() with Stdout {
     }
     __assert_62: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_322: {
-                break __inline_String__with_capacity_322: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: true, zero_pad: false, width: -1, precision: -1, buf: &mut __r };
             Box<i32> { value: -42 }."i32^LowerHex::fmt"(&mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"-0x2a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_323: {
-                    break __inline_String__with_capacity_323: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers_float.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers_float.lowered.wado
@@ -21,9 +21,7 @@
 fn run() with Stdout {
     __assert_0: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -37,9 +35,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"3.14159");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -61,9 +57,7 @@ fn run() with Stdout {
     }
     __assert_1: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_6: {
-                break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_7: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -77,9 +71,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-2.71828");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -101,9 +93,7 @@ fn run() with Stdout {
     }
     __assert_2: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_12: {
-                break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_13: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -117,9 +107,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"0.0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -141,9 +129,7 @@ fn run() with Stdout {
     }
     __assert_3: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_18: {
-                break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_19: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_19: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -157,9 +143,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"1.0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -181,9 +165,7 @@ fn run() with Stdout {
     }
     __assert_4: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_24: {
-                break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_25: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_25: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -197,9 +179,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"0.5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -221,9 +201,7 @@ fn run() with Stdout {
     }
     __assert_5: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_30: {
-                break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_31: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_31: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -237,9 +215,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"-0.5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -261,9 +237,7 @@ fn run() with Stdout {
     }
     __assert_6: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_36: {
-                break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_37: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_37: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -277,9 +251,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"100.0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -301,18 +273,14 @@ fn run() with Stdout {
     }
     __assert_7: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_42: {
-                break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             fmt_f64_fixed(3.14159, 1, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.1");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -334,18 +302,14 @@ fn run() with Stdout {
     }
     __assert_8: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_46: {
-                break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -367,18 +331,14 @@ fn run() with Stdout {
     }
     __assert_9: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_50: {
-                break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 3, buf: &mut __r };
             fmt_f64_fixed(3.14159, 3, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.142");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_51: {
-                    break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -400,18 +360,14 @@ fn run() with Stdout {
     }
     __assert_10: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_54: {
-                break __inline_String__with_capacity_54: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
             fmt_f64_fixed(3.14159, 4, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.1416");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -433,18 +389,14 @@ fn run() with Stdout {
     }
     __assert_11: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_58: {
-                break __inline_String__with_capacity_58: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 5, buf: &mut __r };
             fmt_f64_fixed(3.14159, 5, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14159");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_59: {
-                    break __inline_String__with_capacity_59: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -466,18 +418,14 @@ fn run() with Stdout {
     }
     __assert_12: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_62: {
-                break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 6, buf: &mut __r };
             fmt_f64_fixed(3.14159, 6, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.141590");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_63: {
-                    break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -499,18 +447,14 @@ fn run() with Stdout {
     }
     __assert_13: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_66: {
-                break __inline_String__with_capacity_66: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f64_fixed(-2.71828, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"-2.72");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_67: {
-                    break __inline_String__with_capacity_67: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -532,18 +476,14 @@ fn run() with Stdout {
     }
     __assert_14: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_70: {
-                break __inline_String__with_capacity_70: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
             fmt_f64_fixed(-2.71828, 4, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"-2.7183");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_71: {
-                    break __inline_String__with_capacity_71: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -565,18 +505,14 @@ fn run() with Stdout {
     }
     __assert_15: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_74: {
-                break __inline_String__with_capacity_74: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f64_fixed(0.0, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0.00");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_75: {
-                    break __inline_String__with_capacity_75: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -598,18 +534,14 @@ fn run() with Stdout {
     }
     __assert_16: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_78: {
-                break __inline_String__with_capacity_78: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f64_fixed(100.0, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"100.00");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_79: {
-                    break __inline_String__with_capacity_79: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -631,9 +563,7 @@ fn run() with Stdout {
     }
     __assert_17: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_82: {
-                break __inline_String__with_capacity_82: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_83: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_83: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -641,17 +571,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_84: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_85: {
-                    break __inline_Formatter__precision_85: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14159e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_86: {
-                    break __inline_String__with_capacity_86: String { repr: "array_new<u8>"(107), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(107), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -673,9 +599,7 @@ fn run() with Stdout {
     }
     __assert_18: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_89: {
-                break __inline_String__with_capacity_89: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_90: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_90: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -683,17 +607,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_91: {
                 let self: Box<f64> = move Box<f64> { value: -2.71828 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_92: {
-                    break __inline_Formatter__precision_92: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"-2.71828e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_93: {
-                    break __inline_String__with_capacity_93: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -715,9 +635,7 @@ fn run() with Stdout {
     }
     __assert_19: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_96: {
-                break __inline_String__with_capacity_96: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_97: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_97: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -725,17 +643,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_98: {
                 let self: Box<f64> = move Box<f64> { value: 0.0 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_99: {
-                    break __inline_Formatter__precision_99: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"0e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_100: {
-                    break __inline_String__with_capacity_100: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -757,9 +671,7 @@ fn run() with Stdout {
     }
     __assert_20: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_103: {
-                break __inline_String__with_capacity_103: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_104: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_104: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -767,17 +679,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_105: {
                 let self: Box<f64> = move Box<f64> { value: 1.0 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_106: {
-                    break __inline_Formatter__precision_106: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_107: {
-                    break __inline_String__with_capacity_107: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -799,9 +707,7 @@ fn run() with Stdout {
     }
     __assert_21: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_110: {
-                break __inline_String__with_capacity_110: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_111: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_111: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -809,17 +715,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_112: {
                 let self: Box<f64> = move Box<f64> { value: 100.0 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_113: {
-                    break __inline_Formatter__precision_113: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1e2");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_114: {
-                    break __inline_String__with_capacity_114: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -841,9 +743,7 @@ fn run() with Stdout {
     }
     __assert_22: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_117: {
-                break __inline_String__with_capacity_117: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_118: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_118: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -851,17 +751,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_119: {
                 let self: Box<f64> = move Box<f64> { value: 1.23e15 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_120: {
-                    break __inline_Formatter__precision_120: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.23e15");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_121: {
-                    break __inline_String__with_capacity_121: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -883,9 +779,7 @@ fn run() with Stdout {
     }
     __assert_23: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_124: {
-                break __inline_String__with_capacity_124: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_125: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_125: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -893,17 +787,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_126: {
                 let self: Box<f64> = move Box<f64> { value: 1.5e-10 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_127: {
-                    break __inline_Formatter__precision_127: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.5e-10");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_128: {
-                    break __inline_String__with_capacity_128: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -925,9 +815,7 @@ fn run() with Stdout {
     }
     __assert_24: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_131: {
-                break __inline_String__with_capacity_131: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_132: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_132: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -935,17 +823,13 @@ fn run() with Stdout {
             __inline_f64_UpperExp__fmt_133: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_134: {
-                    break __inline_Formatter__precision_134: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14159E0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_135: {
-                    break __inline_String__with_capacity_135: String { repr: "array_new<u8>"(107), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(107), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -967,9 +851,7 @@ fn run() with Stdout {
     }
     __assert_25: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_138: {
-                break __inline_String__with_capacity_138: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_139: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_139: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -977,17 +859,13 @@ fn run() with Stdout {
             __inline_f64_UpperExp__fmt_140: {
                 let self: Box<f64> = move Box<f64> { value: -2.71828 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_141: {
-                    break __inline_Formatter__precision_141: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"-2.71828E0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_142: {
-                    break __inline_String__with_capacity_142: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1009,9 +887,7 @@ fn run() with Stdout {
     }
     __assert_26: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_145: {
-                break __inline_String__with_capacity_145: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_146: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_146: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1019,17 +895,13 @@ fn run() with Stdout {
             __inline_f64_UpperExp__fmt_147: {
                 let self: Box<f64> = move Box<f64> { value: 0.0 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_148: {
-                    break __inline_Formatter__precision_148: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"0E0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_149: {
-                    break __inline_String__with_capacity_149: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1051,9 +923,7 @@ fn run() with Stdout {
     }
     __assert_27: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_152: {
-                break __inline_String__with_capacity_152: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_153: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_153: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1061,17 +931,13 @@ fn run() with Stdout {
             __inline_f64_UpperExp__fmt_154: {
                 let self: Box<f64> = move Box<f64> { value: 1.23e15 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_155: {
-                    break __inline_Formatter__precision_155: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.23E15");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_156: {
-                    break __inline_String__with_capacity_156: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1093,9 +959,7 @@ fn run() with Stdout {
     }
     __assert_28: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_159: {
-                break __inline_String__with_capacity_159: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_160: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_160: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1103,17 +967,13 @@ fn run() with Stdout {
             __inline_f64_UpperExp__fmt_161: {
                 let self: Box<f64> = move Box<f64> { value: 1.5e-10 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_162: {
-                    break __inline_Formatter__precision_162: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.5E-10");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_163: {
-                    break __inline_String__with_capacity_163: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1135,24 +995,18 @@ fn run() with Stdout {
     }
     __assert_29: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_166: {
-                break __inline_String__with_capacity_166: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_167: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_168: {
-                    break __inline_Formatter__precision_168: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.1e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_169: {
-                    break __inline_String__with_capacity_169: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1174,24 +1028,18 @@ fn run() with Stdout {
     }
     __assert_30: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_172: {
-                break __inline_String__with_capacity_172: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             __inline_f64_LowerExp__fmt_173: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_174: {
-                    break __inline_Formatter__precision_174: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_175: {
-                    break __inline_String__with_capacity_175: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1213,24 +1061,18 @@ fn run() with Stdout {
     }
     __assert_31: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_178: {
-                break __inline_String__with_capacity_178: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
             __inline_f64_LowerExp__fmt_179: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_180: {
-                    break __inline_Formatter__precision_180: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.1416e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_181: {
-                    break __inline_String__with_capacity_181: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1252,24 +1094,18 @@ fn run() with Stdout {
     }
     __assert_32: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_184: {
-                break __inline_String__with_capacity_184: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             __inline_f64_UpperExp__fmt_185: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_186: {
-                    break __inline_Formatter__precision_186: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.1E0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_187: {
-                    break __inline_String__with_capacity_187: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1291,24 +1127,18 @@ fn run() with Stdout {
     }
     __assert_33: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_190: {
-                break __inline_String__with_capacity_190: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             __inline_f64_UpperExp__fmt_191: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_192: {
-                    break __inline_Formatter__precision_192: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14E0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_193: {
-                    break __inline_String__with_capacity_193: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1330,24 +1160,18 @@ fn run() with Stdout {
     }
     __assert_34: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_196: {
-                break __inline_String__with_capacity_196: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             __inline_f64_LowerExp__fmt_197: {
                 let self: Box<f64> = move Box<f64> { value: -2.71828 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_198: {
-                    break __inline_Formatter__precision_198: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"-2.72e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_199: {
-                    break __inline_String__with_capacity_199: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1369,24 +1193,18 @@ fn run() with Stdout {
     }
     __assert_35: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_202: {
-                break __inline_String__with_capacity_202: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_203: {
                 let self: Box<f64> = move Box<f64> { value: 1.23e15 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_204: {
-                    break __inline_Formatter__precision_204: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.2e15");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_205: {
-                    break __inline_String__with_capacity_205: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1408,24 +1226,18 @@ fn run() with Stdout {
     }
     __assert_36: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_208: {
-                break __inline_String__with_capacity_208: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             __inline_f64_LowerExp__fmt_209: {
                 let self: Box<f64> = move Box<f64> { value: 1.23e15 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_210: {
-                    break __inline_Formatter__precision_210: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.23e15");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_211: {
-                    break __inline_String__with_capacity_211: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1447,24 +1259,18 @@ fn run() with Stdout {
     }
     __assert_37: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_214: {
-                break __inline_String__with_capacity_214: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 3, buf: &mut __r };
             __inline_f64_LowerExp__fmt_215: {
                 let self: Box<f64> = move Box<f64> { value: 1.5e-10 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_216: {
-                    break __inline_Formatter__precision_216: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.500e-10");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_217: {
-                    break __inline_String__with_capacity_217: String { repr: "array_new<u8>"(107), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(107), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1486,24 +1292,18 @@ fn run() with Stdout {
     }
     __assert_38: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_220: {
-                break __inline_String__with_capacity_220: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             __inline_f64_LowerExp__fmt_221: {
                 let self: Box<f64> = move Box<f64> { value: 0.0 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_222: {
-                    break __inline_Formatter__precision_222: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"0.00e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_223: {
-                    break __inline_String__with_capacity_223: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1525,9 +1325,7 @@ fn run() with Stdout {
     }
     __assert_39: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_226: {
-                break __inline_String__with_capacity_226: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_227: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_227: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -1535,17 +1333,13 @@ fn run() with Stdout {
             __inline_f64_LowerExp__fmt_228: {
                 let self: Box<f64> = move Box<f64> { value: 123456.789 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_229: {
-                    break __inline_Formatter__precision_229: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.23456789e5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_230: {
-                    break __inline_String__with_capacity_230: String { repr: "array_new<u8>"(110), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(110), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1567,24 +1361,18 @@ fn run() with Stdout {
     }
     __assert_40: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_233: {
-                break __inline_String__with_capacity_233: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_234: {
                 let self: Box<f64> = move Box<f64> { value: 123456.789 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_235: {
-                    break __inline_Formatter__precision_235: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.2e5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_236: {
-                    break __inline_String__with_capacity_236: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1606,24 +1394,18 @@ fn run() with Stdout {
     }
     __assert_41: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_239: {
-                break __inline_String__with_capacity_239: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
             __inline_f64_LowerExp__fmt_240: {
                 let self: Box<f64> = move Box<f64> { value: 123456.789 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_241: {
-                    break __inline_Formatter__precision_241: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.2346e5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_242: {
-                    break __inline_String__with_capacity_242: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1645,18 +1427,14 @@ fn run() with Stdout {
     }
     __assert_42: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_245: {
-                break __inline_String__with_capacity_245: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"      3.14");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_246: {
-                    break __inline_String__with_capacity_246: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1678,18 +1456,14 @@ fn run() with Stdout {
     }
     __assert_43: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_249: {
-                break __inline_String__with_capacity_249: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14      ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_250: {
-                    break __inline_String__with_capacity_250: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1711,18 +1485,14 @@ fn run() with Stdout {
     }
     __assert_44: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_253: {
-                break __inline_String__with_capacity_253: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"   3.14   ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_254: {
-                    break __inline_String__with_capacity_254: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1744,18 +1514,14 @@ fn run() with Stdout {
     }
     __assert_45: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_257: {
-                break __inline_String__with_capacity_257: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '*', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"******3.14");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_258: {
-                    break __inline_String__with_capacity_258: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1777,18 +1543,14 @@ fn run() with Stdout {
     }
     __assert_46: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_261: {
-                break __inline_String__with_capacity_261: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '*', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14******");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_262: {
-                    break __inline_String__with_capacity_262: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1810,18 +1572,14 @@ fn run() with Stdout {
     }
     __assert_47: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_265: {
-                break __inline_String__with_capacity_265: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: '*', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
             fmt_f64_fixed(3.14159, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"***3.14***");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_266: {
-                    break __inline_String__with_capacity_266: String { repr: "array_new<u8>"(108), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(108), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1843,9 +1601,7 @@ fn run() with Stdout {
     }
     __assert_48: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_269: {
-                break __inline_String__with_capacity_269: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 15, precision: -1, buf: &mut __r };
             __inline_f64_Display__fmt_270: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
@@ -1856,9 +1612,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"        3.14159");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_271: {
-                    break __inline_String__with_capacity_271: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1880,9 +1634,7 @@ fn run() with Stdout {
     }
     __assert_49: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_274: {
-                break __inline_String__with_capacity_274: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 15, precision: -1, buf: &mut __r };
             __inline_f64_Display__fmt_275: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
@@ -1893,9 +1645,7 @@ fn run() with Stdout {
         }."String^Eq::eq"(&"3.14159        ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_276: {
-                    break __inline_String__with_capacity_276: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1917,24 +1667,18 @@ fn run() with Stdout {
     }
     __assert_50: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_279: {
-                break __inline_String__with_capacity_279: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 15, precision: -1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_280: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_281: {
-                    break __inline_Formatter__precision_281: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"      3.14159e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_282: {
-                    break __inline_String__with_capacity_282: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1956,24 +1700,18 @@ fn run() with Stdout {
     }
     __assert_51: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_285: {
-                break __inline_String__with_capacity_285: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 15, precision: -1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_286: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_287: {
-                    break __inline_Formatter__precision_287: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14159e0      ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_288: {
-                    break __inline_String__with_capacity_288: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1995,24 +1733,18 @@ fn run() with Stdout {
     }
     __assert_52: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_291: {
-                break __inline_String__with_capacity_291: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 15, precision: -1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_292: {
                 let self: Box<f64> = move Box<f64> { value: -2.71828 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_293: {
-                    break __inline_Formatter__precision_293: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"     -2.71828e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_294: {
-                    break __inline_String__with_capacity_294: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2034,24 +1766,18 @@ fn run() with Stdout {
     }
     __assert_53: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_297: {
-                break __inline_String__with_capacity_297: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 15, precision: -1, buf: &mut __r };
             __inline_f64_LowerExp__fmt_298: {
                 let self: Box<f64> = move Box<f64> { value: -2.71828 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_299: {
-                    break __inline_Formatter__precision_299: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"-2.71828e0     ");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_300: {
-                    break __inline_String__with_capacity_300: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2074,18 +1800,14 @@ fn run() with Stdout {
     let f: f32 = 3.14 as f32;
     __assert_54: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_303: {
-                break __inline_String__with_capacity_303: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f32_fixed(f, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.14");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_304: {
-                    break __inline_String__with_capacity_304: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2107,18 +1829,14 @@ fn run() with Stdout {
     }
     __assert_55: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_307: {
-                break __inline_String__with_capacity_307: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
             fmt_f32_fixed(f, 4, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"3.1400");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_308: {
-                    break __inline_String__with_capacity_308: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2141,18 +1859,14 @@ fn run() with Stdout {
     let f2: f32 = 2.5 as f32;
     __assert_56: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_311: {
-                break __inline_String__with_capacity_311: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             fmt_f32_fixed(f2, 1, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"2.5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_312: {
-                    break __inline_String__with_capacity_312: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2174,18 +1888,14 @@ fn run() with Stdout {
     }
     __assert_57: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_315: {
-                break __inline_String__with_capacity_315: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 3, buf: &mut __r };
             fmt_f32_fixed(f2, 3, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"2.500");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_316: {
-                    break __inline_String__with_capacity_316: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2207,24 +1917,18 @@ fn run() with Stdout {
     }
     __assert_58: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_319: {
-                break __inline_String__with_capacity_319: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             __inline_f32_LowerExp__fmt_320: {
                 let self: Box<f32> = move Box<f32> { value: f2 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, __inline_Formatter__precision_321: {
-                    break __inline_Formatter__precision_321: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"2.5e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_322: {
-                    break __inline_String__with_capacity_322: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2246,24 +1950,18 @@ fn run() with Stdout {
     }
     __assert_59: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_325: {
-                break __inline_String__with_capacity_325: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
             __inline_f32_UpperExp__fmt_326: {
                 let self: Box<f32> = move Box<f32> { value: f2 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, __inline_Formatter__precision_327: {
-                    break __inline_Formatter__precision_327: f.precision;
-                }, 1, f);
+                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, f.precision, 1, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"2.5E0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_328: {
-                    break __inline_String__with_capacity_328: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2285,9 +1983,7 @@ fn run() with Stdout {
     }
     __assert_60: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_331: {
-                break __inline_String__with_capacity_331: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_332: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_332: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2295,17 +1991,13 @@ fn run() with Stdout {
             __inline_f32_LowerExp__fmt_333: {
                 let self: Box<f32> = move Box<f32> { value: f2 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, __inline_Formatter__precision_334: {
-                    break __inline_Formatter__precision_334: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"2.5e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_335: {
-                    break __inline_String__with_capacity_335: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2328,18 +2020,14 @@ fn run() with Stdout {
     let fz: f32 = 0.0 as f32;
     __assert_61: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_338: {
-                break __inline_String__with_capacity_338: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f32_fixed(fz, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"0.00");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_339: {
-                    break __inline_String__with_capacity_339: String { repr: "array_new<u8>"(102), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(102), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2361,9 +2049,7 @@ fn run() with Stdout {
     }
     __assert_62: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_342: {
-                break __inline_String__with_capacity_342: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_343: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_343: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -2371,17 +2057,13 @@ fn run() with Stdout {
             __inline_f32_LowerExp__fmt_344: {
                 let self: Box<f32> = move Box<f32> { value: fz };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, __inline_Formatter__precision_345: {
-                    break __inline_Formatter__precision_345: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f32_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"0e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_346: {
-                    break __inline_String__with_capacity_346: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2403,24 +2085,18 @@ fn run() with Stdout {
     }
     __assert_63: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_349: {
-                break __inline_String__with_capacity_349: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 0, buf: &mut __r };
             __inline_f64_LowerExp__fmt_350: {
                 let self: Box<f64> = move Box<f64> { value: 3.14159 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_351: {
-                    break __inline_Formatter__precision_351: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"3e0");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_352: {
-                    break __inline_String__with_capacity_352: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2442,24 +2118,18 @@ fn run() with Stdout {
     }
     __assert_64: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_355: {
-                break __inline_String__with_capacity_355: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 0, buf: &mut __r };
             __inline_f64_LowerExp__fmt_356: {
                 let self: Box<f64> = move Box<f64> { value: 123456.789 };
                 let f: &mut Formatter = &mut __f;
-                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, __inline_Formatter__precision_357: {
-                    break __inline_Formatter__precision_357: f.precision;
-                }, 0, f);
+                "core::prelude/primitives.wado::fmt_f64_exp"(self.value, f.precision, 0, f);
             };
             break __tmpl: __r;
         }."String^Eq::eq"(&"1e5");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_358: {
-                    break __inline_String__with_capacity_358: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2481,18 +2151,14 @@ fn run() with Stdout {
     }
     __assert_65: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_361: {
-                break __inline_String__with_capacity_361: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
             fmt_f64_fixed(-0.0, 2, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"-0.00");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_362: {
-                    break __inline_String__with_capacity_362: String { repr: "array_new<u8>"(103), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(103), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -2514,18 +2180,14 @@ fn run() with Stdout {
     }
     __assert_66: {
         let __cond: bool = __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_365: {
-                break __inline_String__with_capacity_365: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = move Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 10, buf: &mut __r };
             fmt_f64_fixed(1.0, 10, &mut __f);
             break __tmpl: __r;
         }."String^Eq::eq"(&"1.0000000000");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_366: {
-                    break __inline_String__with_capacity_366: String { repr: "array_new<u8>"(110), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(110), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/enum-display-basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/enum-display-basic.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
     let g: Color = Color::Green;
     let b: Color = Color::Blue;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -31,9 +29,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -42,9 +38,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/enum-display-template.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/enum-display-template.lowered.wado
@@ -18,9 +18,7 @@ enum Fruit {
 fn describe(f: Fruit) -> String {
     return match f {
         Apple => __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "I like ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn describe(f: Fruit) -> String {
             break __tmpl: __r;
         },
         Banana => __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_2: {
-                break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(26), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_3: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -42,9 +38,7 @@ fn describe(f: Fruit) -> String {
             break __tmpl: __r;
         },
         Cherry => __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_4: {
-                break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(25), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_5: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -59,9 +53,7 @@ fn describe(f: Fruit) -> String {
 fn run() with Stdout {
     let f: Fruit = Fruit::Apple;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "fruit: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/float_to_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/float_to_string.lowered.wado
@@ -12,9 +12,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f is ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -28,9 +26,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "pi is approximately ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -45,9 +41,7 @@ fn run() with Stdout {
     });
     let result: f64 = (10.5 + 2.5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "10.5 + 2.5 = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/for_break.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_break.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
             }
             __for_0_body: {
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_0: {
-                        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(19), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
                     __r.String::append(move "i: ");
                     let mut __f: Formatter = __inline_Formatter__new_1: {
                         let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/for_continue.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_continue.lowered.wado
@@ -21,9 +21,7 @@ fn run() with Stdout {
                     break __for_0_body;
                 }
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_0: {
-                        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(19), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
                     __r.String::append(move "i: ");
                     let mut __f: Formatter = __inline_Formatter__new_1: {
                         let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/for_let_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_let_basic.lowered.wado
@@ -17,11 +17,7 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let items: Array<i32> = move [10, 20, 30];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };
     let mut count: i32 = 0;
     __for_0: {
         loop {
@@ -30,9 +26,7 @@ fn run() with Stdout {
                 let x: i32 = __unwrap_option(__pattern_temp_0).value;
                 __for_0_body: {
                     core::cli::println(__tmpl: {
-                        let mut __r: String = __inline_String__with_capacity_2: {
-                            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(39), used: 0 };
-                        };
+                        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
                         __r.String::append(move "item ");
                         let mut __f: Formatter = __inline_Formatter__new_3: {
                             let buf: &mut String = &mut __r;
@@ -63,9 +57,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "total: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/for_of_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_basic.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     let numbers: Array<i32> = move [1, 2, 3, 4, 5];
     let mut sum: i32 = 0;
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
@@ -33,9 +31,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "sum = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/for_of_break.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_break.lowered.wado
@@ -18,9 +18,7 @@ pub struct "ArrayIter<i32>" {
 fn run() with Stdout {
     let numbers: Array<i32> = move [1, 2, 3, 4, 5];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
@@ -29,9 +27,7 @@ fn run() with Stdout {
                     break;
                 }
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/for_of_continue.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_continue.lowered.wado
@@ -18,9 +18,7 @@ pub struct "ArrayIter<i32>" {
 fn run() with Stdout {
     let numbers: Array<i32> = move [1, 2, 3, 4, 5];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
@@ -29,9 +27,7 @@ fn run() with Stdout {
                     continue;
                 }
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/for_of_empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_empty.lowered.wado
@@ -18,17 +18,13 @@ pub struct "ArrayIter<i32>" {
 fn run() with Stdout {
     let empty: Array<i32> = move [];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: empty.repr, used: empty.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: empty.repr, used: empty.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let item: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(34), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
                     __r.String::append(move "should not print: ");
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/for_of_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_mut.lowered.wado
@@ -18,18 +18,14 @@ pub struct "ArrayIter<i32>" {
 fn run() with Stdout {
     let numbers: Array<i32> = move [1, 2, 3];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: numbers.repr, used: numbers.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let n: i32 = __unwrap_option(__pattern_temp_0).value;
                 n = (n * 2);
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/for_of_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_nested.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     let outer: Array<i32> = move [1, 2, 3];
     let inner: Array<i32> = move [10, 20];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: outer.repr, used: outer.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: outer.repr, used: outer.used, index: 0 };
         let _licm_repr: builtin::array<i32> = inner.repr;
         let _licm_used: i32 = inner.used;
         loop {
@@ -29,17 +27,13 @@ fn run() with Stdout {
             if __is_not_null(__pattern_temp_0) {
                 let i: i32 = __unwrap_option(__pattern_temp_0).value;
                 __for_of_1: {
-                    let mut __iter_1: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_1: {
-                        break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: _licm_repr, used: _licm_used, index: 0 };
-                    };
+                    let mut __iter_1: ArrayIter<i32> = move ArrayIter<i32> { repr: _licm_repr, used: _licm_used, index: 0 };
                     loop {
                         let __pattern_temp_1: Option<i32> = __iter_1."ArrayIter<i32>^Iterator::next"();
                         if __is_not_null(__pattern_temp_1) {
                             let j: i32 = __unwrap_option(__pattern_temp_1).value;
                             core::cli::println(__tmpl: {
-                                let mut __r: String = __inline_String__with_capacity_2: {
-                                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(33), used: 0 };
-                                };
+                                let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
                                 let mut __f: Formatter = __inline_Formatter__new_3: {
                                     let buf: &mut String = &mut __r;
                                     break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/for_of_side_effect.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_side_effect.lowered.wado
@@ -31,9 +31,7 @@ fn run() with Stdout {
             if __is_not_null(__pattern_temp_0) {
                 let n: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/for_of_strings.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_strings.lowered.wado
@@ -18,17 +18,13 @@ pub struct "ArrayIter<String>" {
 fn run() with Stdout {
     let names: Array<String> = move ["Alice", "Bob", "Charlie"];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<String> = __inline_Array_String__IntoIterator__into_iter_0: {
-            break __inline_Array_String__IntoIterator__into_iter_0: ArrayIter<String> { repr: names.repr, used: names.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<String> = move ArrayIter<String> { repr: names.repr, used: names.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<String> = move __iter_0."ArrayIter<String>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let name: String = __unwrap_option(__pattern_temp_0);
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(24), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
                     __r.String::append(move "Hello, ");
                     __r.String::append(name);
                     __r.String::append(move "!");

--- a/wado-compiler/tests/fixtures.golden/for_of_structs.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_structs.lowered.wado
@@ -25,17 +25,13 @@ fn run() with Stdout {
     let p2: Point = move Point { x: 3, y: 4 };
     let points: Array<Point> = move [p1, p2];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<Point> = __inline_Array_Point__IntoIterator__into_iter_0: {
-            break __inline_Array_Point__IntoIterator__into_iter_0: ArrayIter<Point> { repr: points.repr, used: points.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<Point> = move ArrayIter<Point> { repr: points.repr, used: points.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<Point> = move __iter_0."ArrayIter<Point>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let p: Point = __unwrap_option(__pattern_temp_0);
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(33), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/for_of_tuple_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_tuple_array.lowered.wado
@@ -18,9 +18,7 @@ pub struct "ArrayIter<Tuple<String,i32>>" {
 fn run() with Stdout {
     let items: Array<[String, i32]> = move [["a", 1], ["b", 2]];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<Tuple<String,i32>> = __inline_Array_Tuple_String_i32___IntoIterator__into_iter_0: {
-            break __inline_Array_Tuple_String_i32___IntoIterator__into_iter_0: ArrayIter<Tuple<String,i32>> { repr: items.repr, used: items.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<Tuple<String,i32>> = move ArrayIter<Tuple<String,i32>> { repr: items.repr, used: items.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<[String, i32]> = move __iter_0."ArrayIter<Tuple<String,i32>>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {

--- a/wado-compiler/tests/fixtures.golden/for_of_tuples.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_tuples.lowered.wado
@@ -20,17 +20,13 @@ fn run() with Stdout {
     let t2: [i32, i32] = move [3, 4];
     let pairs: Array<[i32, i32]> = move [t1, t2];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<Tuple<i32,i32>> = __inline_Array_Tuple_i32_i32___IntoIterator__into_iter_0: {
-            break __inline_Array_Tuple_i32_i32___IntoIterator__into_iter_0: ArrayIter<Tuple<i32,i32>> { repr: pairs.repr, used: pairs.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<Tuple<i32,i32>> = move ArrayIter<Tuple<i32,i32>> { repr: pairs.repr, used: pairs.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<[i32, i32]> = move __iter_0."ArrayIter<Tuple<i32,i32>>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let p: [i32, i32] = __unwrap_option(__pattern_temp_0);
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(33), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/generic-array-direct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-array-direct.lowered.wado
@@ -13,18 +13,14 @@ fn run() with Stdout {
     let mut arr: Array<i32> = move [];
     arr."Array<i32>::append"(42);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Length: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_3: {
-                break __inline_Array_i32___len_3: arr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.lowered.wado
@@ -58,9 +58,7 @@ fn print_array(arr: &Array<i32>) with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = arr.used;
         loop {
-            if !(i < __inline_Array_i32___len_0: {
-                break __inline_Array_i32___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -68,9 +66,7 @@ fn print_array(arr: &Array<i32>) with Stdout {
                     core::cli::print(move " ");
                 }
                 core::cli::print(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_1: {
-                        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_2: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -91,13 +87,9 @@ fn print_array(arr: &Array<i32>) with Stdout {
 
 fn run() with Stdout {
     let mut arr: Array<i32> = move [5, 3, 8, 1, 9, 2, 7, 4, 6];
-    "quicksort$__Closure_0"(&mut arr, 0, (__inline_Array_i32___len_0: {
-        break __inline_Array_i32___len_0: arr.used;
-    } - 1), &__Closure_0 {  });
+    "quicksort$__Closure_0"(&mut arr, 0, (arr.used - 1), &__Closure_0 {  });
     print_array(&arr);
-    "quicksort$__Closure_1"(&mut arr, 0, (__inline_Array_i32___len_1: {
-        break __inline_Array_i32___len_1: arr.used;
-    } - 1), &__Closure_1 {  });
+    "quicksort$__Closure_1"(&mut arr, 0, (arr.used - 1), &__Closure_1 {  });
     print_array(&arr);
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic-method-closure-param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-closure-param.lowered.wado
@@ -20,19 +20,13 @@ struct __Closure_1 {
 }
 
 fn run() with Stdout {
-    let c: Container<i32> = __inline_Container_i32___new_0: {
-        break __inline_Container_i32___new_0: Container<i32> { value: 5 };
-    };
-    let result1: i32 = __inline_Container_i32___transform___Closure_0_1: {
-        break __inline_Container_i32___transform___Closure_0_1: __inline___Closure_0____call_2: {
-            let __sroa_x_value: i32 = c.value;
-            break __inline___Closure_0____call_2: (__sroa_x_value * 2);
-        };
+    let c: Container<i32> = move Container<i32> { value: 5 };
+    let result1: i32 = __inline___Closure_0____call_2: {
+        let __sroa_x_value: i32 = c.value;
+        break __inline___Closure_0____call_2: (__sroa_x_value * 2);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "transform: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -47,9 +41,7 @@ fn run() with Stdout {
     });
     let result2: i32 = c."Container<i32>::double_transform$__Closure_1"(&__Closure_1 {  });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "double_transform: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -74,9 +66,7 @@ fn __Closure_1::__call(self: &__Closure_1, x: Box<i32>) -> i32 {
 
 fn "Container<i32>::double_transform$__Closure_1"(self: &Container<i32>, f: &__Closure_1) -> i32 {
     let intermediate: i32 = self."Container<i32>::transform"(f);
-    let c2: Container<i32> = __inline_Container_i32___new_0: {
-        break __inline_Container_i32___new_0: Container<i32> { value: intermediate };
-    };
+    let c2: Container<i32> = move Container<i32> { value: intermediate };
     return c2."Container<i32>::transform"(f);
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic-method-self-call.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-self-call.lowered.wado
@@ -14,16 +14,10 @@ struct "Wrapper<i32>" {
 }
 
 fn run() with Stdout {
-    let w: Wrapper<i32> = __inline_Wrapper_i32___new_0: {
-        break __inline_Wrapper_i32___new_0: Wrapper<i32> { value: 42 };
-    };
-    let v: i32 = __inline_Wrapper_i32___get_1: {
-        break __inline_Wrapper_i32___get_1: w.value;
-    };
+    let w: Wrapper<i32> = move Wrapper<i32> { value: 42 };
+    let v: i32 = w.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "get: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -37,18 +31,12 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     let pair: [i32, i32] = __inline_Wrapper_i32___get_twice_5: {
-        let a: i32 = __inline_Wrapper_i32___get_6: {
-            break __inline_Wrapper_i32___get_6: w.value;
-        };
-        let b: i32 = __inline_Wrapper_i32___get_7: {
-            break __inline_Wrapper_i32___get_7: w.value;
-        };
+        let a: i32 = w.value;
+        let b: i32 = w.value;
         break __inline_Wrapper_i32___get_twice_5: [a, b];
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(45), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(45), used: 0 };
         __r.String::append(move "get_twice: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.lowered.wado
@@ -18,9 +18,7 @@ struct "Container<i32>" {
 }
 
 fn run() with Stdout {
-    let mut container: Container<i32> = __inline_Container_i32___new_0: {
-        break __inline_Container_i32___new_0: Container<i32> { items: [] };
-    };
+    let mut container: Container<i32> = move Container<i32> { items: [] };
     __inline_Container_i32___add_1: {
         container.items."Array<i32>::append"(10);
     };
@@ -31,20 +29,16 @@ fn run() with Stdout {
         container.items."Array<i32>::append"(30);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Length: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Container_i32___len_7: {
-                break __inline_Container_i32___len_7: __inline_Array_i32___len_0: {
-                    let self: &Array<i32> = &container.items;
-                    break __inline_Array_i32___len_0: self.used;
-                };
+            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_0: {
+                let self: &Array<i32> = &container.items;
+                break __inline_Array_i32___len_0: self.used;
             } };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
@@ -52,54 +46,42 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "First: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_10: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Container_i32___get_11: {
-                break __inline_Container_i32___get_11: container.items."Array<i32>^IndexValue::index_value"(0);
-            } };
+            let self: Box<i32> = move Box<i32> { value: container.items."Array<i32>^IndexValue::index_value"(0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Second: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_14: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Container_i32___get_15: {
-                break __inline_Container_i32___get_15: container.items."Array<i32>^IndexValue::index_value"(1);
-            } };
+            let self: Box<i32> = move Box<i32> { value: container.items."Array<i32>^IndexValue::index_value"(1) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Third: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_17: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_18: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Container_i32___get_19: {
-                break __inline_Container_i32___get_19: container.items."Array<i32>^IndexValue::index_value"(2);
-            } };
+            let self: Box<i32> = move Box<i32> { value: container.items."Array<i32>^IndexValue::index_value"(2) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/generic-struct-import.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-import.lowered.wado
@@ -49,9 +49,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_0) {
         let val: i32 = __unwrap_option(__pattern_temp_0).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_2: {
-                break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "value: ");
             let mut __f: Formatter = __inline_Formatter__new_3: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_generic.lowered.wado
@@ -21,9 +21,7 @@ struct "Pair<i32,String>" {
 fn run() with Stdout {
     let pairs: Array<Pair<i32, String>> = move [Pair<i32,String> { first: 1, second: "one" }, Pair<i32,String> { first: 2, second: "two" }];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(46), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(46), used: 0 };
         __r.String::append(move "pairs[0]: (");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -40,9 +38,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(46), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(46), used: 0 };
         __r.String::append(move "pairs[1]: (");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_struct.lowered.wado
@@ -21,9 +21,7 @@ struct Point {
 fn run() with Stdout {
     let points: Array<Point> = move [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(47), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(47), used: 0 };
         __r.String::append(move "points[0]: (");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -48,9 +46,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(47), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(47), used: 0 };
         __r.String::append(move "points[1]: (");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_free_func_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_free_func_basic.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i32 = __inline_identity_i32__0: {
-        break __inline_identity_i32__0: 42;
-    };
+    let a: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "identity i32: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -29,13 +25,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let b: i64 = __inline_identity_i64__4: {
-        break __inline_identity_i64__4: 100;
-    };
+    let b: i64 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "identity i64: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -53,9 +45,7 @@ fn run() with Stdout {
         break __inline_first_i32_i64__8: 10;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "first: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -73,9 +63,7 @@ fn run() with Stdout {
         break __inline_second_i32_i64__12: 20;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "second: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -89,15 +77,11 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     let e: i32 = __inline_identity_i32__16: {
-        let x: i32 = __inline_identity_i32__17: {
-            break __inline_identity_i32__17: 99;
-        };
+        let x: i32 = 99;
         break __inline_identity_i32__16: x;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "nested identity: ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_free_func_with_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_free_func_with_struct.lowered.wado
@@ -18,24 +18,16 @@ struct "Box<i32>" {
 }
 
 fn run() with Stdout {
-    let b1: Box<i32> = __inline_make_box_i32__0: {
-        break __inline_make_box_i32__0: __inline_Box_i32___new_1: {
-            break __inline_Box_i32___new_1: Box<i32> { value: 42 };
-        };
-    };
+    let b1: Box<i32> = move Box<i32> { value: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "make_box: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Box_i32___get_5: {
-                break __inline_Box_i32___get_5: b1.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: b1.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -43,14 +35,10 @@ fn run() with Stdout {
     });
     let v: i32 = __inline_unwrap_box_i32__6: {
         let b: Box<i32> = b1;
-        break __inline_unwrap_box_i32__6: __inline_Box_i32___get_7: {
-            break __inline_Box_i32___get_7: b.value;
-        };
+        break __inline_unwrap_box_i32__6: b.value;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "unwrap_box: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -63,32 +51,20 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let b2: Box<i64> = __inline_make_box_i64__11: {
-        break __inline_make_box_i64__11: __inline_Box_i64___new_12: {
-            break __inline_Box_i64___new_12: Box<i64> { value: 100 };
-        };
-    };
+    let b2: Box<i64> = move Box<i64> { value: 100 };
     let b3: Box<i64> = __inline_transform_box_i64__13: {
-        let v: i64 = __inline_Box_i64___get_14: {
-            break __inline_Box_i64___get_14: b2.value;
-        };
-        break __inline_transform_box_i64__13: __inline_Box_i64___new_15: {
-            break __inline_Box_i64___new_15: Box<i64> { value: v };
-        };
+        let v: i64 = b2.value;
+        break __inline_transform_box_i64__13: Box<i64> { value: v };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "transform_box: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_17: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i64_Display__fmt_18: {
-            let self: Box<i64> = move Box<i64> { value: __inline_Box_i64___get_19: {
-                break __inline_Box_i64___get_19: b3.value;
-            } };
+            let self: Box<i64> = move Box<i64> { value: b3.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i64_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/generic_function_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_basic.lowered.wado
@@ -10,16 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i32 = __inline_identity_i32__0: {
-        break __inline_identity_i32__0: 42;
-    };
-    let b: i64 = __inline_identity_i64__1: {
-        break __inline_identity_i64__1: 100;
-    };
+    let a: i32 = 42;
+    let b: i64 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -33,9 +27,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_calls_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_calls_generic.lowered.wado
@@ -10,20 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i32 = __inline_wrap_identity_i32_0: {
-        break __inline_wrap_identity_i32_0: __inline_identity_i32__1: {
-            break __inline_identity_i32__1: 42;
-        };
-    };
-    let b: i64 = __inline_wrap_identity_i64_2: {
-        break __inline_wrap_identity_i64_2: __inline_identity_i64__3: {
-            break __inline_identity_i64__3: 100;
-        };
-    };
+    let a: i32 = 42;
+    let b: i64 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_multi_instantiations.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_multi_instantiations.lowered.wado
@@ -12,26 +12,16 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i32 = __inline_identity_i32__0: {
-        break __inline_identity_i32__0: 1;
-    };
-    let b: i64 = __inline_identity_i64__1: {
-        break __inline_identity_i64__1: 2;
-    };
+    let a: i32 = 1;
+    let b: i64 = 2;
     let c: f32 = __inline_identity_f32__2: {
         let x: f32 = 3.5 as f32;
         break __inline_identity_f32__2: x;
     };
-    let d: f64 = __inline_identity_f64__3: {
-        break __inline_identity_f64__3: 4.5;
-    };
-    let e: bool = __inline_identity_bool__4: {
-        break __inline_identity_bool__4: true;
-    };
+    let d: f64 = 4.5;
+    let e: bool = true;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(84), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(84), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/generic_function_multi_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_multi_params.lowered.wado
@@ -10,16 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i32 = __inline_first_i32_i64__0: {
-        break __inline_first_i32_i64__0: 10;
-    };
-    let b: i64 = __inline_second_i32_i64__1: {
-        break __inline_second_i32_i64__1: 40;
-    };
+    let a: i32 = 10;
+    let b: i64 = 40;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -33,9 +27,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_nested_calls.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_nested_calls.lowered.wado
@@ -12,17 +12,13 @@
 fn run() with Stdout {
     let result: i32 = __inline_identity_i32__0: {
         let x: i32 = __inline_identity_i32__1: {
-            let x: i32 = __inline_identity_i32__2: {
-                break __inline_identity_i32__2: 42;
-            };
+            let x: i32 = 42;
             break __inline_identity_i32__1: x;
         };
         break __inline_identity_i32__0: x;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_returns_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_returns_struct.lowered.wado
@@ -18,16 +18,10 @@ struct "Box<i32>" {
 }
 
 fn run() with Stdout {
-    let b1: Box<i32> = __inline_make_box_i32_0: {
-        break __inline_make_box_i32_0: Box<i32> { value: 42 };
-    };
-    let b2: Box<i64> = __inline_make_box_i64_1: {
-        break __inline_make_box_i64_1: Box<i64> { value: 100 };
-    };
+    let b1: Box<i32> = move Box<i32> { value: 42 };
+    let b2: Box<i64> = move Box<i64> { value: 100 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "b1: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -41,9 +35,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "b2: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_two_params_swap.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_two_params_swap.lowered.wado
@@ -10,20 +10,14 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_first_i32_i64__0: {
-        break __inline_first_i32_i64__0: 10;
-    };
-    let y: i64 = __inline_second_i32_i64__1: {
-        break __inline_second_i32_i64__1: 20;
-    };
+    let x: i32 = 10;
+    let y: i64 = 20;
     let z: String = __inline_first_String_i32__2: {
         let a: String = move "hello";
         break __inline_first_String_i32__2: a;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(61), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(61), used: 0 };
         __r.String::append(move "x: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_with_ref.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_with_ref.lowered.wado
@@ -10,16 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: i32 = __inline_get_value_i32__0: {
-        break __inline_get_value_i32__0: 42;
-    };
-    let b: i64 = __inline_get_value_i64__1: {
-        break __inline_get_value_i64__1: 100;
-    };
+    let a: i32 = 42;
+    let b: i64 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_function_with_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_with_string.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
         break __inline_identity_String__0: x;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "s: ");
         __r.String::append(s);
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/generic_method_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_basic.lowered.wado
@@ -14,13 +14,9 @@ struct Container {
 }
 
 fn run() with Stdout {
-    let result: i64 = __inline_Container__transform_i64__0: {
-        break __inline_Container__transform_i64__0: 100;
-    };
+    let result: i64 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_method_double_generics.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_double_generics.lowered.wado
@@ -18,22 +18,16 @@ struct "Container<i32>" {
 }
 
 fn run() with Stdout {
-    let c: Container<i32> = __inline_Container_i32___new_0: {
-        break __inline_Container_i32___new_0: Container<i32> { value: 42 };
-    };
+    let c: Container<i32> = move Container<i32> { value: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Container_i32___get_4: {
-                break __inline_Container_i32___get_4: c.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -44,9 +38,7 @@ fn run() with Stdout {
         break __inline_Container_i32___transform_i32__5: 100;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "transform: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -64,9 +56,7 @@ fn run() with Stdout {
         break __inline_Container_i32___combine_i32_i32__9: 200;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "combine same: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -84,9 +74,7 @@ fn run() with Stdout {
         break __inline_Container_i32___combine_i32_i64__13: 400;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "combine mixed: ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
@@ -99,17 +87,13 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c2: Container<i64> = __inline_Container_i64___new_17: {
-        break __inline_Container_i64___new_17: Container<i64> { value: 1000 };
-    };
+    let c2: Container<i64> = move Container<i64> { value: 1000 };
     let result2: i32 = __inline_Container_i64___transform_i32__18: {
         c2.value;
         break __inline_Container_i64___transform_i32__18: 99;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "c2 transform: ");
         let mut __f: Formatter = __inline_Formatter__new_20: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_method_multi_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_multi_params.lowered.wado
@@ -15,16 +15,10 @@ struct Pair {
 }
 
 fn run() with Stdout {
-    let x: i32 = __inline_Pair__combine_i32_i64__0: {
-        break __inline_Pair__combine_i32_i64__0: 10;
-    };
-    let y: i64 = __inline_Pair__swap_i32_i64__1: {
-        break __inline_Pair__swap_i32_i64__1: 40;
-    };
+    let x: i32 = 10;
+    let y: i64 = 40;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "x: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -38,9 +32,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "y: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_method_on_generic_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_on_generic_struct.lowered.wado
@@ -15,16 +15,10 @@ struct Wrapper {
 }
 
 fn run() with Stdout {
-    let x: i64 = __inline_Wrapper__convert_i64__0: {
-        break __inline_Wrapper__convert_i64__0: 100;
-    };
-    let y: f64 = __inline_Wrapper__convert_f64__1: {
-        break __inline_Wrapper__convert_f64__1: 3.14;
-    };
+    let x: i64 = 100;
+    let y: f64 = 3.14;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "x: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_method_returns_self_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_returns_self_field.lowered.wado
@@ -14,16 +14,10 @@ struct Holder {
 }
 
 fn run() with Stdout {
-    let x: i32 = __inline_Holder__add_to_i32__0: {
-        break __inline_Holder__add_to_i32__0: 5;
-    };
-    let b: i32 = __inline_Holder__get_base_1: {
-        break __inline_Holder__get_base_1: 10;
-    };
+    let x: i32 = 5;
+    let b: i32 = 10;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(43), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(43), used: 0 };
         __r.String::append(move "x: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct.lowered.wado
@@ -15,9 +15,7 @@ struct "Box<i32>" {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_box_trait_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_box_trait_method.lowered.wado
@@ -28,13 +28,9 @@ fn "Point^Eq::eq"(self: &Point, other: &Point) -> bool {
 
 fn run() with Stdout {
     let mut __sroa_b_value: Point = move Point { x: 10, y: 20 };
-    let p: Point = __inline_Box_Point___get_0: {
-        break __inline_Box_Point___get_0: __sroa_b_value;
-    };
+    let p: Point = __sroa_b_value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(43), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(43), used: 0 };
         __r.String::append(move "point: (");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -63,9 +59,7 @@ fn run() with Stdout {
         __sroa_b_value = v;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(46), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(46), used: 0 };
         __r.String::append(move "original: (");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -90,9 +84,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(45), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(45), used: 0 };
         __r.String::append(move "updated: (");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -119,36 +111,28 @@ fn run() with Stdout {
     let b1: Box<i32> = move Box<i32> { value: 42 };
     let b2: Box<i32> = b1;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_17: {
-            break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "b1: ");
         let mut __f: Formatter = __inline_Formatter__new_18: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_18: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_19: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Box_i32___get_20: {
-                break __inline_Box_i32___get_20: b1.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: b1.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "b2: ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_22: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_23: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Box_i32___get_24: {
-                break __inline_Box_i32___get_24: b2.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: b2.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -156,11 +140,7 @@ fn run() with Stdout {
     });
     let __sroa_pa_value: Point = move Point { x: 1, y: 2 };
     let __sroa_pb_value: Point = move Point { x: 1, y: 2 };
-    if __inline_Box_Point___get_25: {
-        break __inline_Box_Point___get_25: __sroa_pa_value;
-    }."Point^Eq::eq"(&__inline_Box_Point___get_26: {
-        break __inline_Box_Point___get_26: __sroa_pb_value;
-    }) {
+    if __sroa_pa_value."Point^Eq::eq"(&__sroa_pb_value) {
         core::cli::println(move "equal");
     } else {
         core::cli::println(move "not equal");

--- a/wado-compiler/tests/fixtures.golden/generic_struct_explicit.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_explicit.lowered.wado
@@ -43,9 +43,7 @@ fn run() with Stdout {
     let __sroa_f32_box_value: f32 = 2.5 as f32;
     let __sroa_str_box_value: String = move "world";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i32: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -59,9 +57,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -75,9 +71,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f32: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -91,9 +85,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -107,9 +99,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "bool: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -127,9 +117,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "char: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -139,9 +127,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_17: {
-            break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "str: ");
         __r.String::append(__sroa_str_box_value);
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_func.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_func.lowered.wado
@@ -14,16 +14,10 @@ struct "Box<i32>" {
 }
 
 fn run() with Stdout {
-    let b: Box<i32> = __inline_make_box_0: {
-        break __inline_make_box_0: Box<i32> { value: 42 };
-    };
-    let v: i32 = __inline_get_value_1: {
-        break __inline_get_value_1: b.value;
-    };
+    let b: Box<i32> = move Box<i32> { value: 42 };
+    let v: i32 = b.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_impl.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_impl.lowered.wado
@@ -14,13 +14,9 @@ struct "Box<i32>" {
 }
 
 fn run() with Stdout {
-    let v: i32 = __inline_Box_i32___get_0: {
-        break __inline_Box_i32___get_0: 42;
-    };
+    let v: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/generic_struct_multi_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_multi_params.lowered.wado
@@ -17,9 +17,7 @@ struct "Pair<i32,String>" {
 fn run() with Stdout {
     let __sroa_p_second: String = move "hello";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(49), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(49), used: 0 };
         __r.String::append(move "first: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_mut.lowered.wado
@@ -16,9 +16,7 @@ struct "Box<i32>" {
 fn run() with Stdout {
     let mut __sroa_b_value: i32 = 10;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -33,9 +31,7 @@ fn run() with Stdout {
     });
     __sroa_b_value = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_nested.lowered.wado
@@ -19,9 +19,7 @@ struct "Box<i32>" {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "nested value: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_types.lowered.wado
@@ -33,9 +33,7 @@ struct "Box<i32>" {
 fn run() with Stdout {
     let __sroa_str_box_value: String = move "hello";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i32: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -49,9 +47,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -65,17 +61,13 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "str: ");
         __r.String::append(__sroa_str_box_value);
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "bool: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -93,9 +85,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "char: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_with_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_with_struct.lowered.wado
@@ -29,9 +29,7 @@ struct "Box<Point>" {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(43), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(43), used: 0 };
         __r.String::append(move "point: (");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -57,9 +55,7 @@ fn run() with Stdout {
     });
     let __sroa___sroa_pair_box_value_second: String = move "one";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "pair: (");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/geometry.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/geometry.lowered.wado
@@ -16,36 +16,28 @@ pub struct Point {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__sum_3: {
-                break __inline_Point__sum_3: 7;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 7 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "product: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__product_7: {
-                break __inline_Point__product_7: 12;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 12 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/global_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_basic.lowered.wado
@@ -18,9 +18,7 @@ global FLAG: bool = true;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "ANSWER=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -34,9 +32,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "PI=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -50,9 +46,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "FLAG=");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_const_expr.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_const_expr.lowered.wado
@@ -17,9 +17,7 @@ global NEGATIVE: i32 = -42;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "DOUBLED=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -33,9 +31,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "OFFSET=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -49,9 +45,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "NEGATIVE=");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_functions.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_functions.lowered.wado
@@ -15,18 +15,14 @@ global MULTIPLIER: i32 = 2;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "initial=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_value_3: {
-                break __inline_get_value_3: shared;
-            } };
+            let self: Box<i32> = move Box<i32> { value: shared };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -36,18 +32,14 @@ fn run() with Stdout {
         shared = (shared + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "after increment=");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_value_8: {
-                break __inline_get_value_8: shared;
-            } };
+            let self: Box<i32> = move Box<i32> { value: shared };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -57,18 +49,14 @@ fn run() with Stdout {
         shared = (shared * MULTIPLIER);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "after double=");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_11: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_12: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_value_13: {
-                break __inline_get_value_13: shared;
-            } };
+            let self: Box<i32> = move Box<i32> { value: shared };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -81,18 +69,14 @@ fn run() with Stdout {
         shared = (shared + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "after two increments=");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_17: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_18: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_value_19: {
-                break __inline_get_value_19: shared;
-            } };
+            let self: Box<i32> = move Box<i32> { value: shared };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/global_import.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_import.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let c: i32 = __inline_get_constant_0: {
-        break __inline_get_constant_0: ./sub/global_import_module.wado::CONSTANT;
-    };
+    let c: i32 = ./sub/global_import_module.wado::CONSTANT;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "get_constant=");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -30,9 +26,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "CONSTANT=");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_multimod.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_multimod.lowered.wado
@@ -13,9 +13,7 @@ global mut MAIN_VALUE: i32 = 0;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "HELPER_COUNTER=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -29,27 +27,21 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "get_counter()=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_5: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_counter_6: {
-                break __inline_get_counter_6: ./sub/global_multimod_helper.wado::HELPER_COUNTER;
-            } };
+            let self: Box<i32> = move Box<i32> { value: ./sub/global_multimod_helper.wado::HELPER_COUNTER };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "MAIN_VALUE=");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -66,18 +58,14 @@ fn run() with Stdout {
         ./sub/global_multimod_helper.wado::HELPER_COUNTER = (./sub/global_multimod_helper.wado::HELPER_COUNTER + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "after increment=");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_12: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_13: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_counter_14: {
-                break __inline_get_counter_14: ./sub/global_multimod_helper.wado::HELPER_COUNTER;
-            } };
+            let self: Box<i32> = move Box<i32> { value: ./sub/global_multimod_helper.wado::HELPER_COUNTER };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/global_mutable.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_mutable.lowered.wado
@@ -13,9 +13,7 @@ global mut counter: i32 = 0;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "counter=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn run() with Stdout {
     });
     counter = (counter + 1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "counter=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -47,9 +43,7 @@ fn run() with Stdout {
     });
     counter = (counter + 10);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "counter=");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_negative.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_negative.lowered.wado
@@ -13,9 +13,7 @@ global POW10_MIN: i32 = -348;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "POW10_MIN=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_negative_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_negative_edge.lowered.wado
@@ -15,9 +15,7 @@ global I64_MIN: i64 = -9223372036854775808;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "NEGATIVE_ONE=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -31,9 +29,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "I64_MIN=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_object_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_object_array.lowered.wado
@@ -17,9 +17,7 @@ global mut ITEMS: Array<i32> = null;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "len=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -36,9 +34,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "item0=");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -53,9 +49,7 @@ fn run() with Stdout {
     });
     ITEMS."Array<i32>::append"(4);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "after append len=");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_object_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_object_struct.lowered.wado
@@ -18,9 +18,7 @@ struct Point {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "x=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -45,9 +43,7 @@ fn run() with Stdout {
     });
     ORIGIN = Point { x: 10, y: 20 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "x=");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/global_topological_sort.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_topological_sort.lowered.wado
@@ -21,9 +21,7 @@ global mut Y: i32 = 0;
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "A=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -37,9 +35,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "B=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -53,9 +49,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "C=");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -69,9 +63,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "X=");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -85,9 +77,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "Y=");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/i64_arithmetic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/i64_arithmetic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/i64_to_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/i64_to_string.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "negative: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "zero: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/if_expr_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_basic.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let x: i32 = core::builtin::select::<i32>(true, 42, 0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -28,9 +26,7 @@ fn run() with Stdout {
     });
     let y: i32 = core::builtin::select::<i32>(false, 100, 200);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_expr_complex_let.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_complex_let.lowered.wado
@@ -29,9 +29,7 @@ fn compute(mode: Mode, precision: i32, exp_est: i32) -> i32 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -44,9 +42,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -59,9 +55,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_expr_else_if.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_else_if.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -40,9 +38,7 @@ fn run() with Stdout {
         core::builtin::select::<i32>((25 == 24), 200, 300);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_expr_nested_let.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_nested_let.lowered.wado
@@ -24,9 +24,7 @@ fn compute(mode: Mode, x: i32) -> i32 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -39,9 +37,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_expr_no_trailing_semi.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_no_trailing_semi.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let x: i32 = core::builtin::select::<i32>(true, 42, 0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_expr_with_let.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_with_let.lowered.wado
@@ -23,9 +23,7 @@ fn compute(x: i32) -> i32 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -38,9 +36,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_expr_with_trailing_semi.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_with_trailing_semi.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let x: i32 = core::builtin::select::<i32>(true, 42, 0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/if_let_init_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_let_init_basic.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     if (10 > 5) {
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
             __r.String::append(move "x = ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/if_let_init_else.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_let_init_else.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
         core::cli::println(move "big");
     } else {
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "small: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/if_let_init_mutable.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/if_let_init_mutable.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     if (x > 0) {
         x = (x + 1);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/import_from_nested_subdir.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/import_from_nested_subdir.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_triple_0: {
-        break __inline_triple_0: 42;
-    };
+    let x: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "tripled: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/import_from_subdir.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/import_from_subdir.lowered.wado
@@ -10,16 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_get_magic_0: {
-        break __inline_get_magic_0: 42;
-    };
-    let y: i32 = __inline_double_1: {
-        break __inline_double_1: (x * 2);
-    };
+    let x: i32 = 42;
+    let y: i32 = (x * 2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         __r.String::append(move "magic: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/import_transitive_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/import_transitive_simple.lowered.wado
@@ -11,15 +11,11 @@
 
 fn run() with Stdout {
     let result: i32 = __inline_add_and_double_0: {
-        let sum: i32 = __inline_add_1: {
-            break __inline_add_1: 21;
-        };
+        let sum: i32 = 21;
         break __inline_add_and_double_0: (sum * 2);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "result: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/import_with_dot_segments.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/import_with_dot_segments.lowered.wado
@@ -10,16 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: i32 = __inline_get_magic_0: {
-        break __inline_get_magic_0: 42;
-    };
-    let y: i32 = __inline_double_1: {
-        break __inline_double_1: (x * 2);
-    };
+    let x: i32 = 42;
+    let y: i32 = (x * 2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         __r.String::append(move "magic: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index-value-option-pattern.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index-value-option-pattern.lowered.wado
@@ -26,9 +26,7 @@ fn __test_0_if_let_some_on_index_value_returning_option() {
             let __cond: bool = (val == 42);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_0: {
-                        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(117), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "__test_0_if_let_some_on_index_value_returning_option");
                     __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/index_assign_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_basic.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     arr."Array<i32>^IndexAssign::index_assign"(1, 200);
     arr."Array<i32>^IndexAssign::index_assign"(2, 300);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/index_assign_expression_value.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_expression_value.lowered.wado
@@ -16,16 +16,12 @@
 fn run() with Stdout {
     let mut arr: Array<i32> = move [0, 0, 0, 0];
     arr."Array<i32>^IndexAssign::index_assign"(0, 70);
-    arr."Array<i32>^IndexAssign::index_assign"(1, __inline_compute_0: {
-        break __inline_compute_0: 25;
-    });
+    arr."Array<i32>^IndexAssign::index_assign"(1, 25);
     let other: Array<i32> = move [100];
     arr."Array<i32>^IndexAssign::index_assign"(2, (other."Array<i32>^IndexValue::index_value"(0) + 50));
     arr."Array<i32>^IndexAssign::index_assign"(3, ((arr."Array<i32>^IndexValue::index_value"(0) + arr."Array<i32>^IndexValue::index_value"(1)) / 2));
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(67), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(67), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_conditional.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_conditional.lowered.wado
@@ -31,9 +31,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_function.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_function.lowered.wado
@@ -17,9 +17,7 @@ fn run() with Stdout {
     let mut arr: Array<i32> = move [0, 0, 0];
     fill_array(&mut arr);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -53,9 +51,7 @@ fn run() with Stdout {
     });
     let result: Array<i32> = move create_and_fill();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_8: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_loop.lowered.wado
@@ -28,9 +28,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(89), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(89), used: 0 };
         __r.String::append(move "for: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -93,9 +91,7 @@ fn run() with Stdout {
         j = (j + 1);
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(57), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(57), used: 0 };
         __r.String::append(move "while: ");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
@@ -138,9 +134,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(56), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(56), used: 0 };
         __r.String::append(move "loop: ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_assign_multiple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_multiple.lowered.wado
@@ -30,9 +30,7 @@ fn run() with Stdout {
     d."Array<f64>^IndexAssign::index_assign"(0, 1.5);
     d."Array<f64>^IndexAssign::index_assign"(1, 2.5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(53), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(53), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -66,9 +64,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(53), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(53), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -102,9 +98,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "c: ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
@@ -128,9 +122,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "d: ");
         let mut __f: Formatter = __inline_Formatter__new_20: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_assign_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_nested.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
     values."Array<i32>^IndexAssign::index_assign"(indices."Array<i32>^IndexValue::index_value"(1), 200);
     values."Array<i32>^IndexAssign::index_assign"(indices."Array<i32>^IndexValue::index_value"(2), 300);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -60,9 +58,7 @@ fn run() with Stdout {
     dest."Array<i32>^IndexAssign::index_assign"(1, source."Array<i32>^IndexValue::index_value"(0));
     dest."Array<i32>^IndexAssign::index_assign"(2, source."Array<i32>^IndexValue::index_value"(1));
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_8: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/index_assign_ref_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_ref_array.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
     strings."Array<String>^IndexAssign::index_assign"(0, move "hello");
     strings."Array<String>^IndexAssign::index_assign"(1, move "world");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(50), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
         __r.String::append(move strings."Array<String>^IndexValue::index_value"(0));
         __r.String::append(move " ");
         __r.String::append(move strings."Array<String>^IndexValue::index_value"(1));
@@ -32,9 +30,7 @@ fn run() with Stdout {
     messages."Array<String>^IndexAssign::index_assign"(0, move "first");
     messages."Array<String>^IndexAssign::index_assign"(1, move "second");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move messages."Array<String>^IndexValue::index_value"(0));
         __r.String::append(move " ");
         __r.String::append(move messages."Array<String>^IndexValue::index_value"(1));

--- a/wado-compiler/tests/fixtures.golden/index_assign_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_types.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     let mut arr_i32: Array<i32> = move [0];
     arr_i32."Array<i32>^IndexAssign::index_assign"(0, 42);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i32: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -37,9 +35,7 @@ fn run() with Stdout {
     let mut arr_i64: Array<i64> = move [0];
     arr_i64."Array<i64>^IndexAssign::index_assign"(0, 9999999999);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -55,9 +51,7 @@ fn run() with Stdout {
     let mut arr_f32: Array<f32> = move [0.0 as f32];
     arr_f32."Array<f32>^IndexAssign::index_assign"(0, 3.14 as f32);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f32: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -73,9 +67,7 @@ fn run() with Stdout {
     let mut arr_f64: Array<f64> = move [0.0];
     arr_f64."Array<f64>^IndexAssign::index_assign"(0, 2.718281828);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -91,9 +83,7 @@ fn run() with Stdout {
     let mut arr_bool: Array<bool> = move [false];
     arr_bool."Array<bool>^IndexAssign::index_assign"(0, true);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "bool: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_mut_method_call.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_mut_method_call.lowered.wado
@@ -20,27 +20,19 @@ struct Container {
 fn run() with Stdout {
     let mut __sroa_c_item: Counter = move Counter { value: 0 };
     __inline_Counter__increment_0: {
-        let self: &mut Counter = __inline_Container_IndexMut__index_mut_1: {
-            break __inline_Container_IndexMut__index_mut_1: &mut __sroa_c_item;
-        };
+        let self: &mut Counter = &mut __sroa_c_item;
         self.value = (self.value + 1);
     };
     __inline_Counter__increment_2: {
-        let self: &mut Counter = __inline_Container_IndexMut__index_mut_3: {
-            break __inline_Container_IndexMut__index_mut_3: &mut __sroa_c_item;
-        };
+        let self: &mut Counter = &mut __sroa_c_item;
         self.value = (self.value + 1);
     };
     __inline_Counter__increment_4: {
-        let self: &mut Counter = __inline_Container_IndexMut__index_mut_5: {
-            break __inline_Container_IndexMut__index_mut_5: &mut __sroa_c_item;
-        };
+        let self: &mut Counter = &mut __sroa_c_item;
         self.value = (self.value + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "Counter value: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_assign.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_assign.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
         __sroa_box_value = 42;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_both.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_both.lowered.wado
@@ -16,25 +16,19 @@ struct SimpleArray {
 }
 
 fn run() with Stdout {
-    let mut arr: SimpleArray = __inline_SimpleArray__new_0: {
-        break __inline_SimpleArray__new_0: SimpleArray { a: 0, b: 0, c: 0 };
-    };
+    let mut arr: SimpleArray = move SimpleArray { a: 0, b: 0, c: 0 };
     __inline_SimpleArray_IndexAssign__index_assign_1: {
         arr.a = 42;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "arr[0] = ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_SimpleArray_Index__index_5: {
-                break __inline_SimpleArray_Index__index_5: Box<i32> { value: arr.a };
-            }.value };
+            let self: Box<i32> = move Box<i32> { value: Box<i32> { value: arr.a }.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/index_trait_chained.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_chained.lowered.wado
@@ -20,30 +20,22 @@ struct NumHolder {
 fn run() with Stdout {
     let mut __sroa_h_num: Number = move Number { n: 0 };
     let r1: i32 = __inline_Number__add_and_get_0: {
-        let self: &mut Number = __inline_NumHolder_IndexMut__index_mut_1: {
-            break __inline_NumHolder_IndexMut__index_mut_1: &mut __sroa_h_num;
-        };
+        let self: &mut Number = &mut __sroa_h_num;
         self.n = (self.n + 10);
         break __inline_Number__add_and_get_0: self.n;
     };
     let r2: i32 = __inline_Number__add_and_get_2: {
-        let self: &mut Number = __inline_NumHolder_IndexMut__index_mut_3: {
-            break __inline_NumHolder_IndexMut__index_mut_3: &mut __sroa_h_num;
-        };
+        let self: &mut Number = &mut __sroa_h_num;
         self.n = (self.n + 5);
         break __inline_Number__add_and_get_2: self.n;
     };
     let r3: i32 = __inline_Number__add_and_get_4: {
-        let self: &mut Number = __inline_NumHolder_IndexMut__index_mut_5: {
-            break __inline_NumHolder_IndexMut__index_mut_5: &mut __sroa_h_num;
-        };
+        let self: &mut Number = &mut __sroa_h_num;
         self.n = (self.n + 3);
         break __inline_Number__add_and_get_4: self.n;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(61), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(61), used: 0 };
         __r.String::append(move "Results: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -77,9 +69,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Final: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_complex_static.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_complex_static.lowered.wado
@@ -18,18 +18,10 @@ struct Container {
 }
 
 fn run() with Stdout {
-    let mut c: Container = __inline_Container__new_0: {
-        break __inline_Container__new_0: Container { item: __inline_Value__new_0: {
-            break __inline_Value__new_0: Value { n: 10 };
-        } };
-    };
-    let v: Value = *__inline_Container_Index__index_1: {
-        break __inline_Container_Index__index_1: &c.item;
-    };
+    let mut c: Container = move Container { item: Value { n: 10 } };
+    let v: Value = *&c.item;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "Initial: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -43,15 +35,11 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     __inline_Value__double_5: {
-        let self: &mut Value = __inline_Container_IndexMut__index_mut_6: {
-            break __inline_Container_IndexMut__index_mut_6: &mut c.item;
-        };
+        let self: &mut Value = &mut c.item;
         self.n = (self.n * 2);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "After double: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -65,15 +53,11 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     __inline_Container_IndexAssign__index_assign_10: {
-        let value: Value = __inline_Value__new_11: {
-            break __inline_Value__new_11: Value { n: 100 };
-        };
+        let value: Value = move Value { n: 100 };
         c.item = value;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "After assign: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_conditional.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_conditional.lowered.wado
@@ -21,29 +21,21 @@ fn run() with Stdout {
     let mut __sroa_b_item: Counter = move Counter { value: 10 };
     if true {
         __inline_Counter__increment_0: {
-            let self: &mut Counter = __inline_Box_IndexMut__index_mut_1: {
-                break __inline_Box_IndexMut__index_mut_1: &mut __sroa_b_item;
-            };
+            let self: &mut Counter = &mut __sroa_b_item;
             self.value = (self.value + 1);
         };
         __inline_Counter__increment_2: {
-            let self: &mut Counter = __inline_Box_IndexMut__index_mut_3: {
-                break __inline_Box_IndexMut__index_mut_3: &mut __sroa_b_item;
-            };
+            let self: &mut Counter = &mut __sroa_b_item;
             self.value = (self.value + 1);
         };
     } else {
         __inline_Counter__decrement_4: {
-            let self: &mut Counter = __inline_Box_IndexMut__index_mut_5: {
-                break __inline_Box_IndexMut__index_mut_5: &mut __sroa_b_item;
-            };
+            let self: &mut Counter = &mut __sroa_b_item;
             self.value = (self.value - 1);
         };
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_full_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_full_struct.lowered.wado
@@ -24,9 +24,7 @@ struct Container {
 
 fn Value::describe(self: &Value) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(self.tag);
         __r.String::append(move ":");
         let mut __f: Formatter = __inline_Formatter__new_1: {
@@ -44,9 +42,7 @@ fn Value::describe(self: &Value) -> String {
 
 fn Container::stats(self: &Container) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(47), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(47), used: 0 };
         __r.String::append(move "reads=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -131,18 +127,14 @@ fn run() with Stdout {
     };
     let v0: Value = *c."Container^Index::index"(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "v0: ");
         __r.String::append(move v0.Value::describe());
         break __tmpl: __r;
     });
     let v1: Value = *c."Container^Index::index"(1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "v1: ");
         __r.String::append(move v1.Value::describe());
         break __tmpl: __r;
@@ -161,25 +153,19 @@ fn run() with Stdout {
     };
     core::cli::println(move "After mutations:");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "v0: ");
         __r.String::append(move c.v0.Value::describe());
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "v1: ");
         __r.String::append(move c.v1.Value::describe());
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "v2: ");
         __r.String::append(move c.v2.Value::describe());
         break __tmpl: __r;
@@ -189,17 +175,13 @@ fn run() with Stdout {
         break __inline_Value__new_12: Value { n: 999, tag: tag };
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "After replace: ");
         __r.String::append(move c.v2.Value::describe());
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Total: ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
@@ -213,9 +195,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_17: {
-            break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Stats: ");
         __r.String::append(move c.Container::stats());
         break __tmpl: __r;
@@ -225,9 +205,7 @@ fn run() with Stdout {
         c.write_count = 0;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "After reset: ");
         __r.String::append(move c.Container::stats());
         break __tmpl: __r;
@@ -241,9 +219,7 @@ fn run() with Stdout {
         self.n = (self.n + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_22: {
-            break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "Final stats: ");
         __r.String::append(move c.Container::stats());
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_function.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_function.lowered.wado
@@ -21,19 +21,13 @@ fn run() with Stdout {
     let mut __sroa_h_data: Data = move Data { value: 0 };
     __inline_modify_holder_0: {
         __inline_Data__set_value_1: {
-            let self: &mut Data = __inline_Holder_IndexMut__index_mut_2: {
-                break __inline_Holder_IndexMut__index_mut_2: &mut __sroa_h_data;
-            };
+            let self: &mut Data = &mut __sroa_h_data;
             self.value = 42;
         };
     };
-    let d: Data = *__inline_Holder_Index__index_3: {
-        break __inline_Holder_Index__index_3: &__sroa_h_data;
-    };
+    let d: Data = *&__sroa_h_data;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_loop.lowered.wado
@@ -27,9 +27,7 @@ fn run() with Stdout {
             }
             __for_0_body: {
                 __inline_Accumulator__add_0: {
-                    let self: &mut Accumulator = __inline_Wrapper_IndexMut__index_mut_1: {
-                        break __inline_Wrapper_IndexMut__index_mut_1: &mut __sroa_w_acc;
-                    };
+                    let self: &mut Accumulator = &mut __sroa_w_acc;
                     self.sum = (self.sum + i);
                 };
             }
@@ -37,9 +35,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "Sum 1-5: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_multiple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_multiple.lowered.wado
@@ -26,22 +26,12 @@ fn Point::move_by(self: &mut Point, dx: i32, dy: i32) {
 fn run() with Stdout {
     let mut __sroa_h1_point: Point = move Point { x: 0, y: 0 };
     let mut __sroa_h2_point: Point = move Point { x: 10, y: 10 };
-    __inline_PointHolder_IndexMut__index_mut_0: {
-        break __inline_PointHolder_IndexMut__index_mut_0: &mut __sroa_h1_point;
-    }.Point::move_by(5, 5);
-    __inline_PointHolder_IndexMut__index_mut_1: {
-        break __inline_PointHolder_IndexMut__index_mut_1: &mut __sroa_h2_point;
-    }.Point::move_by(-3, -3);
-    let p1: Point = *__inline_PointHolder_Index__index_2: {
-        break __inline_PointHolder_Index__index_2: &__sroa_h1_point;
-    };
-    let p2: Point = *__inline_PointHolder_Index__index_3: {
-        break __inline_PointHolder_Index__index_3: &__sroa_h2_point;
-    };
+    __sroa_h1_point.Point::move_by(5, 5);
+    __sroa_h2_point.Point::move_by(-3, -3);
+    let p1: Point = *&__sroa_h1_point;
+    let p2: Point = *&__sroa_h2_point;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "h1: (");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -66,9 +56,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "h2: (");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_trait_read.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_read.lowered.wado
@@ -14,13 +14,9 @@ struct ReadOnlyBox {
 }
 
 fn run() with Stdout {
-    let x: i32 = __inline_ReadOnlyBox_Index__index_0: {
-        break __inline_ReadOnlyBox_Index__index_0: Box<i32> { value: 42 };
-    }.value;
+    let x: i32 = Box<i32> { value: 42 }.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "Value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_value_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_value_generic.lowered.wado
@@ -27,9 +27,7 @@ fn run() with Stdout {
     let n1: i32 = nums."Triple<i32>^IndexValue::index_value"(1);
     let n2: i32 = nums."Triple<i32>^IndexValue::index_value"(2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(58), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(58), used: 0 };
         __r.String::append(move "nums: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -66,9 +64,7 @@ fn run() with Stdout {
     let l0: i64 = longs."Triple<i64>^IndexValue::index_value"(0);
     let l1: i64 = longs."Triple<i64>^IndexValue::index_value"(1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "longs: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -93,9 +89,7 @@ fn run() with Stdout {
     });
     let sum: i32 = ((nums."Triple<i32>^IndexValue::index_value"(0) + nums."Triple<i32>^IndexValue::index_value"(1)) + nums."Triple<i32>^IndexValue::index_value"(2));
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/index_value_trait.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_value_trait.lowered.wado
@@ -28,16 +28,12 @@ fn "IntStore^IndexValue::index_value"(self: &IntStore, index: i32) -> i32 {
 }
 
 fn run() with Stdout {
-    let store: IntStore = __inline_IntStore__new_0: {
-        break __inline_IntStore__new_0: IntStore { a: 10, b: 20, c: 30 };
-    };
+    let store: IntStore = move IntStore { a: 10, b: 20, c: 30 };
     let first: i32 = store."IntStore^IndexValue::index_value"(0);
     let second: i32 = store."IntStore^IndexValue::index_value"(1);
     let third: i32 = store."IntStore^IndexValue::index_value"(2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "first: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -51,9 +47,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "second: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -67,9 +61,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "third: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -84,9 +76,7 @@ fn run() with Stdout {
     });
     let sum: i32 = ((store."IntStore^IndexValue::index_value"(0) + store."IntStore^IndexValue::index_value"(1)) + store."IntStore^IndexValue::index_value"(2));
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.lowered.wado
@@ -24,18 +24,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "len=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_3: {
-                break __inline_Array_i32___len_3: arr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_nested.lowered.wado
@@ -40,9 +40,7 @@ fn Container::process(self: &mut Container) {
         let _licm_items: Array<i32> = self.items;
         let _licm_used: i32 = _licm_items.used;
         loop {
-            if !(i < __inline_Array_i32___len_0: {
-                break __inline_Array_i32___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -58,9 +56,7 @@ fn Container::process(self: &mut Container) {
         let mut j: i32 = 0;
         let _licm_used: i32 = temp.used;
         loop {
-            if !(j < __inline_Array_i32___len_1: {
-                break __inline_Array_i32___len_1: _licm_used;
-            }) {
+            if !(j < _licm_used) {
                 break __for_2;
             }
             __for_2_body: {
@@ -76,9 +72,7 @@ fn run() with Stdout {
     c.Container::add_items(3);
     c.Container::process();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "len=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/inline_match_tuple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_match_tuple.lowered.wado
@@ -64,9 +64,7 @@ fn outer(e: i32) -> i64 {
         p = -z;
     }
     let pm: S = __inline_get_val_0: {
-        let idx: i32 = (p - __inline_MIN_1: {
-            break __inline_MIN_1: -50;
-        });
+        let idx: i32 = (p - -50);
         break __inline_get_val_0: big_match(idx);
     };
     let __pattern_temp_0: [i64, i32] = __inline_tuple_fn_2: {
@@ -81,9 +79,7 @@ fn outer(e: i32) -> i64 {
 fn run() with Stdout {
     let s: i64 = outer(-50);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/inline_method_minimal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_method_minimal.lowered.wado
@@ -22,9 +22,7 @@ fn run() with Stdout {
     let a: i32 = arr1."Array<i32>^IndexValue::index_value"(0);
     let b: i32 = arr2."Array<i32>^IndexValue::index_value"(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "Result: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/inlining_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inlining_test.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_simple_add_0: {
-        break __inline_simple_add_0: 42;
-    };
+    let result: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "result=");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_basic.lowered.wado
@@ -14,17 +14,11 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 100, high: 0 };
-    };
-    let b: u128 = __inline_u128__from_u64_1: {
-        break __inline_u128__from_u64_1: u128 { low: 50, high: 0 };
-    };
+    let a: u128 = move u128 { low: 100, high: 0 };
+    let b: u128 = move u128 { low: 50, high: 0 };
     let sum: u128 = move a.u128::add(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "u128 100 + 50 = ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -41,9 +35,7 @@ fn run() with Stdout {
     });
     let diff: u128 = move a.u128::sub(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "u128 100 - 50 = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -58,9 +50,7 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c: u128 = __inline_u128__from_u64_10: {
-        break __inline_u128__from_u64_10: u128 { low: 100, high: 0 };
-    };
+    let c: u128 = move u128 { low: 100, high: 0 };
     if a."u128^Eq::eq"(&c) {
         core::cli::println(move "u128: 100 == 100 is true");
     }
@@ -71,9 +61,7 @@ fn run() with Stdout {
     let y: i128 = move i128::from_i64(-50);
     let sum2: i128 = move x.i128::add(&y);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "i128 100 + (-50) = ");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
@@ -91,9 +79,7 @@ fn run() with Stdout {
     let z: i128 = move i128::from_i64(30);
     let diff2: i128 = move z.i128::sub(&x);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "i128 30 - 100 = ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -110,15 +96,11 @@ fn run() with Stdout {
     });
     let neg_x: i128 = __inline_i128__neg_19: {
         let self: &i128 = &x;
-        let zero: i128 = __inline_i128__zero_20: {
-            break __inline_i128__zero_20: i128 { low: 0, high: 0 };
-        };
+        let zero: i128 = move i128 { low: 0, high: 0 };
         break __inline_i128__neg_19: zero.i128::sub(self);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "i128 -100 = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_bitwise.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_bitwise.lowered.wado
@@ -14,17 +14,11 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 65280, high: 0 };
-    };
-    let b: u128 = __inline_u128__from_u64_1: {
-        break __inline_u128__from_u64_1: u128 { low: 4080, high: 0 };
-    };
+    let a: u128 = move u128 { low: 65280, high: 0 };
+    let b: u128 = move u128 { low: 4080, high: 0 };
     let and_result: u128 = move a."u128^BitAnd::bitand"(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u128 AND: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -41,9 +35,7 @@ fn run() with Stdout {
     });
     let or_result: u128 = move a."u128^BitOr::bitor"(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "u128 OR: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -60,9 +52,7 @@ fn run() with Stdout {
     });
     let xor_result: u128 = move a."u128^BitXor::bitxor"(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u128 XOR: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -78,13 +68,9 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     let not_a: u128 = move a."u128^BitNot::bitnot"();
-    let not_masked: u128 = move not_a."u128^BitAnd::bitand"(&__inline_u128__from_u64_14: {
-        break __inline_u128__from_u64_14: u128 { low: 65535, high: 0 };
-    });
+    let not_masked: u128 = move not_a."u128^BitAnd::bitand"(&u128 { low: 65535, high: 0 });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "u128 NOT masked: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -99,13 +85,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let shl_result: u128 = move __inline_u128__from_u64_19: {
-        break __inline_u128__from_u64_19: u128 { low: 1, high: 0 };
-    }."u128^Shl::shl"(4);
+    let shl_result: u128 = move u128 { low: 1, high: 0 }."u128^Shl::shl"(4);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u128 SHL: ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
@@ -120,13 +102,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let shr_result: u128 = move __inline_u128__from_u64_24: {
-        break __inline_u128__from_u64_24: u128 { low: 256, high: 0 };
-    }."u128^Shr::shr"(4);
+    let shr_result: u128 = move u128 { low: 256, high: 0 }."u128^Shr::shr"(4);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_25: {
-            break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u128 SHR: ");
         let mut __f: Formatter = __inline_Formatter__new_26: {
             let buf: &mut String = &mut __r;
@@ -145,9 +123,7 @@ fn run() with Stdout {
     let y: i128 = move i128::from_i64(4080);
     let i_and: i128 = move x."i128^BitAnd::bitand"(&y);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_29: {
-            break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i128 AND: ");
         let mut __f: Formatter = __inline_Formatter__new_30: {
             let buf: &mut String = &mut __r;
@@ -164,9 +140,7 @@ fn run() with Stdout {
     });
     let i_shl: i128 = move i128::from_i64(1)."i128^Shl::shl"(8);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i128 SHL: ");
         let mut __f: Formatter = __inline_Formatter__new_34: {
             let buf: &mut String = &mut __r;
@@ -184,9 +158,7 @@ fn run() with Stdout {
     let neg: i128 = move i128::from_i64(-256);
     let neg_shr: i128 = move neg."i128^Shr::shr"(4);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_37: {
-            break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "i128 SHR negative: ");
         let mut __f: Formatter = __inline_Formatter__new_38: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_coercion.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_coercion.lowered.wado
@@ -14,13 +14,9 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 100, high: 0 };
-    };
+    let a: u128 = move u128 { low: 100, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(39), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
         __r.String::append(move "u128 literal coercion: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -37,9 +33,7 @@ fn run() with Stdout {
     });
     let b: i128 = move i128::from_i64(42);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(39), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
         __r.String::append(move "i128 literal coercion: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -54,13 +48,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c: i128 = __inline_i128__from_pair_9: {
-        break __inline_i128__from_pair_9: i128 { low: 18446744073709551516, high: -1 };
-    };
+    let c: i128 = move i128 { low: 18446744073709551516, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(48), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(48), used: 0 };
         __r.String::append(move "i128 negative literal coercion: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -75,13 +65,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let d: u128 = __inline_u128__from_u64_14: {
-        break __inline_u128__from_u64_14: u128 { low: 200, high: 0 };
-    };
+    let d: u128 = move u128 { low: 200, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u128 cast: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -98,9 +84,7 @@ fn run() with Stdout {
     });
     let e: i128 = move i128::from_i64(300);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i128 cast: ");
         let mut __f: Formatter = __inline_Formatter__new_20: {
             let buf: &mut String = &mut __r;
@@ -115,13 +99,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let g: u128 = __inline_u128__from_u64_23: {
-        break __inline_u128__from_u64_23: u128 { low: 500, high: 0 };
-    };
+    let g: u128 = move u128 { low: 500, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "u128 from i64 variable: ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -138,9 +118,7 @@ fn run() with Stdout {
     });
     let h: i128 = move i128::from_i64(500);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_28: {
-            break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "i128 from i64 variable: ");
         let mut __f: Formatter = __inline_Formatter__new_29: {
             let buf: &mut String = &mut __r;
@@ -155,16 +133,10 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let sum: u128 = __inline_u128__from_u64_32: {
-        break __inline_u128__from_u64_32: u128 { low: 10, high: 0 };
-    };
-    let sum2: u128 = move sum."u128^Add::add"(&__inline_u128__from_u64_33: {
-        break __inline_u128__from_u64_33: u128 { low: 5, high: 0 };
-    });
+    let sum: u128 = move u128 { low: 10, high: 0 };
+    let sum2: u128 = move sum."u128^Add::add"(&u128 { low: 5, high: 0 });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_34: {
-            break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "u128 arithmetic: ");
         let mut __f: Formatter = __inline_Formatter__new_35: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_edge_cases.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_edge_cases.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let u128_max: u128 = move u128::from_string(move "340282366920938463463374607431768211455");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u128 max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -33,13 +31,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let u128_zero: u128 = __inline_u128__from_u64_4: {
-        break __inline_u128__from_u64_4: u128 { low: 0, high: 0 };
-    };
+    let u128_zero: u128 = move u128 { low: 0, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "u128 zero: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -54,13 +48,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let u128_one: u128 = __inline_u128__from_u64_9: {
-        break __inline_u128__from_u64_9: u128 { low: 1, high: 0 };
-    };
+    let u128_one: u128 = move u128 { low: 1, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "u128 one: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -75,13 +65,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let u128_max_u64: u128 = __inline_u128__from_u64_14: {
-        break __inline_u128__from_u64_14: u128 { low: 18446744073709551615, high: 0 };
-    };
+    let u128_max_u64: u128 = move u128 { low: 18446744073709551615, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "u128 max_u64: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -98,9 +84,7 @@ fn run() with Stdout {
     });
     let i128_max: i128 = move i128::from_string(move "170141183460469231731687303715884105727");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i128 max: ");
         let mut __f: Formatter = __inline_Formatter__new_20: {
             let buf: &mut String = &mut __r;
@@ -117,9 +101,7 @@ fn run() with Stdout {
     });
     let i128_min: i128 = move i128::from_string(move "-170141183460469231731687303715884105728");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_23: {
-            break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i128 min: ");
         let mut __f: Formatter = __inline_Formatter__new_24: {
             let buf: &mut String = &mut __r;
@@ -136,9 +118,7 @@ fn run() with Stdout {
     });
     let i128_zero: i128 = move i128::from_i64(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "i128 zero: ");
         let mut __f: Formatter = __inline_Formatter__new_28: {
             let buf: &mut String = &mut __r;
@@ -155,9 +135,7 @@ fn run() with Stdout {
     });
     let i128_one: i128 = move i128::from_i64(1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_31: {
-            break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "i128 one: ");
         let mut __f: Formatter = __inline_Formatter__new_32: {
             let buf: &mut String = &mut __r;
@@ -172,13 +150,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let i128_neg_one: i128 = __inline_i128__from_pair_35: {
-        break __inline_i128__from_pair_35: i128 { low: 18446744073709551615, high: -1 };
-    };
+    let i128_neg_one: i128 = move i128 { low: 18446744073709551615, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "i128 neg_one: ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -195,9 +169,7 @@ fn run() with Stdout {
     });
     let i128_max_i64: i128 = move i128::from_i64(9223372036854775807);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_40: {
-            break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "i128 max_i64: ");
         let mut __f: Formatter = __inline_Formatter__new_41: {
             let buf: &mut String = &mut __r;
@@ -214,9 +186,7 @@ fn run() with Stdout {
     });
     let i128_min_i64: i128 = move i128::from_i64(-9223372036854775808);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_44: {
-            break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "i128 min_i64: ");
         let mut __f: Formatter = __inline_Formatter__new_45: {
             let buf: &mut String = &mut __r;
@@ -231,16 +201,10 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    if ((__inline_u128__low_48: {
-        break __inline_u128__low_48: u128_max.low;
-    } == 18446744073709551615) && (__inline_u128__high_49: {
-        break __inline_u128__high_49: u128_max.high;
-    } == 18446744073709551615)) {
+    if ((u128_max.low == 18446744073709551615) && (u128_max.high == 18446744073709551615)) {
         core::cli::println(move "u128 max low/high correct");
     }
-    if __inline_i128__is_negative_50: {
-        break __inline_i128__is_negative_50: (i128_min.high < 0);
-    } {
+    if (i128_min.high < 0) {
         core::cli::println(move "i128 min is negative");
     }
     core::cli::println(move "All edge case tests passed!");

--- a/wado-compiler/tests/fixtures.golden/int128_from_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_from_string.lowered.wado
@@ -16,9 +16,7 @@
 fn run() with Stdout {
     let a: u128 = move u128::from_string(move "100");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "u128 from \"100\": ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -35,9 +33,7 @@ fn run() with Stdout {
     });
     let b: u128 = move u128::from_string(move "18446744073709551616");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "u128 from \"2^64\": ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -54,9 +50,7 @@ fn run() with Stdout {
     });
     let x: i128 = move i128::from_string(move "100");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "i128 from \"100\": ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -73,9 +67,7 @@ fn run() with Stdout {
     });
     let y: i128 = move i128::from_string(move "-100");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "i128 from \"-100\": ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -92,9 +84,7 @@ fn run() with Stdout {
     });
     let sum: u128 = move a."u128^Add::add"(&u128::from_string(move "50"));
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "100 + 50 = ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_large_literal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_large_literal.lowered.wado
@@ -14,13 +14,9 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let large_u128: u128 = __inline_u128__from_pair_0: {
-        break __inline_u128__from_pair_0: u128 { low: 0, high: 1 };
-    };
+    let large_u128: u128 = move u128 { low: 0, high: 1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "large_u128 = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -35,13 +31,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let max_u128: u128 = __inline_u128__from_pair_5: {
-        break __inline_u128__from_pair_5: u128 { low: 18446744073709551615, high: -1 };
-    };
+    let max_u128: u128 = move u128 { low: 18446744073709551615, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "max_u128 = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -56,13 +48,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let large_i128: i128 = __inline_i128__from_pair_10: {
-        break __inline_i128__from_pair_10: i128 { low: 9223372036854775808, high: 0 };
-    };
+    let large_i128: i128 = move i128 { low: 9223372036854775808, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "large_i128 = ");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
@@ -77,13 +65,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let max_i128: i128 = __inline_i128__from_pair_15: {
-        break __inline_i128__from_pair_15: i128 { low: 18446744073709551615, high: 9223372036854775807 };
-    };
+    let max_i128: i128 = move i128 { low: 18446744073709551615, high: 9223372036854775807 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "max_i128 = ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
@@ -98,13 +82,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let min_i128: i128 = __inline_i128__from_pair_20: {
-        break __inline_i128__from_pair_20: i128 { low: 0, high: -9223372036854775808 };
-    };
+    let min_i128: i128 = move i128 { low: 0, high: -9223372036854775808 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "min_i128 = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
@@ -119,13 +99,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let cast_u128: u128 = __inline_u128__from_pair_25: {
-        break __inline_u128__from_pair_25: u128 { low: 0, high: 1 };
-    };
+    let cast_u128: u128 = move u128 { low: 0, high: 1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_26: {
-            break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "cast_u128 = ");
         let mut __f: Formatter = __inline_Formatter__new_27: {
             let buf: &mut String = &mut __r;
@@ -140,13 +116,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let cast_i128: i128 = __inline_i128__from_pair_30: {
-        break __inline_i128__from_pair_30: i128 { low: 9223372036854775808, high: 0 };
-    };
+    let cast_i128: i128 = move i128 { low: 9223372036854775808, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_31: {
-            break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "cast_i128 = ");
         let mut __f: Formatter = __inline_Formatter__new_32: {
             let buf: &mut String = &mut __r;
@@ -161,13 +133,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let with_underscores: u128 = __inline_u128__from_pair_35: {
-        break __inline_u128__from_pair_35: u128 { low: 18446744073709551615, high: -1 };
-    };
+    let with_underscores: u128 = move u128 { low: 18446744073709551615, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "with_underscores = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -182,13 +150,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let hex_large: u128 = __inline_u128__from_pair_40: {
-        break __inline_u128__from_pair_40: u128 { low: 0, high: 1 };
-    };
+    let hex_large: u128 = move u128 { low: 0, high: 1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_41: {
-            break __inline_String__with_capacity_41: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "hex_large = ");
         let mut __f: Formatter = __inline_Formatter__new_42: {
             let buf: &mut String = &mut __r;
@@ -203,13 +167,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let hex_max: u128 = __inline_u128__from_pair_45: {
-        break __inline_u128__from_pair_45: u128 { low: 18446744073709551615, high: -1 };
-    };
+    let hex_max: u128 = move u128 { low: 18446744073709551615, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_46: {
-            break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "hex_max = ");
         let mut __f: Formatter = __inline_Formatter__new_47: {
             let buf: &mut String = &mut __r;
@@ -224,13 +184,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let bin_large: u128 = __inline_u128__from_pair_50: {
-        break __inline_u128__from_pair_50: u128 { low: 0, high: 1 };
-    };
+    let bin_large: u128 = move u128 { low: 0, high: 1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_51: {
-            break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "bin_large = ");
         let mut __f: Formatter = __inline_Formatter__new_52: {
             let buf: &mut String = &mut __r;
@@ -245,13 +201,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let hex_cast: u128 = __inline_u128__from_pair_55: {
-        break __inline_u128__from_pair_55: u128 { low: 0, high: 1 };
-    };
+    let hex_cast: u128 = move u128 { low: 0, high: 1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_56: {
-            break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "hex_cast = ");
         let mut __f: Formatter = __inline_Formatter__new_57: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_mul_div.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_mul_div.lowered.wado
@@ -14,17 +14,11 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 100, high: 0 };
-    };
-    let b: u128 = __inline_u128__from_u64_1: {
-        break __inline_u128__from_u64_1: u128 { low: 200, high: 0 };
-    };
+    let a: u128 = move u128 { low: 100, high: 0 };
+    let b: u128 = move u128 { low: 200, high: 0 };
     let mul_result: u128 = move a."u128^Mul::mul"(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "u128 100 * 200 = ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -39,17 +33,11 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c: u128 = __inline_u128__from_u64_6: {
-        break __inline_u128__from_u64_6: u128 { low: 1000000, high: 0 };
-    };
-    let d: u128 = __inline_u128__from_u64_7: {
-        break __inline_u128__from_u64_7: u128 { low: 1000000, high: 0 };
-    };
+    let c: u128 = move u128 { low: 1000000, high: 0 };
+    let d: u128 = move u128 { low: 1000000, high: 0 };
     let large_mul: u128 = move c."u128^Mul::mul"(&d);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "u128 1M * 1M = ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -66,9 +54,7 @@ fn run() with Stdout {
     });
     let div_result: u128 = move mul_result."u128^Div::div"(&a);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "u128 20000 / 100 = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -83,17 +69,11 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let e: u128 = __inline_u128__from_u64_16: {
-        break __inline_u128__from_u64_16: u128 { low: 17, high: 0 };
-    };
-    let f: u128 = __inline_u128__from_u64_17: {
-        break __inline_u128__from_u64_17: u128 { low: 5, high: 0 };
-    };
+    let e: u128 = move u128 { low: 17, high: 0 };
+    let f: u128 = move u128 { low: 5, high: 0 };
     let rem_result: u128 = move e."u128^Rem::rem"(&f);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "u128 17 % 5 = ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -112,9 +92,7 @@ fn run() with Stdout {
     let y: i128 = move i128::from_i64(-20);
     let i_mul: i128 = move x."i128^Mul::mul"(&y);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_22: {
-            break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "i128 100 * (-20) = ");
         let mut __f: Formatter = __inline_Formatter__new_23: {
             let buf: &mut String = &mut __r;
@@ -131,9 +109,7 @@ fn run() with Stdout {
     });
     let i_div: i128 = move i_mul."i128^Div::div"(&x);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_26: {
-            break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "i128 (-2000) / 100 = ");
         let mut __f: Formatter = __inline_Formatter__new_27: {
             let buf: &mut String = &mut __r;
@@ -152,9 +128,7 @@ fn run() with Stdout {
     let pos5: i128 = move i128::from_i64(5);
     let i_rem: i128 = move neg17."i128^Rem::rem"(&pos5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_30: {
-            break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "i128 (-17) % 5 = ");
         let mut __f: Formatter = __inline_Formatter__new_31: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_operators.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_operators.lowered.wado
@@ -14,17 +14,11 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 100, high: 0 };
-    };
-    let b: u128 = __inline_u128__from_u64_1: {
-        break __inline_u128__from_u64_1: u128 { low: 50, high: 0 };
-    };
+    let a: u128 = move u128 { low: 100, high: 0 };
+    let b: u128 = move u128 { low: 50, high: 0 };
     let sum: u128 = move a."u128^Add::add"(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "u128 100 + 50 = ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -41,9 +35,7 @@ fn run() with Stdout {
     });
     let diff: u128 = move a."u128^Sub::sub"(&b);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "u128 100 - 50 = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -62,9 +54,7 @@ fn run() with Stdout {
     let y: i128 = move i128::from_i64(-50);
     let sum2: i128 = move x."i128^Add::add"(&y);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "i128 100 + (-50) = ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -81,9 +71,7 @@ fn run() with Stdout {
     });
     let neg_x: i128 = move x."i128^Neg::neg"();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "i128 -100 = ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/int128_stringify.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_stringify.lowered.wado
@@ -14,13 +14,9 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let a: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 12345, high: 0 };
-    };
+    let a: u128 = move u128 { low: 12345, high: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "u128 value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -37,9 +33,7 @@ fn run() with Stdout {
     });
     let b: i128 = move i128::from_i64(42);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "i128 value: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -54,13 +48,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c: i128 = __inline_i128__from_pair_9: {
-        break __inline_i128__from_pair_9: i128 { low: 18446744073709541740, high: -1 };
-    };
+    let c: i128 = move i128 { low: 18446744073709541740, high: -1 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "i128 negative: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -75,13 +65,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let d: u128 = __inline_u128__from_u64_14: {
-        break __inline_u128__from_u64_14: u128 { low: 100, high: 0 };
-    };
+    let d: u128 = move u128 { low: 100, high: 0 };
     core::cli::println(move d.u128::to_string());
-    let e: i128 = __inline_i128__from_pair_15: {
-        break __inline_i128__from_pair_15: i128 { low: 18446744073709551416, high: -1 };
-    };
+    let e: i128 = move i128 { low: 18446744073709551416, high: -1 };
     core::cli::println(move e.i128::to_string());
     core::cli::println(move "All stringify tests passed!");
 }

--- a/wado-compiler/tests/fixtures.golden/int128_to_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/int128_to_string.lowered.wado
@@ -14,21 +14,13 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let zero: u128 = __inline_u128__zero_0: {
-        break __inline_u128__zero_0: u128 { low: 0, high: 0 };
-    };
+    let zero: u128 = move u128 { low: 0, high: 0 };
     core::cli::println(move zero.u128::to_string());
-    let small: u128 = __inline_u128__from_u64_1: {
-        break __inline_u128__from_u64_1: u128 { low: 12345, high: 0 };
-    };
+    let small: u128 = move u128 { low: 12345, high: 0 };
     core::cli::println(move small.u128::to_string());
-    let large: u128 = __inline_u128__from_u64_2: {
-        break __inline_u128__from_u64_2: u128 { low: 9999999999, high: 0 };
-    };
+    let large: u128 = move u128 { low: 9999999999, high: 0 };
     core::cli::println(move large.u128::to_string());
-    let i_zero: i128 = __inline_i128__zero_3: {
-        break __inline_i128__zero_3: i128 { low: 0, high: 0 };
-    };
+    let i_zero: i128 = move i128 { low: 0, high: 0 };
     core::cli::println(move i_zero.i128::to_string());
     let pos: i128 = move i128::from_i64(42);
     core::cli::println(move pos.i128::to_string());

--- a/wado-compiler/tests/fixtures.golden/integer_i16_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i16_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_i16_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i16_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "neg + pos: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "-100 / 7: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "-100 % 7: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_i32_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i32_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_i32_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i32_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "neg + pos: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "-1000 / 7: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "-1000 % 7: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_i64_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i64_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "neg + pos: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "-1000000000000 / 7: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "-1000000000000 % 7: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_i8_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i8_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_i8_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i8_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "neg + pos: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "-10 / 3: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "-10 % 3: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u16_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u16_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u16_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u16_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "60000 / 7: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "60000 % 7: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u32_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u32_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u32_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u32_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "large: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "3000000000 / 2: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "3000000000 % 7: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u64_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u64_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u64_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u64_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "large: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "10000000000000000000 / 2: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "10000000000000000000 % 7: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u8_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u8_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "diff: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "prod: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "quot: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "rem: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/integer_u8_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u8_edge.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "min: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "200 / 3: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "200 % 3: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/internal_f64_to_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/internal_f64_to_string.lowered.wado
@@ -12,9 +12,7 @@
 
 fn run() with Stdout {
     let s: String = __inline_f64__to_string_0: {
-        let mut buf: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut buf: String = move String { repr: "array_new<u8>"(24), used: 0 };
         let mut f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut buf;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/iterator_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_basic.lowered.wado
@@ -17,18 +17,12 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [10, 20, 30];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
     let __pattern_temp_0: Option<i32> = iter."ArrayIter<i32>^Iterator::next"();
     if __is_not_null(__pattern_temp_0) {
         let a: i32 = __unwrap_option(__pattern_temp_0).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_2: {
-                break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "first: ");
             let mut __f: Formatter = __inline_Formatter__new_3: {
                 let buf: &mut String = &mut __r;
@@ -46,9 +40,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_1) {
         let b: i32 = __unwrap_option(__pattern_temp_1).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_5: {
-                break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(24), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
             __r.String::append(move "second: ");
             let mut __f: Formatter = __inline_Formatter__new_6: {
                 let buf: &mut String = &mut __r;
@@ -66,9 +58,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_2) {
         let c: i32 = __unwrap_option(__pattern_temp_2).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_8: {
-                break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "third: ");
             let mut __f: Formatter = __inline_Formatter__new_9: {
                 let buf: &mut String = &mut __r;
@@ -86,9 +76,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_3) {
         let d: i32 = __unwrap_option(__pattern_temp_3).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_11: {
-                break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(28), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
             __r.String::append(move "unexpected: ");
             let mut __f: Formatter = __inline_Formatter__new_12: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/iterator_collect.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_collect.lowered.wado
@@ -17,24 +17,16 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3, 4, 5];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
     let collected: Array<i32> = move iter."ArrayIter<i32>::collect"();
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_2: {
-            break __inline_Array_i32__IntoIterator__into_iter_2: ArrayIter<i32> { repr: collected.repr, used: collected.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: collected.repr, used: collected.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_3: {
-                        break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_4: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -52,18 +44,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "len: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_9: {
-                break __inline_Array_i32___len_9: collected.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: collected.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/iterator_empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_empty.lowered.wado
@@ -17,18 +17,12 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
     let __pattern_temp_0: Option<i32> = iter."ArrayIter<i32>^Iterator::next"();
     if __is_not_null(__pattern_temp_0) {
         let a: i32 = __unwrap_option(__pattern_temp_0).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_2: {
-                break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(28), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
             __r.String::append(move "unexpected: ");
             let mut __f: Formatter = __inline_Formatter__new_3: {
                 let buf: &mut String = &mut __r;
@@ -48,9 +42,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_1) {
         let b: i32 = __unwrap_option(__pattern_temp_1).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_5: {
-                break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(28), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
             __r.String::append(move "unexpected: ");
             let mut __f: Formatter = __inline_Formatter__new_6: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/iterator_enumerate.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_enumerate.lowered.wado
@@ -25,11 +25,7 @@ pub struct "ArrayIter<String>" {
 fn run() with Stdout {
     let arr: Array<String> = move ["a", "b", "c"];
     let mut iter: EnumerateIter<String> = __inline_ArrayIter_String___enumerate_0: {
-        let self: &ArrayIter<String> = &__inline_Array_String___iter_1: {
-            break __inline_Array_String___iter_1: __inline_Array_String__IntoIterator__into_iter_0: {
-                break __inline_Array_String__IntoIterator__into_iter_0: ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };
-            };
-        };
+        let self: &ArrayIter<String> = &ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };
         break __inline_ArrayIter_String___enumerate_0: EnumerateIter<String> { repr: self.repr, used: self.used, index: self.index, count: 0 };
     };
     loop {
@@ -39,9 +35,7 @@ fn run() with Stdout {
             let idx: i32 = pair.0;
             let val: String = pair.1;
             core::cli::println(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(34), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
                 let mut __f: Formatter = __inline_Formatter__new_3: {
                     let buf: &mut String = &mut __r;
                     break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/iterator_filter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_filter.lowered.wado
@@ -31,27 +31,19 @@ struct __Closure_1 {
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let evens: Array<i32> = move __inline_ArrayIter_i32___filter_1: {
-        let self: &ArrayIter<i32> = &__inline_Array_i32___iter_0: {
-            break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_0: {
-                break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-            };
-        };
+        let self: &ArrayIter<i32> = &ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         let pred: fn(i32) -> bool = &__Closure_0 {  };
         break __inline_ArrayIter_i32___filter_1: FilterIter<i32> { repr: self.repr, used: self.used, index: self.index, pred: pred };
     }."FilterIter<i32>^Iterator::collect"();
     core::cli::println(move "evens:");
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_2: {
-            break __inline_Array_i32__IntoIterator__into_iter_2: ArrayIter<i32> { repr: evens.repr, used: evens.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: evens.repr, used: evens.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_3: {
-                        break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_4: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -69,27 +61,19 @@ fn run() with Stdout {
         }
     }
     let large: Array<i32> = move __inline_ArrayIter_i32___filter_7: {
-        let self: &ArrayIter<i32> = &__inline_Array_i32___iter_6: {
-            break __inline_Array_i32___iter_6: __inline_Array_i32__IntoIterator__into_iter_1: {
-                break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-            };
-        };
+        let self: &ArrayIter<i32> = &ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         let pred: fn(i32) -> bool = &__Closure_1 {  };
         break __inline_ArrayIter_i32___filter_7: FilterIter<i32> { repr: self.repr, used: self.used, index: self.index, pred: pred };
     }."FilterIter<i32>^Iterator::collect"();
     core::cli::println(move "large:");
     __for_of_1: {
-        let mut __iter_1: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_8: {
-            break __inline_Array_i32__IntoIterator__into_iter_8: ArrayIter<i32> { repr: large.repr, used: large.used, index: 0 };
-        };
+        let mut __iter_1: ArrayIter<i32> = move ArrayIter<i32> { repr: large.repr, used: large.used, index: 0 };
         loop {
             let __pattern_temp_1: Option<i32> = __iter_1."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_1) {
                 let x: i32 = __unwrap_option(__pattern_temp_1).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_9: {
-                        break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_10: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/iterator_fold.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_fold.lowered.wado
@@ -29,15 +29,9 @@ struct __Closure_3 {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3, 4, 5];
-    let sum: i32 = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_0: {
-            break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    }."ArrayIter<i32>::fold<i32>$__Closure_0"(0, &__Closure_0 {  });
+    let sum: i32 = ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_0"(0, &__Closure_0 {  });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -50,15 +44,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let product: i32 = __inline_Array_i32___iter_4: {
-        break __inline_Array_i32___iter_4: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    }."ArrayIter<i32>::fold<i32>$__Closure_1"(1, &__Closure_1 {  });
+    let product: i32 = ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_1"(1, &__Closure_1 {  });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "product: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -71,15 +59,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let count: i32 = __inline_Array_i32___iter_8: {
-        break __inline_Array_i32___iter_8: __inline_Array_i32__IntoIterator__into_iter_2: {
-            break __inline_Array_i32__IntoIterator__into_iter_2: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    }."ArrayIter<i32>::fold<i32>$__Closure_2"(0, &__Closure_2 {  });
+    let count: i32 = ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_2"(0, &__Closure_2 {  });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "count: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -93,15 +75,9 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     let arr2: Array<i32> = move [3, 1, 4, 1, 5, 9, 2, 6];
-    let max: i32 = __inline_Array_i32___iter_12: {
-        break __inline_Array_i32___iter_12: __inline_Array_i32__IntoIterator__into_iter_3: {
-            break __inline_Array_i32__IntoIterator__into_iter_3: ArrayIter<i32> { repr: arr2.repr, used: arr2.used, index: 0 };
-        };
-    }."ArrayIter<i32>::fold<i32>$__Closure_3"(0, &__Closure_3 {  });
+    let max: i32 = ArrayIter<i32> { repr: arr2.repr, used: arr2.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_3"(0, &__Closure_3 {  });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "max: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -131,9 +107,7 @@ fn "ArrayIter<i32>::fold<i32>$__Closure_0"(self: &mut ArrayIter<i32>, init: i32,
         let __pattern_temp_0: Option<i32> = self."ArrayIter<i32>^Iterator::next"();
         if __is_not_null(__pattern_temp_0) {
             let item: i32 = __unwrap_option(__pattern_temp_0).value;
-            acc = __inline___Closure_0____call_0: {
-                break __inline___Closure_0____call_0: (acc + item);
-            };
+            acc = (acc + item);
         } else {
             break;
         }
@@ -147,9 +121,7 @@ fn "ArrayIter<i32>::fold<i32>$__Closure_1"(self: &mut ArrayIter<i32>, init: i32,
         let __pattern_temp_0: Option<i32> = self."ArrayIter<i32>^Iterator::next"();
         if __is_not_null(__pattern_temp_0) {
             let item: i32 = __unwrap_option(__pattern_temp_0).value;
-            acc = __inline___Closure_1____call_0: {
-                break __inline___Closure_1____call_0: (acc * item);
-            };
+            acc = (acc * item);
         } else {
             break;
         }
@@ -163,9 +135,7 @@ fn "ArrayIter<i32>::fold<i32>$__Closure_2"(self: &mut ArrayIter<i32>, init: i32,
         let __pattern_temp_0: Option<i32> = self."ArrayIter<i32>^Iterator::next"();
         if __is_not_null(__pattern_temp_0) {
             let item: i32 = __unwrap_option(__pattern_temp_0).value;
-            acc = __inline___Closure_2____call_0: {
-                break __inline___Closure_2____call_0: (acc + 1);
-            };
+            acc = (acc + 1);
         } else {
             break;
         }
@@ -179,12 +149,10 @@ fn "ArrayIter<i32>::fold<i32>$__Closure_3"(self: &mut ArrayIter<i32>, init: i32,
         let __pattern_temp_0: Option<i32> = self."ArrayIter<i32>^Iterator::next"();
         if __is_not_null(__pattern_temp_0) {
             let item: i32 = __unwrap_option(__pattern_temp_0).value;
-            acc = __inline___Closure_3____call_0: {
-                break __inline___Closure_3____call_0: if (item > acc) {
-                    item;
-                } else {
-                    acc;
-                };
+            acc = if (item > acc) {
+                item;
+            } else {
+                acc;
             };
         } else {
             break;

--- a/wado-compiler/tests/fixtures.golden/iterator_into_iter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_into_iter.lowered.wado
@@ -17,9 +17,7 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_0: {
-        break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
     let mut sum: i32 = 0;
     loop {
         let __pattern_temp_0: Option<i32> = iter."ArrayIter<i32>^Iterator::next"();
@@ -31,9 +29,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/iterator_map.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_map.lowered.wado
@@ -31,26 +31,18 @@ struct __Closure_1 {
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3, 4, 5];
     let doubled: Array<i32> = move __inline_ArrayIter_i32___map_i32__1: {
-        let self: &ArrayIter<i32> = &__inline_Array_i32___iter_0: {
-            break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_0: {
-                break __inline_Array_i32__IntoIterator__into_iter_0: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-            };
-        };
+        let self: &ArrayIter<i32> = &ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         let f: fn(i32) -> i32 = &__Closure_0 {  };
         break __inline_ArrayIter_i32___map_i32__1: MapIter<i32,i32> { repr: self.repr, used: self.used, index: self.index, f: f };
     }."MapIter<i32,i32>^Iterator::collect"();
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_2: {
-            break __inline_Array_i32__IntoIterator__into_iter_2: ArrayIter<i32> { repr: doubled.repr, used: doubled.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: doubled.repr, used: doubled.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let x: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_3: {
-                        break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_4: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -68,27 +60,19 @@ fn run() with Stdout {
         }
     }
     let squared: Array<i32> = move __inline_ArrayIter_i32___map_i32__7: {
-        let self: &ArrayIter<i32> = &__inline_Array_i32___iter_6: {
-            break __inline_Array_i32___iter_6: __inline_Array_i32__IntoIterator__into_iter_1: {
-                break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-            };
-        };
+        let self: &ArrayIter<i32> = &ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         let f: fn(i32) -> i32 = &__Closure_1 {  };
         break __inline_ArrayIter_i32___map_i32__7: MapIter<i32,i32> { repr: self.repr, used: self.used, index: self.index, f: f };
     }."MapIter<i32,i32>^Iterator::collect"();
     core::cli::println(move "squares:");
     __for_of_1: {
-        let mut __iter_1: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_8: {
-            break __inline_Array_i32__IntoIterator__into_iter_8: ArrayIter<i32> { repr: squared.repr, used: squared.used, index: 0 };
-        };
+        let mut __iter_1: ArrayIter<i32> = move ArrayIter<i32> { repr: squared.repr, used: squared.used, index: 0 };
         loop {
             let __pattern_temp_1: Option<i32> = __iter_1."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_1) {
                 let x: i32 = __unwrap_option(__pattern_temp_1).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_9: {
-                        break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_10: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/iterator_strings.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_strings.lowered.wado
@@ -17,11 +17,7 @@ pub struct "ArrayIter<String>" {
 
 fn run() with Stdout {
     let arr: Array<String> = move ["hello", "world", "!"];
-    let mut iter: ArrayIter<String> = __inline_Array_String___iter_0: {
-        break __inline_Array_String___iter_0: __inline_Array_String__IntoIterator__into_iter_1: {
-            break __inline_Array_String__IntoIterator__into_iter_1: ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<String> = move ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };
     loop {
         let __pattern_temp_0: Option<String> = move iter."ArrayIter<String>^Iterator::next"();
         if __is_not_null(__pattern_temp_0) {

--- a/wado-compiler/tests/fixtures.golden/labeled_block_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_basic.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     scope: {
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
             __r.String::append(move "x in scope: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -29,9 +27,7 @@ fn run() with Stdout {
         });
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "x after scope: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -47,9 +43,7 @@ fn run() with Stdout {
     outer: {
         inner: {
             core::cli::println(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(24), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
                 __r.String::append(move "a + b = ");
                 let mut __f: Formatter = __inline_Formatter__new_7: {
                     let buf: &mut String = &mut __r;
@@ -64,9 +58,7 @@ fn run() with Stdout {
             });
         }
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_9: {
-                break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(20), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
             __r.String::append(move "a = ");
             let mut __f: Formatter = __inline_Formatter__new_10: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_break_label.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_break_label.lowered.wado
@@ -26,9 +26,7 @@ fn run() with Stdout {
         let __cond: bool = (count == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(120), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(120), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/labeled_block_expr_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_expr_nested.lowered.wado
@@ -15,18 +15,14 @@
 
 fn run() with Stdout {
     let result: i32 = outer: {
-        let x: i32 = inner: {
-            break inner: 10;
-        };
+        let x: i32 = 10;
         break outer: (x * 2);
     };
     __assert_0: {
         let __cond: bool = (result == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(123), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(123), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/labeled_block_expr_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_expr_simple.lowered.wado
@@ -24,9 +24,7 @@ fn run() with Stdout {
         let __cond: bool = (result == 30);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(123), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(123), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/labeled_block_expr_value.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_expr_value.lowered.wado
@@ -37,9 +37,7 @@ fn run() with Stdout {
         break foo: -1;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "x=");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_in_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_in_loop.lowered.wado
@@ -37,9 +37,7 @@ fn run() with Stdout {
         let __cond: bool = (sum == 23);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/labeled_block_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_nested.lowered.wado
@@ -30,9 +30,7 @@ fn run() with Stdout {
         let __cond: bool = (result == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(122), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(122), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/libm.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/libm.lowered.wado
@@ -52,9 +52,7 @@ fn run() with Stdout {
         let __cond: bool = (sin_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -93,9 +91,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(278), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(278), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -175,9 +171,7 @@ fn run() with Stdout {
         let __cond: bool = (cos_0 == 1.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -216,9 +210,7 @@ fn run() with Stdout {
         let __cond: bool = (__v2 && __v4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(304), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(304), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -308,9 +300,7 @@ fn run() with Stdout {
         let __cond: bool = (tan_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -349,9 +339,7 @@ fn run() with Stdout {
         let __cond: bool = (asin_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -390,9 +378,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_44: {
-                    break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(248), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(248), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -472,9 +458,7 @@ fn run() with Stdout {
         let __cond: bool = (acos_1 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -513,9 +497,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_60: {
-                    break __inline_String__with_capacity_60: String { repr: "array_new<u8>"(248), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(248), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -595,9 +577,7 @@ fn run() with Stdout {
         let __cond: bool = (atan_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_71: {
-                    break __inline_String__with_capacity_71: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -636,9 +616,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_76: {
-                    break __inline_String__with_capacity_76: String { repr: "array_new<u8>"(248), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(248), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -719,9 +697,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_87: {
-                    break __inline_String__with_capacity_87: String { repr: "array_new<u8>"(284), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(284), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -802,9 +778,7 @@ fn run() with Stdout {
         let __cond: bool = (sinh_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_98: {
-                    break __inline_String__with_capacity_98: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -841,9 +815,7 @@ fn run() with Stdout {
         let __cond: bool = (cosh_0 == 1.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_103: {
-                    break __inline_String__with_capacity_103: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -880,9 +852,7 @@ fn run() with Stdout {
         let __cond: bool = (tanh_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_108: {
-                    break __inline_String__with_capacity_108: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -922,9 +892,7 @@ fn run() with Stdout {
         let __cond: bool = (asinh_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_113: {
-                    break __inline_String__with_capacity_113: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -961,9 +929,7 @@ fn run() with Stdout {
         let __cond: bool = (acosh_1 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_118: {
-                    break __inline_String__with_capacity_118: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1000,9 +966,7 @@ fn run() with Stdout {
         let __cond: bool = (atanh_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_123: {
-                    break __inline_String__with_capacity_123: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1041,9 +1005,7 @@ fn run() with Stdout {
         let __cond: bool = (exp_0 == 1.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_128: {
-                    break __inline_String__with_capacity_128: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1082,9 +1044,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_133: {
-                    break __inline_String__with_capacity_133: String { repr: "array_new<u8>"(242), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(242), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1164,9 +1124,7 @@ fn run() with Stdout {
         let __cond: bool = (exp2_0 == 1.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_144: {
-                    break __inline_String__with_capacity_144: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1203,9 +1161,7 @@ fn run() with Stdout {
         let __cond: bool = (exp2_3 == 8.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_149: {
-                    break __inline_String__with_capacity_149: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1243,9 +1199,7 @@ fn run() with Stdout {
         let __cond: bool = (expm1_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_154: {
-                    break __inline_String__with_capacity_154: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1284,9 +1238,7 @@ fn run() with Stdout {
         let __cond: bool = (ln_1 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_159: {
-                    break __inline_String__with_capacity_159: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1325,9 +1277,7 @@ fn run() with Stdout {
         let __cond: bool = (__v1 && __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_164: {
-                    break __inline_String__with_capacity_164: String { repr: "array_new<u8>"(236), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(236), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1407,9 +1357,7 @@ fn run() with Stdout {
         let __cond: bool = (log2_1 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_175: {
-                    break __inline_String__with_capacity_175: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1446,9 +1394,7 @@ fn run() with Stdout {
         let __cond: bool = (log2_8 == 3.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_180: {
-                    break __inline_String__with_capacity_180: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1487,9 +1433,7 @@ fn run() with Stdout {
         let __cond: bool = (log10_1 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_185: {
-                    break __inline_String__with_capacity_185: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1526,9 +1470,7 @@ fn run() with Stdout {
         let __cond: bool = (log10_100 == 2.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_190: {
-                    break __inline_String__with_capacity_190: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1566,9 +1508,7 @@ fn run() with Stdout {
         let __cond: bool = (ln1p_0 == 0.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_195: {
-                    break __inline_String__with_capacity_195: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1606,9 +1546,7 @@ fn run() with Stdout {
         let __cond: bool = (pow_2_3 == 8.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_200: {
-                    break __inline_String__with_capacity_200: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1647,9 +1585,7 @@ fn run() with Stdout {
         let __cond: bool = (cbrt_8 == 2.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_205: {
-                    break __inline_String__with_capacity_205: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1686,9 +1622,7 @@ fn run() with Stdout {
         let __cond: bool = (cbrt_27 == 3.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_210: {
-                    break __inline_String__with_capacity_210: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1726,9 +1660,7 @@ fn run() with Stdout {
         let __cond: bool = (hypot_3_4 == 5.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_215: {
-                    break __inline_String__with_capacity_215: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1766,9 +1698,7 @@ fn run() with Stdout {
         let __cond: bool = (fmod_7_3 == 1.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_220: {
-                    break __inline_String__with_capacity_220: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1806,9 +1736,7 @@ fn run() with Stdout {
         let __cond: bool = (sin_f32 == 0.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_225: {
-                    break __inline_String__with_capacity_225: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1846,9 +1774,7 @@ fn run() with Stdout {
         let __cond: bool = (cos_f32 == 1.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_230: {
-                    break __inline_String__with_capacity_230: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1886,9 +1812,7 @@ fn run() with Stdout {
         let __cond: bool = (exp_f32 == 1.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_235: {
-                    break __inline_String__with_capacity_235: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1926,9 +1850,7 @@ fn run() with Stdout {
         let __cond: bool = (ln_f32 == 0.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_240: {
-                    break __inline_String__with_capacity_240: String { repr: "array_new<u8>"(149), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(149), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1966,9 +1888,7 @@ fn run() with Stdout {
         let __cond: bool = (pow_f32 == 8.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_245: {
-                    break __inline_String__with_capacity_245: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/likely_unlikely.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/likely_unlikely.lowered.wado
@@ -29,9 +29,7 @@ fn run() with Stdout {
     let r3: i32 = check_unlikely(10);
     let r4: i32 = check_unlikely(-1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(82), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(82), used: 0 };
         __r.String::append(move "r1=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/location_literal_line.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/location_literal_line.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__inline_i32__to_string_0: {
-        let mut buf: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(12), used: 0 };
-        };
+        let mut buf: String = move String { repr: "array_new<u8>"(12), used: 0 };
         let mut f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut buf;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/location_literal_line_template.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/location_literal_line_template.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "line: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/loop_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_basic.lowered.wado
@@ -13,9 +13,7 @@ fn run() with Stdout {
     let mut count: i32 = 0;
     loop {
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "count: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/loop_continue.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_continue.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
             continue;
         }
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "count: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/loop_nested_deep.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_nested_deep.lowered.wado
@@ -34,9 +34,7 @@ fn run() with Stdout {
                                 }
                                 __for_1_body: {
                                     core::cli::println(__tmpl: {
-                                        let mut __r: String = __inline_String__with_capacity_0: {
-                                            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(67), used: 0 };
-                                        };
+                                        let mut __r: String = move String { repr: "array_new<u8>"(67), used: 0 };
                                         let mut __f: Formatter = __inline_Formatter__new_1: {
                                             let buf: &mut String = &mut __r;
                                             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/loop_nested_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_nested_loop.lowered.wado
@@ -17,9 +17,7 @@ fn run() with Stdout {
         loop {
             inner = (inner + 1);
             core::cli::println(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(45), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(45), used: 0 };
                 __r.String::append(move "outer:");
                 let mut __f: Formatter = __inline_Formatter__new_1: {
                     let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/loop_nested_mixed.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_nested_mixed.lowered.wado
@@ -27,9 +27,7 @@ fn run() with Stdout {
                     }
                     __for_0_body: {
                         core::cli::println(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_0: {
-                                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(56), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(56), used: 0 };
                             __r.String::append(move "a:");
                             let mut __f: Formatter = __inline_Formatter__new_1: {
                                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/match_literal_u128.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_literal_u128.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let x: u128 = __inline_u128__from_u64_0: {
-        break __inline_u128__from_u64_0: u128 { low: 42, high: 0 };
-    };
+    let x: u128 = move u128 { low: 42, high: 0 };
     let r1: String = if x."i128^Eq::eq"(&i128::from_i64(0)) {
         "zero";
     } else {

--- a/wado-compiler/tests/fixtures.golden/match_option_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_option_basic.lowered.wado
@@ -17,9 +17,7 @@ fn run() with Stdout {
         None => 0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "Result from Some: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -37,9 +35,7 @@ fn run() with Stdout {
         None => -1,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "Result from None: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/match_variant_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_basic.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
         Point => 0.0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "Circle area: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -38,9 +36,7 @@ fn run() with Stdout {
         Point => 0.0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "Point area: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/match_variant_import_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_import_module.lowered.wado
@@ -18,18 +18,12 @@ pub struct FormatSpec {
 
 pub fn apply_padding(s: String, spec: FormatSpec) -> String {
     let width: i32 = spec.width;
-    if ((width <= 0) || (__inline_String__len_0: {
-        break __inline_String__len_0: s.used;
-    } >= width)) {
+    if ((width <= 0) || (s.used >= width)) {
         return s;
     }
     let fill: char = spec.fill;
-    let pad_len: i32 = (width - __inline_String__len_1: {
-        break __inline_String__len_1: s.used;
-    });
-    let mut result: String = __inline_String__with_capacity_2: {
-        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(width), used: 0 };
-    };
+    let pad_len: i32 = (width - s.used);
+    let mut result: String = move String { repr: "array_new<u8>"(width), used: 0 };
     return match spec.align {
         Left => {
             result.String::append(s);
@@ -98,9 +92,7 @@ pub fn apply_padding(s: String, spec: FormatSpec) -> String {
 
 pub fn f64_to_string_fill(value: f64, width: i32, fill: char, align: Align) -> String {
     let s: String = __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/match_variant_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_loop.lowered.wado
@@ -17,18 +17,12 @@ struct FormatSpec {
 
 fn apply_padding(s: String, spec: FormatSpec) -> String {
     let width: i32 = spec.width;
-    if ((width <= 0) || (__inline_String__len_0: {
-        break __inline_String__len_0: s.used;
-    } >= width)) {
+    if ((width <= 0) || (s.used >= width)) {
         return s;
     }
     let fill: char = spec.fill;
-    let pad_len: i32 = (width - __inline_String__len_1: {
-        break __inline_String__len_1: s.used;
-    });
-    let mut result: String = __inline_String__with_capacity_2: {
-        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(width), used: 0 };
-    };
+    let pad_len: i32 = (width - s.used);
+    let mut result: String = move String { repr: "array_new<u8>"(width), used: 0 };
     return match spec.align {
         Left => {
             result.String::append(s);

--- a/wado-compiler/tests/fixtures.golden/match_variant_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_simple.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
         Point => 0.0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "Circle result: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -38,9 +36,7 @@ fn run() with Stdout {
         Point => 0.0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "Point result: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/match_variant_tuple_payload.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_tuple_payload.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
         Point => 0.0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "Rectangle area: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/math_f32_constants.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/math_f32_constants.lowered.wado
@@ -12,9 +12,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "PI = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -28,9 +26,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "TAU = ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -44,9 +40,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "E = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -60,9 +54,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "LN2 = ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -76,9 +68,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "LN10 = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -92,9 +82,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "LOG2_E = ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -108,9 +96,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "LOG10_E = ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -124,9 +110,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "SQRT2 = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
@@ -140,9 +124,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "FRAC_1_SQRT2 = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -156,9 +138,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "FRAC_PI_2 = ");
         let mut __f: Formatter = __inline_Formatter__new_28: {
             let buf: &mut String = &mut __r;
@@ -172,9 +152,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_30: {
-            break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "FRAC_PI_4 = ");
         let mut __f: Formatter = __inline_Formatter__new_31: {
             let buf: &mut String = &mut __r;
@@ -188,9 +166,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "INFINITY = ");
         let mut __f: Formatter = __inline_Formatter__new_34: {
             let buf: &mut String = &mut __r;
@@ -204,9 +180,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "NEG_INFINITY = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -220,9 +194,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_39: {
-            break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "TAU == 2*PI: ");
         let mut __f: Formatter = __inline_Formatter__new_40: {
             let buf: &mut String = &mut __r;
@@ -240,9 +212,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_42: {
-            break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "FRAC_PI_2 == PI/2: ");
         let mut __f: Formatter = __inline_Formatter__new_43: {
             let buf: &mut String = &mut __r;
@@ -260,9 +230,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_45: {
-            break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "FRAC_PI_4 == PI/4: ");
         let mut __f: Formatter = __inline_Formatter__new_46: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/math_f32_functions.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/math_f32_functions.lowered.wado
@@ -36,9 +36,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "abs(-3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -55,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "abs(2.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
@@ -74,9 +70,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "ceil(2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -93,9 +87,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "ceil(-2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -112,9 +104,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "floor(2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
@@ -131,9 +121,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "floor(-2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
@@ -150,9 +138,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "trunc(2.9) = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -169,9 +155,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_28: {
-            break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "trunc(-2.9) = ");
         let mut __f: Formatter = __inline_Formatter__new_29: {
             let buf: &mut String = &mut __r;
@@ -188,9 +172,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_32: {
-            break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "round(2.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_33: {
             let buf: &mut String = &mut __r;
@@ -207,9 +189,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "round(3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -226,9 +206,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_40: {
-            break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sqrt(4.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_41: {
             let buf: &mut String = &mut __r;
@@ -245,9 +223,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_44: {
-            break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sqrt(2.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_45: {
             let buf: &mut String = &mut __r;
@@ -264,9 +240,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_48: {
-            break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "min(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_49: {
             let buf: &mut String = &mut __r;
@@ -284,9 +258,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_52: {
-            break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "max(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_53: {
             let buf: &mut String = &mut __r;
@@ -304,9 +276,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_56: {
-            break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "copysign(5.0, -1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_57: {
             let buf: &mut String = &mut __r;
@@ -324,9 +294,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_60: {
-            break __inline_String__with_capacity_60: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "copysign(-5.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_61: {
             let buf: &mut String = &mut __r;
@@ -344,9 +312,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_64: {
-            break __inline_String__with_capacity_64: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "sin(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_65: {
             let buf: &mut String = &mut __r;
@@ -363,9 +329,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_68: {
-            break __inline_String__with_capacity_68: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sin(PI/2) = ");
         let mut __f: Formatter = __inline_Formatter__new_69: {
             let buf: &mut String = &mut __r;
@@ -382,9 +346,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_72: {
-            break __inline_String__with_capacity_72: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "cos(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_73: {
             let buf: &mut String = &mut __r;
@@ -401,27 +363,21 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_76: {
-            break __inline_String__with_capacity_76: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "cos(PI) = ");
         let mut __f: Formatter = __inline_Formatter__new_77: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_77: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f32_Display__fmt_78: {
-            let self: Box<f32> = move Box<f32> { value: __inline_f32__cos_79: {
-                break __inline_f32__cos_79: core::builtin::f32_cos(3.14159265358979323846);
-            } };
+            let self: Box<f32> = move Box<f32> { value: core::builtin::f32_cos(3.14159265358979323846) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f32"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_80: {
-            break __inline_String__with_capacity_80: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "tan(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_81: {
             let buf: &mut String = &mut __r;
@@ -438,9 +394,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_84: {
-            break __inline_String__with_capacity_84: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "asin(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_85: {
             let buf: &mut String = &mut __r;
@@ -457,9 +411,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_88: {
-            break __inline_String__with_capacity_88: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "acos(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_89: {
             let buf: &mut String = &mut __r;
@@ -476,9 +428,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_92: {
-            break __inline_String__with_capacity_92: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "atan(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_93: {
             let buf: &mut String = &mut __r;
@@ -495,9 +445,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_96: {
-            break __inline_String__with_capacity_96: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "atan2(1.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_97: {
             let buf: &mut String = &mut __r;
@@ -515,9 +463,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_100: {
-            break __inline_String__with_capacity_100: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sinh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_101: {
             let buf: &mut String = &mut __r;
@@ -534,9 +480,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_104: {
-            break __inline_String__with_capacity_104: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "cosh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_105: {
             let buf: &mut String = &mut __r;
@@ -553,9 +497,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_108: {
-            break __inline_String__with_capacity_108: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "tanh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_109: {
             let buf: &mut String = &mut __r;
@@ -572,9 +514,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_112: {
-            break __inline_String__with_capacity_112: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "asinh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_113: {
             let buf: &mut String = &mut __r;
@@ -591,9 +531,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_116: {
-            break __inline_String__with_capacity_116: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "acosh(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_117: {
             let buf: &mut String = &mut __r;
@@ -610,9 +548,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_120: {
-            break __inline_String__with_capacity_120: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "atanh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_121: {
             let buf: &mut String = &mut __r;
@@ -629,9 +565,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_124: {
-            break __inline_String__with_capacity_124: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "exp(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_125: {
             let buf: &mut String = &mut __r;
@@ -648,9 +582,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_128: {
-            break __inline_String__with_capacity_128: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "exp(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_129: {
             let buf: &mut String = &mut __r;
@@ -667,9 +599,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_132: {
-            break __inline_String__with_capacity_132: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "exp2(3.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_133: {
             let buf: &mut String = &mut __r;
@@ -686,9 +616,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_136: {
-            break __inline_String__with_capacity_136: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "expm1(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_137: {
             let buf: &mut String = &mut __r;
@@ -705,9 +633,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_140: {
-            break __inline_String__with_capacity_140: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "ln(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_141: {
             let buf: &mut String = &mut __r;
@@ -724,27 +650,21 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_144: {
-            break __inline_String__with_capacity_144: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "ln(E) = ");
         let mut __f: Formatter = __inline_Formatter__new_145: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_145: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f32_Display__fmt_146: {
-            let self: Box<f32> = move Box<f32> { value: __inline_f32__ln_147: {
-                break __inline_f32__ln_147: core::builtin::f32_ln(2.71828182845904523536);
-            } };
+            let self: Box<f32> = move Box<f32> { value: core::builtin::f32_ln(2.71828182845904523536) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f32"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_148: {
-            break __inline_String__with_capacity_148: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "log2(8.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_149: {
             let buf: &mut String = &mut __r;
@@ -761,9 +681,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_152: {
-            break __inline_String__with_capacity_152: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "log10(1000.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_153: {
             let buf: &mut String = &mut __r;
@@ -780,9 +698,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_156: {
-            break __inline_String__with_capacity_156: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "ln1p(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_157: {
             let buf: &mut String = &mut __r;
@@ -799,9 +715,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_160: {
-            break __inline_String__with_capacity_160: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "pow(2.0, 10.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_161: {
             let buf: &mut String = &mut __r;
@@ -819,9 +733,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_164: {
-            break __inline_String__with_capacity_164: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "pow(3.0, 3.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_165: {
             let buf: &mut String = &mut __r;
@@ -839,9 +751,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_168: {
-            break __inline_String__with_capacity_168: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "cbrt(27.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_169: {
             let buf: &mut String = &mut __r;
@@ -858,9 +768,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_172: {
-            break __inline_String__with_capacity_172: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "hypot(3.0, 4.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_173: {
             let buf: &mut String = &mut __r;
@@ -878,9 +786,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_176: {
-            break __inline_String__with_capacity_176: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "fmod(7.0, 3.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_177: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/math_f64_constants.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/math_f64_constants.lowered.wado
@@ -12,9 +12,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "PI = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -28,9 +26,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "TAU = ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -44,9 +40,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "E = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -60,9 +54,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "LN2 = ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -76,9 +68,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "LN10 = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -92,9 +82,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "LOG2_E = ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -108,9 +96,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "LOG10_E = ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -124,9 +110,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "SQRT2 = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
@@ -140,9 +124,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "FRAC_1_SQRT2 = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -156,9 +138,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "FRAC_PI_2 = ");
         let mut __f: Formatter = __inline_Formatter__new_28: {
             let buf: &mut String = &mut __r;
@@ -172,9 +152,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_30: {
-            break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "FRAC_PI_4 = ");
         let mut __f: Formatter = __inline_Formatter__new_31: {
             let buf: &mut String = &mut __r;
@@ -188,9 +166,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "INFINITY = ");
         let mut __f: Formatter = __inline_Formatter__new_34: {
             let buf: &mut String = &mut __r;
@@ -204,9 +180,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "NEG_INFINITY = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -220,9 +194,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_39: {
-            break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "TAU == 2*PI: ");
         let mut __f: Formatter = __inline_Formatter__new_40: {
             let buf: &mut String = &mut __r;
@@ -240,9 +212,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_42: {
-            break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "FRAC_PI_2 == PI/2: ");
         let mut __f: Formatter = __inline_Formatter__new_43: {
             let buf: &mut String = &mut __r;
@@ -260,9 +230,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_45: {
-            break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "FRAC_PI_4 == PI/4: ");
         let mut __f: Formatter = __inline_Formatter__new_46: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/math_f64_functions.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/math_f64_functions.lowered.wado
@@ -36,315 +36,245 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "abs(-3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_2: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__abs_3: {
-                break __inline_f64__abs_3: core::builtin::f64_abs(-3.5);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_abs(-3.5) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "abs(2.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_6: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__abs_7: {
-                break __inline_f64__abs_7: core::builtin::f64_abs(2.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_abs(2.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "ceil(2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_10: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__ceil_11: {
-                break __inline_f64__ceil_11: core::builtin::f64_ceil(2.3);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_ceil(2.3) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "ceil(-2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_14: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__ceil_15: {
-                break __inline_f64__ceil_15: core::builtin::f64_ceil(-2.3);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_ceil(-2.3) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "floor(2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_17: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_18: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__floor_19: {
-                break __inline_f64__floor_19: core::builtin::f64_floor(2.7);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_floor(2.7) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "floor(-2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_21: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_22: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__floor_23: {
-                break __inline_f64__floor_23: core::builtin::f64_floor(-2.7);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_floor(-2.7) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "trunc(2.9) = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_25: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_26: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__trunc_27: {
-                break __inline_f64__trunc_27: core::builtin::f64_trunc(2.9);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_trunc(2.9) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_28: {
-            break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "trunc(-2.9) = ");
         let mut __f: Formatter = __inline_Formatter__new_29: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_29: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_30: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__trunc_31: {
-                break __inline_f64__trunc_31: core::builtin::f64_trunc(-2.9);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_trunc(-2.9) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_32: {
-            break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "round(2.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_33: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_33: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_34: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__round_35: {
-                break __inline_f64__round_35: core::builtin::f64_nearest(2.5);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_nearest(2.5) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "round(3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_37: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_38: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__round_39: {
-                break __inline_f64__round_39: core::builtin::f64_nearest(3.5);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_nearest(3.5) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_40: {
-            break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sqrt(4.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_41: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_41: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_42: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__sqrt_43: {
-                break __inline_f64__sqrt_43: core::builtin::f64_sqrt(4.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_sqrt(4.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_44: {
-            break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sqrt(2.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_45: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_45: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_46: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__sqrt_47: {
-                break __inline_f64__sqrt_47: core::builtin::f64_sqrt(2.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_sqrt(2.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_48: {
-            break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "min(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_49: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_49: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_50: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__min_51: {
-                break __inline_f64__min_51: core::builtin::f64_min(3.0, 5.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_min(3.0, 5.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_52: {
-            break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "max(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_53: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_53: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_54: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__max_55: {
-                break __inline_f64__max_55: core::builtin::f64_max(3.0, 5.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_max(3.0, 5.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_56: {
-            break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "copysign(5.0, -1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_57: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_57: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_58: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__copysign_59: {
-                break __inline_f64__copysign_59: core::builtin::f64_copysign(5.0, -1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_copysign(5.0, -1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_60: {
-            break __inline_String__with_capacity_60: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "copysign(-5.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_61: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_61: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_62: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__copysign_63: {
-                break __inline_f64__copysign_63: core::builtin::f64_copysign(-5.0, 1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_copysign(-5.0, 1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_64: {
-            break __inline_String__with_capacity_64: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "sin(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_65: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_65: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_66: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__sin_67: {
-                break __inline_f64__sin_67: core::builtin::f64_sin(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_sin(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_68: {
-            break __inline_String__with_capacity_68: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sin(PI/2) = ");
         let mut __f: Formatter = __inline_Formatter__new_69: {
             let buf: &mut String = &mut __r;
@@ -361,486 +291,378 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_72: {
-            break __inline_String__with_capacity_72: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "cos(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_73: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_73: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_74: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__cos_75: {
-                break __inline_f64__cos_75: core::builtin::f64_cos(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_cos(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_76: {
-            break __inline_String__with_capacity_76: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "cos(PI) = ");
         let mut __f: Formatter = __inline_Formatter__new_77: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_77: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_78: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__cos_79: {
-                break __inline_f64__cos_79: core::builtin::f64_cos(3.14159265358979323846);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_cos(3.14159265358979323846) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_80: {
-            break __inline_String__with_capacity_80: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "tan(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_81: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_81: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_82: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__tan_83: {
-                break __inline_f64__tan_83: core::builtin::f64_tan(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_tan(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_84: {
-            break __inline_String__with_capacity_84: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "asin(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_85: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_85: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_86: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__asin_87: {
-                break __inline_f64__asin_87: core::builtin::f64_asin(1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_asin(1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_88: {
-            break __inline_String__with_capacity_88: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "acos(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_89: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_89: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_90: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__acos_91: {
-                break __inline_f64__acos_91: core::builtin::f64_acos(1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_acos(1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_92: {
-            break __inline_String__with_capacity_92: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "atan(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_93: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_93: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_94: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__atan_95: {
-                break __inline_f64__atan_95: core::builtin::f64_atan(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_atan(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_96: {
-            break __inline_String__with_capacity_96: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "atan2(1.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_97: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_97: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_98: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__atan2_99: {
-                break __inline_f64__atan2_99: core::builtin::f64_atan2(1.0, 1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_atan2(1.0, 1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_100: {
-            break __inline_String__with_capacity_100: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "sinh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_101: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_101: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_102: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__sinh_103: {
-                break __inline_f64__sinh_103: core::builtin::f64_sinh(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_sinh(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_104: {
-            break __inline_String__with_capacity_104: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "cosh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_105: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_105: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_106: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__cosh_107: {
-                break __inline_f64__cosh_107: core::builtin::f64_cosh(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_cosh(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_108: {
-            break __inline_String__with_capacity_108: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "tanh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_109: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_109: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_110: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__tanh_111: {
-                break __inline_f64__tanh_111: core::builtin::f64_tanh(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_tanh(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_112: {
-            break __inline_String__with_capacity_112: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "asinh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_113: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_113: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_114: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__asinh_115: {
-                break __inline_f64__asinh_115: core::builtin::f64_asinh(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_asinh(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_116: {
-            break __inline_String__with_capacity_116: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "acosh(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_117: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_117: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_118: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__acosh_119: {
-                break __inline_f64__acosh_119: core::builtin::f64_acosh(1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_acosh(1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_120: {
-            break __inline_String__with_capacity_120: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "atanh(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_121: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_121: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_122: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__atanh_123: {
-                break __inline_f64__atanh_123: core::builtin::f64_atanh(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_atanh(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_124: {
-            break __inline_String__with_capacity_124: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "exp(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_125: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_125: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_126: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__exp_127: {
-                break __inline_f64__exp_127: core::builtin::f64_exp(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_exp(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_128: {
-            break __inline_String__with_capacity_128: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "exp(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_129: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_129: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_130: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__exp_131: {
-                break __inline_f64__exp_131: core::builtin::f64_exp(1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_exp(1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_132: {
-            break __inline_String__with_capacity_132: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "exp2(3.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_133: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_133: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_134: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__exp2_135: {
-                break __inline_f64__exp2_135: core::builtin::f64_exp2(3.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_exp2(3.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_136: {
-            break __inline_String__with_capacity_136: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "expm1(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_137: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_137: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_138: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__expm1_139: {
-                break __inline_f64__expm1_139: core::builtin::f64_expm1(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_expm1(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_140: {
-            break __inline_String__with_capacity_140: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "ln(1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_141: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_141: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_142: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__ln_143: {
-                break __inline_f64__ln_143: core::builtin::f64_ln(1.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_ln(1.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_144: {
-            break __inline_String__with_capacity_144: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "ln(E) = ");
         let mut __f: Formatter = __inline_Formatter__new_145: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_145: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_146: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__ln_147: {
-                break __inline_f64__ln_147: core::builtin::f64_ln(2.71828182845904523536);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_ln(2.71828182845904523536) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_148: {
-            break __inline_String__with_capacity_148: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "log2(8.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_149: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_149: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_150: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__log2_151: {
-                break __inline_f64__log2_151: core::builtin::f64_log2(8.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_log2(8.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_152: {
-            break __inline_String__with_capacity_152: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "log10(1000.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_153: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_153: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_154: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__log10_155: {
-                break __inline_f64__log10_155: core::builtin::f64_log10(1000.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_log10(1000.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_156: {
-            break __inline_String__with_capacity_156: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "ln1p(0.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_157: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_157: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_158: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__ln1p_159: {
-                break __inline_f64__ln1p_159: core::builtin::f64_ln1p(0.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_ln1p(0.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_160: {
-            break __inline_String__with_capacity_160: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "pow(2.0, 10.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_161: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_161: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_162: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__pow_163: {
-                break __inline_f64__pow_163: core::builtin::f64_pow(2.0, 10.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_pow(2.0, 10.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_164: {
-            break __inline_String__with_capacity_164: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "pow(3.0, 3.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_165: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_165: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_166: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__pow_167: {
-                break __inline_f64__pow_167: core::builtin::f64_pow(3.0, 3.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_pow(3.0, 3.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_168: {
-            break __inline_String__with_capacity_168: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "cbrt(27.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_169: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_169: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_170: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__cbrt_171: {
-                break __inline_f64__cbrt_171: core::builtin::f64_cbrt(27.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_cbrt(27.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_172: {
-            break __inline_String__with_capacity_172: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "hypot(3.0, 4.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_173: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_173: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_174: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__hypot_175: {
-                break __inline_f64__hypot_175: core::builtin::f64_hypot(3.0, 4.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_hypot(3.0, 4.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_176: {
-            break __inline_String__with_capacity_176: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "fmod(7.0, 3.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_177: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_177: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_178: {
-            let self: Box<f64> = move Box<f64> { value: __inline_f64__fmod_179: {
-                break __inline_f64__fmod_179: core::builtin::f64_fmod(7.0, 3.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: core::builtin::f64_fmod(7.0, 3.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/mixed_int_float_arithmetic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/mixed_int_float_arithmetic.lowered.wado
@@ -13,9 +13,7 @@
 fn run() with Stdout {
     let dx: f64 = ((1.0 - -2.5) / 100 as f64);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "dx: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_basic.lowered.wado
@@ -13,9 +13,7 @@
 fn run() with Stdout {
     let sum: Meters = (1000.0 + 500.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "sum of meters: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn run() with Stdout {
     });
     let raw: f64 = 1000.0 as f64;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "raw: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -47,9 +43,7 @@ fn run() with Stdout {
     });
     let from_raw: Meters = 100.0 as Meters;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "from_raw: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -64,9 +58,7 @@ fn run() with Stdout {
     });
     let km_from_m: Kilometers = (1000.0 as f64 / 1000.0) as Kilometers;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "km_from_m: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_chained.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_chained.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(78), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(78), used: 0 };
         __r.String::append(move "c=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -57,9 +55,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_chained_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_chained_method.lowered.wado
@@ -23,9 +23,7 @@ fn run() with Stdout {
     let c2: C = Point { x: 3, y: 4 } as C;
     let c3: C = c1.C::add(&c2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "x: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_impl.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_impl.lowered.wado
@@ -11,13 +11,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let d: Degrees = __inline_Radians__to_degrees_0: {
-        break __inline_Radians__to_degrees_0: ((3.14159 * 180.0) / 3.14159) as Degrees;
-    };
+    let d: Degrees = ((3.14159 * 180.0) / 3.14159) as Degrees;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "radians to degrees: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -30,13 +26,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let r2: Radians = __inline_Degrees__to_radians_4: {
-        break __inline_Degrees__to_radians_4: ((90.0 * 3.14159) / 180.0) as Radians;
-    };
+    let r2: Radians = ((90.0 * 3.14159) / 180.0) as Radians;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "degrees to radians: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_integer_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_integer_types.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "user: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "time: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "count: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -59,9 +53,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "next_user: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -75,9 +67,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "later: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -91,9 +81,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "more: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_method_inheritance.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_method_inheritance.lowered.wado
@@ -27,9 +27,7 @@ fn run() with Stdout {
     let loc2: Location = Point { x: 5, y: 5 } as Location;
     let s: i32 = loc1.Location::sum();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -44,9 +42,7 @@ fn run() with Stdout {
     });
     let loc3: Location = loc1.Location::add(&loc2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(43), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(43), used: 0 };
         __r.String::append(move "added: (");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_multiple_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_multiple_params.lowered.wado
@@ -24,9 +24,7 @@ fn run() with Stdout {
     let loc3: Location = Point { x: 3, y: 3 } as Location;
     let result: Location = loc1.Location::combine(&loc2, &loc3);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/newtype_option_pattern.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_option_pattern.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     if __is_not_null(angle) {
         let r: Radians = __unwrap_option(angle).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "angle: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -37,9 +35,7 @@ fn run() with Stdout {
     if __is_not_null(empty) {
         let r: Radians = __unwrap_option(empty).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_3: {
-                break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(28), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
             __r.String::append(move "unexpected: ");
             let mut __f: Formatter = __inline_Formatter__new_4: {
                 let buf: &mut String = &mut __r;
@@ -60,9 +56,7 @@ fn run() with Stdout {
         None => 0.0,
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "doubled: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_return_type.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_return_type.lowered.wado
@@ -26,9 +26,7 @@ fn run() with Stdout {
     let loc: Location = Point { x: 10, y: 20 } as Location;
     let loc2: Location = loc.Location::clone_point();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(43), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(43), used: 0 };
         __r.String::append(move "clone: (");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -54,9 +52,7 @@ fn run() with Stdout {
     });
     let loc4: Location = loc.Location::offset(5, 5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(44), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(44), used: 0 };
         __r.String::append(move "offset: (");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_static_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_static_method.lowered.wado
@@ -15,13 +15,9 @@ struct Point {
 }
 
 fn run() with Stdout {
-    let loc: Location = __inline_Point__origin_0: {
-        break __inline_Point__origin_0: Point { x: 0, y: 0 };
-    } as Location;
+    let loc: Location = Point { x: 0, y: 0 } as Location;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/newtype_string_coercion.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_string_coercion.lowered.wado
@@ -11,9 +11,7 @@
 
 fn greet(name: Name) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Hello, ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -34,9 +32,7 @@ fn run() with Stdout {
     let greeting: String = move greet("Alice");
     let x: String = move "world";
     let label2: Label = __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "hello ");
         __r.String::append(x);
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/newtype_trait_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_trait_method.lowered.wado
@@ -22,9 +22,7 @@ fn run() with Stdout {
     let loc: Location = Point { x: 10, y: 20 } as Location;
     let d: i32 = loc."Location^Describable::describe"();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/number_literal_coercion.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/number_literal_coercion.lowered.wado
@@ -13,9 +13,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(58), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(58), used: 0 };
         __r.String::append(move "a=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -49,9 +47,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(58), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(58), used: 0 };
         __r.String::append(move "d=");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;
@@ -85,9 +81,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(38), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(38), used: 0 };
         __r.String::append(move "g=");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
@@ -111,9 +105,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(58), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(58), used: 0 };
         __r.String::append(move "i=");
         let mut __f: Formatter = __inline_Formatter__new_20: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/opt_inline_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_array.lowered.wado
@@ -11,17 +11,11 @@
 
 fn run() with Stdout {
     let x: i32 = __inline_test_0: {
-        let arr: Array<i32> = __inline_Array_i32___with_capacity_1: {
-            break __inline_Array_i32___with_capacity_1: Array<i32> { repr: core::builtin::array_new::<i32>(10), used: 0 };
-        };
-        break __inline_test_0: __inline_Array_i32___len_2: {
-            break __inline_Array_i32___len_2: arr.used;
-        };
+        let arr: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(10), used: 0 };
+        break __inline_test_0: arr.used;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/opt_inline_multireturn.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_multireturn.lowered.wado
@@ -27,9 +27,7 @@ fn run() {
         let __cond: bool = (a == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -64,9 +62,7 @@ fn run() {
         let __cond: bool = (b == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/opt_inline_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_nested.lowered.wado
@@ -14,20 +14,12 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() {
-    let result: i32 = __inline_sum_of_squares_0: {
-        break __inline_sum_of_squares_0: (__inline_square_1: {
-            break __inline_square_1: 9;
-        } + __inline_square_2: {
-            break __inline_square_2: 16;
-        });
-    };
+    let result: i32 = (9 + 16);
     __assert_0: {
         let __cond: bool = (result == 25);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(123), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(123), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/opt_inline_recursive.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_recursive.lowered.wado
@@ -26,9 +26,7 @@ fn run() {
         let __cond: bool = (result == 120);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(124), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(124), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/opt_inline_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_simple.lowered.wado
@@ -14,19 +14,13 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() {
-    let b: i32 = __inline_double_0: {
-        break __inline_double_0: 10;
-    };
-    let c: i32 = __inline_add_1: {
-        break __inline_add_1: (b + 3);
-    };
+    let b: i32 = 10;
+    let c: i32 = (b + 3);
     __assert_0: {
         let __cond: bool = (c == 13);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/option_i32_struct_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/option_i32_struct_field.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
     if __is_not_null(__sroa_c_width) {
         let w: i32 = __unwrap_option(__sroa_c_width).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "width: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/precedence_arithmetic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_arithmetic.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (14 == 14);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -56,9 +54,7 @@ fn run() {
         let __cond: bool = (6 == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -93,9 +89,7 @@ fn run() {
         let __cond: bool = (6 == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -130,9 +124,7 @@ fn run() {
         let __cond: bool = (10 == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -167,9 +159,7 @@ fn run() {
         let __cond: bool = (9 == 9);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -204,9 +194,7 @@ fn run() {
         let __cond: bool = (11 == 11);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -242,9 +230,7 @@ fn run() {
         let __cond: bool = (g == 14.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -280,9 +266,7 @@ fn run() {
         let __cond: bool = (h == 6.0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(114), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_assignment.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_assignment.lowered.wado
@@ -20,9 +20,7 @@ fn run() {
         let __cond: bool = (a == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -59,9 +57,7 @@ fn run() {
         let __cond: bool = (b == 7);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -97,9 +93,7 @@ fn run() {
         let __cond: bool = (c == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -139,9 +133,7 @@ fn run() {
         let __cond: bool = (d == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -181,9 +173,7 @@ fn run() {
         let __cond: bool = (e == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -223,9 +213,7 @@ fn run() {
         let __cond: bool = (f == 7);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -261,9 +249,7 @@ fn run() {
         let __cond: bool = (g == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -301,9 +287,7 @@ fn run() {
         let __cond: bool = (h == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -338,9 +322,7 @@ fn run() {
         let __cond: bool = (i == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -375,9 +357,7 @@ fn run() {
         let __cond: bool = (13 == 13);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_45: {
-                    break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_bitwise.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_bitwise.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (a == 0b0111);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -57,9 +55,7 @@ fn run() {
         let __cond: bool = (b == 0b01);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -95,9 +91,7 @@ fn run() {
         let __cond: bool = (c == 0b110);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -133,9 +127,7 @@ fn run() {
         let __cond: bool = (d == 0b000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -171,9 +163,7 @@ fn run() {
         let __cond: bool = (e == 0b1100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -209,9 +199,7 @@ fn run() {
         let __cond: bool = (f == 0b111);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -247,9 +235,7 @@ fn run() {
         let __cond: bool = (g == 0b0011);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -285,9 +271,7 @@ fn run() {
         let __cond: bool = (h == 0b111);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_bitwise_vs_comparison.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_bitwise_vs_comparison.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (result_and == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -61,9 +59,7 @@ fn run() {
         let __cond: bool = (result_or == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -103,9 +99,7 @@ fn run() {
         let __cond: bool = (result_xor == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -145,9 +139,7 @@ fn run() {
         let __cond: bool = (result_ne == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -187,9 +179,7 @@ fn run() {
         let __cond: bool = (result_lt == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -229,9 +219,7 @@ fn run() {
         let __cond: bool = (result_gt == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -271,9 +259,7 @@ fn run() {
         let __cond: bool = (result_le == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -313,9 +299,7 @@ fn run() {
         let __cond: bool = (result_ge == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -355,9 +339,7 @@ fn run() {
         let __cond: bool = (complex == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(127), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(127), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_comparison_chaining.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_comparison_chaining.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (a == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -61,9 +59,7 @@ fn run() {
         let __cond: bool = (b == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -103,9 +99,7 @@ fn run() {
         let __cond: bool = (c == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -145,9 +139,7 @@ fn run() {
         let __cond: bool = (d == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -187,9 +179,7 @@ fn run() {
         let __cond: bool = (e == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -229,9 +219,7 @@ fn run() {
         let __cond: bool = (f == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -271,9 +259,7 @@ fn run() {
         let __cond: bool = (g == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -313,9 +299,7 @@ fn run() {
         let __cond: bool = (h == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -355,9 +339,7 @@ fn run() {
         let __cond: bool = (i == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_comparison_vs_logical.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_comparison_vs_logical.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (a == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -61,9 +59,7 @@ fn run() {
         let __cond: bool = (b == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -103,9 +99,7 @@ fn run() {
         let __cond: bool = (c == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -145,9 +139,7 @@ fn run() {
         let __cond: bool = (d == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -187,9 +179,7 @@ fn run() {
         let __cond: bool = (e == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -229,9 +219,7 @@ fn run() {
         let __cond: bool = (f == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -271,9 +259,7 @@ fn run() {
         let __cond: bool = (g == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -313,9 +299,7 @@ fn run() {
         let __cond: bool = (h == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -355,9 +339,7 @@ fn run() {
         let __cond: bool = (i == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_parentheses.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_parentheses.lowered.wado
@@ -18,9 +18,7 @@ fn run() {
         let __cond: bool = (14 == 14);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(139), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(139), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -55,9 +53,7 @@ fn run() {
         let __cond: bool = (20 == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_shift_vs_arithmetic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_shift_vs_arithmetic.lowered.wado
@@ -19,9 +19,7 @@ fn run() {
         let __cond: bool = (a == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -57,9 +55,7 @@ fn run() {
         let __cond: bool = (b == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -95,9 +91,7 @@ fn run() {
         let __cond: bool = (c == 16);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -133,9 +127,7 @@ fn run() {
         let __cond: bool = (d == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -171,9 +163,7 @@ fn run() {
         let __cond: bool = (e == 7);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -209,9 +199,7 @@ fn run() {
         let __cond: bool = (f == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -247,9 +235,7 @@ fn run() {
         let __cond: bool = (g == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -285,9 +271,7 @@ fn run() {
         let __cond: bool = (h == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_35: {
-                    break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -323,9 +307,7 @@ fn run() {
         let __cond: bool = (i == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/precedence_unary.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_unary.lowered.wado
@@ -18,9 +18,7 @@ fn run() {
         let __cond: bool = (2 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -55,9 +53,7 @@ fn run() {
         let __cond: bool = (-6 == -6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -103,9 +99,7 @@ fn run() {
         let __cond: bool = (13 == 13);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -141,9 +135,7 @@ fn run() {
         let __cond: bool = (d == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -183,9 +175,7 @@ fn run() {
         let __cond: bool = (e == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -225,9 +215,7 @@ fn run() {
         let __cond: bool = (f == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -263,9 +251,7 @@ fn run() {
         let __cond: bool = (g == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -300,9 +286,7 @@ fn run() {
         let __cond: bool = (--5 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -338,9 +322,7 @@ fn run() {
         let __cond: bool = (i == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_42: {
-                    break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -380,9 +362,7 @@ fn run() {
         let __cond: bool = (j == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -422,9 +402,7 @@ fn run() {
         let __cond: bool = (k == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_52: {
-                    break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(112), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -460,9 +438,7 @@ fn run() {
         let __cond: bool = (n == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_57: {
-                    break __inline_String__with_capacity_57: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -502,9 +478,7 @@ fn run() {
         let __cond: bool = (o == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -543,9 +517,7 @@ fn run() {
         let __cond: bool = (-14 == -14);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_67: {
-                    break __inline_String__with_capacity_67: String { repr: "array_new<u8>"(136), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(136), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/pub_use.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_use.lowered.wado
@@ -10,17 +10,13 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_multiply_0: {
-        break __inline_multiply_0: 42;
-    };
+    let result: i32 = 42;
     if (result == 42) {
         core::cli::println(move "multiply ok");
     } else {
         core::cli::println(move "multiply fail");
     }
-    let msg: String = __inline_greet_1: {
-        break __inline_greet_1: "hello from lib";
-    };
+    let msg: String = move "hello from lib";
     core::cli::println(msg);
 }
 

--- a/wado-compiler/tests/fixtures.golden/pub_use_alias.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_use_alias.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_multiply_0: {
-        break __inline_multiply_0: 42;
-    };
+    let result: i32 = 42;
     if (result == 42) {
         core::cli::println(move "success");
     } else {

--- a/wado-compiler/tests/fixtures.golden/pub_use_chain.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_use_chain.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let v: i32 = __inline_chain_value_0: {
-        break __inline_chain_value_0: 123;
-    };
+    let v: i32 = 123;
     if (v == 123) {
         core::cli::println(move "success");
     } else {

--- a/wado-compiler/tests/fixtures.golden/pub_use_prelude.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_use_prelude.lowered.wado
@@ -10,20 +10,14 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let p: MyPoint = __inline_MyPoint__new_0: {
-        break __inline_MyPoint__new_0: MyPoint { x: 10, y: 20 };
-    };
-    let sum: i32 = __inline_MyPoint__sum_1: {
-        break __inline_MyPoint__sum_1: (p.x + p.y);
-    };
+    let p: MyPoint = move MyPoint { x: 10, y: 20 };
+    let sum: i32 = (p.x + p.y);
     if (sum == 30) {
         core::cli::println(move "struct ok");
     } else {
         core::cli::println(move "struct fail");
     }
-    let doubled: i32 = __inline_helper_fn_2: {
-        break __inline_helper_fn_2: 42;
-    };
+    let doubled: i32 = 42;
     if (doubled == 42) {
         core::cli::println(move "fn ok");
     } else {

--- a/wado-compiler/tests/fixtures.golden/recursive-generic-struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/recursive-generic-struct.lowered.wado
@@ -26,9 +26,7 @@ fn __test_0_create_recursive_node() {
         let __cond: bool = (__v0 == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_0_create_recursive_node");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/ref_alias_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_alias_mut.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     let r2: Box<i32> = x;
     r1.value = 10;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "after r1: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -32,9 +30,7 @@ fn run() with Stdout {
     });
     r2.value = 20;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "after r2: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -49,9 +45,7 @@ fn run() with Stdout {
     });
     r1.value = ((r1.value + r2.value) + 5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "final: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_array_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array_basic.lowered.wado
@@ -17,9 +17,7 @@ fn run() with Stdout {
     let mut nums: Array<i32> = move [1, 2, 3];
     let before: i32 = nums."Array<i32>^IndexValue::index_value"(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -38,9 +36,7 @@ fn run() with Stdout {
     };
     let after: i32 = nums."Array<i32>^IndexValue::index_value"(0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_array_ref_element.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array_ref_element.lowered.wado
@@ -17,9 +17,7 @@ fn run() with Stdout {
     let mut arr: Array<i32> = move [10, 20, 30];
     let __sroa_r_value: i32 = arr."Array<i32>^IndexValue::index_value"(1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "ref element: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -34,9 +32,7 @@ fn run() with Stdout {
     });
     arr."Array<i32>^IndexAssign::index_assign"(1, 999);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "arr[1]: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -50,9 +46,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "ref still: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_closure_capture.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_closure_capture.lowered.wado
@@ -20,14 +20,10 @@ fn run() with Stdout {
     let x: Box<i32> = move Box<i32> { value: 42 };
     let result: i32 = __inline_apply_to_ref___Closure_0_0: {
         let r: Box<i32> = x;
-        break __inline_apply_to_ref___Closure_0_0: __inline___Closure_0____call_1: {
-            break __inline___Closure_0____call_1: (r.value * 2);
-        };
+        break __inline_apply_to_ref___Closure_0_0: (r.value * 2);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "doubled: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -42,14 +38,10 @@ fn run() with Stdout {
     });
     let result2: i32 = __inline_apply_to_ref___Closure_1_5: {
         let r: Box<i32> = x;
-        break __inline_apply_to_ref___Closure_1_5: __inline___Closure_1____call_6: {
-            break __inline___Closure_1____call_6: (r.value * 3);
-        };
+        break __inline_apply_to_ref___Closure_1_5: (r.value * 3);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "tripled: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_closure_mut_param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_closure_mut_param.lowered.wado
@@ -21,9 +21,7 @@ fn run() with Stdout {
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "modified: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_conditional_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_conditional_mut.lowered.wado
@@ -23,9 +23,7 @@ fn run() with Stdout {
     let mut a: Box<i32> = move Box<i32> { value: 50 };
     clamp(a, 0, 100);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "clamped 50: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -41,9 +39,7 @@ fn run() with Stdout {
     let mut b: Box<i32> = move Box<i32> { value: -10 };
     clamp(b, 0, 100);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "clamped -10: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -59,9 +55,7 @@ fn run() with Stdout {
     let mut c: Box<i32> = move Box<i32> { value: 200 };
     clamp(c, 0, 100);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "clamped 200: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_deref_assign_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_deref_assign_struct.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
     let mut __sroa_p_x: i32 = 10;
     let mut __sroa_p_y: i32 = 20;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -47,9 +45,7 @@ fn run() with Stdout {
         __sroa_p_y = 0;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_deref_reassign.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_deref_reassign.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     let val: i32 = r.value;
     r.value = ((val * 2) + 1);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "modified: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -33,9 +31,7 @@ fn run() with Stdout {
     let __sroa_val2_value: i32 = r.value;
     r.value = 0;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "original: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -49,9 +45,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "copy: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_edge_coercion.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_coercion.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_read_value_0: {
-        break __inline_read_value_0: 42;
-    };
+    let result: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_edge_double_deref.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_double_deref.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     let rr: &mut Box<i32> = &mut r;
     *rr.value = 99;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_edge_multi_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_multi_mut.lowered.wado
@@ -24,9 +24,7 @@ fn run() with Stdout {
         x.value = (x.value + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_edge_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_nested.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     let r: Box<i32> = a;
     let rr: &Box<i32> = &r;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_edge_temp.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_temp.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_loop_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_loop_mut.lowered.wado
@@ -28,9 +28,7 @@ fn run() with Stdout {
     let mut sum: Box<i32> = move Box<i32> { value: 0 };
     accumulate(sum, 5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "sum 0..4: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -52,9 +50,7 @@ fn run() with Stdout {
         r.value = (r.value + 1);
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "count: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_method_receivers.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_method_receivers.lowered.wado
@@ -14,22 +14,16 @@ struct Counter {
 }
 
 fn run() with Stdout {
-    let mut c: Counter = __inline_Counter__new_0: {
-        break __inline_Counter__new_0: Counter { value: 0 };
-    };
+    let mut c: Counter = move Counter { value: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "get: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_4: {
-                break __inline_Counter__get_4: c.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -45,18 +39,14 @@ fn run() with Stdout {
         c.value = (c.value + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "after increment: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_10: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_11: {
-                break __inline_Counter__get_11: c.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -67,9 +57,7 @@ fn run() with Stdout {
         break __inline_Counter__into_value_12: self.value;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "into_value: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -83,18 +71,14 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "still usable: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_17: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_18: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_19: {
-                break __inline_Counter__get_19: c.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/ref_mut_array_ops.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_mut_array_ops.lowered.wado
@@ -18,9 +18,7 @@ fn double_all(arr: &mut Array<i32>) {
         let mut i: i32 = 0;
         let _licm_used: i32 = arr.used;
         loop {
-            if !(i < __inline_Array_i32___len_0: {
-                break __inline_Array_i32___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -34,18 +32,14 @@ fn double_all(arr: &mut Array<i32>) {
 fn run() with Stdout {
     let mut nums: Array<i32> = move [1, 2, 3];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "len: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_3: {
-                break __inline_Array_i32___len_3: nums.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: nums.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -57,18 +51,14 @@ fn run() with Stdout {
         arr."Array<i32>::append"(5);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "len: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_8: {
-                break __inline_Array_i32___len_8: nums.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: nums.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -79,16 +69,12 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = nums.used;
         loop {
-            if !(i < __inline_Array_i32___len_9: {
-                break __inline_Array_i32___len_9: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_10: {
-                        break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_11: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_11: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_nested_mut_write.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_nested_mut_write.lowered.wado
@@ -27,18 +27,14 @@ fn run() with Stdout {
     let mut __sroa___sroa___sroa_data_middle_inner_value: i32 = 0;
     let mut __sroa___sroa_data_middle_label: String = move "initial";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_inner_value_3: {
-                break __inline_get_inner_value_3: __sroa___sroa___sroa_data_middle_inner_value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: __sroa___sroa___sroa_data_middle_inner_value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -54,18 +50,14 @@ fn run() with Stdout {
         __sroa___sroa_data_middle_label = s;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_inner_value_9: {
-                break __inline_get_inner_value_9: __sroa___sroa___sroa_data_middle_inner_value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: __sroa___sroa___sroa_data_middle_inner_value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/ref_pass_through.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_pass_through.lowered.wado
@@ -11,9 +11,7 @@
 
 fn read_and_format(r: Box<i32>) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "value=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_basic.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let mut a: Box<i32> = move Box<i32> { value: 10 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -34,9 +32,7 @@ fn run() with Stdout {
         x.value = (x.value + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_read.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_read.lowered.wado
@@ -11,17 +11,13 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_read_value_3: {
-                break __inline_read_value_3: 42;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 42 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_semantic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_semantic.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
         break __inline_get_and_modify_0: original;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "original=");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -34,9 +32,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "modified=");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_types.lowered.wado
@@ -13,9 +13,7 @@
 fn run() with Stdout {
     let mut a: Box<i64> = move Box<i64> { value: 100 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -36,9 +34,7 @@ fn run() with Stdout {
         r.value = 200;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "i64: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -53,9 +49,7 @@ fn run() with Stdout {
     });
     let mut b: Box<f64> = move Box<f64> { value: 3.14 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -76,9 +70,7 @@ fn run() with Stdout {
         r.value = 2.718;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "f64: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -93,9 +85,7 @@ fn run() with Stdout {
     });
     let mut c: Box<bool> = move Box<bool> { value: true };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "bool: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
@@ -120,9 +110,7 @@ fn run() with Stdout {
         r.value = false;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "bool: ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_reassign.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_reassign.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     let mut b: Box<i32> = move Box<i32> { value: 20 };
     let mut r: Box<i32> = a;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -30,9 +28,7 @@ fn run() with Stdout {
     });
     r = b;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -49,9 +45,7 @@ fn run() with Stdout {
     mr = b;
     mr.value = 200;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -64,9 +58,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_return.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
         break __inline_get_first_0: Box<i32> { value: arr."Array<i32>^IndexValue::index_value"(0) };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_return_local.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_return_local.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
         break __inline_make_ref_0: x;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_struct_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_basic.lowered.wado
@@ -16,9 +16,7 @@ struct Point {
 
 fn print_point(p: &Point) with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_struct_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_mut.lowered.wado
@@ -23,9 +23,7 @@ fn run() with Stdout {
     let mut p: Point = move Point { x: 1, y: 2 };
     move_point(&mut p);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/ref_struct_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_nested.lowered.wado
@@ -20,17 +20,13 @@ struct Outer {
 fn run() with Stdout {
     let mut __sroa___sroa_o_inner_value: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_inner_value_3: {
-                break __inline_get_inner_value_3: __sroa___sroa_o_inner_value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: __sroa___sroa_o_inner_value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -40,17 +36,13 @@ fn run() with Stdout {
         __sroa___sroa_o_inner_value = 100;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_inner_value_8: {
-                break __inline_get_inner_value_8: __sroa___sroa_o_inner_value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: __sroa___sroa_o_inner_value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/ref_struct_string_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_string_field.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
     let mut __sroa_u_name: String = move "Alice";
     let mut __sroa_u_age: i32 = 30;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(__sroa_u_name);
         __r.String::append(move ", ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
@@ -42,9 +40,7 @@ fn run() with Stdout {
         __sroa_u_age = (__sroa_u_age + 1);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(__sroa_u_name);
         __r.String::append(move ", ");
         let mut __f: Formatter = __inline_Formatter__new_6: {

--- a/wado-compiler/tests/fixtures.golden/ref_swap.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_swap.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     let mut x: Box<i32> = move Box<i32> { value: 1 };
     let mut y: Box<i32> = move Box<i32> { value: 2 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -46,9 +44,7 @@ fn run() with Stdout {
     });
     swap(x, y);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/ref_tuple_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_tuple_basic.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let mut __sroa_pair_0: i32 = 1;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -31,9 +29,7 @@ fn run() with Stdout {
         __sroa_pair_0 = 100;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/return_array_var.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/return_array_var.lowered.wado
@@ -21,17 +21,13 @@ fn run() with Stdout {
         break __inline_get_numbers_0: arr;
     };
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: nums.repr, used: nums.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: nums.repr, used: nums.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let n: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_2: {
-                        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_3: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/return_empty_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/return_empty_array.lowered.wado
@@ -16,21 +16,15 @@ pub struct "ArrayIter<i32>" {
 }
 
 fn run() with Stdout {
-    let arr: Array<i32> = __inline_get_empty_0: {
-        break __inline_get_empty_0: [];
-    };
+    let arr: Array<i32> = move [];
     __for_of_0: {
-        let mut __iter_0: ArrayIter<i32> = __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
+        let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<i32> = __iter_0."ArrayIter<i32>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
                 let n: i32 = __unwrap_option(__pattern_temp_0).value;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_2: {
-                        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(16), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                     let mut __f: Formatter = __inline_Formatter__new_3: {
                         let buf: &mut String = &mut __r;
                         break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/return_tuple_literal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/return_tuple_literal.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let t: [i32, i32, i32] = __inline_get_pair_0: {
-        break __inline_get_pair_0: [42, 1, 2];
-    };
+    let t: [i32, i32, i32] = move [42, 1, 2];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/return_tuple_var.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/return_tuple_var.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
         break __inline_get_pair_0: t;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/scalarize_chain.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/scalarize_chain.lowered.wado
@@ -24,13 +24,9 @@ fn transform(p: Pair) -> Pair {
 }
 
 fn run() with Stdout {
-    let r: Pair = move transform(__inline_make_pair_0: {
-        break __inline_make_pair_0: Pair { x: 10, y: 20 };
-    });
+    let r: Pair = move transform(move Pair { x: 10, y: 20 });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/scope_nested_blocks.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/scope_nested_blocks.lowered.wado
@@ -13,9 +13,7 @@ fn run() with Stdout {
     if true {
         if true {
             core::cli::println(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(50), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(50), used: 0 };
                 let mut __f: Formatter = __inline_Formatter__new_1: {
                     let buf: &mut String = &mut __r;
                     break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -49,9 +47,7 @@ fn run() with Stdout {
             });
         }
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_7: {
-                break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(33), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
             let mut __f: Formatter = __inline_Formatter__new_8: {
                 let buf: &mut String = &mut __r;
                 break __inline_Formatter__new_8: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -75,9 +71,7 @@ fn run() with Stdout {
         });
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/scope_shadowing_in_block.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/scope_shadowing_in_block.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     if true {
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "inner: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -29,9 +27,7 @@ fn run() with Stdout {
         });
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "outer: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/select_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/select_basic.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i32>((10 > 20), 10, 20) == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(98), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(98), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -44,9 +42,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i32>((10 < 20), 10, 20) == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(98), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(98), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -70,9 +66,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i32>(true, 42, 0) == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(98), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(98), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -96,9 +90,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i32>(false, 100, 200) == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(99), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(99), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -122,9 +114,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i64>((10 > 20), 10, 20) == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -148,9 +138,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i8>((10 < 20), 10, 20) == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -174,9 +162,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<i16>((10 < 20), 10, 20) == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_18: {
-                    break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -200,9 +186,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<u8>((10 > 20), 10, 20) == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(104), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(104), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -226,9 +210,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<u16>((10 > 20), 10, 20) == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_24: {
-                    break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -252,9 +234,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<u32>((10 > 20), 10, 20) == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -278,9 +258,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<u64>((10 > 20), 10, 20) == 20);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(105), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(105), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -304,9 +282,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<f64>((3.14 > 2.71), 3.14, 2.71) == 3.14);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -330,9 +306,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<f64>(true, 1.5, 2.5) == 1.5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_36: {
-                    break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(99), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(99), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -358,9 +332,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<f32>((fa32 > fb32), fa32, fb32) == 3.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -388,9 +360,7 @@ fn run() with Stdout {
         } == 2.0 as f32);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_42: {
-                    break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(106), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(106), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -414,9 +384,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<bool>(true, true, false) == true);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_45: {
-                    break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(100), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(100), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -440,9 +408,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<bool>(false, true, false) == false);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_48: {
-                    break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(101), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(101), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -466,9 +432,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<char>(true, 'a', 'z') == 'a');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_51: {
-                    break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(99), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(99), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -492,9 +456,7 @@ fn run() with Stdout {
         let __cond: bool = (core::builtin::select::<char>(false, 'a', 'z') == 'z');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_54: {
-                    break __inline_String__with_capacity_54: String { repr: "array_new<u8>"(99), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(99), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/select_no_opt.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/select_no_opt.lowered.wado
@@ -11,9 +11,7 @@
 
 fn side_effect(x: i32) -> i32 with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
         __r.String::append(move "called with ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -36,9 +34,7 @@ fn run() with Stdout {
         side_effect(2);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -55,9 +51,7 @@ fn run() with Stdout {
         val = 42;
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/short_circuit.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/short_circuit.lowered.wado
@@ -15,9 +15,7 @@
 
 fn side_effect(msg: String, result: bool) -> bool with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "side_effect called: ");
         __r.String::append(msg);
         break __tmpl: __r;
@@ -47,15 +45,11 @@ fn run() with Stdout {
     let mut i: i32 = 0;
     let _licm_used: i32 = arr.used;
     loop {
-        if !((i < __inline_Array_i32___len_0: {
-            break __inline_Array_i32___len_0: _licm_used;
-        }) && (arr."Array<i32>^IndexValue::index_value"(i) < 100)) {
+        if !((i < _licm_used) && (arr."Array<i32>^IndexValue::index_value"(i) < 100)) {
             break;
         }
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_1: {
-                break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(40), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
             __r.String::append(move "arr[");
             let mut __f: Formatter = __inline_Formatter__new_2: {
                 let buf: &mut String = &mut __r;
@@ -81,9 +75,7 @@ fn run() with Stdout {
         i = (i + 1);
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "Loop ended at i = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/static_method_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_basic.lowered.wado
@@ -15,13 +15,9 @@ struct Point {
 }
 
 fn run() with Stdout {
-    let p: Point = __inline_Point__origin_0: {
-        break __inline_Point__origin_0: Point { x: 0, y: 0 };
-    };
+    let p: Point = move Point { x: 0, y: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(44), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(44), used: 0 };
         __r.String::append(move "origin: (");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -46,18 +42,14 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__sum_9: {
-                break __inline_Point__sum_9: (p.x + p.y);
-            } };
+            let self: Box<i32> = move Box<i32> { value: (p.x + p.y) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/static_method_chained.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_chained.lowered.wado
@@ -28,73 +28,51 @@ struct "Pair<i32,i64>" {
 }
 
 fn run() with Stdout {
-    let p: Pair<i32,i64> = __inline_Pair_i32_i64___create_0: {
-        break __inline_Pair_i32_i64___create_0: Pair<i32,i64> { first: 10, second: 20 };
-    };
+    let p: Pair<i32,i64> = move Pair<i32,i64> { first: 10, second: 20 };
     let boxed: Box<i32> = __inline_Box_i32___new_2: {
-        let value: i32 = __inline_Pair_i32_i64___get_first_1: {
-            break __inline_Pair_i32_i64___get_first_1: p.first;
-        };
+        let value: i32 = p.first;
         break __inline_Box_i32___new_2: Box<i32> { value: value };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "boxed first: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_5: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Box_i32___get_6: {
-                break __inline_Box_i32___get_6: boxed.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: boxed.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    let pair: Pair<i32,i32> = __inline_Pair_i32_i32___create_7: {
-        break __inline_Pair_i32_i32___create_7: Pair<i32,i32> { first: 100, second: 200 };
-    };
-    let boxed_pair: Box<Pair<i32,i32>> = __inline_Box_Pair_i32_i32____new_8: {
-        break __inline_Box_Pair_i32_i32____new_8: Box<Pair<i32,i32>> { value: pair };
-    };
-    let inner_pair: Pair<i32,i32> = __inline_Box_Pair_i32_i32____get_9: {
-        break __inline_Box_Pair_i32_i32____get_9: boxed_pair.value;
-    };
+    let pair: Pair<i32,i32> = move Pair<i32,i32> { first: 100, second: 200 };
+    let boxed_pair: Box<Pair<i32,i32>> = move Box<Pair<i32,i32>> { value: pair };
+    let inner_pair: Pair<i32,i32> = boxed_pair.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "inner first: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_11: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_12: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Pair_i32_i32___get_first_13: {
-                break __inline_Pair_i32_i32___get_first_13: inner_pair.first;
-            } };
+            let self: Box<i32> = move Box<i32> { value: inner_pair.first };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "inner second: ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_15: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_16: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Pair_i32_i32___get_second_17: {
-                break __inline_Pair_i32_i32___get_second_17: inner_pair.second;
-            } };
+            let self: Box<i32> = move Box<i32> { value: inner_pair.second };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -103,9 +81,7 @@ fn run() with Stdout {
     let val: i32 = __inline_Box_i32___get_18: {
         let self: &Box<i32> = &__inline_Box_i32___new_21: {
             let value: i32 = __inline_Pair_i32_i32___get_second_20: {
-                let self: &Pair<i32,i32> = &__inline_Pair_i32_i32___create_19: {
-                    break __inline_Pair_i32_i32___create_19: Pair<i32,i32> { first: 5, second: 10 };
-                };
+                let self: &Pair<i32,i32> = &Pair<i32,i32> { first: 5, second: 10 };
                 break __inline_Pair_i32_i32___get_second_20: self.second;
             };
             break __inline_Box_i32___new_21: Box<i32> { value: value };
@@ -113,9 +89,7 @@ fn run() with Stdout {
         break __inline_Box_i32___get_18: self.value;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_22: {
-            break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "chained result: ");
         let mut __f: Formatter = __inline_Formatter__new_23: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/static_method_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_generic.lowered.wado
@@ -14,22 +14,16 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let mut arr: Array<i32> = __inline_Array_i32___with_capacity_0: {
-        break __inline_Array_i32___with_capacity_0: Array<i32> { repr: core::builtin::array_new::<i32>(10), used: 0 };
-    };
+    let mut arr: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(10), used: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "initial len: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_4: {
-                break __inline_Array_i32___len_4: arr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -39,27 +33,21 @@ fn run() with Stdout {
     arr."Array<i32>::append"(2);
     arr."Array<i32>::append"(3);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "after append len: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_8: {
-                break __inline_Array_i32___len_8: arr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "arr[0]: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -73,9 +61,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "arr[1]: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -89,9 +75,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "arr[2]: ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/static_method_generic_non_constructor.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_generic_non_constructor.lowered.wado
@@ -14,13 +14,9 @@ struct "Counter<i32>" {
 }
 
 fn run() with Stdout {
-    let z: i32 = __inline_Counter_i32___zero_0: {
-        break __inline_Counter_i32___zero_0: 0;
-    };
+    let z: i32 = 0;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "zero: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -33,13 +29,9 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let d: i32 = __inline_Counter_i32___default_value_4: {
-        break __inline_Counter_i32___default_value_4: 100;
-    };
+    let d: i32 = 100;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "default: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -52,22 +44,16 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c: Counter<i32> = __inline_Counter_i32___new_8: {
-        break __inline_Counter_i32___new_8: Counter<i32> { value: 42 };
-    };
+    let c: Counter<i32> = move Counter<i32> { value: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "counter value: ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_11: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter_i32___get_12: {
-                break __inline_Counter_i32___get_12: c.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/static_method_multi_type_params.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_multi_type_params.lowered.wado
@@ -15,40 +15,30 @@ struct "Pair<i32,i64>" {
 }
 
 fn run() with Stdout {
-    let p: Pair<i32,i64> = __inline_Pair_i32_i64___create_0: {
-        break __inline_Pair_i32_i64___create_0: Pair<i32,i64> { first: 10, second: 20 };
-    };
+    let p: Pair<i32,i64> = move Pair<i32,i64> { first: 10, second: 20 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "first: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Pair_i32_i64___get_first_4: {
-                break __inline_Pair_i32_i64___get_first_4: p.first;
-            } };
+            let self: Box<i32> = move Box<i32> { value: p.first };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "second: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i64_Display__fmt_7: {
-            let self: Box<i64> = move Box<i64> { value: __inline_Pair_i32_i64___get_second_8: {
-                break __inline_Pair_i32_i64___get_second_8: p.second;
-            } };
+            let self: Box<i64> = move Box<i64> { value: p.second };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i64_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/static_method_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_nested.lowered.wado
@@ -26,15 +26,11 @@ fn Point::distance_squared(a: Point, b: Point) -> i32 {
 
 fn run() with Stdout {
     let p1: Point = __inline_Point__scale_1: {
-        let p: Point = __inline_Point__origin_0: {
-            break __inline_Point__origin_0: Point { x: 0, y: 0 };
-        };
+        let p: Point = move Point { x: 0, y: 0 };
         break __inline_Point__scale_1: Point { x: (p.x * 5), y: (p.y * 5) };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(51), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(51), used: 0 };
         __r.String::append(move "scaled origin: (");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -58,15 +54,9 @@ fn run() with Stdout {
         __r.String::append(move ")");
         break __tmpl: __r;
     });
-    let p2: Point = move Point::add(__inline_Point__new_7: {
-        break __inline_Point__new_7: Point { x: 1, y: 2 };
-    }, __inline_Point__new_8: {
-        break __inline_Point__new_8: Point { x: 3, y: 4 };
-    });
+    let p2: Point = move Point::add(move Point { x: 1, y: 2 }, move Point { x: 3, y: 4 });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(51), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(51), used: 0 };
         __r.String::append(move "sum of points: (");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -90,15 +80,9 @@ fn run() with Stdout {
         __r.String::append(move ")");
         break __tmpl: __r;
     });
-    let dist: i32 = Point::distance_squared(__inline_Point__origin_14: {
-        break __inline_Point__origin_14: Point { x: 0, y: 0 };
-    }, __inline_Point__new_15: {
-        break __inline_Point__new_15: Point { x: 3, y: 4 };
-    });
+    let dist: i32 = Point::distance_squared(move Point { x: 0, y: 0 }, move Point { x: 3, y: 4 });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "distance squared: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/static_method_nested_generics.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_nested_generics.lowered.wado
@@ -27,34 +27,24 @@ struct "Box<Array<i32>>" {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3];
-    let boxed_arr: Box<Array<i32>> = __inline_Box_Array_i32____new_0: {
-        break __inline_Box_Array_i32____new_0: Box<Array<i32>> { value: arr };
-    };
-    let inner: Array<i32> = __inline_Box_Array_i32____get_1: {
-        break __inline_Box_Array_i32____get_1: boxed_arr.value;
-    };
+    let boxed_arr: Box<Array<i32>> = move Box<Array<i32>> { value: arr };
+    let inner: Array<i32> = boxed_arr.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "inner len: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_i32___len_5: {
-                break __inline_Array_i32___len_5: inner.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: inner.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "inner[0]: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -67,28 +57,18 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let inner_box: Box<i32> = __inline_Box_i32___new_9: {
-        break __inline_Box_i32___new_9: Box<i32> { value: 42 };
-    };
-    let outer_box: Box<Box<i32>> = __inline_Box_Box_i32____new_10: {
-        break __inline_Box_Box_i32____new_10: Box<Box<i32>> { value: inner_box };
-    };
-    let unwrapped: Box<i32> = __inline_Box_Box_i32____get_11: {
-        break __inline_Box_Box_i32____get_11: outer_box.value;
-    };
+    let inner_box: Box<i32> = move Box<i32> { value: 42 };
+    let outer_box: Box<Box<i32>> = move Box<Box<i32>> { value: inner_box };
+    let unwrapped: Box<i32> = outer_box.value;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "unwrapped value: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_14: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Box_i32___get_15: {
-                break __inline_Box_i32___get_15: unwrapped.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: unwrapped.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/static_method_non_constructor.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_non_constructor.lowered.wado
@@ -14,13 +14,9 @@ struct Counter {
 }
 
 fn run() with Stdout {
-    let z: i32 = __inline_Counter__zero_0: {
-        break __inline_Counter__zero_0: 0;
-    };
+    let z: i32 = 0;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "zero: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -33,43 +29,31 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c1: Counter = __inline_Counter__from_pair_4: {
-        break __inline_Counter__from_pair_4: Counter { value: 30 };
-    };
+    let c1: Counter = move Counter { value: 30 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "from_pair: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_8: {
-                break __inline_Counter__get_8: c1.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c1.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    let c2: Counter = __inline_Counter__new_9: {
-        break __inline_Counter__new_9: Counter { value: 42 };
-    };
+    let c2: Counter = move Counter { value: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "counter value: ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_11: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_12: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_13: {
-                break __inline_Counter__get_13: c2.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c2.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/static_method_user_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_user_generic.lowered.wado
@@ -14,22 +14,16 @@ struct "Box<i32>" {
 }
 
 fn run() with Stdout {
-    let b: Box<i32> = __inline_Box_i32___new_0: {
-        break __inline_Box_i32___new_0: Box<i32> { value: 42 };
-    };
+    let b: Box<i32> = move Box<i32> { value: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "box value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Box_i32___get_4: {
-                break __inline_Box_i32___get_4: b.value;
-            } };
+            let self: Box<i32> = move Box<i32> { value: b.value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/static_method_with_args.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_with_args.lowered.wado
@@ -15,13 +15,9 @@ struct Point {
 }
 
 fn run() with Stdout {
-    let p1: Point = __inline_Point__new_0: {
-        break __inline_Point__new_0: Point { x: 3, y: 4 };
-    };
+    let p1: Point = move Point { x: 3, y: 4 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(40), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(40), used: 0 };
         __r.String::append(move "p1: (");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -50,9 +46,7 @@ fn run() with Stdout {
         break __inline_Point__scale_6: Point { x: (p.x * 2), y: (p.y * 2) };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(49), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(49), used: 0 };
         __r.String::append(move "p2 (scaled): (");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/string_append_concat.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/string_append_concat.lowered.wado
@@ -15,29 +15,21 @@ fn run() with Stdout {
     let c: String = move "World!";
     let combined: String = move String::concat(move String::concat(a, b), c);
     core::cli::println(combined);
-    let mut builder: String = __inline_String__with_capacity_0: {
-        break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-    };
+    let mut builder: String = move String { repr: "array_new<u8>"(20), used: 0 };
     builder.String::append(move "Hello");
     builder.String::append(move ", ");
     builder.String::append(move "World!");
     core::cli::println(builder);
-    let mut s: String = __inline_String__with_capacity_1: {
-        break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(10), used: 0 };
-    };
+    let mut s: String = move String { repr: "array_new<u8>"(10), used: 0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "len: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_String__len_5: {
-                break __inline_String__len_5: s.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: s.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -45,35 +37,25 @@ fn run() with Stdout {
     });
     s.String::append(move "Hi");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "len: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_String__len_9: {
-                break __inline_String__len_9: s.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: s.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    let empty: String = __inline_String__with_capacity_10: {
-        break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(0), used: 0 };
-    };
-    if __inline_String__is_empty_11: {
-        break __inline_String__is_empty_11: (empty.used == 0);
-    } {
+    let empty: String = move String { repr: "array_new<u8>"(0), used: 0 };
+    if (empty.used == 0) {
         core::cli::println(move "empty is empty");
     }
     let nonempty: String = move "test";
-    if !__inline_String__is_empty_12: {
-        break __inline_String__is_empty_12: (nonempty.used == 0);
-    } {
+    if !(nonempty.used == 0) {
         core::cli::println(move "nonempty is not empty");
     }
 }

--- a/wado-compiler/tests/fixtures.golden/string_bytes_iter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/string_bytes_iter.lowered.wado
@@ -15,19 +15,13 @@
 
 fn run() with Stdout {
     let s: String = move "Hello";
-    let bytes: Array<u8> = move __inline_String__bytes_0: {
-        break __inline_String__bytes_0: StrUtf8ByteIter { repr: s.repr, used: s.used, index: 0 };
-    }."StrUtf8ByteIter^Iterator::collect"();
+    let bytes: Array<u8> = move StrUtf8ByteIter { repr: s.repr, used: s.used, index: 0 }."StrUtf8ByteIter^Iterator::collect"();
     __assert_0: {
-        let __v0: i32 = __inline_Array_u8___len_1: {
-            break __inline_Array_u8___len_1: bytes.used;
-        };
+        let __v0: i32 = bytes.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -63,9 +57,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'H' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -101,9 +93,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'e' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -139,9 +129,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'l' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -177,9 +165,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'l' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -215,9 +201,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'o' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -256,9 +240,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -294,15 +276,11 @@ fn run() with Stdout {
         break __inline_String__bytes_38: StrUtf8ByteIter { repr: self.repr, used: self.used, index: 0 };
     }."StrUtf8ByteIter^Iterator::collect"();
     __assert_7: {
-        let __v0: i32 = __inline_Array_u8___len_39: {
-            break __inline_Array_u8___len_39: jp_bytes.used;
-        };
+        let __v0: i32 = jp_bytes.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -338,9 +316,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 230);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_45: {
-                    break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(141), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(141), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -376,9 +352,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 151);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_50: {
-                    break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(141), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(141), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -414,9 +388,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 165);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(141), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(141), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/string_char_count.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/string_char_count.lowered.wado
@@ -16,15 +16,11 @@
 fn run() with Stdout {
     let ascii: String = move "Hello";
     __assert_0: {
-        let __v0: i32 = __inline_String__len_0: {
-            break __inline_String__len_0: ascii.used;
-        };
+        let __v0: i32 = ascii.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -56,15 +52,11 @@ fn run() with Stdout {
         }
     }
     __assert_1: {
-        let __v0: i32 = __inline_String__chars_6: {
-            break __inline_String__chars_6: StrCharIter { repr: ascii.repr, used: ascii.used, byte_index: 0 };
-        }."StrCharIter^Iterator::count"();
+        let __v0: i32 = StrCharIter { repr: ascii.repr, used: ascii.used, byte_index: 0 }."StrCharIter^Iterator::count"();
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -97,15 +89,11 @@ fn run() with Stdout {
     }
     let japanese: String = move "日本";
     __assert_2: {
-        let __v0: i32 = __inline_String__len_12: {
-            break __inline_String__len_12: japanese.used;
-        };
+        let __v0: i32 = japanese.used;
         let __cond: bool = (__v0 == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -137,15 +125,11 @@ fn run() with Stdout {
         }
     }
     __assert_3: {
-        let __v0: i32 = __inline_String__chars_18: {
-            break __inline_String__chars_18: StrCharIter { repr: japanese.repr, used: japanese.used, byte_index: 0 };
-        }."StrCharIter^Iterator::count"();
+        let __v0: i32 = StrCharIter { repr: japanese.repr, used: japanese.used, byte_index: 0 }."StrCharIter^Iterator::count"();
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_19: {
-                    break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(158), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(158), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -178,15 +162,11 @@ fn run() with Stdout {
     }
     let emoji: String = move "😀";
     __assert_4: {
-        let __v0: i32 = __inline_String__len_24: {
-            break __inline_String__len_24: emoji.used;
-        };
+        let __v0: i32 = emoji.used;
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -218,15 +198,11 @@ fn run() with Stdout {
         }
     }
     __assert_5: {
-        let __v0: i32 = __inline_String__chars_30: {
-            break __inline_String__chars_30: StrCharIter { repr: emoji.repr, used: emoji.used, byte_index: 0 };
-        }."StrCharIter^Iterator::count"();
+        let __v0: i32 = StrCharIter { repr: emoji.repr, used: emoji.used, byte_index: 0 }."StrCharIter^Iterator::count"();
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_31: {
-                    break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -259,15 +235,11 @@ fn run() with Stdout {
     }
     let mixed: String = move "Aéï日😀";
     __assert_6: {
-        let __v0: i32 = __inline_String__len_36: {
-            break __inline_String__len_36: mixed.used;
-        };
+        let __v0: i32 = mixed.used;
         let __cond: bool = (__v0 == 12);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -299,15 +271,11 @@ fn run() with Stdout {
         }
     }
     __assert_7: {
-        let __v0: i32 = __inline_String__chars_42: {
-            break __inline_String__chars_42: StrCharIter { repr: mixed.repr, used: mixed.used, byte_index: 0 };
-        }."StrCharIter^Iterator::count"();
+        let __v0: i32 = StrCharIter { repr: mixed.repr, used: mixed.used, byte_index: 0 }."StrCharIter^Iterator::count"();
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -340,15 +308,11 @@ fn run() with Stdout {
     }
     let empty: String = move "";
     __assert_8: {
-        let __v0: i32 = __inline_String__len_48: {
-            break __inline_String__len_48: empty.used;
-        };
+        let __v0: i32 = empty.used;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_49: {
-                    break __inline_String__with_capacity_49: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -380,15 +344,11 @@ fn run() with Stdout {
         }
     }
     __assert_9: {
-        let __v0: i32 = __inline_String__chars_54: {
-            break __inline_String__chars_54: StrCharIter { repr: empty.repr, used: empty.used, byte_index: 0 };
-        }."StrCharIter^Iterator::count"();
+        let __v0: i32 = StrCharIter { repr: empty.repr, used: empty.used, byte_index: 0 }."StrCharIter^Iterator::count"();
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -420,18 +380,12 @@ fn run() with Stdout {
         }
     }
     __assert_10: {
-        let __v0: i32 = __inline_String__bytes_60: {
-            break __inline_String__bytes_60: StrUtf8ByteIter { repr: mixed.repr, used: mixed.used, index: 0 };
-        }."StrUtf8ByteIter^Iterator::count"();
-        let __v1: i32 = __inline_String__len_61: {
-            break __inline_String__len_61: mixed.used;
-        };
+        let __v0: i32 = StrUtf8ByteIter { repr: mixed.repr, used: mixed.used, index: 0 }."StrUtf8ByteIter^Iterator::count"();
+        let __v1: i32 = mixed.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(192), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(192), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/string_chars_iter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/string_chars_iter.lowered.wado
@@ -19,15 +19,11 @@ fn run() with Stdout {
         break __inline_String__chars_0: StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
     }."StrCharIter^Iterator::collect"();
     __assert_0: {
-        let __v0: i32 = __inline_Array_char___len_1: {
-            break __inline_Array_char___len_1: ascii_chars.used;
-        };
+        let __v0: i32 = ascii_chars.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -63,9 +59,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'A');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -97,9 +91,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'B');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -131,9 +123,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'C');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -165,15 +155,11 @@ fn run() with Stdout {
         break __inline_String__chars_19: StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
     }."StrCharIter^Iterator::collect"();
     __assert_4: {
-        let __v0: i32 = __inline_Array_char___len_20: {
-            break __inline_Array_char___len_20: two_chars.used;
-        };
+        let __v0: i32 = two_chars.used;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -208,9 +194,7 @@ fn run() with Stdout {
         let __cond: bool = (two_chars."Array<char>^IndexValue::index_value"(0) as i32 == 0x00F1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -234,9 +218,7 @@ fn run() with Stdout {
         let __cond: bool = (two_chars."Array<char>^IndexValue::index_value"(1) as i32 == 0x00E9);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_29: {
-                    break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(115), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(115), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -261,15 +243,11 @@ fn run() with Stdout {
         break __inline_String__chars_32: StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
     }."StrCharIter^Iterator::collect"();
     __assert_7: {
-        let __v0: i32 = __inline_Array_char___len_33: {
-            break __inline_Array_char___len_33: three_chars.used;
-        };
+        let __v0: i32 = three_chars.used;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -304,9 +282,7 @@ fn run() with Stdout {
         let __cond: bool = (three_chars."Array<char>^IndexValue::index_value"(0) as i32 == 0x65E5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -330,9 +306,7 @@ fn run() with Stdout {
         let __cond: bool = (three_chars."Array<char>^IndexValue::index_value"(1) as i32 == 0x672C);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_42: {
-                    break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -357,15 +331,11 @@ fn run() with Stdout {
         break __inline_String__chars_45: StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
     }."StrCharIter^Iterator::collect"();
     __assert_10: {
-        let __v0: i32 = __inline_Array_char___len_46: {
-            break __inline_Array_char___len_46: four_chars.used;
-        };
+        let __v0: i32 = four_chars.used;
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -400,9 +370,7 @@ fn run() with Stdout {
         let __cond: bool = (four_chars."Array<char>^IndexValue::index_value"(0) as i32 == 0x1F600);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_52: {
-                    break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -430,9 +398,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_56: {
-                    break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -468,15 +434,11 @@ fn run() with Stdout {
         break __inline_String__chars_61: StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
     }."StrCharIter^Iterator::collect"();
     __assert_13: {
-        let __v0: i32 = __inline_Array_char___len_62: {
-            break __inline_Array_char___len_62: mixed_chars.used;
-        };
+        let __v0: i32 = mixed_chars.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_63: {
-                    break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -512,9 +474,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'A');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_68: {
-                    break __inline_String__with_capacity_68: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -545,9 +505,7 @@ fn run() with Stdout {
         let __cond: bool = (mixed_chars."Array<char>^IndexValue::index_value"(1) as i32 == 0x00E9);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_72: {
-                    break __inline_String__with_capacity_72: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -571,9 +529,7 @@ fn run() with Stdout {
         let __cond: bool = (mixed_chars."Array<char>^IndexValue::index_value"(2) as i32 == 0x00EF);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_75: {
-                    break __inline_String__with_capacity_75: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -597,9 +553,7 @@ fn run() with Stdout {
         let __cond: bool = (mixed_chars."Array<char>^IndexValue::index_value"(3) as i32 == 0x65E5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_78: {
-                    break __inline_String__with_capacity_78: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -623,9 +577,7 @@ fn run() with Stdout {
         let __cond: bool = (mixed_chars."Array<char>^IndexValue::index_value"(4) as i32 == 0x1F600);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_81: {
-                    break __inline_String__with_capacity_81: String { repr: "array_new<u8>"(118), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(118), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/string_equality.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/string_equality.lowered.wado
@@ -23,9 +23,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&__v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -57,9 +55,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0."String^Eq::eq"(&__v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -92,9 +88,7 @@ fn run() with Stdout {
         let __cond: bool = !__v2;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(158), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(158), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -142,9 +136,7 @@ fn run() with Stdout {
         let __cond: bool = !__v2;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(158), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(158), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -193,9 +185,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&__v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -229,9 +219,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0."String^Eq::eq"(&__v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_19: {
-                    break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -265,9 +253,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0."String^Eq::eq"(&__v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/string_iter_collect.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/string_iter_collect.lowered.wado
@@ -15,19 +15,13 @@
 
 fn run() with Stdout {
     let s: String = move "Hi!";
-    let bytes: Array<u8> = move __inline_String__bytes_0: {
-        break __inline_String__bytes_0: StrUtf8ByteIter { repr: s.repr, used: s.used, index: 0 };
-    }."StrUtf8ByteIter^Iterator::collect"();
+    let bytes: Array<u8> = move StrUtf8ByteIter { repr: s.repr, used: s.used, index: 0 }."StrUtf8ByteIter^Iterator::collect"();
     __assert_0: {
-        let __v0: i32 = __inline_Array_u8___len_1: {
-            break __inline_Array_u8___len_1: bytes.used;
-        };
+        let __v0: i32 = bytes.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -63,9 +57,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'H' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -101,9 +93,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'i' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -139,9 +129,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == '!' as u8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -172,19 +160,13 @@ fn run() with Stdout {
             });
         }
     }
-    let chars: Array<char> = move __inline_String__chars_22: {
-        break __inline_String__chars_22: StrCharIter { repr: s.repr, used: s.used, byte_index: 0 };
-    }."StrCharIter^Iterator::collect"();
+    let chars: Array<char> = move StrCharIter { repr: s.repr, used: s.used, byte_index: 0 }."StrCharIter^Iterator::collect"();
     __assert_4: {
-        let __v0: i32 = __inline_Array_char___len_23: {
-            break __inline_Array_char___len_23: chars.used;
-        };
+        let __v0: i32 = chars.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_24: {
-                    break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -220,9 +202,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'H');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_29: {
-                    break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -254,9 +234,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 'i');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -288,9 +266,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == '!');
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -318,19 +294,13 @@ fn run() with Stdout {
         }
     }
     let utf8: String = move "日😀";
-    let utf8_chars: Array<char> = move __inline_String__chars_41: {
-        break __inline_String__chars_41: StrCharIter { repr: utf8.repr, used: utf8.used, byte_index: 0 };
-    }."StrCharIter^Iterator::collect"();
+    let utf8_chars: Array<char> = move StrCharIter { repr: utf8.repr, used: utf8.used, byte_index: 0 }."StrCharIter^Iterator::collect"();
     __assert_8: {
-        let __v0: i32 = __inline_Array_char___len_42: {
-            break __inline_Array_char___len_42: utf8_chars.used;
-        };
+        let __v0: i32 = utf8_chars.used;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -365,9 +335,7 @@ fn run() with Stdout {
         let __cond: bool = (utf8_chars."Array<char>^IndexValue::index_value"(0) as i32 == 0x65E5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_48: {
-                    break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(116), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -391,9 +359,7 @@ fn run() with Stdout {
         let __cond: bool = (utf8_chars."Array<char>^IndexValue::index_value"(1) as i32 == 0x1F600);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_51: {
-                    break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(117), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -413,19 +379,13 @@ fn run() with Stdout {
             });
         }
     }
-    let utf8_bytes: Array<u8> = move __inline_String__bytes_54: {
-        break __inline_String__bytes_54: StrUtf8ByteIter { repr: utf8.repr, used: utf8.used, index: 0 };
-    }."StrUtf8ByteIter^Iterator::collect"();
+    let utf8_bytes: Array<u8> = move StrUtf8ByteIter { repr: utf8.repr, used: utf8.used, index: 0 }."StrUtf8ByteIter^Iterator::collect"();
     __assert_11: {
-        let __v0: i32 = __inline_Array_u8___len_55: {
-            break __inline_Array_u8___len_55: utf8_bytes.used;
-        };
+        let __v0: i32 = utf8_bytes.used;
         let __cond: bool = (__v0 == 7);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_56: {
-                    break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -461,15 +421,11 @@ fn run() with Stdout {
         break __inline_String__bytes_61: StrUtf8ByteIter { repr: self.repr, used: self.used, index: 0 };
     }."StrUtf8ByteIter^Iterator::collect"();
     __assert_12: {
-        let __v0: i32 = __inline_Array_u8___len_62: {
-            break __inline_Array_u8___len_62: empty_bytes.used;
-        };
+        let __v0: i32 = empty_bytes.used;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_63: {
-                    break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -505,15 +461,11 @@ fn run() with Stdout {
         break __inline_String__chars_68: StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
     }."StrCharIter^Iterator::collect"();
     __assert_13: {
-        let __v0: i32 = __inline_Array_char___len_69: {
-            break __inline_Array_char___len_69: empty_chars.used;
-        };
+        let __v0: i32 = empty_chars.used;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_70: {
-                    break __inline_String__with_capacity_70: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/struct_impl_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_basic.lowered.wado
@@ -15,13 +15,9 @@ struct Point {
 }
 
 fn run() with Stdout {
-    let s: i32 = __inline_Point__sum_0: {
-        break __inline_Point__sum_0: 30;
-    };
+    let s: i32 = 30;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/struct_impl_f64_fields.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_f64_fields.lowered.wado
@@ -25,36 +25,28 @@ pub fn Vector2D::length_squared(self: &Vector2D) -> f64 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "diameter: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_2: {
-            let self: Box<f64> = move Box<f64> { value: __inline_Circle__diameter_3: {
-                break __inline_Circle__diameter_3: (5.0 * 2.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: (5.0 * 2.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "circumference: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_6: {
-            let self: Box<f64> = move Box<f64> { value: __inline_Circle__circumference_7: {
-                break __inline_Circle__circumference_7: ((2.0 * 3.14159) * 5.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: ((2.0 * 3.14159) * 5.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
@@ -62,9 +54,7 @@ fn run() with Stdout {
     });
     let v: Vector2D = move Vector2D { x: 3.0, y: 4.0 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "length_squared: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
@@ -78,18 +68,14 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_11: {
-            break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "dot(1,2): ");
         let mut __f: Formatter = __inline_Formatter__new_12: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_12: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_13: {
-            let self: Box<f64> = move Box<f64> { value: __inline_Vector2D__dot_14: {
-                break __inline_Vector2D__dot_14: ((v.x * 1.0) + (v.y * 2.0));
-            } };
+            let self: Box<f64> = move Box<f64> { value: ((v.x * 1.0) + (v.y * 2.0)) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/struct_impl_multiple_methods.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_multiple_methods.lowered.wado
@@ -16,72 +16,56 @@ struct Counter {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_3: {
-                break __inline_Counter__get_3: 10;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 10 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "step: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__get_step_7: {
-                break __inline_Counter__get_step_7: 3;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 3 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "double: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_10: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__double_11: {
-                break __inline_Counter__double_11: 20;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 20 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "add_step: ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_13: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_14: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter__add_step_15: {
-                break __inline_Counter__add_step_15: 13;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 13 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/struct_impl_two_structs.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_two_structs.lowered.wado
@@ -21,36 +21,28 @@ struct Rectangle {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "point sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__sum_3: {
-                break __inline_Point__sum_3: 7;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 7 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "rect area: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Rectangle__area_7: {
-                break __inline_Rectangle__area_7: 30;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 30 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/struct_implicit_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_implicit_basic.lowered.wado
@@ -16,9 +16,7 @@ struct Point {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/struct_implicit_shorthand.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_implicit_shorthand.lowered.wado
@@ -16,9 +16,7 @@ struct Point {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/struct_import_alias.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_import_alias.lowered.wado
@@ -11,36 +11,28 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__sum_3: {
-                break __inline_Point__sum_3: 14;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 14 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "product: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__product_7: {
-                break __inline_Point__product_7: 40;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 40 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/struct_import_collision.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_import_collision.lowered.wado
@@ -17,54 +17,42 @@ struct Point {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "local total: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__total_3: {
-                break __inline_Point__total_3: 6;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 6 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "other sum: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__sum_7: {
-                break __inline_Point__sum_7: 14;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 14 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_8: {
-            break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "other product: ");
         let mut __f: Formatter = __inline_Formatter__new_9: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_9: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_10: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Point__product_11: {
-                break __inline_Point__product_11: 40;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 40 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/struct_literal_restrict_condition.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_literal_restrict_condition.lowered.wado
@@ -33,9 +33,7 @@ fn dispatch(x: i32) -> i32 {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -48,9 +46,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_4: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -63,9 +59,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
@@ -78,9 +72,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/struct_param_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_param_return.lowered.wado
@@ -15,16 +15,10 @@ struct Point {
 }
 
 fn run() with Stdout {
-    let p: Point = __inline_create_point_0: {
-        break __inline_create_point_0: Point { x: 17, y: 25 };
-    };
-    let sum: i32 = __inline_point_sum_1: {
-        break __inline_point_sum_1: (p.x + p.y);
-    };
+    let p: Point = move Point { x: 17, y: 25 };
+    let sum: i32 = (p.x + p.y);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "sum: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/struct_point_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_point_basic.lowered.wado
@@ -16,9 +16,7 @@ struct Point {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/struct_point_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_point_mut.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
     let mut __sroa_p_x: i32 = 10;
     let mut __sroa_p_y: i32 = 20;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -46,9 +44,7 @@ fn run() with Stdout {
     __sroa_p_x = 100;
     __sroa_p_y = 200;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/struct_with_generic_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_with_generic_field.lowered.wado
@@ -18,13 +18,9 @@ struct "Box<i32>" {
 }
 
 fn run() with Stdout {
-    let c: Container = __inline_create_0: {
-        break __inline_create_0: Container { box_int: Box<i32> { value: 42 } };
-    };
+    let c: Container = move Container { box_int: Box<i32> { value: 42 } };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "box value: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/struct_with_trait_bound_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_with_trait_bound_generic.lowered.wado
@@ -19,9 +19,7 @@ struct "Wrapper<i32>" {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "value: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_bool.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_bool.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "true: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -31,9 +29,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "false: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_char.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_char.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "char A: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -23,9 +21,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "char Z: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_f64.lowered.wado
@@ -13,9 +13,7 @@
 fn run() with Stdout {
     let neg: f64 = (0.0 - 2.5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "pi: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -29,9 +27,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "negative: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_i32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_i32.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "positive: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "negative: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "zero: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_i64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_i64.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "positive: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -27,9 +25,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "big: ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -43,9 +39,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "negative: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_multiline.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_multiline.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     core::cli::println(simple);
     let name: String = move "Alice";
     let greeting: String = __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(54), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(54), used: 0 };
         __r.String::append(move "Dear ");
         __r.String::append(name);
         __r.String::append(move ",\n\nWelcome to Wado!\n\nBest regards");
@@ -24,9 +22,7 @@ fn run() with Stdout {
     };
     core::cli::println(greeting);
     let result: String = __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(70), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(70), used: 0 };
         __r.String::append(move "First: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/template_string_three_interp.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_three_interp.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     let s2: String = move "Y";
     let s3: String = move "Z";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(54), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(54), used: 0 };
         __r.String::append(s1);
         __r.String::append(move " a ");
         __r.String::append(s2);

--- a/wado-compiler/tests/fixtures.golden/template_string_two_end.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_two_end.lowered.wado
@@ -13,9 +13,7 @@ fn run() with Stdout {
     let s1: String = move "X";
     let s2: String = move "Y";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "a ");
         __r.String::append(s1);
         __r.String::append(move " b ");

--- a/wado-compiler/tests/fixtures.golden/template_string_two_interp.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_two_interp.lowered.wado
@@ -13,9 +13,7 @@ fn run() with Stdout {
     let s1: String = move "X";
     let s2: String = move "Y";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(s1);
         __r.String::append(move " a ");
         __r.String::append(s2);

--- a/wado-compiler/tests/fixtures.golden/template_string_two_middle.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_two_middle.lowered.wado
@@ -13,9 +13,7 @@ fn run() with Stdout {
     let s1: String = move "X";
     let s2: String = move "Y";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(39), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
         __r.String::append(move "a ");
         __r.String::append(s1);
         __r.String::append(move " b ");

--- a/wado-compiler/tests/fixtures.golden/test_fail.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/test_fail.lowered.wado
@@ -21,9 +21,7 @@ fn __test_1_failing() {
         let __cond: bool = (1 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(110), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(110), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "__test_1_failing");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/trait_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_basic.lowered.wado
@@ -15,9 +15,7 @@ struct Person {
 
 fn "Person^Greet::greet"(self: &Person) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Hello, ");
         __r.String::append(self.name);
         __r.String::append(move "!");

--- a/wado-compiler/tests/fixtures.golden/trait_bound_check.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_check.lowered.wado
@@ -19,8 +19,6 @@ struct "Container<StringWrapper>" {
 
 fn run() with Stdout {
     let __sroa___sroa_c_item_value: String = move "hello";
-    core::cli::println(__inline_StringWrapper_Printable__print_0: {
-        break __inline_StringWrapper_Printable__print_0: __sroa___sroa_c_item_value;
-    });
+    core::cli::println(__sroa___sroa_c_item_value);
 }
 

--- a/wado-compiler/tests/fixtures.golden/trait_bound_fn.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_fn.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let result: i32 = "max<i32>"(3, 7);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/trait_bound_impl_block.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_impl_block.lowered.wado
@@ -15,25 +15,19 @@ struct "Wrapper<i32>" {
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Wrapper_i32___get_3: {
-                break __inline_Wrapper_i32___get_3: 10;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 10 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    if __inline_Wrapper_i32___is_greater_than_4: {
-        break __inline_Wrapper_i32___is_greater_than_4: (20 > 10);
-    } {
+    if (20 > 10) {
         core::cli::println(move "b is greater");
     }
 }

--- a/wado-compiler/tests/fixtures.golden/trait_default_assoc_type.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_assoc_type.lowered.wado
@@ -14,9 +14,7 @@ struct IntBox {
 }
 
 pub fn "IntBox^Container::has_items"(self: &IntBox) -> bool {
-    let __pattern_temp_0: Option<i32> = __inline_IntBox_Container__get_first_0: {
-        break __inline_IntBox_Container__get_first_0: Option::Some(Box<i32> { value: self.value });
-    };
+    let __pattern_temp_0: Option<i32> = Option::Some(Box<i32> { value: self.value });
     if __is_not_null(__pattern_temp_0) {
         __unwrap_option(__pattern_temp_0).value;
         return true;

--- a/wado-compiler/tests/fixtures.golden/trait_default_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_basic.lowered.wado
@@ -19,13 +19,9 @@ struct Robot {
 
 fn "Person^Greet::greet"(self: &Person) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "Hi, ");
-        __r.String::append(__inline_Person_Greet__name_1: {
-            break __inline_Person_Greet__name_1: self.name;
-        });
+        __r.String::append(self.name);
         __r.String::append(move "!");
         break __tmpl: __r;
     };
@@ -33,9 +29,7 @@ fn "Person^Greet::greet"(self: &Person) -> String {
 
 fn "Robot^Greet::name"(self: &Robot) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Robot-");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -52,9 +46,7 @@ fn "Robot^Greet::name"(self: &Robot) -> String {
 
 pub fn "Robot^Greet::greet"(self: &Robot) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Hello, ");
         __r.String::append(move self."Robot^Greet::name"());
         __r.String::append(move "!");

--- a/wado-compiler/tests/fixtures.golden/trait_default_calls_default.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_calls_default.lowered.wado
@@ -15,13 +15,9 @@ struct Item {
 
 pub fn "Item^Describable::short_desc"(self: &Item) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
-        __r.String::append(__inline_Item_Describable__label_1: {
-            break __inline_Item_Describable__label_1: self.name;
-        });
+        __r.String::append(self.name);
         __r.String::append(move "]");
         break __tmpl: __r;
     };
@@ -29,16 +25,12 @@ pub fn "Item^Describable::short_desc"(self: &Item) -> String {
 
 fn run() with Stdout {
     let item: Item = move Item { name: "Widget" };
-    core::cli::println(__inline_Item_Describable__label_0: {
-        break __inline_Item_Describable__label_0: item.name;
-    });
+    core::cli::println(item.name);
     core::cli::println(move item."Item^Describable::short_desc"());
     core::cli::println(__inline_Item_Describable__full_desc_0: {
         let self: &Item = &item;
         break __inline_Item_Describable__full_desc_0: __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(29), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
             __r.String::append(move "Description: ");
             __r.String::append(move self."Item^Describable::short_desc"());
             break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/trait_default_count.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_count.lowered.wado
@@ -17,17 +17,11 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let arr: Array<i32> = move [1, 2, 3, 4, 5];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
     iter."ArrayIter<i32>^Iterator::next"();
     let remaining: i32 = iter."ArrayIter<i32>^Iterator::count"();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/trait_default_override.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_override.lowered.wado
@@ -20,9 +20,7 @@ struct Tweet {
 
 fn "Article^Summary::summary"(self: &Article) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(self.headline);
         __r.String::append(move " - ");
         __r.String::append(self.content);
@@ -34,17 +32,11 @@ fn run() with Stdout {
     let a: Article = move Article { headline: "Breaking News", content: "Something happened" };
     core::cli::println(move a."Article^Summary::summary"());
     let __sroa_t_text: String = move "Hello world";
-    core::cli::println(__inline_Tweet_Summary__summary_0: {
-        break __inline_Tweet_Summary__summary_0: __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
-            __r.String::append(move "Title: ");
-            __r.String::append(__inline_Tweet_Summary__title_1: {
-                break __inline_Tweet_Summary__title_1: __sroa_t_text;
-            });
-            break __tmpl: __r;
-        };
+    core::cli::println(__tmpl: {
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
+        __r.String::append(move "Title: ");
+        __r.String::append(__sroa_t_text);
+        break __tmpl: __r;
     });
 }
 

--- a/wado-compiler/tests/fixtures.golden/trait_generic_option_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_generic_option_return.lowered.wado
@@ -14,15 +14,11 @@ struct "Box_<i32>" {
 }
 
 fn run() with Stdout {
-    let result: Option<i32> = __inline_Box__i32__Container__get_0: {
-        break __inline_Box__i32__Container__get_0: Option::Some(Box<i32> { value: 42 });
-    };
+    let result: Option<i32> = Option::Some(Box<i32> { value: 42 });
     if __is_not_null(result) {
         let v: i32 = __unwrap_option(result).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_1: {
-                break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
             __r.String::append(move "Got: ");
             let mut __f: Formatter = __inline_Formatter__new_2: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/trait_inherent_priority.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_inherent_priority.lowered.wado
@@ -15,9 +15,7 @@ struct Robot {
 
 fn Robot::greet(self: &Robot) -> String {
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(39), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(39), used: 0 };
         __r.String::append(move "Beep boop, I am Robot #");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/trait_method_calls_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_method_calls_method.lowered.wado
@@ -15,13 +15,9 @@ struct Point {
 }
 
 fn "Point^Describable::describe"(self: &Point) -> String {
-    let s: i32 = __inline_Point__sum_0: {
-        break __inline_Point__sum_0: (self.x + self.y);
-    };
+    let s: i32 = (self.x + self.y);
     return __tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(62), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(62), used: 0 };
         __r.String::append(move "Point(");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/trait_multiple_impls.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_multiple_impls.lowered.wado
@@ -20,25 +20,17 @@ struct Dog {
 fn run() with Stdout {
     let __sroa_cat_name: String = move "Whiskers";
     let __sroa_dog_name: String = move "Buddy";
-    core::cli::println(__inline_Cat_Describe__describe_0: {
-        break __inline_Cat_Describe__describe_0: __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-            };
-            __r.String::append(move "A cat named ");
-            __r.String::append(__sroa_cat_name);
-            break __tmpl: __r;
-        };
+    core::cli::println(__tmpl: {
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
+        __r.String::append(move "A cat named ");
+        __r.String::append(__sroa_cat_name);
+        break __tmpl: __r;
     });
-    core::cli::println(__inline_Dog_Describe__describe_1: {
-        break __inline_Dog_Describe__describe_1: __tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(28), used: 0 };
-            };
-            __r.String::append(move "A dog named ");
-            __r.String::append(__sroa_dog_name);
-            break __tmpl: __r;
-        };
+    core::cli::println(__tmpl: {
+        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
+        __r.String::append(move "A dog named ");
+        __r.String::append(__sroa_dog_name);
+        break __tmpl: __r;
     });
 }
 

--- a/wado-compiler/tests/fixtures.golden/trait_multiple_methods.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_multiple_methods.lowered.wado
@@ -16,40 +16,30 @@ struct Rectangle {
 }
 
 fn run() with Stdout {
-    core::cli::println(__inline_Rectangle_Shape__name_0: {
-        break __inline_Rectangle_Shape__name_0: "Rectangle";
-    });
+    core::cli::println(move "Rectangle");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Area: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_3: {
-            let self: Box<f64> = move Box<f64> { value: __inline_Rectangle_Shape__area_4: {
-                break __inline_Rectangle_Shape__area_4: (3.0 * 4.0);
-            } };
+            let self: Box<f64> = move Box<f64> { value: (3.0 * 4.0) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "Perimeter: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_f64_Display__fmt_7: {
-            let self: Box<f64> = move Box<f64> { value: __inline_Rectangle_Shape__perimeter_8: {
-                break __inline_Rectangle_Shape__perimeter_8: (2.0 * (3.0 + 4.0));
-            } };
+            let self: Box<f64> = move Box<f64> { value: (2.0 * (3.0 + 4.0)) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_f64"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/trait_multiple_traits.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_multiple_traits.lowered.wado
@@ -19,41 +19,29 @@ fn run() with Stdout {
     let __sroa_p_name: String = move "Alice";
     let __sroa_p_city: String = move "Tokyo";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Name: ");
-        __r.String::append(__inline_Person_Named__name_1: {
-            break __inline_Person_Named__name_1: __sroa_p_name;
-        });
+        __r.String::append(__sroa_p_name);
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "Age: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Person_Aged__age_5: {
-                break __inline_Person_Aged__age_5: 30;
-            } };
+            let self: Box<i32> = move Box<i32> { value: 30 };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(26), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(26), used: 0 };
         __r.String::append(move "Location: ");
-        __r.String::append(__inline_Person_Located__location_7: {
-            break __inline_Person_Located__location_7: __sroa_p_city;
-        });
+        __r.String::append(__sroa_p_city);
         break __tmpl: __r;
     });
 }

--- a/wado-compiler/tests/fixtures.golden/trait_mut_self.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_mut_self.lowered.wado
@@ -16,18 +16,14 @@ struct Counter {
 fn run() with Stdout {
     let mut __sroa_c_count: i32 = 42;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(24), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(24), used: 0 };
         __r.String::append(move "Before: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter_Resettable__value_3: {
-                break __inline_Counter_Resettable__value_3: __sroa_c_count;
-            } };
+            let self: Box<i32> = move Box<i32> { value: __sroa_c_count };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -37,18 +33,14 @@ fn run() with Stdout {
         __sroa_c_count = 0;
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "After: ");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Counter_Resettable__value_8: {
-                break __inline_Counter_Resettable__value_8: __sroa_c_count;
-            } };
+            let self: Box<i32> = move Box<i32> { value: __sroa_c_count };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/trait_option_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_option_return.lowered.wado
@@ -14,15 +14,11 @@ struct IntBox {
 }
 
 fn run() with Stdout {
-    let result: Option<i32> = __inline_IntBox_Container__get_0: {
-        break __inline_IntBox_Container__get_0: Option::Some(Box<i32> { value: 42 });
-    };
+    let result: Option<i32> = Option::Some(Box<i32> { value: 42 });
     if __is_not_null(result) {
         let v: i32 = __unwrap_option(result).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_1: {
-                break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(21), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
             __r.String::append(move "Got: ");
             let mut __f: Formatter = __inline_Formatter__new_2: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/trait_unit_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_unit_return.lowered.wado
@@ -15,9 +15,7 @@ struct Message {
 
 fn "Message^Printable::print"(self: &Message) with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "Message: ");
         __r.String::append(self.text);
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/treemap-basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-basic.lowered.wado
@@ -37,14 +37,10 @@ pub struct "TreeMap<String,i32>" {
 fn run() with Stdout {
     let mut map: TreeMap<String,i32> = move "TreeMap<String,i32>::new"();
     __assert_0: {
-        let __v0: bool = __inline_TreeMap_String_i32___is_empty_0: {
-            break __inline_TreeMap_String_i32___is_empty_0: (map.size == 0);
-        };
+        let __v0: bool = (map.size == 0);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -80,15 +76,11 @@ fn run() with Stdout {
         }
     }
     __assert_1: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_6: {
-            break __inline_TreeMap_String_i32___len_6: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_7: {
-                    break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -128,9 +120,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -171,15 +161,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 1);
     };
     __assert_3: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_19: {
-            break __inline_TreeMap_String_i32___len_19: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -218,9 +204,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -266,9 +250,7 @@ fn run() with Stdout {
             let __cond: bool = (v1 == 1);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_32: {
-                        break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -306,15 +288,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 100);
     };
     __assert_6: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_38: {
-            break __inline_TreeMap_String_i32___len_38: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -356,9 +334,7 @@ fn run() with Stdout {
             let __cond: bool = (v2 == 100);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_45: {
-                        break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(116), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -401,15 +377,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 3);
     };
     __assert_8: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_52: {
-            break __inline_TreeMap_String_i32___len_52: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_53: {
-                    break __inline_String__with_capacity_53: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-clear.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-clear.lowered.wado
@@ -52,15 +52,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 3);
     };
     __assert_0: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_3: {
-            break __inline_TreeMap_String_i32___len_3: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_4: {
-                    break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -93,14 +89,10 @@ fn run() with Stdout {
     }
     map."TreeMap<String,i32>::clear"();
     __assert_1: {
-        let __v0: bool = __inline_TreeMap_String_i32___is_empty_9: {
-            break __inline_TreeMap_String_i32___is_empty_9: (map.size == 0);
-        };
+        let __v0: bool = (map.size == 0);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -136,15 +128,11 @@ fn run() with Stdout {
         }
     }
     __assert_2: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_15: {
-            break __inline_TreeMap_String_i32___len_15: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -184,9 +172,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -230,9 +216,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_28: {
-                    break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -276,9 +260,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -319,15 +301,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 42);
     };
     __assert_6: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_40: {
-            break __inline_TreeMap_String_i32___len_40: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_41: {
-                    break __inline_String__with_capacity_41: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -366,9 +344,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-compact.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-compact.lowered.wado
@@ -93,15 +93,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 10);
     };
     __assert_0: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_10: {
-            break __inline_TreeMap_String_i32___len_10: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -139,15 +135,11 @@ fn run() with Stdout {
     map."TreeMap<String,i32>::remove"(move "h");
     map."TreeMap<String,i32>::remove"(move "i");
     __assert_1: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_16: {
-            break __inline_TreeMap_String_i32___len_16: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -180,15 +172,11 @@ fn run() with Stdout {
     }
     let keys: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_2: {
-        let __v0: i32 = __inline_Array_String___len_22: {
-            break __inline_Array_String___len_22: keys.used;
-        };
+        let __v0: i32 = keys.used;
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_23: {
-                    break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -224,9 +212,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_28: {
-                    break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -256,9 +242,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"d");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_31: {
-                    break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -288,9 +272,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"f");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -320,9 +302,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"j");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -353,9 +333,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -391,9 +369,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_45: {
-                    break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -429,9 +405,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_50: {
-                    break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -467,9 +441,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 10);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -507,15 +479,11 @@ fn run() with Stdout {
     };
     let keys2: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_11: {
-        let __v0: i32 = __inline_Array_String___len_61: {
-            break __inline_Array_String___len_61: keys2.used;
-        };
+        let __v0: i32 = keys2.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -551,9 +519,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"new");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_67: {
-                    break __inline_String__with_capacity_67: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -587,9 +553,7 @@ fn run() with Stdout {
             let __cond: bool = (v == 4);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_71: {
-                        break __inline_String__with_capacity_71: String { repr: "array_new<u8>"(112), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(112), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -634,9 +598,7 @@ fn run() with Stdout {
             let __cond: bool = (v == 100);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_77: {
-                        break __inline_String__with_capacity_77: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-entries.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-entries.lowered.wado
@@ -59,15 +59,11 @@ fn run() with Stdout {
     };
     let pairs: Array<[String, i32]> = move map."TreeMap<String,i32>::entries"();
     __assert_0: {
-        let __v0: i32 = __inline_Array_Tuple_String_i32____len_3: {
-            break __inline_Array_Tuple_String_i32____len_3: pairs.used;
-        };
+        let __v0: i32 = pairs.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_4: {
-                    break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -103,9 +99,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"first");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(136), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(136), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -133,9 +127,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -171,9 +163,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"second");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(137), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(137), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -201,9 +191,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -239,9 +227,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"third");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(136), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(136), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -269,9 +255,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_28: {
-                    break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -313,9 +297,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"second");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(139), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(139), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -343,9 +325,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -379,15 +359,11 @@ fn run() with Stdout {
     map."TreeMap<String,i32>::remove"(move "second");
     let pairs3: Array<[String, i32]> = move map."TreeMap<String,i32>::entries"();
     __assert_9: {
-        let __v0: i32 = __inline_Array_Tuple_String_i32____len_42: {
-            break __inline_Array_Tuple_String_i32____len_42: pairs3.used;
-        };
+        let __v0: i32 = pairs3.used;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -423,9 +399,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"first");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_48: {
-                    break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -453,9 +427,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"third");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_51: {
-                    break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-index.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-index.lowered.wado
@@ -52,15 +52,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 3);
     };
     __assert_0: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_3: {
-            break __inline_TreeMap_String_i32___len_3: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_4: {
-                    break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -99,9 +95,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -144,9 +138,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -189,9 +181,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(155), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(155), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -237,9 +227,7 @@ fn run() with Stdout {
             let __cond: bool = (v1 == 1);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_28: {
-                        break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -282,9 +270,7 @@ fn run() with Stdout {
             let __cond: bool = (v2 == 2);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_34: {
-                        break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -332,9 +318,7 @@ fn run() with Stdout {
             let __cond: bool = (v3 == 100);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_41: {
-                        break __inline_String__with_capacity_41: String { repr: "array_new<u8>"(116), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(116), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -376,9 +360,7 @@ fn run() with Stdout {
         __assert_7: {
             if !false {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_47: {
-                        break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(109), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(109), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-large.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-large.lowered.wado
@@ -52,9 +52,7 @@ fn run() with Stdout {
                 __inline_TreeMap_String_i32__IndexAssign__index_assign_0: {
                     let self: &mut TreeMap<String,i32> = &mut map;
                     let key: String = __tmpl: {
-                        let mut __r: String = __inline_String__with_capacity_1: {
-                            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(20), used: 0 };
-                        };
+                        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
                         __r.String::append(move "item");
                         let mut __f: Formatter = __inline_Formatter__new_2: {
                             let buf: &mut String = &mut __r;
@@ -73,15 +71,11 @@ fn run() with Stdout {
         }
     }
     __assert_0: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_4: {
-            break __inline_TreeMap_String_i32___len_4: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 50);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -123,9 +117,7 @@ fn run() with Stdout {
             let __cond: bool = (v0 == 0);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_11: {
-                        break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(114), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -168,9 +160,7 @@ fn run() with Stdout {
             let __cond: bool = (v49 == 49);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_17: {
-                        break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(117), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(117), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -210,9 +200,7 @@ fn run() with Stdout {
             }
             __for_1_body: {
                 map."TreeMap<String,i32>::remove"(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_22: {
-                        break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(20), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
                     __r.String::append(move "item");
                     let mut __f: Formatter = __inline_Formatter__new_23: {
                         let buf: &mut String = &mut __r;
@@ -230,15 +218,11 @@ fn run() with Stdout {
         }
     }
     __assert_3: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_25: {
-            break __inline_TreeMap_String_i32___len_25: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 25);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -277,9 +261,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(155), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(155), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -322,9 +304,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_38: {
-                    break __inline_String__with_capacity_38: String { repr: "array_new<u8>"(155), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(155), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -368,9 +348,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_44: {
-                    break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -414,9 +392,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_50: {
-                    break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-ordering.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-ordering.lowered.wado
@@ -88,15 +88,11 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 8);
     };
     __assert_0: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_9: {
-            break __inline_TreeMap_String_i32___len_9: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 9);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -133,9 +129,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"echo");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -163,9 +157,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"charlie");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_18: {
-                    break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -193,9 +185,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"golf");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(129), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(129), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -223,9 +213,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"alpha");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_24: {
-                    break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -253,9 +241,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"india");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -283,9 +269,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"delta");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -313,9 +297,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"foxtrot");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -343,9 +325,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"bravo");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_36: {
-                    break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -373,9 +353,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"hotel");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -404,9 +382,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_42: {
-                    break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -442,9 +418,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -480,9 +454,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 7);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_52: {
-                    break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -518,9 +490,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_57: {
-                    break __inline_String__with_capacity_57: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -556,9 +526,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 9);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -594,9 +562,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = keys.used;
         loop {
-            if !(i < __inline_Array_String___len_67: {
-                break __inline_Array_String___len_67: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {

--- a/wado-compiler/tests/fixtures.golden/treemap-reinsert-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-reinsert-order.lowered.wado
@@ -61,9 +61,7 @@ fn run() with Stdout {
         let __v0: bool = map."TreeMap<String,i32>::remove"(move "b");
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(135), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(135), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -100,15 +98,11 @@ fn run() with Stdout {
     }
     let keys1: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_1: {
-        let __v0: i32 = __inline_Array_String___len_8: {
-            break __inline_Array_String___len_8: keys1.used;
-        };
+        let __v0: i32 = keys1.used;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -144,9 +138,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_14: {
-                    break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -174,9 +166,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"c");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -206,15 +196,11 @@ fn run() with Stdout {
     };
     let keys2: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_4: {
-        let __v0: i32 = __inline_Array_String___len_21: {
-            break __inline_Array_String___len_21: keys2.used;
-        };
+        let __v0: i32 = keys2.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -250,9 +236,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -282,9 +266,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"c");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -314,9 +296,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"b");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -347,9 +327,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_36: {
-                    break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -385,9 +363,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_41: {
-                    break __inline_String__with_capacity_41: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -423,9 +399,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 999);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_46: {
-                    break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -468,9 +442,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"c");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_52: {
-                    break __inline_String__with_capacity_52: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -498,9 +470,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"b");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -528,9 +498,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_58: {
-                    break __inline_String__with_capacity_58: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-remove-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-remove-order.lowered.wado
@@ -71,9 +71,7 @@ fn run() with Stdout {
         let __v0: bool = map."TreeMap<String,i32>::remove"(move "third");
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(143), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(143), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -110,15 +108,11 @@ fn run() with Stdout {
     }
     let keys: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_1: {
-        let __v0: i32 = __inline_Array_String___len_10: {
-            break __inline_Array_String___len_10: keys.used;
-        };
+        let __v0: i32 = keys.used;
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -154,9 +148,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"first");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -186,9 +178,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"second");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_19: {
-                    break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(149), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(149), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -218,9 +208,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"fourth");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(149), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(149), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -250,9 +238,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"fifth");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -281,9 +267,7 @@ fn run() with Stdout {
         let __v0: bool = map."TreeMap<String,i32>::remove"(move "first");
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_28: {
-                    break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(143), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(143), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -320,15 +304,11 @@ fn run() with Stdout {
     }
     let keys2: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_7: {
-        let __v0: i32 = __inline_Array_String___len_33: {
-            break __inline_Array_String___len_33: keys2.used;
-        };
+        let __v0: i32 = keys2.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -364,9 +344,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"second");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(151), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(151), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -396,9 +374,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"fourth");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_42: {
-                    break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -426,9 +402,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"fifth");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_45: {
-                    break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -455,9 +429,7 @@ fn run() with Stdout {
         let __v0: bool = map."TreeMap<String,i32>::remove"(move "fifth");
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_48: {
-                    break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(143), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(143), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -494,15 +466,11 @@ fn run() with Stdout {
     }
     let keys3: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_12: {
-        let __v0: i32 = __inline_Array_String___len_53: {
-            break __inline_Array_String___len_53: keys3.used;
-        };
+        let __v0: i32 = keys3.used;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_54: {
-                    break __inline_String__with_capacity_54: String { repr: "array_new<u8>"(132), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(132), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -538,9 +506,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"second");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_59: {
-                    break __inline_String__with_capacity_59: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -568,9 +534,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"fourth");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-remove.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-remove.lowered.wado
@@ -61,9 +61,7 @@ fn run() with Stdout {
         let __v0: bool = map."TreeMap<String,i32>::remove"(move "b");
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(135), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(135), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -107,9 +105,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -145,15 +141,11 @@ fn run() with Stdout {
         }
     }
     __assert_2: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_14: {
-            break __inline_TreeMap_String_i32___len_14: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -192,9 +184,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -237,9 +227,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_27: {
-                    break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -279,9 +267,7 @@ fn run() with Stdout {
         let __cond: bool = !__v0;
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(136), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(136), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -317,15 +303,11 @@ fn run() with Stdout {
         }
     }
     __assert_6: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_37: {
-            break __inline_TreeMap_String_i32___len_37: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_38: {
-                    break __inline_String__with_capacity_38: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -369,9 +351,7 @@ fn run() with Stdout {
         };
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_45: {
-                    break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -417,9 +397,7 @@ fn run() with Stdout {
             let __cond: bool = (val == 999);
             if !__cond {
                 core::internal::panic(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_51: {
-                        break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(118), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(118), used: 0 };
                     __r.String::append(move "Assertion failed in ");
                     __r.String::append(move "run");
                     __r.String::append(move " at ");
@@ -452,15 +430,11 @@ fn run() with Stdout {
         }
     }
     __assert_9: {
-        let __v0: i32 = __inline_TreeMap_String_i32___len_56: {
-            break __inline_TreeMap_String_i32___len_56: map.size;
-        };
+        let __v0: i32 = map.size;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_57: {
-                    break __inline_String__with_capacity_57: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap-update-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-update-order.lowered.wado
@@ -69,15 +69,11 @@ fn run() with Stdout {
     };
     let keys: Array<String> = move map."TreeMap<String,i32>::keys"();
     __assert_0: {
-        let __v0: i32 = __inline_Array_String___len_5: {
-            break __inline_Array_String___len_5: keys.used;
-        };
+        let __v0: i32 = keys.used;
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(130), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(130), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -113,9 +109,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"a");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -145,9 +139,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"b");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_14: {
-                    break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -177,9 +169,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"c");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -210,9 +200,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -250,9 +238,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_25: {
-                    break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -290,9 +276,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -336,9 +320,7 @@ fn run() with Stdout {
         let __cond: bool = __v0."String^Eq::eq"(&"d");
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_36: {
-                    break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/treemap_btree.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree.lowered.wado
@@ -35,9 +35,7 @@ struct "BTreeNode<String,i32>" {
 }
 
 fn run() with Stdout {
-    let mut map: TreeMap<String,i32> = __inline_TreeMap_String_i32___with_default_degree_0: {
-        break __inline_TreeMap_String_i32___with_default_degree_0: "TreeMap<String,i32>::new"(3);
-    };
+    let mut map: TreeMap<String,i32> = move "TreeMap<String,i32>::new"(3);
     map."TreeMap<String,i32>::insert"(move "apple", 1);
     map."TreeMap<String,i32>::insert"(move "banana", 2);
     map."TreeMap<String,i32>::insert"(move "cherry", 3);
@@ -45,18 +43,14 @@ fn run() with Stdout {
     map."TreeMap<String,i32>::insert"(move "elderberry", 5);
     core::cli::println(move "=== After insertion ===");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Size: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_TreeMap_String_i32___len_4: {
-                break __inline_TreeMap_String_i32___len_4: map.size;
-            } };
+            let self: Box<i32> = move Box<i32> { value: map.size };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -66,9 +60,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_0) {
         let val: i32 = __unwrap_option(__pattern_temp_0).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_5: {
-                break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(25), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
             __r.String::append(move "banana = ");
             let mut __f: Formatter = __inline_Formatter__new_6: {
                 let buf: &mut String = &mut __r;
@@ -86,9 +78,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_1) {
         let val2: i32 = __unwrap_option(__pattern_temp_1).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_8: {
-                break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "date = ");
             let mut __f: Formatter = __inline_Formatter__new_9: {
                 let buf: &mut String = &mut __r;
@@ -107,9 +97,7 @@ fn run() with Stdout {
     if __is_not_null(__pattern_temp_2) {
         let val3: i32 = __unwrap_option(__pattern_temp_2).value;
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_11: {
-                break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(35), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
             __r.String::append(move "banana (updated) = ");
             let mut __f: Formatter = __inline_Formatter__new_12: {
                 let buf: &mut String = &mut __r;
@@ -126,18 +114,14 @@ fn run() with Stdout {
     core::cli::println(move "\n=== After deleting cherry ===");
     map."TreeMap<String,i32>::delete"(&"cherry");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_14: {
-            break __inline_String__with_capacity_14: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Size: ");
         let mut __f: Formatter = __inline_Formatter__new_15: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_15: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_16: {
-            let self: Box<i32> = move Box<i32> { value: __inline_TreeMap_String_i32___len_17: {
-                break __inline_TreeMap_String_i32___len_17: map.size;
-            } };
+            let self: Box<i32> = move Box<i32> { value: map.size };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -150,9 +134,7 @@ fn run() with Stdout {
     core::cli::println(move "\n=== Iteration (sorted) ===");
     let entries: Array<[String, i32]> = move map."TreeMap<String,i32>::iter"();
     __for_of_7: {
-        let mut __iter_7: ArrayIter<Tuple<String,i32>> = __inline_Array_Tuple_String_i32___IntoIterator__into_iter_18: {
-            break __inline_Array_Tuple_String_i32___IntoIterator__into_iter_18: ArrayIter<Tuple<String,i32>> { repr: entries.repr, used: entries.used, index: 0 };
-        };
+        let mut __iter_7: ArrayIter<Tuple<String,i32>> = move ArrayIter<Tuple<String,i32>> { repr: entries.repr, used: entries.used, index: 0 };
         loop {
             let __pattern_temp_4: Option<[String, i32]> = move __iter_7."ArrayIter<Tuple<String,i32>>^Iterator::next"();
             if __is_not_null(__pattern_temp_4) {
@@ -160,9 +142,7 @@ fn run() with Stdout {
                 let key: String = entry.0;
                 let value: i32 = entry.1;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_19: {
-                        break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(35), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
                     __r.String::append(key);
                     __r.String::append(move " = ");
                     let mut __f: Formatter = __inline_Formatter__new_20: {
@@ -187,27 +167,21 @@ fn run() with Stdout {
         map."TreeMap<String,i32>::compact"();
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_22: {
-            break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Size: ");
         let mut __f: Formatter = __inline_Formatter__new_23: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_23: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_24: {
-            let self: Box<i32> = move Box<i32> { value: __inline_TreeMap_String_i32___len_25: {
-                break __inline_TreeMap_String_i32___len_25: map.size;
-            } };
+            let self: Box<i32> = move Box<i32> { value: map.size };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_26: {
-            break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "Deleted count: ");
         let mut __f: Formatter = __inline_Formatter__new_27: {
             let buf: &mut String = &mut __r;
@@ -223,9 +197,7 @@ fn run() with Stdout {
     core::cli::println(move "\n=== Final iteration ===");
     let final_entries: Array<[String, i32]> = move map."TreeMap<String,i32>::iter"();
     __for_of_8: {
-        let mut __iter_8: ArrayIter<Tuple<String,i32>> = __inline_Array_Tuple_String_i32___IntoIterator__into_iter_29: {
-            break __inline_Array_Tuple_String_i32___IntoIterator__into_iter_29: ArrayIter<Tuple<String,i32>> { repr: final_entries.repr, used: final_entries.used, index: 0 };
-        };
+        let mut __iter_8: ArrayIter<Tuple<String,i32>> = move ArrayIter<Tuple<String,i32>> { repr: final_entries.repr, used: final_entries.used, index: 0 };
         loop {
             let __pattern_temp_5: Option<[String, i32]> = move __iter_8."ArrayIter<Tuple<String,i32>>^Iterator::next"();
             if __is_not_null(__pattern_temp_5) {
@@ -233,9 +205,7 @@ fn run() with Stdout {
                 let key: String = entry.0;
                 let value: i32 = entry.1;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_30: {
-                        break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(35), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
                     __r.String::append(key);
                     __r.String::append(move " = ");
                     let mut __f: Formatter = __inline_Formatter__new_31: {
@@ -276,9 +246,7 @@ fn "BTreeNode<String,i32>::compact"(self: &mut BTreeNode<String,i32>) {
         let _licm_values: Array<i32> = self.values;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -423,9 +391,7 @@ fn "TreeMap<String,i32>::collect_entries"(self: &TreeMap<String,i32>, node: &BTr
     let _licm_values: Array<i32> = node.values;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !(i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) {
+        if !(i < _licm_used) {
             break;
         }
         if (!_licm_is_leaf && (i < _licm_children."Array<BTreeNode<String,i32>>::len"())) {
@@ -471,9 +437,7 @@ fn "TreeMap<String,i32>::delete_in_node"(self: &mut TreeMap<String,i32>, node: &
     let _licm_keys: Array<String> = node.keys;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
+        if !((i < _licm_used) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
             break;
         }
         i = (i + 1);
@@ -517,9 +481,7 @@ fn "TreeMap<String,i32>::search_in_node"(self: &TreeMap<String,i32>, node: &BTre
     let _licm_keys: Array<String> = node.keys;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
+        if !((i < _licm_used) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
             break;
         }
         i = (i + 1);
@@ -553,9 +515,7 @@ fn "TreeMap<String,i32>::insert"(self: &mut TreeMap<String,i32>, key: String, va
     let __pattern_temp_1: Option<&mut BTreeNode<String,i32>> = self.root;
     if __is_not_null(__pattern_temp_1) {
         let root: &mut BTreeNode<String,i32> = __unwrap_option(__pattern_temp_1);
-        if root."BTreeNode<String,i32>::is_full"(__inline_TreeMap_String_i32___max_keys_0: {
-            break __inline_TreeMap_String_i32___max_keys_0: ((2 * self.t) - 1);
-        }) {
+        if root."BTreeNode<String,i32>::is_full"(((2 * self.t) - 1)) {
             let mut new_root: BTreeNode<String,i32> = move "BTreeNode<String,i32>::new_internal"();
             new_root.children."Array<BTreeNode<String,i32>>::append"(root);
             self."TreeMap<String,i32>::split_child"(&mut new_root, 0);
@@ -575,9 +535,7 @@ fn "TreeMap<String,i32>::insert_non_full"(self: &mut TreeMap<String,i32>, node: 
         let _licm_keys: Array<String> = node.keys;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !((pos < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) && (_licm_keys."Array<String>^IndexValue::index_value"(pos)."String^Ord::cmp"(&key) == Ordering::Less)) {
+            if !((pos < _licm_used) && (_licm_keys."Array<String>^IndexValue::index_value"(pos)."String^Ord::cmp"(&key) == Ordering::Less)) {
                 break;
             }
             pos = (pos + 1);
@@ -603,16 +561,12 @@ fn "TreeMap<String,i32>::insert_non_full"(self: &mut TreeMap<String,i32>, node: 
         let _licm_keys: Array<String> = node.keys;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !((pos < __inline_Array_String___len_2: {
-                break __inline_Array_String___len_2: _licm_used;
-            }) && (key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(pos)) == Ordering::Greater)) {
+            if !((pos < _licm_used) && (key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(pos)) == Ordering::Greater)) {
                 break;
             }
             pos = (pos + 1);
         }
-        if node.children."Array<BTreeNode<String,i32>>^IndexValue::index_value"(pos)."BTreeNode<String,i32>::is_full"(__inline_TreeMap_String_i32___max_keys_3: {
-            break __inline_TreeMap_String_i32___max_keys_3: ((2 * self.t) - 1);
-        }) {
+        if node.children."Array<BTreeNode<String,i32>>^IndexValue::index_value"(pos)."BTreeNode<String,i32>::is_full"(((2 * self.t) - 1)) {
             self."TreeMap<String,i32>::split_child"(node, pos);
             if (key."String^Ord::cmp"(&node.keys."Array<String>^IndexValue::index_value"(pos)) == Ordering::Greater) {
                 pos = (pos + 1);
@@ -692,9 +646,7 @@ fn "TreeMap<String,i32>::split_child"(self: &mut TreeMap<String,i32>, parent: &m
         let _licm_deleted: Array<bool> = full_child.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_3;
             }
             __for_3_body: {
@@ -758,9 +710,7 @@ fn "BTreeNode<String,i32>::is_full"(self: &BTreeNode<String,i32>, max_keys: i32)
         let _licm_deleted: Array<bool> = self.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {

--- a/wado-compiler/tests/fixtures.golden/treemap_btree2.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree2.lowered.wado
@@ -35,9 +35,7 @@ struct "BTreeNode<String,i32>" {
 }
 
 fn run() with Stdout {
-    let mut map: TreeMap<String,i32> = __inline_TreeMap_String_i32___with_default_degree_0: {
-        break __inline_TreeMap_String_i32___with_default_degree_0: "TreeMap<String,i32>::new"(3);
-    };
+    let mut map: TreeMap<String,i32> = move "TreeMap<String,i32>::new"(3);
     __inline_TreeMap_String_i32__IndexAssign__index_assign_1: {
         let self: &mut TreeMap<String,i32> = &mut map;
         let key: String = move "apple";
@@ -65,27 +63,21 @@ fn run() with Stdout {
     };
     core::cli::println(move "=== After insertion ===");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Size: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_TreeMap_String_i32___len_9: {
-                break __inline_TreeMap_String_i32___len_9: map.size;
-            } };
+            let self: Box<i32> = move Box<i32> { value: map.size };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "banana = ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -99,9 +91,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(23), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
         __r.String::append(move "date = ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -120,9 +110,7 @@ fn run() with Stdout {
         self."TreeMap<String,i32>::insert"(key, 20);
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_17: {
-            break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "banana (updated) = ");
         let mut __f: Formatter = __inline_Formatter__new_18: {
             let buf: &mut String = &mut __r;
@@ -138,18 +126,14 @@ fn run() with Stdout {
     core::cli::println(move "\n=== After deleting cherry ===");
     map."TreeMap<String,i32>::delete"(&"cherry");
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Size: ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_21: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_22: {
-            let self: Box<i32> = move Box<i32> { value: __inline_TreeMap_String_i32___len_23: {
-                break __inline_TreeMap_String_i32___len_23: map.size;
-            } };
+            let self: Box<i32> = move Box<i32> { value: map.size };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -158,9 +142,7 @@ fn run() with Stdout {
     core::cli::println(move "\n=== Iteration (sorted) ===");
     let entries: Array<[String, i32]> = move map."TreeMap<String,i32>::iter"();
     __for_of_7: {
-        let mut __iter_7: ArrayIter<Tuple<String,i32>> = __inline_Array_Tuple_String_i32___IntoIterator__into_iter_24: {
-            break __inline_Array_Tuple_String_i32___IntoIterator__into_iter_24: ArrayIter<Tuple<String,i32>> { repr: entries.repr, used: entries.used, index: 0 };
-        };
+        let mut __iter_7: ArrayIter<Tuple<String,i32>> = move ArrayIter<Tuple<String,i32>> { repr: entries.repr, used: entries.used, index: 0 };
         loop {
             let __pattern_temp_0: Option<[String, i32]> = move __iter_7."ArrayIter<Tuple<String,i32>>^Iterator::next"();
             if __is_not_null(__pattern_temp_0) {
@@ -168,9 +150,7 @@ fn run() with Stdout {
                 let key: String = entry.0;
                 let value: i32 = entry.1;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_25: {
-                        break __inline_String__with_capacity_25: String { repr: "array_new<u8>"(35), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
                     __r.String::append(key);
                     __r.String::append(move " = ");
                     let mut __f: Formatter = __inline_Formatter__new_26: {
@@ -195,27 +175,21 @@ fn run() with Stdout {
         map."TreeMap<String,i32>::compact"();
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_28: {
-            break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(22), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(22), used: 0 };
         __r.String::append(move "Size: ");
         let mut __f: Formatter = __inline_Formatter__new_29: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_29: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_30: {
-            let self: Box<i32> = move Box<i32> { value: __inline_TreeMap_String_i32___len_31: {
-                break __inline_TreeMap_String_i32___len_31: map.size;
-            } };
+            let self: Box<i32> = move Box<i32> { value: map.size };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_32: {
-            break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "Deleted count: ");
         let mut __f: Formatter = __inline_Formatter__new_33: {
             let buf: &mut String = &mut __r;
@@ -231,9 +205,7 @@ fn run() with Stdout {
     core::cli::println(move "\n=== Final iteration ===");
     let final_entries: Array<[String, i32]> = move map."TreeMap<String,i32>::iter"();
     __for_of_8: {
-        let mut __iter_8: ArrayIter<Tuple<String,i32>> = __inline_Array_Tuple_String_i32___IntoIterator__into_iter_35: {
-            break __inline_Array_Tuple_String_i32___IntoIterator__into_iter_35: ArrayIter<Tuple<String,i32>> { repr: final_entries.repr, used: final_entries.used, index: 0 };
-        };
+        let mut __iter_8: ArrayIter<Tuple<String,i32>> = move ArrayIter<Tuple<String,i32>> { repr: final_entries.repr, used: final_entries.used, index: 0 };
         loop {
             let __pattern_temp_1: Option<[String, i32]> = move __iter_8."ArrayIter<Tuple<String,i32>>^Iterator::next"();
             if __is_not_null(__pattern_temp_1) {
@@ -241,9 +213,7 @@ fn run() with Stdout {
                 let key: String = entry.0;
                 let value: i32 = entry.1;
                 core::cli::println(__tmpl: {
-                    let mut __r: String = __inline_String__with_capacity_36: {
-                        break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(35), used: 0 };
-                    };
+                    let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
                     __r.String::append(key);
                     __r.String::append(move " = ");
                     let mut __f: Formatter = __inline_Formatter__new_37: {
@@ -284,9 +254,7 @@ fn "BTreeNode<String,i32>::compact"(self: &mut BTreeNode<String,i32>) {
         let _licm_values: Array<i32> = self.values;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -431,9 +399,7 @@ fn "TreeMap<String,i32>::collect_entries"(self: &TreeMap<String,i32>, node: &BTr
     let _licm_values: Array<i32> = node.values;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !(i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) {
+        if !(i < _licm_used) {
             break;
         }
         if (!_licm_is_leaf && (i < _licm_children."Array<BTreeNode<String,i32>>::len"())) {
@@ -479,9 +445,7 @@ fn "TreeMap<String,i32>::delete_in_node"(self: &mut TreeMap<String,i32>, node: &
     let _licm_keys: Array<String> = node.keys;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
+        if !((i < _licm_used) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
             break;
         }
         i = (i + 1);
@@ -534,9 +498,7 @@ fn "TreeMap<String,i32>::search_in_node"(self: &TreeMap<String,i32>, node: &BTre
     let _licm_keys: Array<String> = node.keys;
     let _licm_used: i32 = _licm_keys.used;
     loop {
-        if !((i < __inline_Array_String___len_0: {
-            break __inline_Array_String___len_0: _licm_used;
-        }) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
+        if !((i < _licm_used) && (*key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(i)) == Ordering::Greater)) {
             break;
         }
         i = (i + 1);
@@ -570,9 +532,7 @@ fn "TreeMap<String,i32>::insert"(self: &mut TreeMap<String,i32>, key: String, va
     let __pattern_temp_1: Option<&mut BTreeNode<String,i32>> = self.root;
     if __is_not_null(__pattern_temp_1) {
         let root: &mut BTreeNode<String,i32> = __unwrap_option(__pattern_temp_1);
-        if root."BTreeNode<String,i32>::is_full"(__inline_TreeMap_String_i32___max_keys_0: {
-            break __inline_TreeMap_String_i32___max_keys_0: ((2 * self.t) - 1);
-        }) {
+        if root."BTreeNode<String,i32>::is_full"(((2 * self.t) - 1)) {
             let mut new_root: BTreeNode<String,i32> = move "BTreeNode<String,i32>::new_internal"();
             new_root.children."Array<BTreeNode<String,i32>>::append"(root);
             self."TreeMap<String,i32>::split_child"(&mut new_root, 0);
@@ -592,9 +552,7 @@ fn "TreeMap<String,i32>::insert_non_full"(self: &mut TreeMap<String,i32>, node: 
         let _licm_keys: Array<String> = node.keys;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !((pos < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) && (_licm_keys."Array<String>^IndexValue::index_value"(pos)."String^Ord::cmp"(&key) == Ordering::Less)) {
+            if !((pos < _licm_used) && (_licm_keys."Array<String>^IndexValue::index_value"(pos)."String^Ord::cmp"(&key) == Ordering::Less)) {
                 break;
             }
             pos = (pos + 1);
@@ -620,16 +578,12 @@ fn "TreeMap<String,i32>::insert_non_full"(self: &mut TreeMap<String,i32>, node: 
         let _licm_keys: Array<String> = node.keys;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !((pos < __inline_Array_String___len_2: {
-                break __inline_Array_String___len_2: _licm_used;
-            }) && (key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(pos)) == Ordering::Greater)) {
+            if !((pos < _licm_used) && (key."String^Ord::cmp"(&_licm_keys."Array<String>^IndexValue::index_value"(pos)) == Ordering::Greater)) {
                 break;
             }
             pos = (pos + 1);
         }
-        if node.children."Array<BTreeNode<String,i32>>^IndexValue::index_value"(pos)."BTreeNode<String,i32>::is_full"(__inline_TreeMap_String_i32___max_keys_3: {
-            break __inline_TreeMap_String_i32___max_keys_3: ((2 * self.t) - 1);
-        }) {
+        if node.children."Array<BTreeNode<String,i32>>^IndexValue::index_value"(pos)."BTreeNode<String,i32>::is_full"(((2 * self.t) - 1)) {
             self."TreeMap<String,i32>::split_child"(node, pos);
             if (key."String^Ord::cmp"(&node.keys."Array<String>^IndexValue::index_value"(pos)) == Ordering::Greater) {
                 pos = (pos + 1);
@@ -709,9 +663,7 @@ fn "TreeMap<String,i32>::split_child"(self: &mut TreeMap<String,i32>, parent: &m
         let _licm_deleted: Array<bool> = full_child.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_3;
             }
             __for_3_body: {
@@ -775,9 +727,7 @@ fn "BTreeNode<String,i32>::is_full"(self: &BTreeNode<String,i32>, max_keys: i32)
         let _licm_deleted: Array<bool> = self.deleted;
         let _licm_used: i32 = _licm_keys.used;
         loop {
-            if !(i < __inline_Array_String___len_0: {
-                break __inline_Array_String___len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {

--- a/wado-compiler/tests/fixtures.golden/tuple_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_basic.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_bracket_index.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_bracket_index.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_basic.lowered.wado
@@ -10,15 +10,11 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let __pattern_temp_0: [i32, String] = __inline_make_pair_0: {
-        break __inline_make_pair_0: [42, "hello"];
-    };
+    let __pattern_temp_0: [i32, String] = move [42, "hello"];
     let a: i32 = __pattern_temp_0.0;
     let b: String = __pattern_temp_0.1;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_mut.lowered.wado
@@ -10,15 +10,11 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let __pattern_temp_0: [i32, i32] = __inline_make_pair_0: {
-        break __inline_make_pair_0: [10, 20];
-    };
+    let __pattern_temp_0: [i32, i32] = move [10, 20];
     let mut a: i32 = __pattern_temp_0.0;
     let mut b: i32 = __pattern_temp_0.1;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "before: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -44,9 +40,7 @@ fn run() with Stdout {
     a = 100;
     b = 200;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "after: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_nested.lowered.wado
@@ -10,17 +10,13 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let __pattern_temp_0: [[i32, i32], String] = __inline_make_nested_0: {
-        break __inline_make_nested_0: [[1, 2], "nested"];
-    };
+    let __pattern_temp_0: [[i32, i32], String] = move [[1, 2], "nested"];
     let __pattern_temp_1: [i32, i32] = __pattern_temp_0.0;
     let a: i32 = __pattern_temp_1.0;
     let b: i32 = __pattern_temp_1.1;
     let c: String = __pattern_temp_0.1;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_wildcard.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_wildcard.lowered.wado
@@ -10,16 +10,12 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let __pattern_temp_0: [i32, i32, i32] = __inline_make_triple_0: {
-        break __inline_make_triple_0: [1, 2, 3];
-    };
+    let __pattern_temp_0: [i32, i32, i32] = move [1, 2, 3];
     let first: i32 = __pattern_temp_0.0;
     __pattern_temp_0.1;
     let third: i32 = __pattern_temp_0.2;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_elision_multivalue.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_elision_multivalue.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let [lo1, hi1] = move core::builtin::i64_add128(100, 200, 50, 25);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(48), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(48), used: 0 };
         __r.String::append(move "add128: lo=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -39,9 +37,7 @@ fn run() with Stdout {
     });
     let [lo2, hi2] = move core::builtin::i64_sub128(150, 225, 50, 25);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_5: {
-            break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(48), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(48), used: 0 };
         __r.String::append(move "sub128: lo=");
         let mut __f: Formatter = __inline_Formatter__new_6: {
             let buf: &mut String = &mut __r;
@@ -66,9 +62,7 @@ fn run() with Stdout {
     });
     let [lo3, hi3] = move core::builtin::i64_mul_wide_u(10, 20);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         __r.String::append(move "mul_wide_u: lo=");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -93,9 +87,7 @@ fn run() with Stdout {
     });
     let [lo4, hi4] = move core::builtin::i64_mul_wide_s(-10, 20);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         __r.String::append(move "mul_wide_s: lo=");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -120,9 +112,7 @@ fn run() with Stdout {
     });
     let [lo5, _] = move core::builtin::i64_mul_wide_u(100, 100);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "mul_wide_u lo only: ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
@@ -137,9 +127,7 @@ fn run() with Stdout {
     });
     let [_, hi6] = move core::builtin::i64_mul_wide_u((1 << 63), 2);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_23: {
-            break __inline_String__with_capacity_23: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "mul_wide_u hi only: ");
         let mut __f: Formatter = __inline_Formatter__new_24: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/tuple_heterogeneous.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_heterogeneous.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let __sroa_t_1: String = move "hello";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_nested.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(70), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(70), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_param.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_sum_pair_0: {
-        break __inline_sum_pair_0: 30;
-    };
+    let result: i32 = 30;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_return.lowered.wado
@@ -10,13 +10,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let p: [i32, i32] = __inline_get_pair_0: {
-        break __inline_get_pair_0: [10, 20];
-    };
+    let p: [i32, i32] = move [10, 20];
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_single.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_single.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_trailing_comma.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_trailing_comma.lowered.wado
@@ -11,9 +11,7 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/tuple_type_annotation.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_type_annotation.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let __sroa_t_1: String = move "hello";
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(52), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(52), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/u64_arithmetic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/u64_arithmetic.lowered.wado
@@ -24,15 +24,11 @@ fn run() with Stdout {
         v = (v / 10);
     }
     __assert_0: {
-        let __v0: i32 = __inline_Array_i32___len_0: {
-            break __inline_Array_i32___len_0: digits.used;
-        };
+        let __v0: i32 = digits.used;
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(134), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(134), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -68,9 +64,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -106,9 +100,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -144,9 +136,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -182,9 +172,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -220,9 +208,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(128), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(128), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -257,9 +243,7 @@ fn run() with Stdout {
         let __cond: bool = (255 == 255);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_31: {
-                    break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(114), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(114), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -294,9 +278,7 @@ fn run() with Stdout {
         let __cond: bool = (1000 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_36: {
-                    break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(122), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(122), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -331,9 +313,7 @@ fn run() with Stdout {
         let __cond: bool = (42 == 42);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_41: {
-                    break __inline_String__with_capacity_41: String { repr: "array_new<u8>"(113), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(113), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -368,9 +348,7 @@ fn run() with Stdout {
         let __cond: bool = (100 == 100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_46: {
-                    break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(121), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(121), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/unary_neg_float.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/unary_neg_float.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     let y: f64 = (-1.0 + 3.5);
     let z: f64 = -(4.0 + 2.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "x = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "y = ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -46,9 +42,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "z = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/use_local_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/use_local_module.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_add_0: {
-        break __inline_add_0: 42;
-    };
+    let result: i32 = 42;
     if (result == 42) {
         core::cli::println(move "success");
     } else {

--- a/wado-compiler/tests/fixtures.golden/user_func_return_f32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/user_func_return_f32.lowered.wado
@@ -13,13 +13,9 @@
 fn run() with Stdout {
     let a: f32 = 2.0 as f32;
     let b: f32 = 3.0 as f32;
-    let result: f32 = __inline_compute_f32_0: {
-        break __inline_compute_f32_0: ((a * b) + 1.5 as f32);
-    };
+    let result: f32 = ((a * b) + 1.5 as f32);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "result = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/user_func_return_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/user_func_return_f64.lowered.wado
@@ -11,13 +11,9 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: f64 = __inline_compute_f64_0: {
-        break __inline_compute_f64_0: ((2.0 * 3.0) + 1.5);
-    };
+    let result: f64 = ((2.0 * 3.0) + 1.5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "result = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/user_function_call.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/user_function_call.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: i32 = __inline_add_0: {
-        break __inline_add_0: 42;
-    };
+    let result: i32 = 42;
     if (result == 42) {
         core::cli::println(move "success");
     } else {

--- a/wado-compiler/tests/fixtures.golden/value_semantics_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_array.lowered.wado
@@ -18,9 +18,7 @@ fn run() with Stdout {
     let mut b: Array<i32> = a;
     b."Array<i32>^IndexAssign::index_assign"(0, 99);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "a[0]=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -34,9 +32,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(21), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "b[0]=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/value_semantics_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_string.lowered.wado
@@ -13,17 +13,13 @@ fn run() with Stdout {
     let a: String = move "hello";
     let b: String = a;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "a=");
         __r.String::append(a);
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "b=");
         __r.String::append(b);
         break __tmpl: __r;

--- a/wado-compiler/tests/fixtures.golden/value_semantics_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_struct.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
     let mut b: Point = a;
     b.x = 99;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "a.x=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -35,9 +33,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "b.x=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/value_semantics_tuple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_tuple.lowered.wado
@@ -14,9 +14,7 @@ fn run() with Stdout {
     let mut b: [i32, i32] = a;
     b.0 = 99;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "a.0=");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -30,9 +28,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(20), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(20), used: 0 };
         __r.String::append(move "b.0=");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/variant_f64_payload.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_f64_payload.lowered.wado
@@ -10,12 +10,8 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let n: JsonValue = __inline_make_number_0: {
-        break __inline_make_number_0: JsonValue::Number(3.14);
-    };
-    let s: JsonValue = __inline_make_str_1: {
-        break __inline_make_str_1: JsonValue::Str("hello");
-    };
+    let n: JsonValue = move JsonValue::Number(3.14);
+    let s: JsonValue = move JsonValue::Str("hello");
     let x: JsonValue = move JsonValue::Null;
     core::cli::println(move "done");
 }

--- a/wado-compiler/tests/fixtures.golden/variant_if_let_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_if_let_basic.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     if __variant_test(c, case=0, name=Circle) {
         let r: f64 = __variant_payload(c, case=0);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(35), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
             __r.String::append(move "Circle with radius ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -37,9 +35,7 @@ fn run() with Stdout {
     if __variant_test(p, case=0, name=Circle) {
         let r: f64 = __variant_payload(p, case=0);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_3: {
-                break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(35), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
             __r.String::append(move "Circle with radius ");
             let mut __f: Formatter = __inline_Formatter__new_4: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/variant_import_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_import_module.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let color: Color = __inline_make_red_0: {
-        break __inline_make_red_0: Color::Red;
-    };
+    let color: Color = move Color::Red;
     core::cli::println(move "ok");
 }
 

--- a/wado-compiler/tests/fixtures.golden/variant_import_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_import_mut.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let mut opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right };
-    };
+    let mut opts: Opts = move Opts { align: Align::Right };
     core::cli::println(__inline_get_align_name_1: {
         let opts: Opts = opts;
         break __inline_get_align_name_1: match opts.align {

--- a/wado-compiler/tests/fixtures.golden/variant_import_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_import_struct.lowered.wado
@@ -10,15 +10,11 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let mut opts: Options = __inline_Options__default_0: {
-        break __inline_Options__default_0: Options { align: Align::Right, width: 0 };
-    };
+    let mut opts: Options = move Options { align: Align::Right, width: 0 };
     opts.width = 10;
     let s1: String = move "./variant_import_struct_module.wado::format_with_opts"(move "hi", opts);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
         __r.String::append(s1);
         __r.String::append(move "]");
@@ -27,9 +23,7 @@ fn run() with Stdout {
     opts.align = move Align::Left;
     let s2: String = move "./variant_import_struct_module.wado::format_with_opts"(move "hi", opts);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
         __r.String::append(s2);
         __r.String::append(move "]");
@@ -38,9 +32,7 @@ fn run() with Stdout {
     opts.align = move Align::Center;
     let s3: String = move "./variant_import_struct_module.wado::format_with_opts"(move "hi", opts);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
         __r.String::append(s3);
         __r.String::append(move "]");

--- a/wado-compiler/tests/fixtures.golden/variant_import_struct_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_import_struct_module.lowered.wado
@@ -18,17 +18,11 @@ pub fn format_with_opts(s: String, opts: Options) -> String {
     if (opts.width <= 0) {
         return s;
     }
-    if (__inline_String__len_0: {
-        break __inline_String__len_0: s.used;
-    } >= opts.width) {
+    if (s.used >= opts.width) {
         return s;
     }
-    let pad_len: i32 = (opts.width - __inline_String__len_1: {
-        break __inline_String__len_1: s.used;
-    });
-    let mut pad: String = __inline_String__with_capacity_2: {
-        break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(pad_len), used: 0 };
-    };
+    let pad_len: i32 = (opts.width - s.used);
+    let mut pad: String = move String { repr: "array_new<u8>"(pad_len), used: 0 };
     __for_0: {
         let mut i: i32 = 0;
         loop {
@@ -47,12 +41,8 @@ pub fn format_with_opts(s: String, opts: Options) -> String {
         Center => {
             let left: i32 = (pad_len / 2);
             let right: i32 = (pad_len - left);
-            let mut lpad: String = __inline_String__with_capacity_3: {
-                break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(left), used: 0 };
-            };
-            let mut rpad: String = __inline_String__with_capacity_4: {
-                break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(right), used: 0 };
-            };
+            let mut lpad: String = move String { repr: "array_new<u8>"(left), used: 0 };
+            let mut rpad: String = move String { repr: "array_new<u8>"(right), used: 0 };
             __for_0: {
                 let mut i: i32 = 0;
                 loop {
@@ -83,9 +73,7 @@ pub fn format_with_opts(s: String, opts: Options) -> String {
 }
 
 fn run() with Stdout {
-    let opts: Options = __inline_Options__default_0: {
-        break __inline_Options__default_0: Options { align: Align::Right, width: 0 };
-    };
+    let opts: Options = move Options { align: Align::Right, width: 0 };
     let s: String = move format_with_opts(move "test", opts);
     core::cli::println(s);
 }

--- a/wado-compiler/tests/fixtures.golden/variant_import_struct_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_import_struct_simple.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let opts: Options = __inline_Options__default_0: {
-        break __inline_Options__default_0: Options { align: Align::Right, width: 0 };
-    };
+    let opts: Options = move Options { align: Align::Right, width: 0 };
     let s1: String = move "./variant_import_struct_module.wado::format_with_opts"(move "hi", opts);
     core::cli::println(s1);
 }

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_field.lowered.wado
@@ -15,9 +15,7 @@ struct ParseResult {
 }
 
 fn run() with Stdout {
-    let result: ParseResult = __inline_parse_0: {
-        break __inline_parse_0: ParseResult { ok: true, value: JsonValue::Number(42) };
-    };
+    let result: ParseResult = move ParseResult { ok: true, value: JsonValue::Number(42) };
     core::cli::println(move "variant in struct field works");
 }
 

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_match.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_match.lowered.wado
@@ -10,14 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right };
-    };
-    core::cli::println(__inline_get_align_name_1: {
-        break __inline_get_align_name_1: match opts.align {
-            Left => "left",
-            Right => "right",
-        };
+    let opts: Opts = move Opts { align: Align::Right };
+    core::cli::println(match opts.align {
+        Left => "left",
+        Right => "right",
     });
 }
 

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_match_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_match_module.lowered.wado
@@ -14,14 +14,10 @@ pub struct Opts {
 }
 
 fn run() with Stdout {
-    let opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right };
-    };
-    let name: String = __inline_get_align_name_1: {
-        break __inline_get_align_name_1: match opts.align {
-            Left => "left",
-            Right => "right",
-        };
+    let opts: Opts = move Opts { align: Align::Right };
+    let name: String = match opts.align {
+        Left => "left",
+        Right => "right",
     };
     core::cli::println(name);
 }

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_simple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_simple.lowered.wado
@@ -12,9 +12,7 @@
 fn run() with Stdout {
     let __sroa_item_status: Status = move Status::Active;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_simple_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_simple_module.lowered.wado
@@ -17,9 +17,7 @@ pub struct Item {
 fn run() with Stdout {
     let __sroa_item_status: Status = move Status::Active;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(16), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/variant_option_of_variant.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_option_of_variant.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let result: Option<JsonValue> = __inline_parse_0: {
-        break __inline_parse_0: Option::Some(JsonValue::Number(42));
-    };
+    let result: Option<JsonValue> = move Option::Some(JsonValue::Number(42));
     core::cli::println(move "Option of variant works");
 }
 

--- a/wado-compiler/tests/fixtures.golden/variant_struct_concat.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_struct_concat.lowered.wado
@@ -10,14 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right, width: 0 };
-    };
+    let opts: Opts = move Opts { align: Align::Right, width: 0 };
     let s: String = move "./variant_struct_concat_module.wado::format_str"(move "hi", opts);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
         __r.String::append(s);
         __r.String::append(move "]");

--- a/wado-compiler/tests/fixtures.golden/variant_struct_concat_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_struct_concat_module.lowered.wado
@@ -24,14 +24,10 @@ pub fn format_str(s: String, opts: Opts) -> String {
 }
 
 fn run() with Stdout {
-    let opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right, width: 0 };
-    };
+    let opts: Opts = move Opts { align: Align::Right, width: 0 };
     let s: String = move format_str(move "hi", opts);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(18), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(18), used: 0 };
         __r.String::append(move "[");
         __r.String::append(s);
         __r.String::append(move "]");

--- a/wado-compiler/tests/fixtures.golden/variant_struct_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_struct_string.lowered.wado
@@ -10,9 +10,7 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right, width: 0 };
-    };
+    let opts: Opts = move Opts { align: Align::Right, width: 0 };
     let s: String = move "./variant_struct_string_module.wado::format_str"(move "hello", opts);
     core::cli::println(s);
 }

--- a/wado-compiler/tests/fixtures.golden/variant_struct_string_module.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_struct_string_module.lowered.wado
@@ -26,9 +26,7 @@ pub fn format_str(s: String, opts: Opts) -> String {
 }
 
 fn run() with Stdout {
-    let opts: Opts = __inline_Opts__default_0: {
-        break __inline_Opts__default_0: Opts { align: Align::Right, width: 0 };
-    };
+    let opts: Opts = move Opts { align: Align::Right, width: 0 };
     let s: String = move format_str(move "hello", opts);
     core::cli::println(s);
 }

--- a/wado-compiler/tests/fixtures.golden/variant_value_semantics.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_value_semantics.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     if __variant_test(c1, case=0, name=Circle) {
         let r: f64 = __variant_payload(c1, case=0);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(27), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
             __r.String::append(move "c1 radius: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;
@@ -34,9 +32,7 @@ fn run() with Stdout {
     if __variant_test(c1, case=0, name=Circle) {
         let r: f64 = __variant_payload(c1, case=0);
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_3: {
-                break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(27), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
             __r.String::append(move "c2 radius: ");
             let mut __f: Formatter = __inline_Formatter__new_4: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/wasi_cli.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_cli.lowered.wado
@@ -14,18 +14,14 @@ fn run() with Stdout, Stderr, Environment {
     core::cli::eprintln(move "test: stderr works");
     let arguments: Array<String> = move Environment::get_arguments();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(57), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(57), used: 0 };
         __r.String::append(move "test: Environment::get_arguments().len = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_String___len_3: {
-                break __inline_Array_String___len_3: arguments.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: arguments.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -33,18 +29,14 @@ fn run() with Stdout, Stderr, Environment {
     });
     let env_vars: Array<[String, String]> = move Environment::get_environment();
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(59), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(59), used: 0 };
         __r.String::append(move "test: Environment::get_environment().len = ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_Tuple_String_String____len_7: {
-                break __inline_Array_Tuple_String_String____len_7: env_vars.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: env_vars.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/wasm_instructions_float_math.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_instructions_float_math.lowered.wado
@@ -15,9 +15,7 @@ fn run() with Stdout {
     let abs_neg: f64 = core::builtin::f64_abs(-3.5);
     let abs_pos: f64 = core::builtin::f64_abs(3.5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f64_abs(-3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
@@ -31,9 +29,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_3: {
-            break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "f64_abs(3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_4: {
             let buf: &mut String = &mut __r;
@@ -48,9 +44,7 @@ fn run() with Stdout {
     });
     let abs_neg32: f32 = core::builtin::f32_abs(-2.5 as f32);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f32_abs(-2.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
@@ -67,9 +61,7 @@ fn run() with Stdout {
     let ceil2: f64 = core::builtin::f64_ceil(-2.3);
     let ceil3: f64 = core::builtin::f64_ceil(2.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_9: {
-            break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f64_ceil(2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_10: {
             let buf: &mut String = &mut __r;
@@ -83,9 +75,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_12: {
-            break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "f64_ceil(-2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_13: {
             let buf: &mut String = &mut __r;
@@ -99,9 +89,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_15: {
-            break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f64_ceil(2.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_16: {
             let buf: &mut String = &mut __r;
@@ -118,9 +106,7 @@ fn run() with Stdout {
     let floor2: f64 = core::builtin::f64_floor(-2.7);
     let floor3: f64 = core::builtin::f64_floor(2.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_18: {
-            break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "f64_floor(2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_19: {
             let buf: &mut String = &mut __r;
@@ -134,9 +120,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_21: {
-            break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "f64_floor(-2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_22: {
             let buf: &mut String = &mut __r;
@@ -150,9 +134,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "f64_floor(2.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
@@ -168,9 +150,7 @@ fn run() with Stdout {
     let trunc1: f64 = core::builtin::f64_trunc(2.9);
     let trunc2: f64 = core::builtin::f64_trunc(-2.9);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_27: {
-            break __inline_String__with_capacity_27: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "f64_trunc(2.9) = ");
         let mut __f: Formatter = __inline_Formatter__new_28: {
             let buf: &mut String = &mut __r;
@@ -184,9 +164,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_30: {
-            break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "f64_trunc(-2.9) = ");
         let mut __f: Formatter = __inline_Formatter__new_31: {
             let buf: &mut String = &mut __r;
@@ -204,9 +182,7 @@ fn run() with Stdout {
     let near3: f64 = core::builtin::f64_nearest(2.3);
     let near4: f64 = core::builtin::f64_nearest(2.7);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_33: {
-            break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "f64_nearest(2.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_34: {
             let buf: &mut String = &mut __r;
@@ -220,9 +196,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_36: {
-            break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "f64_nearest(3.5) = ");
         let mut __f: Formatter = __inline_Formatter__new_37: {
             let buf: &mut String = &mut __r;
@@ -236,9 +210,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_39: {
-            break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "f64_nearest(2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_40: {
             let buf: &mut String = &mut __r;
@@ -252,9 +224,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_42: {
-            break __inline_String__with_capacity_42: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "f64_nearest(2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_43: {
             let buf: &mut String = &mut __r;
@@ -271,9 +241,7 @@ fn run() with Stdout {
     let sqrt2: f64 = core::builtin::f64_sqrt(9.0);
     let sqrt3: f64 = core::builtin::f64_sqrt(2.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_45: {
-            break __inline_String__with_capacity_45: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f64_sqrt(4.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_46: {
             let buf: &mut String = &mut __r;
@@ -287,9 +255,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_48: {
-            break __inline_String__with_capacity_48: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f64_sqrt(9.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_49: {
             let buf: &mut String = &mut __r;
@@ -310,9 +276,7 @@ fn run() with Stdout {
     let max1: f64 = core::builtin::f64_max(3.0, 5.0);
     let max2: f64 = core::builtin::f64_max(-1.0, 1.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_51: {
-            break __inline_String__with_capacity_51: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "f64_min(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_52: {
             let buf: &mut String = &mut __r;
@@ -326,9 +290,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_54: {
-            break __inline_String__with_capacity_54: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "f64_min(-1.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_55: {
             let buf: &mut String = &mut __r;
@@ -342,9 +304,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_57: {
-            break __inline_String__with_capacity_57: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "f64_max(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_58: {
             let buf: &mut String = &mut __r;
@@ -358,9 +318,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_60: {
-            break __inline_String__with_capacity_60: String { repr: "array_new<u8>"(37), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(37), used: 0 };
         __r.String::append(move "f64_max(-1.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_61: {
             let buf: &mut String = &mut __r;
@@ -377,9 +335,7 @@ fn run() with Stdout {
     let copy2: f64 = core::builtin::f64_copysign(-3.0, 1.0);
     let copy3: f64 = core::builtin::f64_copysign(5.0, 5.0);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_63: {
-            break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "f64_copysign(3.0, -1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_64: {
             let buf: &mut String = &mut __r;
@@ -393,9 +349,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_66: {
-            break __inline_String__with_capacity_66: String { repr: "array_new<u8>"(42), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(42), used: 0 };
         __r.String::append(move "f64_copysign(-3.0, 1.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_67: {
             let buf: &mut String = &mut __r;
@@ -409,9 +363,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_69: {
-            break __inline_String__with_capacity_69: String { repr: "array_new<u8>"(41), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(41), used: 0 };
         __r.String::append(move "f64_copysign(5.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_70: {
             let buf: &mut String = &mut __r;
@@ -430,9 +382,7 @@ fn run() with Stdout {
     let f32_min: f32 = core::builtin::f32_min(3.0 as f32, 5.0 as f32);
     let f32_max: f32 = core::builtin::f32_max(3.0 as f32, 5.0 as f32);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_72: {
-            break __inline_String__with_capacity_72: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f32_ceil(2.3) = ");
         let mut __f: Formatter = __inline_Formatter__new_73: {
             let buf: &mut String = &mut __r;
@@ -446,9 +396,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_75: {
-            break __inline_String__with_capacity_75: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "f32_floor(2.7) = ");
         let mut __f: Formatter = __inline_Formatter__new_76: {
             let buf: &mut String = &mut __r;
@@ -462,9 +410,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_78: {
-            break __inline_String__with_capacity_78: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "f32_sqrt(4.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_79: {
             let buf: &mut String = &mut __r;
@@ -478,9 +424,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_81: {
-            break __inline_String__with_capacity_81: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "f32_min(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_82: {
             let buf: &mut String = &mut __r;
@@ -494,9 +438,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_84: {
-            break __inline_String__with_capacity_84: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "f32_max(3.0, 5.0) = ");
         let mut __f: Formatter = __inline_Formatter__new_85: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_enum.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_enum.lowered.wado
@@ -12,14 +12,10 @@
 fn run() with Stdout {
     let u: Direction = Direction::Up;
     let l: DirectionB = DirectionB::Left;
-    if __inline_is_up_0: {
-        break __inline_is_up_0: (u == Direction::Up);
-    } {
+    if (u == Direction::Up) {
         core::cli::println(move "up: true");
     }
-    if __inline_is_left_b_1: {
-        break __inline_is_left_b_1: (l == Direction::Left);
-    } {
+    if (l == Direction::Left) {
         core::cli::println(move "left: true");
     }
 }

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_global.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_global.lowered.wado
@@ -11,36 +11,28 @@
 
 fn run() with Stdout {
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_0: {
-            break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_1: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_1: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_2: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_limit_a_3: {
-                break __inline_get_limit_a_3: ./sub/wasm_name_conflict_global_mod_a.wado::LIMIT;
-            } };
+            let self: Box<i32> = move Box<i32> { value: ./sub/wasm_name_conflict_global_mod_a.wado::LIMIT };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_4: {
-            break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_5: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_5: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_6: {
-            let self: Box<i32> = move Box<i32> { value: __inline_get_limit_b_7: {
-                break __inline_get_limit_b_7: ./sub/wasm_name_conflict_global_mod_b.wado::LIMIT;
-            } };
+            let self: Box<i32> = move Box<i32> { value: ./sub/wasm_name_conflict_global_mod_b.wado::LIMIT };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_method.lowered.wado
@@ -10,16 +10,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let ca: ContainerA = __inline_ContainerA__make_0: {
-        break __inline_ContainerA__make_0: ContainerA { config: Config { value: 42 } };
-    };
-    let cfg_a: Config = __inline_ContainerA__get_config_1: {
-        break __inline_ContainerA__get_config_1: ca.config;
-    };
+    let ca: ContainerA = move ContainerA { config: Config { value: 42 } };
+    let cfg_a: Config = ca.config;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -36,13 +30,9 @@ fn run() with Stdout {
         let n: String = move "hello";
         break __inline_ContainerB__make_5: ContainerB { config: Config { name: n, count: 7 } };
     };
-    let cfg_b: Config = __inline_ContainerB__get_config_6: {
-        break __inline_ContainerB__get_config_6: cb.config;
-    };
+    let cfg_b: Config = cb.config;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "b: ");
         __r.String::append(cfg_b.name);
         __r.String::append(move " ");

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_newtype.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_newtype.lowered.wado
@@ -11,16 +11,10 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: Measurement = __inline_make_measurement_a_0: {
-        break __inline_make_measurement_a_0: 3.14 as Measurement;
-    };
-    let va: f64 = __inline_measurement_a_value_1: {
-        break __inline_measurement_a_value_1: a as f64;
-    };
+    let a: Measurement = 3.14 as Measurement;
+    let va: f64 = a as f64;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
@@ -33,16 +27,10 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let b: Measurement = __inline_make_measurement_b_5: {
-        break __inline_make_measurement_b_5: 42;
-    };
-    let vb: i32 = __inline_measurement_b_value_6: {
-        break __inline_measurement_b_value_6: b as i32;
-    };
+    let b: Measurement = 42;
+    let vb: i32 = b as i32;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_8: {
             let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_pub_use_alias.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_pub_use_alias.lowered.wado
@@ -16,9 +16,7 @@ fn run() with Stdout {
         break __inline_make_metric_0: Metric { value: 3.14, unit: u };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_struct.lowered.wado
@@ -10,43 +10,31 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: Pair = __inline_make_pair_a_0: {
-        break __inline_make_pair_a_0: Pair { x: 42 };
-    };
+    let a: Pair = move Pair { x: 42 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_pair_a_value_4: {
-                break __inline_pair_a_value_4: a.x;
-            } };
+            let self: Box<i32> = move Box<i32> { value: a.x };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    let b: Pair = __inline_make_pair_b_5: {
-        break __inline_make_pair_b_5: Pair { a: 10, b: 20 };
-    };
+    let b: Pair = move Pair { a: 10, b: 20 };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_pair_b_sum_9: {
-                break __inline_pair_b_sum_9: (b.a + b.b);
-            } };
+            let self: Box<i32> = move Box<i32> { value: (b.a + b.b) };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_variant.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_variant.lowered.wado
@@ -10,48 +10,36 @@
 // wasi::task-return (task_return)
 
 fn run() with Stdout {
-    let a: Status = __inline_make_active_0: {
-        break __inline_make_active_0: Status::Active;
-    };
+    let a: Status = move Status::Active;
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "a: ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_2: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_3: {
-            let self: Box<i32> = move Box<i32> { value: __inline_status_a_name_4: {
-                break __inline_status_a_name_4: match a {
-                    Active => 1,
-                    Inactive => 0,
-                };
+            let self: Box<i32> = move Box<i32> { value: match a {
+                Active => 1,
+                Inactive => 0,
             } };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
-    let b: Status = __inline_make_ok_5: {
-        break __inline_make_ok_5: Status::Ok(99);
-    };
+    let b: Status = move Status::Ok(99);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_6: {
-            break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(19), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "b: ");
         let mut __f: Formatter = __inline_Formatter__new_7: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_7: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_8: {
-            let self: Box<i32> = move Box<i32> { value: __inline_status_b_value_9: {
-                break __inline_status_b_value_9: match b {
-                    Ok(v) => v,
-                    Error => -1,
-                };
+            let self: Box<i32> = move Box<i32> { value: match b {
+                Ok(v) => v,
+                Error => -1,
             } };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);

--- a/wado-compiler/tests/fixtures.golden/while_break.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/while_break.lowered.wado
@@ -16,9 +16,7 @@ fn run() with Stdout {
             break;
         }
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "count: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/while_continue.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/while_continue.lowered.wado
@@ -20,9 +20,7 @@ fn run() with Stdout {
             continue;
         }
         core::cli::println(__tmpl: {
-            let mut __r: String = __inline_String__with_capacity_0: {
-                break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(23), used: 0 };
-            };
+            let mut __r: String = move String { repr: "array_new<u8>"(23), used: 0 };
             __r.String::append(move "count: ");
             let mut __f: Formatter = __inline_Formatter__new_1: {
                 let buf: &mut String = &mut __r;

--- a/wado-compiler/tests/fixtures.golden/while_let_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/while_let_basic.lowered.wado
@@ -17,19 +17,13 @@ pub struct "ArrayIter<i32>" {
 
 fn run() with Stdout {
     let items: Array<i32> = move [1, 2, 3];
-    let mut iter: ArrayIter<i32> = __inline_Array_i32___iter_0: {
-        break __inline_Array_i32___iter_0: __inline_Array_i32__IntoIterator__into_iter_1: {
-            break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };
-        };
-    };
+    let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };
     loop {
         let __pattern_temp_0: Option<i32> = iter."ArrayIter<i32>^Iterator::next"();
         if __is_not_null(__pattern_temp_0) {
             let x: i32 = __unwrap_option(__pattern_temp_0).value;
             core::cli::println(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(16), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
                 let mut __f: Formatter = __inline_Formatter__new_3: {
                     let buf: &mut String = &mut __r;
                     break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };

--- a/wado-compiler/tests/fixtures.golden/zlib_checksum.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_checksum.lowered.wado
@@ -15,13 +15,9 @@
 
 fn run() with Stdout {
     let data: Array<u8> = move [72, 101, 108, 108, 111];
-    let checksum: u32 = core::zlib::adler32(__inline_adler32_init_0: {
-        break __inline_adler32_init_0: 1;
-    }, &data, 0, 5);
+    let checksum: u32 = core::zlib::adler32(1, &data, 0, 5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_1: {
-            break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(35), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(35), used: 0 };
         __r.String::append(move "adler32(\"Hello\") = ");
         let mut __f: Formatter = __inline_Formatter__new_2: {
             let buf: &mut String = &mut __r;
@@ -38,9 +34,7 @@ fn run() with Stdout {
         let __cond: bool = (checksum == 93061621);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_4: {
-                    break __inline_String__with_capacity_4: String { repr: "array_new<u8>"(158), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(158), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -73,13 +67,9 @@ fn run() with Stdout {
             });
         }
     }
-    let crc: u32 = core::zlib::crc32(__inline_crc32_init_9: {
-        break __inline_crc32_init_9: 0;
-    }, &data, 0, 5);
+    let crc: u32 = core::zlib::crc32(0, &data, 0, 5);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_10: {
-            break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(33), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
         __r.String::append(move "crc32(\"Hello\") = ");
         let mut __f: Formatter = __inline_Formatter__new_11: {
             let buf: &mut String = &mut __r;
@@ -96,9 +86,7 @@ fn run() with Stdout {
         let __cond: bool = (crc == 4157704578);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(150), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(150), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_combine.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_combine.lowered.wado
@@ -21,15 +21,11 @@ fn run() with Stdout {
         let _licm_used: i32 = msg1.used;
         let _licm_repr: builtin::array<u8> = msg1.repr;
         loop {
-            if !(i < __inline_String__len_0: {
-                break __inline_String__len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
-                seg1."Array<u8>::append"(__inline_String__get_byte_1: {
-                    break __inline_String__get_byte_1: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                seg1."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -41,15 +37,11 @@ fn run() with Stdout {
         let _licm_used: i32 = msg2.used;
         let _licm_repr: builtin::array<u8> = msg2.repr;
         loop {
-            if !(i < __inline_String__len_2: {
-                break __inline_String__len_2: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
-                seg2."Array<u8>::append"(__inline_String__get_byte_3: {
-                    break __inline_String__get_byte_3: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                seg2."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -59,9 +51,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = seg1.used;
         loop {
-            if !(i < __inline_Array_u8___len_4: {
-                break __inline_Array_u8___len_4: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_2;
             }
             __for_2_body: {
@@ -74,9 +64,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = seg2.used;
         loop {
-            if !(i < __inline_Array_u8___len_5: {
-                break __inline_Array_u8___len_5: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_3;
             }
             __for_3_body: {
@@ -85,28 +73,12 @@ fn run() with Stdout {
             i = (i + 1);
         }
     }
-    let a1: u32 = core::zlib::adler32(__inline_adler32_init_6: {
-        break __inline_adler32_init_6: 1;
-    }, &seg1, 0, __inline_Array_u8___len_7: {
-        break __inline_Array_u8___len_7: seg1.used;
-    });
-    let a2: u32 = core::zlib::adler32(__inline_adler32_init_8: {
-        break __inline_adler32_init_8: 1;
-    }, &seg2, 0, __inline_Array_u8___len_9: {
-        break __inline_Array_u8___len_9: seg2.used;
-    });
-    let a_combined: u32 = core::zlib::adler32(__inline_adler32_init_10: {
-        break __inline_adler32_init_10: 1;
-    }, &combined, 0, __inline_Array_u8___len_11: {
-        break __inline_Array_u8___len_11: combined.used;
-    });
-    let a_joined: u32 = core::zlib::adler32_combine(a1, a2, __inline_Array_u8___len_12: {
-        break __inline_Array_u8___len_12: seg2.used;
-    });
+    let a1: u32 = core::zlib::adler32(1, &seg1, 0, seg1.used);
+    let a2: u32 = core::zlib::adler32(1, &seg2, 0, seg2.used);
+    let a_combined: u32 = core::zlib::adler32(1, &combined, 0, combined.used);
+    let a_joined: u32 = core::zlib::adler32_combine(a1, a2, seg2.used);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_13: {
-            break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "adler32 seg1: ");
         let mut __f: Formatter = __inline_Formatter__new_14: {
             let buf: &mut String = &mut __r;
@@ -120,9 +92,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_16: {
-            break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "adler32 seg2: ");
         let mut __f: Formatter = __inline_Formatter__new_17: {
             let buf: &mut String = &mut __r;
@@ -136,9 +106,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_19: {
-            break __inline_String__with_capacity_19: String { repr: "array_new<u8>"(34), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(34), used: 0 };
         __r.String::append(move "adler32 combined: ");
         let mut __f: Formatter = __inline_Formatter__new_20: {
             let buf: &mut String = &mut __r;
@@ -152,9 +120,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_22: {
-            break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "adler32 joined: ");
         let mut __f: Formatter = __inline_Formatter__new_23: {
             let buf: &mut String = &mut __r;
@@ -167,28 +133,12 @@ fn run() with Stdout {
         };
         break __tmpl: __r;
     });
-    let c1: u32 = core::zlib::crc32(__inline_crc32_init_25: {
-        break __inline_crc32_init_25: 0;
-    }, &seg1, 0, __inline_Array_u8___len_26: {
-        break __inline_Array_u8___len_26: seg1.used;
-    });
-    let c2: u32 = core::zlib::crc32(__inline_crc32_init_27: {
-        break __inline_crc32_init_27: 0;
-    }, &seg2, 0, __inline_Array_u8___len_28: {
-        break __inline_Array_u8___len_28: seg2.used;
-    });
-    let c_combined: u32 = core::zlib::crc32(__inline_crc32_init_29: {
-        break __inline_crc32_init_29: 0;
-    }, &combined, 0, __inline_Array_u8___len_30: {
-        break __inline_Array_u8___len_30: combined.used;
-    });
-    let c_joined: u32 = core::zlib::crc32_combine(c1, c2, __inline_Array_u8___len_31: {
-        break __inline_Array_u8___len_31: seg2.used;
-    });
+    let c1: u32 = core::zlib::crc32(0, &seg1, 0, seg1.used);
+    let c2: u32 = core::zlib::crc32(0, &seg2, 0, seg2.used);
+    let c_combined: u32 = core::zlib::crc32(0, &combined, 0, combined.used);
+    let c_joined: u32 = core::zlib::crc32_combine(c1, c2, seg2.used);
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_32: {
-            break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(32), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(32), used: 0 };
         __r.String::append(move "crc32 combined: ");
         let mut __f: Formatter = __inline_Formatter__new_33: {
             let buf: &mut String = &mut __r;
@@ -202,9 +152,7 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_35: {
-            break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(30), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
         __r.String::append(move "crc32 joined: ");
         let mut __f: Formatter = __inline_Formatter__new_36: {
             let buf: &mut String = &mut __r;
@@ -221,9 +169,7 @@ fn run() with Stdout {
         let __cond: bool = (c_combined == c_joined);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_38: {
-                    break __inline_String__with_capacity_38: String { repr: "array_new<u8>"(182), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(182), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_compress_huffman.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_compress_huffman.lowered.wado
@@ -14,20 +14,14 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn bytes_equal(a: &Array<u8>, b: &Array<u8>) -> bool {
-    if (__inline_Array_u8___len_0: {
-        break __inline_Array_u8___len_0: a.used;
-    } != __inline_Array_u8___len_1: {
-        break __inline_Array_u8___len_1: b.used;
-    }) {
+    if (a.used != b.used) {
         return false;
     }
     __for_0: {
         let mut i: i32 = 0;
         let _licm_used: i32 = a.used;
         loop {
-            if !(i < __inline_Array_u8___len_2: {
-                break __inline_Array_u8___len_2: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -52,18 +46,14 @@ fn run() with Stdout {
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_2: {
-            break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(60), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(60), used: 0 };
         __r.String::append(move "compressed Hello: ");
         let mut __f: Formatter = __inline_Formatter__new_3: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_5: {
-                break __inline_Array_u8___len_5: data.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: data.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -73,9 +63,7 @@ fn run() with Stdout {
             break __inline_Formatter__new_6: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_7: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_8: {
-                break __inline_Array_u8___len_8: comp_hello.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: comp_hello.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -87,9 +75,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&data, &decomp_hello);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(189), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(189), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -138,15 +124,11 @@ fn run() with Stdout {
     };
     let decomp_empty: Array<u8> = move core::zlib::inflate_zlib(&comp_empty);
     __assert_1: {
-        let __v0: i32 = __inline_Array_u8___len_16: {
-            break __inline_Array_u8___len_16: decomp_empty.used;
-        };
+        let __v0: i32 = decomp_empty.used;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -202,18 +184,14 @@ fn run() with Stdout {
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_24: {
-            break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(61), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(61), used: 0 };
         __r.String::append(move "compressed 1000xA: ");
         let mut __f: Formatter = __inline_Formatter__new_25: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_25: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_26: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_27: {
-                break __inline_Array_u8___len_27: rep_data.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: rep_data.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -223,9 +201,7 @@ fn run() with Stdout {
             break __inline_Formatter__new_28: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_29: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_30: {
-                break __inline_Array_u8___len_30: comp_rep.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: comp_rep.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -233,18 +209,12 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     __assert_2: {
-        let __v0: i32 = __inline_Array_u8___len_31: {
-            break __inline_Array_u8___len_31: comp_rep.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_32: {
-            break __inline_Array_u8___len_32: rep_data.used;
-        };
+        let __v0: i32 = comp_rep.used;
+        let __v1: i32 = rep_data.used;
         let __cond: bool = (__v0 < __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_33: {
-                    break __inline_String__with_capacity_33: String { repr: "array_new<u8>"(201), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(201), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -293,9 +263,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&rep_data, &decomp_rep);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_40: {
-                    break __inline_String__with_capacity_40: String { repr: "array_new<u8>"(193), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(193), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -355,18 +323,14 @@ fn run() with Stdout {
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_47: {
-            break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(64), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(64), used: 0 };
         __r.String::append(move "compressed mixed 500: ");
         let mut __f: Formatter = __inline_Formatter__new_48: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_48: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_49: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_50: {
-                break __inline_Array_u8___len_50: mixed_data.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: mixed_data.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -376,9 +340,7 @@ fn run() with Stdout {
             break __inline_Formatter__new_51: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_52: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_53: {
-                break __inline_Array_u8___len_53: comp_mixed.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: comp_mixed.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -390,9 +352,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&mixed_data, &decomp_mixed);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_54: {
-                    break __inline_String__with_capacity_54: String { repr: "array_new<u8>"(201), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(201), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -464,18 +424,14 @@ fn run() with Stdout {
         };
     };
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_61: {
-            break __inline_String__with_capacity_61: String { repr: "array_new<u8>"(61), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(61), used: 0 };
         __r.String::append(move "compressed HW x20: ");
         let mut __f: Formatter = __inline_Formatter__new_62: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_62: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_63: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_64: {
-                break __inline_Array_u8___len_64: hw_data.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: hw_data.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -485,9 +441,7 @@ fn run() with Stdout {
             break __inline_Formatter__new_65: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_66: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_67: {
-                break __inline_Array_u8___len_67: comp_hw.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: comp_hw.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -495,18 +449,12 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_68: {
-            break __inline_Array_u8___len_68: comp_hw.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_69: {
-            break __inline_Array_u8___len_69: hw_data.used;
-        };
+        let __v0: i32 = comp_hw.used;
+        let __v1: i32 = hw_data.used;
         let __cond: bool = (__v0 < __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_70: {
-                    break __inline_String__with_capacity_70: String { repr: "array_new<u8>"(197), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(197), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -555,9 +503,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&hw_data, &decomp_hw);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_77: {
-                    break __inline_String__with_capacity_77: String { repr: "array_new<u8>"(189), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(189), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_compress_levels.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_compress_levels.lowered.wado
@@ -14,9 +14,7 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let mut data: Array<u8> = __inline_Array_u8___with_capacity_0: {
-        break __inline_Array_u8___with_capacity_0: Array<u8> { repr: core::builtin::array_new::<u8>(1000), used: 0 };
-    };
+    let mut data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(1000), used: 0 };
     __for_0: {
         let mut i: i32 = 0;
         loop {
@@ -34,9 +32,7 @@ fn run() with Stdout {
         let __cond: bool = (bound > 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -77,15 +73,11 @@ fn run() with Stdout {
     };
     let d0: Array<u8> = move core::zlib::inflate_zlib(&c0);
     __assert_1: {
-        let __v0: i32 = __inline_Array_u8___len_7: {
-            break __inline_Array_u8___len_7: d0.used;
-        };
+        let __v0: i32 = d0.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_8: {
-                    break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -131,9 +123,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_13: {
-                                break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(170), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(170), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -182,18 +172,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_20: {
-            break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "level 0: ");
         let mut __f: Formatter = __inline_Formatter__new_21: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_21: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_22: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_23: {
-                break __inline_Array_u8___len_23: c0.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c0.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -208,15 +194,11 @@ fn run() with Stdout {
     };
     let d1: Array<u8> = move core::zlib::inflate_zlib(&c1);
     __assert_3: {
-        let __v0: i32 = __inline_Array_u8___len_25: {
-            break __inline_Array_u8___len_25: d1.used;
-        };
+        let __v0: i32 = d1.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -262,9 +244,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_31: {
-                                break __inline_String__with_capacity_31: String { repr: "array_new<u8>"(170), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(170), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -313,18 +293,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_38: {
-            break __inline_String__with_capacity_38: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "level 1: ");
         let mut __f: Formatter = __inline_Formatter__new_39: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_39: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_40: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_41: {
-                break __inline_Array_u8___len_41: c1.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c1.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -339,15 +315,11 @@ fn run() with Stdout {
     };
     let d6: Array<u8> = move core::zlib::inflate_zlib(&c6);
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_43: {
-            break __inline_Array_u8___len_43: d6.used;
-        };
+        let __v0: i32 = d6.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_44: {
-                    break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -393,9 +365,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_49: {
-                                break __inline_String__with_capacity_49: String { repr: "array_new<u8>"(170), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(170), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -444,18 +414,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_56: {
-            break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "level 6: ");
         let mut __f: Formatter = __inline_Formatter__new_57: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_57: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_58: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_59: {
-                break __inline_Array_u8___len_59: c6.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c6.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -470,15 +436,11 @@ fn run() with Stdout {
     };
     let d9: Array<u8> = move core::zlib::inflate_zlib(&c9);
     __assert_7: {
-        let __v0: i32 = __inline_Array_u8___len_61: {
-            break __inline_Array_u8___len_61: d9.used;
-        };
+        let __v0: i32 = d9.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -524,9 +486,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_67: {
-                                break __inline_String__with_capacity_67: String { repr: "array_new<u8>"(170), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(170), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -575,18 +535,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_74: {
-            break __inline_String__with_capacity_74: String { repr: "array_new<u8>"(31), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(31), used: 0 };
         __r.String::append(move "level 9: ");
         let mut __f: Formatter = __inline_Formatter__new_75: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_75: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_76: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_77: {
-                break __inline_Array_u8___len_77: c9.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: c9.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -594,18 +550,12 @@ fn run() with Stdout {
         break __tmpl: __r;
     });
     __assert_9: {
-        let __v0: i32 = __inline_Array_u8___len_78: {
-            break __inline_Array_u8___len_78: c0.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_79: {
-            break __inline_Array_u8___len_79: c1.used;
-        };
+        let __v0: i32 = c0.used;
+        let __v1: i32 = c1.used;
         let __cond: bool = (__v0 > __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_80: {
-                    break __inline_String__with_capacity_80: String { repr: "array_new<u8>"(177), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(177), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -657,15 +607,11 @@ fn run() with Stdout {
     };
     let dh: Array<u8> = move core::zlib::inflate_zlib(&ch);
     __assert_10: {
-        let __v0: i32 = __inline_Array_u8___len_88: {
-            break __inline_Array_u8___len_88: dh.used;
-        };
+        let __v0: i32 = dh.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_89: {
-                    break __inline_String__with_capacity_89: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -699,27 +645,21 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_94: {
-            break __inline_String__with_capacity_94: String { repr: "array_new<u8>"(36), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(36), used: 0 };
         __r.String::append(move "huffman_only: ");
         let mut __f: Formatter = __inline_Formatter__new_95: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_95: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_96: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_97: {
-                break __inline_Array_u8___len_97: ch.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: ch.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         __r.String::append(move " bytes");
         break __tmpl: __r;
     });
-    let mut rle_data: Array<u8> = __inline_Array_u8___with_capacity_98: {
-        break __inline_Array_u8___with_capacity_98: Array<u8> { repr: core::builtin::array_new::<u8>(1000), used: 0 };
-    };
+    let mut rle_data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(1000), used: 0 };
     __for_5: {
         let mut i: i32 = 0;
         loop {
@@ -740,15 +680,11 @@ fn run() with Stdout {
     };
     let dr: Array<u8> = move core::zlib::inflate_zlib(&cr);
     __assert_11: {
-        let __v0: i32 = __inline_Array_u8___len_100: {
-            break __inline_Array_u8___len_100: dr.used;
-        };
+        let __v0: i32 = dr.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_101: {
-                    break __inline_String__with_capacity_101: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -782,18 +718,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_106: {
-            break __inline_String__with_capacity_106: String { repr: "array_new<u8>"(27), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(27), used: 0 };
         __r.String::append(move "rle: ");
         let mut __f: Formatter = __inline_Formatter__new_107: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_107: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_108: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_109: {
-                break __inline_Array_u8___len_109: cr.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: cr.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
@@ -808,15 +740,11 @@ fn run() with Stdout {
     };
     let df: Array<u8> = move core::zlib::inflate_zlib(&cf);
     __assert_12: {
-        let __v0: i32 = __inline_Array_u8___len_111: {
-            break __inline_Array_u8___len_111: df.used;
-        };
+        let __v0: i32 = df.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_112: {
-                    break __inline_String__with_capacity_112: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -850,18 +778,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_117: {
-            break __inline_String__with_capacity_117: String { repr: "array_new<u8>"(29), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(29), used: 0 };
         __r.String::append(move "fixed: ");
         let mut __f: Formatter = __inline_Formatter__new_118: {
             let buf: &mut String = &mut __r;
             break __inline_Formatter__new_118: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_119: {
-            let self: Box<i32> = move Box<i32> { value: __inline_Array_u8___len_120: {
-                break __inline_Array_u8___len_120: cf.used;
-            } };
+            let self: Box<i32> = move Box<i32> { value: cf.used };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/zlib_compress_stored.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_compress_stored.lowered.wado
@@ -14,20 +14,14 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn bytes_equal(a: &Array<u8>, b: &Array<u8>) -> bool {
-    if (__inline_Array_u8___len_0: {
-        break __inline_Array_u8___len_0: a.used;
-    } != __inline_Array_u8___len_1: {
-        break __inline_Array_u8___len_1: b.used;
-    }) {
+    if (a.used != b.used) {
         return false;
     }
     __for_0: {
         let mut i: i32 = 0;
         let _licm_used: i32 = a.used;
         loop {
-            if !(i < __inline_Array_u8___len_2: {
-                break __inline_Array_u8___len_2: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -49,9 +43,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&data, &decompressed);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(189), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(189), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -108,9 +100,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&long_data, &decompressed2);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(201), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(201), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_constants.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_constants.lowered.wado
@@ -19,9 +19,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(136), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(136), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -59,9 +57,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_5: {
-                    break __inline_String__with_capacity_5: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -99,9 +95,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_10: {
-                    break __inline_String__with_capacity_10: String { repr: "array_new<u8>"(150), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(150), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -139,9 +133,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == -1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_15: {
-                    break __inline_String__with_capacity_15: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -190,9 +182,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == -2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_22: {
-                    break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(178), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(178), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -241,9 +231,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == -3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_29: {
-                    break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(174), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(174), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -292,9 +280,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == -4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_36: {
-                    break __inline_String__with_capacity_36: String { repr: "array_new<u8>"(172), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(172), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -343,9 +329,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == -5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(172), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(172), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -394,9 +378,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == -6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_50: {
-                    break __inline_String__with_capacity_50: String { repr: "array_new<u8>"(180), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(180), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -445,9 +427,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_57: {
-                    break __inline_String__with_capacity_57: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -485,9 +465,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_62: {
-                    break __inline_String__with_capacity_62: String { repr: "array_new<u8>"(158), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(158), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -525,9 +503,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_67: {
-                    break __inline_String__with_capacity_67: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -565,9 +541,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_72: {
-                    break __inline_String__with_capacity_72: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -605,9 +579,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_77: {
-                    break __inline_String__with_capacity_77: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -645,9 +617,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 5);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_82: {
-                    break __inline_String__with_capacity_82: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -685,9 +655,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_87: {
-                    break __inline_String__with_capacity_87: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -725,9 +693,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_92: {
-                    break __inline_String__with_capacity_92: String { repr: "array_new<u8>"(160), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(160), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -765,9 +731,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_97: {
-                    break __inline_String__with_capacity_97: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -805,9 +769,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 9);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_102: {
-                    break __inline_String__with_capacity_102: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -845,9 +807,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 6);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_107: {
-                    break __inline_String__with_capacity_107: String { repr: "array_new<u8>"(170), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(170), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -885,9 +845,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_112: {
-                    break __inline_String__with_capacity_112: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -925,9 +883,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_117: {
-                    break __inline_String__with_capacity_117: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -965,9 +921,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_122: {
-                    break __inline_String__with_capacity_122: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1005,9 +959,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_127: {
-                    break __inline_String__with_capacity_127: String { repr: "array_new<u8>"(138), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(138), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1045,9 +997,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 4);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_132: {
-                    break __inline_String__with_capacity_132: String { repr: "array_new<u8>"(142), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(142), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1085,9 +1035,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_137: {
-                    break __inline_String__with_capacity_137: String { repr: "array_new<u8>"(144), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(144), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1125,9 +1073,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_142: {
-                    break __inline_String__with_capacity_142: String { repr: "array_new<u8>"(140), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(140), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1165,9 +1111,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 2);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_147: {
-                    break __inline_String__with_capacity_147: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1205,9 +1149,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_152: {
-                    break __inline_String__with_capacity_152: String { repr: "array_new<u8>"(148), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(148), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -1245,9 +1187,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 15);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_157: {
-                    break __inline_String__with_capacity_157: String { repr: "array_new<u8>"(147), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(147), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_gzip.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_gzip.lowered.wado
@@ -21,15 +21,11 @@ fn run() with Stdout {
         let _licm_used: i32 = msg.used;
         let _licm_repr: builtin::array<u8> = msg.repr;
         loop {
-            if !(i < __inline_String__len_0: {
-                break __inline_String__len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
-                data."Array<u8>::append"(__inline_String__get_byte_1: {
-                    break __inline_String__get_byte_1: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                data."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -43,9 +39,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 31);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(163), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(163), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -83,9 +77,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 139);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_8: {
-                    break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(163), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(163), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -123,9 +115,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 8);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(160), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(160), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -160,18 +150,12 @@ fn run() with Stdout {
     }
     let decompressed: Array<u8> = move core::zlib::inflate_gzip(&compressed);
     __assert_3: {
-        let __v0: i32 = __inline_Array_u8___len_18: {
-            break __inline_Array_u8___len_18: decompressed.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_19: {
-            break __inline_Array_u8___len_19: data.used;
-        };
+        let __v0: i32 = decompressed.used;
+        let __v1: i32 = data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_20: {
-                    break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(202), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(202), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -219,9 +203,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = data.used;
         loop {
-            if !(i < __inline_Array_u8___len_27: {
-                break __inline_Array_u8___len_27: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -231,9 +213,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_28: {
-                                break __inline_String__with_capacity_28: String { repr: "array_new<u8>"(190), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(190), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -285,18 +265,12 @@ fn run() with Stdout {
     let c1: Array<u8> = move core::zlib::gzip_compress2(&data, core::zlib::Z_BEST_SPEED);
     let d1: Array<u8> = move core::zlib::inflate_gzip(&c1);
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_35: {
-            break __inline_Array_u8___len_35: d1.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_36: {
-            break __inline_Array_u8___len_36: data.used;
-        };
+        let __v0: i32 = d1.used;
+        let __v1: i32 = data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_37: {
-                    break __inline_String__with_capacity_37: String { repr: "array_new<u8>"(182), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(182), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -343,18 +317,12 @@ fn run() with Stdout {
     let c9: Array<u8> = move core::zlib::gzip_compress2(&data, core::zlib::Z_BEST_COMPRESSION);
     let d9: Array<u8> = move core::zlib::inflate_gzip(&c9);
     __assert_6: {
-        let __v0: i32 = __inline_Array_u8___len_44: {
-            break __inline_Array_u8___len_44: d9.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_45: {
-            break __inline_Array_u8___len_45: data.used;
-        };
+        let __v0: i32 = d9.used;
+        let __v1: i32 = data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_46: {
-                    break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(182), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(182), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -399,9 +367,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(move "gzip levels ok");
-    let mut big_data: Array<u8> = __inline_Array_u8___with_capacity_53: {
-        break __inline_Array_u8___with_capacity_53: Array<u8> { repr: core::builtin::array_new::<u8>(5000), used: 0 };
-    };
+    let mut big_data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(5000), used: 0 };
     __for_2: {
         let mut i: i32 = 0;
         loop {
@@ -420,15 +386,11 @@ fn run() with Stdout {
     };
     let big_decompressed: Array<u8> = move core::zlib::inflate_gzip(&big_compressed);
     __assert_7: {
-        let __v0: i32 = __inline_Array_u8___len_55: {
-            break __inline_Array_u8___len_55: big_decompressed.used;
-        };
+        let __v0: i32 = big_decompressed.used;
         let __cond: bool = (__v0 == 5000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_56: {
-                    break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(175), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(175), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -474,9 +436,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_61: {
-                                break __inline_String__with_capacity_61: String { repr: "array_new<u8>"(206), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(206), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -527,15 +487,11 @@ fn run() with Stdout {
     core::cli::println(move "gzip big data ok");
     let auto_gz: Array<u8> = move core::zlib::uncompress(&big_compressed);
     __assert_9: {
-        let __v0: i32 = __inline_Array_u8___len_68: {
-            break __inline_Array_u8___len_68: auto_gz.used;
-        };
+        let __v0: i32 = auto_gz.used;
         let __cond: bool = (__v0 == 5000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_69: {
-                    break __inline_String__with_capacity_69: String { repr: "array_new<u8>"(157), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(157), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -576,15 +532,11 @@ fn run() with Stdout {
         let _licm_used: i32 = m1.used;
         let _licm_repr: builtin::array<u8> = m1.repr;
         loop {
-            if !(i < __inline_String__len_74: {
-                break __inline_String__len_74: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_4;
             }
             __for_4_body: {
-                member1_data."Array<u8>::append"(__inline_String__get_byte_75: {
-                    break __inline_String__get_byte_75: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                member1_data."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -596,15 +548,11 @@ fn run() with Stdout {
         let _licm_used: i32 = m2.used;
         let _licm_repr: builtin::array<u8> = m2.repr;
         loop {
-            if !(i < __inline_String__len_76: {
-                break __inline_String__len_76: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_5;
             }
             __for_5_body: {
-                member2_data."Array<u8>::append"(__inline_String__get_byte_77: {
-                    break __inline_String__get_byte_77: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                member2_data."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -618,20 +566,14 @@ fn run() with Stdout {
         break __inline_gzip_compress_79: core::zlib::gzip_compress2(input, core::zlib::Z_DEFAULT_COMPRESSION);
     };
     let mut multi: Array<u8> = __inline_Array_u8___with_capacity_82: {
-        let capacity: i32 = (__inline_Array_u8___len_80: {
-            break __inline_Array_u8___len_80: gz1.used;
-        } + __inline_Array_u8___len_81: {
-            break __inline_Array_u8___len_81: gz2.used;
-        });
+        let capacity: i32 = (gz1.used + gz2.used);
         break __inline_Array_u8___with_capacity_82: Array<u8> { repr: core::builtin::array_new::<u8>(capacity), used: 0 };
     };
     __for_6: {
         let mut i: i32 = 0;
         let _licm_used: i32 = gz1.used;
         loop {
-            if !(i < __inline_Array_u8___len_83: {
-                break __inline_Array_u8___len_83: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_6;
             }
             __for_6_body: {
@@ -644,9 +586,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = gz2.used;
         loop {
-            if !(i < __inline_Array_u8___len_84: {
-                break __inline_Array_u8___len_84: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_7;
             }
             __for_7_body: {
@@ -657,26 +597,14 @@ fn run() with Stdout {
     }
     let multi_decompressed: Array<u8> = move core::zlib::inflate_gzip(&multi);
     __assert_10: {
-        let __v0: i32 = __inline_Array_u8___len_85: {
-            break __inline_Array_u8___len_85: multi_decompressed.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_86: {
-            break __inline_Array_u8___len_86: member1_data.used;
-        };
-        let __v2: i32 = __inline_Array_u8___len_87: {
-            break __inline_Array_u8___len_87: member2_data.used;
-        };
-        let __v3: i32 = (__inline_Array_u8___len_88: {
-            break __inline_Array_u8___len_88: member1_data.used;
-        } + __inline_Array_u8___len_89: {
-            break __inline_Array_u8___len_89: member2_data.used;
-        });
+        let __v0: i32 = multi_decompressed.used;
+        let __v1: i32 = member1_data.used;
+        let __v2: i32 = member2_data.used;
+        let __v3: i32 = (member1_data.used + member2_data.used);
         let __cond: bool = (__v0 == __v3);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_90: {
-                    break __inline_String__with_capacity_90: String { repr: "array_new<u8>"(346), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(346), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -746,9 +674,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = member1_data.used;
         loop {
-            if !(i < __inline_Array_u8___len_101: {
-                break __inline_Array_u8___len_101: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_8;
             }
             __for_8_body: {
@@ -758,9 +684,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_102: {
-                                break __inline_String__with_capacity_102: String { repr: "array_new<u8>"(218), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(218), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -813,23 +737,17 @@ fn run() with Stdout {
         let _licm_used: i32 = member2_data.used;
         let _licm_used: i32 = member1_data.used;
         loop {
-            if !(i < __inline_Array_u8___len_109: {
-                break __inline_Array_u8___len_109: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_9;
             }
             __for_9_body: {
                 __assert_12: {
-                    let __v0: u8 = multi_decompressed."Array<u8>^IndexValue::index_value"((__inline_Array_u8___len_110: {
-                        break __inline_Array_u8___len_110: _licm_used;
-                    } + i));
+                    let __v0: u8 = multi_decompressed."Array<u8>^IndexValue::index_value"((_licm_used + i));
                     let __v1: u8 = member2_data."Array<u8>^IndexValue::index_value"(i);
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_111: {
-                                break __inline_String__with_capacity_111: String { repr: "array_new<u8>"(260), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(260), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_inflate.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_inflate.lowered.wado
@@ -14,20 +14,14 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn bytes_equal(a: &Array<u8>, b: &Array<u8>) -> bool {
-    if (__inline_Array_u8___len_0: {
-        break __inline_Array_u8___len_0: a.used;
-    } != __inline_Array_u8___len_1: {
-        break __inline_Array_u8___len_1: b.used;
-    }) {
+    if (a.used != b.used) {
         return false;
     }
     __for_0: {
         let mut i: i32 = 0;
         let _licm_used: i32 = a.used;
         loop {
-            if !(i < __inline_Array_u8___len_2: {
-                break __inline_Array_u8___len_2: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
@@ -49,9 +43,7 @@ fn run() with Stdout {
         let __v0: bool = bytes_equal(&expected_hello, &result);
         if !__v0 {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_0: {
-                    break __inline_String__with_capacity_0: String { repr: "array_new<u8>"(197), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(197), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -92,15 +84,11 @@ fn run() with Stdout {
     let zlib_1000a: Array<u8> = move [120, 156, 115, 116, 28, 5, 163, 96, 20, 12, 119, 0, 0, 137, 12, 253, 233];
     let result_1000a: Array<u8> = move core::zlib::inflate_zlib(&zlib_1000a);
     __assert_1: {
-        let __v0: i32 = __inline_Array_u8___len_5: {
-            break __inline_Array_u8___len_5: result_1000a.used;
-        };
+        let __v0: i32 = result_1000a.used;
         let __cond: bool = (__v0 == 1000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_6: {
-                    break __inline_String__with_capacity_6: String { repr: "array_new<u8>"(167), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(167), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -152,9 +140,7 @@ fn run() with Stdout {
     __assert_2: {
         if !all_a {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_11: {
-                    break __inline_String__with_capacity_11: String { repr: "array_new<u8>"(133), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(133), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -195,15 +181,11 @@ fn run() with Stdout {
     let zlib_hw20: Array<u8> = move [120, 156, 243, 72, 205, 201, 201, 215, 81, 8, 207, 47, 202, 73, 81, 84, 240, 24, 229, 65, 121, 0, 245, 131, 90, 181];
     let result_hw20: Array<u8> = move core::zlib::inflate_zlib(&zlib_hw20);
     __assert_3: {
-        let __v0: i32 = __inline_Array_u8___len_16: {
-            break __inline_Array_u8___len_16: result_hw20.used;
-        };
+        let __v0: i32 = result_hw20.used;
         let __cond: bool = (__v0 == 280);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_17: {
-                    break __inline_String__with_capacity_17: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -250,9 +232,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_22: {
-                                break __inline_String__with_capacity_22: String { repr: "array_new<u8>"(202), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(202), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -304,15 +284,11 @@ fn run() with Stdout {
     let zlib_256: Array<u8> = move [120, 156, 1, 0, 1, 255, 254, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 173, 246, 127, 129];
     let result_256: Array<u8> = move core::zlib::inflate_zlib(&zlib_256);
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_29: {
-            break __inline_Array_u8___len_29: result_256.used;
-        };
+        let __v0: i32 = result_256.used;
         let __cond: bool = (__v0 == 256);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_30: {
-                    break __inline_String__with_capacity_30: String { repr: "array_new<u8>"(162), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(162), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -357,9 +333,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == i as u8);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_35: {
-                                break __inline_String__with_capacity_35: String { repr: "array_new<u8>"(160), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(160), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -400,15 +374,11 @@ fn run() with Stdout {
     let zlib_empty: Array<u8> = move [120, 156, 3, 0, 0, 0, 0, 1];
     let result_empty: Array<u8> = move core::zlib::inflate_zlib(&zlib_empty);
     __assert_7: {
-        let __v0: i32 = __inline_Array_u8___len_40: {
-            break __inline_Array_u8___len_40: result_empty.used;
-        };
+        let __v0: i32 = result_empty.used;
         let __cond: bool = (__v0 == 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_41: {
-                    break __inline_String__with_capacity_41: String { repr: "array_new<u8>"(164), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(164), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_raw.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_raw.lowered.wado
@@ -21,15 +21,11 @@ fn run() with Stdout {
         let _licm_used: i32 = msg.used;
         let _licm_repr: builtin::array<u8> = msg.repr;
         loop {
-            if !(i < __inline_String__len_0: {
-                break __inline_String__len_0: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_0;
             }
             __for_0_body: {
-                data."Array<u8>::append"(__inline_String__get_byte_1: {
-                    break __inline_String__get_byte_1: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                data."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -43,9 +39,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 != 120);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_3: {
-                    break __inline_String__with_capacity_3: String { repr: "array_new<u8>"(163), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(163), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -80,23 +74,15 @@ fn run() with Stdout {
     }
     let decompressed: Array<u8> = __inline_inflate_raw_8: {
         let input: &Array<u8> = &compressed;
-        break __inline_inflate_raw_8: core::zlib::inflate_raw_from(input, 0, __inline_Array_u8___len_9: {
-            break __inline_Array_u8___len_9: input.used;
-        });
+        break __inline_inflate_raw_8: core::zlib::inflate_raw_from(input, 0, input.used);
     };
     __assert_1: {
-        let __v0: i32 = __inline_Array_u8___len_10: {
-            break __inline_Array_u8___len_10: decompressed.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_11: {
-            break __inline_Array_u8___len_11: data.used;
-        };
+        let __v0: i32 = decompressed.used;
+        let __v1: i32 = data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_12: {
-                    break __inline_String__with_capacity_12: String { repr: "array_new<u8>"(202), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(202), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -144,9 +130,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = data.used;
         loop {
-            if !(i < __inline_Array_u8___len_19: {
-                break __inline_Array_u8___len_19: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_1;
             }
             __for_1_body: {
@@ -156,9 +140,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_20: {
-                                break __inline_String__with_capacity_20: String { repr: "array_new<u8>"(190), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(190), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -214,23 +196,15 @@ fn run() with Stdout {
     };
     let d1: Array<u8> = __inline_inflate_raw_28: {
         let input: &Array<u8> = &c1;
-        break __inline_inflate_raw_28: core::zlib::inflate_raw_from(input, 0, __inline_Array_u8___len_29: {
-            break __inline_Array_u8___len_29: input.used;
-        });
+        break __inline_inflate_raw_28: core::zlib::inflate_raw_from(input, 0, input.used);
     };
     __assert_3: {
-        let __v0: i32 = __inline_Array_u8___len_30: {
-            break __inline_Array_u8___len_30: d1.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_31: {
-            break __inline_Array_u8___len_31: data.used;
-        };
+        let __v0: i32 = d1.used;
+        let __v1: i32 = data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(182), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(182), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -281,23 +255,15 @@ fn run() with Stdout {
     };
     let d9: Array<u8> = __inline_inflate_raw_40: {
         let input: &Array<u8> = &c9;
-        break __inline_inflate_raw_40: core::zlib::inflate_raw_from(input, 0, __inline_Array_u8___len_41: {
-            break __inline_Array_u8___len_41: input.used;
-        });
+        break __inline_inflate_raw_40: core::zlib::inflate_raw_from(input, 0, input.used);
     };
     __assert_4: {
-        let __v0: i32 = __inline_Array_u8___len_42: {
-            break __inline_Array_u8___len_42: d9.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_43: {
-            break __inline_Array_u8___len_43: data.used;
-        };
+        let __v0: i32 = d9.used;
+        let __v1: i32 = data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_44: {
-                    break __inline_String__with_capacity_44: String { repr: "array_new<u8>"(182), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(182), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -342,9 +308,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(move "raw levels ok");
-    let mut big_data: Array<u8> = __inline_Array_u8___with_capacity_51: {
-        break __inline_Array_u8___with_capacity_51: Array<u8> { repr: core::builtin::array_new::<u8>(2000), used: 0 };
-    };
+    let mut big_data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(2000), used: 0 };
     __for_2: {
         let mut i: i32 = 0;
         loop {
@@ -363,20 +327,14 @@ fn run() with Stdout {
     };
     let big_decompressed: Array<u8> = __inline_inflate_raw_53: {
         let input: &Array<u8> = &big_compressed;
-        break __inline_inflate_raw_53: core::zlib::inflate_raw_from(input, 0, __inline_Array_u8___len_54: {
-            break __inline_Array_u8___len_54: input.used;
-        });
+        break __inline_inflate_raw_53: core::zlib::inflate_raw_from(input, 0, input.used);
     };
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_55: {
-            break __inline_Array_u8___len_55: big_decompressed.used;
-        };
+        let __v0: i32 = big_decompressed.used;
         let __cond: bool = (__v0 == 2000);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_56: {
-                    break __inline_String__with_capacity_56: String { repr: "array_new<u8>"(175), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(175), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -422,9 +380,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_61: {
-                                break __inline_String__with_capacity_61: String { repr: "array_new<u8>"(206), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(206), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_stream_formats.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_stream_formats.lowered.wado
@@ -14,9 +14,7 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let mut data: Array<u8> = __inline_Array_u8___with_capacity_0: {
-        break __inline_Array_u8___with_capacity_0: Array<u8> { repr: core::builtin::array_new::<u8>(200), used: 0 };
-    };
+    let mut data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(200), used: 0 };
     __for_0: {
         let mut i: i32 = 0;
         loop {
@@ -36,9 +34,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 != 120);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_1: {
-                    break __inline_String__with_capacity_1: String { repr: "array_new<u8>"(171), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(171), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -73,20 +69,14 @@ fn run() with Stdout {
     }
     let raw_decompressed: Array<u8> = __inline_inflate_raw_6: {
         let input: &Array<u8> = &raw_compressed;
-        break __inline_inflate_raw_6: core::zlib::inflate_raw_from(input, 0, __inline_Array_u8___len_7: {
-            break __inline_Array_u8___len_7: input.used;
-        });
+        break __inline_inflate_raw_6: core::zlib::inflate_raw_from(input, 0, input.used);
     };
     __assert_1: {
-        let __v0: i32 = __inline_Array_u8___len_8: {
-            break __inline_Array_u8___len_8: raw_decompressed.used;
-        };
+        let __v0: i32 = raw_decompressed.used;
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_9: {
-                    break __inline_String__with_capacity_9: String { repr: "array_new<u8>"(174), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(174), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -126,15 +116,11 @@ fn run() with Stdout {
     };
     let raw_d2: Array<u8> = move is_raw.InflateStream::decompress(&raw_compressed);
     __assert_2: {
-        let __v0: i32 = __inline_Array_u8___len_15: {
-            break __inline_Array_u8___len_15: raw_d2.used;
-        };
+        let __v0: i32 = raw_d2.used;
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(154), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(154), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -175,9 +161,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 31);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_21: {
-                    break __inline_String__with_capacity_21: String { repr: "array_new<u8>"(169), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(169), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -215,9 +199,7 @@ fn run() with Stdout {
         let __cond: bool = (__v0 == 139);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(169), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(169), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -252,15 +234,11 @@ fn run() with Stdout {
     }
     let gz_decompressed: Array<u8> = move core::zlib::inflate_gzip(&gz_compressed);
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_31: {
-            break __inline_Array_u8___len_31: gz_decompressed.used;
-        };
+        let __v0: i32 = gz_decompressed.used;
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_32: {
-                    break __inline_String__with_capacity_32: String { repr: "array_new<u8>"(172), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(172), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -300,15 +278,11 @@ fn run() with Stdout {
     };
     let gz_d2: Array<u8> = move is_gz.InflateStream::decompress(&gz_compressed);
     __assert_6: {
-        let __v0: i32 = __inline_Array_u8___len_38: {
-            break __inline_Array_u8___len_38: gz_d2.used;
-        };
+        let __v0: i32 = gz_d2.used;
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_39: {
-                    break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(152), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(152), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -350,15 +324,11 @@ fn run() with Stdout {
     };
     let auto_d1: Array<u8> = move is_auto_zlib.InflateStream::decompress(&zlib_compressed);
     __assert_7: {
-        let __v0: i32 = __inline_Array_u8___len_45: {
-            break __inline_Array_u8___len_45: auto_d1.used;
-        };
+        let __v0: i32 = auto_d1.used;
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_46: {
-                    break __inline_String__with_capacity_46: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -398,15 +368,11 @@ fn run() with Stdout {
     };
     let auto_d2: Array<u8> = move is_auto_gz.InflateStream::decompress(&gz_compressed);
     __assert_8: {
-        let __v0: i32 = __inline_Array_u8___len_52: {
-            break __inline_Array_u8___len_52: auto_d2.used;
-        };
+        let __v0: i32 = auto_d2.used;
         let __cond: bool = (__v0 == 200);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_53: {
-                    break __inline_String__with_capacity_53: String { repr: "array_new<u8>"(156), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(156), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -445,18 +411,12 @@ fn run() with Stdout {
     ds_reset.DeflateStream::reset();
     let c2: Array<u8> = move ds_reset.DeflateStream::compress(&data);
     __assert_9: {
-        let __v0: i32 = __inline_Array_u8___len_58: {
-            break __inline_Array_u8___len_58: c1.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_59: {
-            break __inline_Array_u8___len_59: c2.used;
-        };
+        let __v0: i32 = c1.used;
+        let __v1: i32 = c2.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_60: {
-                    break __inline_String__with_capacity_60: String { repr: "array_new<u8>"(178), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(178), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -507,18 +467,12 @@ fn run() with Stdout {
     let f1: Array<u8> = move ds_copy.DeflateStream::finish();
     let f2: Array<u8> = move ds_clone.DeflateStream::finish();
     __assert_10: {
-        let __v0: i32 = __inline_Array_u8___len_67: {
-            break __inline_Array_u8___len_67: f1.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_68: {
-            break __inline_Array_u8___len_68: f2.used;
-        };
+        let __v0: i32 = f1.used;
+        let __v1: i32 = f2.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_69: {
-                    break __inline_String__with_capacity_69: String { repr: "array_new<u8>"(178), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(178), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_streaming.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_streaming.lowered.wado
@@ -14,9 +14,7 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let mut data: Array<u8> = __inline_Array_u8___with_capacity_0: {
-        break __inline_Array_u8___with_capacity_0: Array<u8> { repr: core::builtin::array_new::<u8>(500), used: 0 };
-    };
+    let mut data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(500), used: 0 };
     __for_0: {
         let mut i: i32 = 0;
         loop {
@@ -33,15 +31,11 @@ fn run() with Stdout {
     let compressed: Array<u8> = move ds.DeflateStream::compress(&data);
     let decompressed: Array<u8> = move core::zlib::inflate_zlib(&compressed);
     __assert_0: {
-        let __v0: i32 = __inline_Array_u8___len_1: {
-            break __inline_Array_u8___len_1: decompressed.used;
-        };
+        let __v0: i32 = decompressed.used;
         let __cond: bool = (__v0 == 500);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(166), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(166), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -87,9 +81,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_7: {
-                                break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(190), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(190), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -138,20 +130,14 @@ fn run() with Stdout {
         }
     }
     core::cli::println(move "deflate stream ok");
-    let is: InflateStream = __inline_InflateStream__new_14: {
-        break __inline_InflateStream__new_14: InflateStream { dict: [], has_dict: false, format: core::zlib::ZLIB_FORMAT, buffer: [], total_in: 0, total_out: 0 };
-    };
+    let is: InflateStream = move InflateStream { dict: [], has_dict: false, format: core::zlib::ZLIB_FORMAT, buffer: [], total_in: 0, total_out: 0 };
     let decompressed2: Array<u8> = move is.InflateStream::decompress(&compressed);
     __assert_2: {
-        let __v0: i32 = __inline_Array_u8___len_15: {
-            break __inline_Array_u8___len_15: decompressed2.used;
-        };
+        let __v0: i32 = decompressed2.used;
         let __cond: bool = (__v0 == 500);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_16: {
-                    break __inline_String__with_capacity_16: String { repr: "array_new<u8>"(168), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(168), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -186,9 +172,7 @@ fn run() with Stdout {
     }
     core::cli::println(move "inflate stream ok");
     let mut ds2: DeflateStream = move DeflateStream::new(core::zlib::Z_DEFAULT_COMPRESSION);
-    let mut chunk1: Array<u8> = __inline_Array_u8___with_capacity_21: {
-        break __inline_Array_u8___with_capacity_21: Array<u8> { repr: core::builtin::array_new::<u8>(200), used: 0 };
-    };
+    let mut chunk1: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(200), used: 0 };
     __for_2: {
         let mut i: i32 = 0;
         loop {
@@ -201,9 +185,7 @@ fn run() with Stdout {
             i = (i + 1);
         }
     }
-    let mut chunk2: Array<u8> = __inline_Array_u8___with_capacity_22: {
-        break __inline_Array_u8___with_capacity_22: Array<u8> { repr: core::builtin::array_new::<u8>(300), used: 0 };
-    };
+    let mut chunk2: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(300), used: 0 };
     __for_3: {
         let mut i: i32 = 200;
         loop {
@@ -221,15 +203,11 @@ fn run() with Stdout {
     let compressed2: Array<u8> = move ds2.DeflateStream::finish();
     let decompressed3: Array<u8> = move core::zlib::inflate_zlib(&compressed2);
     __assert_3: {
-        let __v0: i32 = __inline_Array_u8___len_23: {
-            break __inline_Array_u8___len_23: decompressed3.used;
-        };
+        let __v0: i32 = decompressed3.used;
         let __cond: bool = (__v0 == 500);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_24: {
-                    break __inline_String__with_capacity_24: String { repr: "array_new<u8>"(168), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(168), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -275,9 +253,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_29: {
-                                break __inline_String__with_capacity_29: String { repr: "array_new<u8>"(192), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(192), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -326,15 +302,9 @@ fn run() with Stdout {
         }
     }
     core::cli::println(move "chunked deflate ok");
-    let mut is2: InflateStream = __inline_InflateStream__new_36: {
-        break __inline_InflateStream__new_36: InflateStream { dict: [], has_dict: false, format: core::zlib::ZLIB_FORMAT, buffer: [], total_in: 0, total_out: 0 };
-    };
-    let half: i32 = (__inline_Array_u8___len_37: {
-        break __inline_Array_u8___len_37: compressed2.used;
-    } / 2);
-    let mut cchunk1: Array<u8> = __inline_Array_u8___with_capacity_38: {
-        break __inline_Array_u8___with_capacity_38: Array<u8> { repr: core::builtin::array_new::<u8>(half), used: 0 };
-    };
+    let mut is2: InflateStream = move InflateStream { dict: [], has_dict: false, format: core::zlib::ZLIB_FORMAT, buffer: [], total_in: 0, total_out: 0 };
+    let half: i32 = (compressed2.used / 2);
+    let mut cchunk1: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(half), used: 0 };
     __for_5: {
         let mut i: i32 = 0;
         loop {
@@ -348,18 +318,14 @@ fn run() with Stdout {
         }
     }
     let mut cchunk2: Array<u8> = __inline_Array_u8___with_capacity_40: {
-        let capacity: i32 = (__inline_Array_u8___len_39: {
-            break __inline_Array_u8___len_39: compressed2.used;
-        } - half);
+        let capacity: i32 = (compressed2.used - half);
         break __inline_Array_u8___with_capacity_40: Array<u8> { repr: core::builtin::array_new::<u8>(capacity), used: 0 };
     };
     __for_6: {
         let mut i: i32 = half;
         let _licm_used: i32 = compressed2.used;
         loop {
-            if !(i < __inline_Array_u8___len_41: {
-                break __inline_Array_u8___len_41: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_6;
             }
             __for_6_body: {
@@ -372,15 +338,11 @@ fn run() with Stdout {
     is2.InflateStream::update(&cchunk2);
     let decompressed4: Array<u8> = move is2.InflateStream::finish();
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_42: {
-            break __inline_Array_u8___len_42: decompressed4.used;
-        };
+        let __v0: i32 = decompressed4.used;
         let __cond: bool = (__v0 == 500);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_43: {
-                    break __inline_String__with_capacity_43: String { repr: "array_new<u8>"(168), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(168), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -421,15 +383,11 @@ fn run() with Stdout {
         let _licm_used: i32 = dict_str.used;
         let _licm_repr: builtin::array<u8> = dict_str.repr;
         loop {
-            if !(i < __inline_String__len_48: {
-                break __inline_String__len_48: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_7;
             }
             __for_7_body: {
-                dict."Array<u8>::append"(__inline_String__get_byte_49: {
-                    break __inline_String__get_byte_49: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                dict."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -441,15 +399,11 @@ fn run() with Stdout {
         let _licm_used: i32 = msg.used;
         let _licm_repr: builtin::array<u8> = msg.repr;
         loop {
-            if !(i < __inline_String__len_50: {
-                break __inline_String__len_50: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_8;
             }
             __for_8_body: {
-                dict_data."Array<u8>::append"(__inline_String__get_byte_51: {
-                    break __inline_String__get_byte_51: core::builtin::array_get_u8(_licm_repr, i);
-                });
+                dict_data."Array<u8>::append"(core::builtin::array_get_u8(_licm_repr, i));
             }
             i = (i + 1);
         }
@@ -457,24 +411,16 @@ fn run() with Stdout {
     let mut ds3: DeflateStream = move DeflateStream::new(core::zlib::Z_DEFAULT_COMPRESSION);
     ds3.DeflateStream::set_dictionary(&dict);
     let compressed3: Array<u8> = move ds3.DeflateStream::compress(&dict_data);
-    let mut is3: InflateStream = __inline_InflateStream__new_52: {
-        break __inline_InflateStream__new_52: InflateStream { dict: [], has_dict: false, format: core::zlib::ZLIB_FORMAT, buffer: [], total_in: 0, total_out: 0 };
-    };
+    let mut is3: InflateStream = move InflateStream { dict: [], has_dict: false, format: core::zlib::ZLIB_FORMAT, buffer: [], total_in: 0, total_out: 0 };
     is3.InflateStream::set_dictionary(&dict);
     let decompressed5: Array<u8> = move is3.InflateStream::decompress(&compressed3);
     __assert_6: {
-        let __v0: i32 = __inline_Array_u8___len_53: {
-            break __inline_Array_u8___len_53: decompressed5.used;
-        };
-        let __v1: i32 = __inline_Array_u8___len_54: {
-            break __inline_Array_u8___len_54: dict_data.used;
-        };
+        let __v0: i32 = decompressed5.used;
+        let __v1: i32 = dict_data.used;
         let __cond: bool = (__v0 == __v1);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_55: {
-                    break __inline_String__with_capacity_55: String { repr: "array_new<u8>"(214), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(214), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -522,9 +468,7 @@ fn run() with Stdout {
         let mut i: i32 = 0;
         let _licm_used: i32 = dict_data.used;
         loop {
-            if !(i < __inline_Array_u8___len_62: {
-                break __inline_Array_u8___len_62: _licm_used;
-            }) {
+            if !(i < _licm_used) {
                 break __for_9;
             }
             __for_9_body: {
@@ -534,9 +478,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_63: {
-                                break __inline_String__with_capacity_63: String { repr: "array_new<u8>"(202), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(202), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -589,15 +531,11 @@ fn run() with Stdout {
     let compressed4: Array<u8> = move ds4.DeflateStream::compress(&data);
     let decompressed6: Array<u8> = move core::zlib::inflate_zlib(&compressed4);
     __assert_8: {
-        let __v0: i32 = __inline_Array_u8___len_70: {
-            break __inline_Array_u8___len_70: decompressed6.used;
-        };
+        let __v0: i32 = decompressed6.used;
         let __cond: bool = (__v0 == 500);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_71: {
-                    break __inline_String__with_capacity_71: String { repr: "array_new<u8>"(168), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(168), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wado-compiler/tests/fixtures.golden/zlib_utility.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/zlib_utility.lowered.wado
@@ -14,19 +14,13 @@
 // wasi::waitable-set-wait (waitable_set_wait)
 
 fn run() with Stdout {
-    let ver: String = __inline_zlib_version_0: {
-        break __inline_zlib_version_0: "1.3.1.wado";
-    };
+    let ver: String = move "1.3.1.wado";
     __assert_0: {
-        let __v0: i32 = __inline_String__len_1: {
-            break __inline_String__len_1: ver.used;
-        };
+        let __v0: i32 = ver.used;
         let __cond: bool = (__v0 > 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_2: {
-                    break __inline_String__with_capacity_2: String { repr: "array_new<u8>"(145), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(145), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -60,9 +54,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(__tmpl: {
-        let mut __r: String = __inline_String__with_capacity_7: {
-            break __inline_String__with_capacity_7: String { repr: "array_new<u8>"(25), used: 0 };
-        };
+        let mut __r: String = move String { repr: "array_new<u8>"(25), used: 0 };
         __r.String::append(move "version: ");
         __r.String::append(ver);
         break __tmpl: __r;
@@ -72,9 +64,7 @@ fn run() with Stdout {
         let __cond: bool = (b0 > 0);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_8: {
-                    break __inline_String__with_capacity_8: String { repr: "array_new<u8>"(131), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(131), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -112,9 +102,7 @@ fn run() with Stdout {
         let __cond: bool = (b100 > 100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_13: {
-                    break __inline_String__with_capacity_13: String { repr: "array_new<u8>"(137), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(137), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -152,9 +140,7 @@ fn run() with Stdout {
         let __cond: bool = (b65535 > 65535);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_18: {
-                    break __inline_String__with_capacity_18: String { repr: "array_new<u8>"(143), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(143), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -188,9 +174,7 @@ fn run() with Stdout {
         }
     }
     core::cli::println(move "compress_bound ok");
-    let mut data: Array<u8> = __inline_Array_u8___with_capacity_23: {
-        break __inline_Array_u8___with_capacity_23: Array<u8> { repr: core::builtin::array_new::<u8>(100), used: 0 };
-    };
+    let mut data: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(100), used: 0 };
     __for_0: {
         let mut i: i32 = 0;
         loop {
@@ -210,15 +194,11 @@ fn run() with Stdout {
         break __inline_compress2_24: core::zlib::zlib_wrap(input, &deflated, level);
     };
     __assert_4: {
-        let __v0: i32 = __inline_Array_u8___len_25: {
-            break __inline_Array_u8___len_25: compressed.used;
-        };
+        let __v0: i32 = compressed.used;
         let __cond: bool = (__v0 <= b100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_26: {
-                    break __inline_String__with_capacity_26: String { repr: "array_new<u8>"(186), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(186), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -265,15 +245,11 @@ fn run() with Stdout {
     core::cli::println(move "bound verified ok");
     let decompressed: Array<u8> = move core::zlib::uncompress(&compressed);
     __assert_5: {
-        let __v0: i32 = __inline_Array_u8___len_33: {
-            break __inline_Array_u8___len_33: decompressed.used;
-        };
+        let __v0: i32 = decompressed.used;
         let __cond: bool = (__v0 == 100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_34: {
-                    break __inline_String__with_capacity_34: String { repr: "array_new<u8>"(166), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(166), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");
@@ -319,9 +295,7 @@ fn run() with Stdout {
                     let __cond: bool = (__v0 == __v1);
                     if !__cond {
                         core::internal::panic(__tmpl: {
-                            let mut __r: String = __inline_String__with_capacity_39: {
-                                break __inline_String__with_capacity_39: String { repr: "array_new<u8>"(190), used: 0 };
-                            };
+                            let mut __r: String = move String { repr: "array_new<u8>"(190), used: 0 };
                             __r.String::append(move "Assertion failed in ");
                             __r.String::append(move "run");
                             __r.String::append(move " at ");
@@ -373,23 +347,17 @@ fn run() with Stdout {
     let d2: Array<u8> = __inline_uncompress2_0: {
         let input: &Array<u8> = &compressed;
         let result: Array<u8> = move core::zlib::uncompress(input);
-        if (__inline_Array_u8___len_0: {
-            break __inline_Array_u8___len_0: result.used;
-        } > 200) {
+        if (result.used > 200) {
             core::internal::panic(move "decompressed size exceeds max_output");
         }
         break __inline_uncompress2_0: result;
     };
     __assert_7: {
-        let __v0: i32 = __inline_Array_u8___len_46: {
-            break __inline_Array_u8___len_46: d2.used;
-        };
+        let __v0: i32 = d2.used;
         let __cond: bool = (__v0 == 100);
         if !__cond {
             core::internal::panic(__tmpl: {
-                let mut __r: String = __inline_String__with_capacity_47: {
-                    break __inline_String__with_capacity_47: String { repr: "array_new<u8>"(146), used: 0 };
-                };
+                let mut __r: String = move String { repr: "array_new<u8>"(146), used: 0 };
                 __r.String::append(move "Assertion failed in ");
                 __r.String::append(move "run");
                 __r.String::append(move " at ");

--- a/wasm-size/README.md
+++ b/wasm-size/README.md
@@ -23,7 +23,7 @@ Compares WebAssembly binary sizes across different languages.
 
 | Language       | Size (bytes) |
 | -------------- | -----------: |
-| wado           |        1,084 |
+| wado           |        1,073 |
 | c              |        2,122 |
 | zig            |        4,449 |
 | assemblyscript |        6,913 |
@@ -35,7 +35,7 @@ Compares WebAssembly binary sizes across different languages.
 
 | Language       | Size (bytes) |
 | -------------- | -----------: |
-| wado           |        6,533 |
+| wado           |        6,451 |
 | zig            |       10,608 |
 | assemblyscript |       11,372 |
 | c              |       14,151 |

--- a/wasm-size/README.md
+++ b/wasm-size/README.md
@@ -35,10 +35,10 @@ Compares WebAssembly binary sizes across different languages.
 
 | Language       | Size (bytes) |
 | -------------- | -----------: |
+| wado           |        6,533 |
 | zig            |       10,608 |
 | assemblyscript |       11,372 |
 | c              |       14,151 |
-| wado           |       15,354 |
 | moonbit        |       32,940 |
 | rust           |       62,952 |
 | tinygo         |      186,022 |


### PR DESCRIPTION
Wado now has the smallest output for both hello_world and pi_approx benchmarks.
The pi_approx reduction is from optimizer improvements on a separate branch.

https://claude.ai/code/session_01U9dk11ydHg59LPN8Gcf7y5