### PR TITLE
Enable DCE for all optimization levels to speed up fixture_test_o0

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -225,7 +225,6 @@ For `-O2` and `-Os`:
 | Field                 | Type                               | Description                                 |
 | --------------------- | ---------------------------------- | ------------------------------------------- |
 | `reachable_functions` | `HashSet<FunctionId>`              | Functions reachable from entry point (DCE)  |
-| `all_reachable`       | `bool`                             | When true, DCE is disabled                  |
 | `used_effects`        | `HashSet<WasiEffect>`              | WASI effects used (Stdout, Stderr, etc.)    |
 | `used_wasi_functions` | `HashSet<String>`                  | WASI functions called                       |
 | `used_builtins`       | `HashSet<CanonBuiltin>`            | Canonical builtins used (stream ops, etc.)  |
@@ -237,8 +236,8 @@ For `-O2` and `-Os`:
 
 | Flag  | Effect                                                      |
 | ----- | ----------------------------------------------------------- |
-| `-O0` | No optimizations, includes all functions/features           |
-| `-O1` | All passes except TIR-level DCE, keeps debug names          |
+| `-O0` | DCE only, no optimization passes                            |
+| `-O1` | All passes with fast iteration + DCE                        |
 | `-O2` | Full optimizations (inline, ref-elim, copy-prop, LICM, DCE) |
 | `-O3` | Aggressive optimizations (100 iterations, higher inline)    |
 | `-Os` | Full optimizations + strips debug name sections             |

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -26,27 +26,29 @@ See [WebAssembly-Native Instruction Opportunities](#webassembly-native-instructi
 
 ## Optimization Levels
 
+All levels run DCE (Dead Code Elimination) to remove unreachable functions and types, which significantly reduces codegen work.
+
 | Flag            | DCE | Iterations | Inline Threshold |
 | --------------- | --- | ---------- | ---------------- |
-| `-O0`           | No  | 0          | N/A              |
-| `-O1`           | No  | 2          | 10               |
+| `-O0`           | Yes | 0          | N/A              |
+| `-O1`           | Yes | 2          | 10               |
 | `-O2` (default) | Yes | 10         | 10               |
 | `-O3`           | Yes | 100        | 20               |
 | `-Os`           | Yes | 10         | 10               |
 
-`-Os` additionally strips the Wasm name section. All passes (except DCE) run in a fixed-point loop with early exit on convergence.
+`-Os` additionally strips the Wasm name section. Optimization passes (inlining, ref-elim, etc.) run in a fixed-point loop with early exit on convergence.
 
 ## Optimization Pipeline
 
-The optimizer runs after lowering and before Wasm plan/codegen. For `-O2` and `-Os`:
+The optimizer runs after lowering and before Wasm plan/codegen:
 
-1. Fixed-point iteration loop:
+1. Fixed-point iteration loop (skipped for `-O0`):
    1. Function Inlining
    2. Reference Elimination
    3. Copy Propagation
    4. Constant Folding
    5. Loop-Invariant Code Motion (LICM)
-2. DCE Analysis and removal of unreachable functions/types
+2. DCE Analysis and removal of unreachable functions/types (all levels)
 3. Post-optimization rewrites (select lowering, move insertion)
 4. Value copy type collection for codegen
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -49,8 +49,10 @@ The optimizer runs after lowering and before Wasm plan/codegen:
    4. Constant Folding
    5. Loop-Invariant Code Motion (LICM)
 2. DCE Analysis and removal of unreachable functions/types (all levels)
-3. Post-optimization rewrites (select lowering, move insertion)
-4. Value copy type collection for codegen
+3. Post-optimization rewrites (select lowering, move insertion, all levels)
+4. Value copy type collection for codegen (all levels)
+
+Note: Steps 3-4 are codegen prerequisites that currently live in the optimizer. They should ideally be a separate pre-codegen phase.
 
 ## Implemented Optimizations
 

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -13,7 +13,7 @@
 use crate::optimize_const_fold::fold_constants;
 use crate::optimize_copy_prop::propagate_copies;
 use crate::optimize_dce::{
-    analyze_project, populate_all_features, remove_unreachable_functions, remove_unreachable_types,
+    analyze_project, remove_unreachable_functions, remove_unreachable_types,
 };
 use crate::optimize_inline::inline_functions;
 
@@ -32,27 +32,27 @@ use crate::project::Project;
 
 /// Optimization level for the compiler.
 ///
-/// The levels are designed for different use cases:
-/// - O0: Debugging - no optimizations
-/// - O1: Development - fast compilation, all optimizations except DCE
-/// - O2: Production - full optimizations with moderate iteration count (default)
-/// - O3: Production - full optimizations with aggressive iteration count
+/// All levels run DCE (Dead Code Elimination) to remove unreachable code.
+/// The levels differ in what optimization passes are run:
+/// - O0: DCE only - no optimization passes
+/// - O1: Development - fast compilation with basic optimization passes
+/// - O2: Production - full optimization passes (default)
+/// - O3: Production - aggressive optimization passes
 /// - Os: Frontend - O2 + name section stripping for smaller binaries
 ///
 /// Configuration for each level:
 /// | Level | DCE | Iterations | Inline Threshold |
 /// |-------|-----|------------|------------------|
-/// | O0    | No  | 0          | N/A              |
-/// | O1    | No  | 2          | 10               |
+/// | O0    | Yes | 0          | N/A              |
+/// | O1    | Yes | 2          | 10               |
 /// | O2    | Yes | 10         | 10               |
 /// | O3    | Yes | 100        | 20               |
 /// | Os    | Yes | 10         | 10               |
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OptLevel {
-    /// No optimizations. Used for debugging.
+    /// No optimization passes. DCE only.
     O0,
-    /// Development optimizations. All passes except DCE.
-    /// Keeps dead code for debugging while improving runtime performance.
+    /// Development optimizations. All passes with fast iteration count.
     /// Iterations: 2, Inline threshold: 10.
     O1,
     /// Production optimizations. All passes including DCE.
@@ -72,27 +72,33 @@ pub enum OptLevel {
 /// This is the main entry point for the optimizer. Based on the optimization
 /// level, it applies different optimization strategies:
 ///
-/// - O0: No optimizations, just populate all features for codegen
-/// - O1: All optimizations except DCE (keeps dead code for debugging)
-/// - O2: Full optimizations including DCE (default)
-/// - O3: Full optimizations with aggressive iteration count
+/// - O0: DCE only (no optimization passes)
+/// - O1: Basic optimization passes + DCE
+/// - O2: Full optimization passes + DCE (default)
+/// - O3: Aggressive optimization passes + DCE
 /// - Os: Same as O2 plus name section stripping
+///
+/// All levels run DCE to remove unreachable functions and types, which
+/// significantly reduces codegen work.
 pub fn optimize(mut project: Project, opt_level: OptLevel) -> Project {
     match opt_level {
         OptLevel::O0 => {
-            // No optimizations - enable all features
-            populate_all_features(&mut project);
+            // No optimizations, but still run DCE to reduce codegen work
+            analyze_project(&mut project);
+            remove_unreachable_functions(&mut project);
+            remove_unreachable_types(&mut project);
         }
         OptLevel::O1 => {
-            // Development mode: all optimizations except DCE
-            // This keeps dead code visible for debugging while improving runtime
+            // Development mode: all optimizations including DCE
             let config = OptConfig {
                 iterations: 2,
                 inline_threshold: 10,
             };
             run_optimization_passes(&mut project, &config);
-            // Still need to populate features without removing unreachable code
-            populate_all_features(&mut project);
+            // DCE: analyze and remove unreachable functions and types
+            analyze_project(&mut project);
+            remove_unreachable_functions(&mut project);
+            remove_unreachable_types(&mut project);
         }
         OptLevel::O2 | OptLevel::Os => {
             // Production mode: full optimizations with DCE

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -184,14 +184,6 @@ pub fn analyze_project(project: &mut Project) {
             // Legacy format: name starts with "builtin::"
             || f.name.starts_with("builtin::")
     };
-    let is_builtin_stream = |f: &FreeFunctionName| {
-        if is_builtin_func(f) {
-            let name = f.name.strip_prefix("builtin::").unwrap_or(&f.name);
-            name.starts_with("stream_")
-        } else {
-            false
-        }
-    };
     let is_builtin_call_indirect_stdout = |f: &FreeFunctionName| {
         if is_builtin_func(f) {
             let name = f.name.strip_prefix("builtin::").unwrap_or(&f.name);
@@ -208,16 +200,6 @@ pub fn analyze_project(project: &mut Project) {
             false
         }
     };
-
-    let uses_stream_builtins = reachable.iter().any(|func_id| {
-        if let FunctionId::Free(f) = func_id {
-            is_builtin_stream(f)
-                || is_builtin_call_indirect_stdout(f)
-                || is_builtin_call_indirect_stderr(f)
-        } else {
-            false
-        }
-    });
 
     // Also mark WASI functions as used if indirect calls are present (for ambient logging)
     if reachable
@@ -282,13 +264,16 @@ pub fn analyze_project(project: &mut Project) {
         add_import_by_name(&mut imports, "f32_to_buffer");
     }
 
-    // Effect usage requires TaskReturn for async entry point
-    // But waitable-set builtins are only needed when effect_wait is actually called
+    // Async exports require task-return and potentially other canonical intrinsics
+    let has_async_export = project
+        .world_registry
+        .get(&project.target_world)
+        .is_some_and(super::world_registry::WorldInfo::has_async_export);
     let has_http_handler_export = project
         .world_registry
         .get(&project.target_world)
         .is_some_and(super::world_registry::WorldInfo::has_http_handler_export);
-    if !used_wasi_functions.is_empty() || uses_stream_builtins || has_http_handler_export {
+    if has_async_export {
         // TaskReturn is always needed for async exports
         add_import_by_name(&mut imports, "task_return");
 
@@ -322,7 +307,6 @@ pub fn analyze_project(project: &mut Project) {
 
     // Apply results to project
     project.reachable_functions = reachable.clone();
-    project.all_reachable = false;
     project.used_wasi_functions = used_wasi_functions;
 
     // Filter string literals in each module to only include strings from reachable functions
@@ -386,207 +370,6 @@ pub fn analyze_project(project: &mut Project) {
         }
 
         module.string_literals = reachable_strings;
-    }
-}
-
-/// Populate project with all features enabled (no DCE, for O0 mode).
-pub fn populate_all_features(project: &mut Project) {
-    project.reachable_functions = IndexSet::new();
-    project.all_reachable = true;
-    // Standard WASI functions + any non-standard WASI functions used in entry module
-    project.used_wasi_functions = project
-        .wasi_registry
-        .standard_function_names()
-        .map(std::string::ToString::to_string)
-        .collect();
-
-    // Scan entry module for non-standard WASI function usage (e.g., TcpSocket, UdpSocket)
-    // This ensures O0 mode discovers WASI resource methods without full DCE analysis.
-    if let Some(entry_module) = project.tir_modules.get(&project.entry_module_source) {
-        let extra = scan_wasi_usage(entry_module);
-        project.used_wasi_functions.extend(extra);
-    }
-
-    // Build all imports from the builtin registry
-    let has_http_handler_export = project
-        .world_registry
-        .get(&project.target_world)
-        .is_some_and(super::world_registry::WorldInfo::has_http_handler_export);
-
-    let mut imports: Vec<TirImport> = Vec::new();
-    for info in project.builtin_registry.imported_builtins() {
-        if let Some(canonical_name) = &info.canonical_name {
-            // Skip future intrinsics unless HTTP handler export needs them
-            if canonical_name.starts_with("future-") && !has_http_handler_export {
-                continue;
-            }
-            imports.push(TirImport {
-                namespace: info.namespace.clone(),
-                canonical_name: canonical_name.clone(),
-                func_name: info.name.clone(),
-                params: info.params.iter().map(|(_, ty)| *ty).collect(),
-                return_type: info.return_type,
-            });
-        }
-    }
-
-    // Sort imports for deterministic output
-    imports.sort_by(|a, b| a.canonical_name.cmp(&b.canonical_name));
-
-    // Store imports in the entry module
-    if let Some(entry_module) = project.tir_modules.get_mut(&project.entry_module_source) {
-        entry_module.imports = imports;
-    }
-}
-
-/// Scan a module for WASI function usage without full DCE analysis.
-/// Returns WASI function names in "`Effect::method`" format (e.g., "`TcpSocket::static_tcp_socket_create`").
-fn scan_wasi_usage(module: &TirModule) -> IndexSet<String> {
-    let mut wasi_funcs = IndexSet::new();
-    for func_rc in &module.functions {
-        let func = func_rc.borrow();
-        if let Some(body) = &func.body {
-            scan_wasi_block(body, &mut wasi_funcs);
-        }
-    }
-    wasi_funcs
-}
-
-fn scan_wasi_block(block: &TirBlock, wasi_funcs: &mut IndexSet<String>) {
-    for stmt in &block.stmts {
-        scan_wasi_stmt(stmt, wasi_funcs);
-    }
-}
-
-fn scan_wasi_stmt(stmt: &crate::tir::TirStmt, wasi_funcs: &mut IndexSet<String>) {
-    match &stmt.kind {
-        TirStmtKind::Let { value, .. } | TirStmtKind::Expr(value) => {
-            scan_wasi_expr(value, wasi_funcs);
-        }
-        TirStmtKind::Return { value } => {
-            if let Some(expr) = value {
-                scan_wasi_expr(expr, wasi_funcs);
-            }
-        }
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        }
-        | TirStmtKind::IfPattern {
-            scrutinee: condition,
-            then_block,
-            else_block,
-            ..
-        } => {
-            scan_wasi_expr(condition, wasi_funcs);
-            scan_wasi_block(then_block, wasi_funcs);
-            if let Some(else_block) = else_block {
-                scan_wasi_block(else_block, wasi_funcs);
-            }
-        }
-        TirStmtKind::Loop { body } => {
-            scan_wasi_block(body, wasi_funcs);
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            scan_wasi_block(block, wasi_funcs);
-        }
-        TirStmtKind::LetPattern { value, .. } => {
-            scan_wasi_expr(value, wasi_funcs);
-        }
-        TirStmtKind::Break { value, .. } => {
-            if let Some(expr) = value {
-                scan_wasi_expr(expr, wasi_funcs);
-            }
-        }
-        TirStmtKind::Continue => {}
-    }
-}
-
-fn scan_wasi_expr(expr: &TirExpr, wasi_funcs: &mut IndexSet<String>) {
-    match &expr.kind {
-        TirExprKind::StaticCall { func, args } => {
-            let module_path = func.module_path();
-            if module_path.len() >= 2 && module_path[0] == "wasi" {
-                let func_name = func.name();
-                if let Some(pos) = func_name.find("::") {
-                    let resource_name = &func_name[..pos];
-                    let method_name = &func_name[pos + 2..];
-                    wasi_funcs.insert(format!("{resource_name}::{method_name}"));
-                }
-            }
-            for arg in args {
-                scan_wasi_expr(arg, wasi_funcs);
-            }
-        }
-        TirExprKind::EffectCall {
-            effect_name,
-            op_name,
-            args,
-            ..
-        } => {
-            wasi_funcs.insert(format!("{effect_name}::{op_name}"));
-            for arg in args {
-                scan_wasi_expr(arg, wasi_funcs);
-            }
-        }
-        TirExprKind::Call { args, .. } | TirExprKind::MethodCall { args, .. } => {
-            for arg in args {
-                scan_wasi_expr(arg, wasi_funcs);
-            }
-        }
-        TirExprKind::Binary { left, right, .. } => {
-            scan_wasi_expr(left, wasi_funcs);
-            scan_wasi_expr(right, wasi_funcs);
-        }
-        TirExprKind::Unary { expr, .. }
-        | TirExprKind::Cast { expr, .. }
-        | TirExprKind::FieldAccess { expr, .. } => {
-            scan_wasi_expr(expr, wasi_funcs);
-        }
-        TirExprKind::Assign { target, value }
-        | TirExprKind::Index {
-            expr: target,
-            index: value,
-        } => {
-            scan_wasi_expr(target, wasi_funcs);
-            scan_wasi_expr(value, wasi_funcs);
-        }
-        TirExprKind::Block(block) => {
-            scan_wasi_block(block, wasi_funcs);
-        }
-        TirExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-            ..
-        } => {
-            scan_wasi_expr(condition, wasi_funcs);
-            scan_wasi_block(then_branch, wasi_funcs);
-            if let Some(else_branch) = else_branch {
-                scan_wasi_block(else_branch, wasi_funcs);
-            }
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            for field in fields {
-                scan_wasi_expr(&field.value, wasi_funcs);
-            }
-        }
-        TirExprKind::ArrayLiteral { elements } | TirExprKind::TupleLiteral { elements } => {
-            for elem in elements {
-                scan_wasi_expr(elem, wasi_funcs);
-            }
-        }
-        TirExprKind::Match { expr, arms } => {
-            scan_wasi_expr(expr, wasi_funcs);
-            for arm in arms {
-                if let Some(guard) = &arm.guard {
-                    scan_wasi_expr(guard, wasi_funcs);
-                }
-                scan_wasi_expr(&arm.body, wasi_funcs);
-            }
-        }
-        _ => {}
     }
 }
 
@@ -1322,11 +1105,6 @@ fn compute_reachable(
 /// This physically removes functions that are not in `reachable_functions`
 /// from the TIR, so codegen doesn't need to filter them.
 pub fn remove_unreachable_functions(project: &mut Project) {
-    // Skip if all functions are reachable (no DCE)
-    if project.all_reachable {
-        return;
-    }
-
     for (module_source, module) in &mut project.tir_modules {
         // Retain only reachable functions
         module.functions.retain(|func_rc| {
@@ -1985,11 +1763,6 @@ fn collect_type_dependencies(
 /// Remove unreachable types from the project's `TypeTable` and module definitions.
 /// This should be called after function DCE.
 pub fn remove_unreachable_types(project: &mut Project) {
-    // Skip if all functions are reachable (no DCE)
-    if project.all_reachable {
-        return;
-    }
-
     let reachable_types = compute_reachable_types(project);
 
     // Remove unreachable struct/variant/enum definitions from each module

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -53,8 +53,6 @@ pub struct Project {
     // ========================================
     /// Set of reachable functions (from DCE analysis)
     pub reachable_functions: IndexSet<FunctionId>,
-    /// When true, all functions are considered reachable (DCE disabled)
-    pub all_reachable: bool,
     /// Set of used WASI functions (e.g., "`Stdout::write_via_stream`")
     pub used_wasi_functions: IndexSet<String>,
     // ========================================
@@ -103,7 +101,6 @@ impl Project {
             builtin_registry,
             // Usage analysis fields default to empty/false
             reachable_functions: IndexSet::new(),
-            all_reachable: false,
             used_wasi_functions: IndexSet::new(),
             // Codegen options
             strip_names: false,
@@ -124,7 +121,7 @@ impl Project {
 
     /// Check if a function is reachable (should be included in the binary)
     pub fn is_reachable(&self, func_id: &FunctionId) -> bool {
-        self.all_reachable || self.reachable_functions.contains(func_id)
+        self.reachable_functions.contains(func_id)
     }
 
     /// Check if any function from the given WASI effect is used.

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -67,6 +67,11 @@ pub struct WorldInfo {
 }
 
 impl WorldInfo {
+    /// Check if this world has any async export.
+    pub fn has_async_export(&self) -> bool {
+        self.exports.iter().any(|e| e.is_async)
+    }
+
     /// Check if this world has an HTTP handler export.
     ///
     /// Returns true if any export returns `Result<Response, ErrorCode>`.


### PR DESCRIPTION
fixture_test_o0 was ~3.7x slower than o2 because O0/O1 skipped DCE,
causing codegen to process all stdlib functions for every test fixture.
Enabling DCE at all optimization levels reduces O0 test time from 69s
to 18s without affecting test correctness.

- Enable DCE (analyze_project + remove_unreachable_functions/types) for O0 and O1
- Remove populate_all_features() and all_reachable flag (no longer needed)
- Fix task-return import condition to check has_async_export instead of
  WASI function usage, ensuring async exports always get task-return
- Add WorldInfo::has_async_export() helper

https://claude.ai/code/session_012XCAQ1UGCqMxLMgxTD7jS4