### PR TITLE
Update Moonbit build configuration for release mode

### DIFF
--- a/wasm-size/README.md
+++ b/wasm-size/README.md
@@ -27,7 +27,7 @@ Compares WebAssembly binary sizes across different languages.
 | c              |        2,122 |
 | zig            |        4,449 |
 | assemblyscript |        6,913 |
-| moonbit        |       22,884 |
+| moonbit        |       21,103 |
 | rust           |       42,587 |
 | tinygo         |      161,350 |
 
@@ -39,7 +39,7 @@ Compares WebAssembly binary sizes across different languages.
 | zig            |       10,608 |
 | assemblyscript |       11,372 |
 | c              |       14,151 |
-| moonbit        |       32,940 |
+| moonbit        |       31,133 |
 | rust           |       62,952 |
 | tinygo         |      186,022 |
 
@@ -70,7 +70,7 @@ All languages are compiled with size optimization and symbol stripping enabled:
 | Zig            | Preview 1    | `-O ReleaseSmall`                                                             | Built-in size optimization mode              |
 | TinyGo         | Preview 1    | `-opt=z -no-debug`                                                            | Size opt + strip debug info                  |
 | AssemblyScript | Preview 1    | `--optimizeLevel 3 --shrinkLevel 2`                                           | Via @assemblyscript/wasi-shim                |
-| Moonbit        | Preview 1    | `--strip`                                                                     | Via peter-jerry-ye/wasi                      |
+| Moonbit        | Preview 1    | `--release --strip`                                                           | Release mode + strip symbols                 |
 | Wado           | Preview 3    | `-Os`                                                                         | Component model                              |
 
 ## Requirements

--- a/wasm-size/mise.toml
+++ b/wasm-size/mise.toml
@@ -109,10 +109,10 @@ mkdir -p "$OUT_DIR"
 
 if command -v moon >/dev/null 2>&1; then
     echo "Building Moonbit..."
-    (cd moonbit/hello_world && moon build --target wasm --strip)
-    (cd moonbit/pi_approx && moon build --target wasm --strip)
-    cp moonbit/hello_world/target/wasm/release/build/src/src.wasm "$OUT_DIR/hello_world_moonbit.wasm"
-    cp moonbit/pi_approx/target/wasm/release/build/src/src.wasm "$OUT_DIR/pi_approx_moonbit.wasm"
+    (cd moonbit/hello_world && moon build --target wasm --release --strip)
+    (cd moonbit/pi_approx && moon build --target wasm --release --strip)
+    cp moonbit/hello_world/_build/wasm/release/build/src/src.wasm "$OUT_DIR/hello_world_moonbit.wasm"
+    cp moonbit/pi_approx/_build/wasm/release/build/src/src.wasm "$OUT_DIR/pi_approx_moonbit.wasm"
 else
     echo "SKIP: Moonbit (not installed)"
 fi
@@ -191,7 +191,7 @@ run = """
 #!/usr/bin/env bash
 rm -rf "$OUT_DIR"
 rm -rf rust/hello_world/target rust/pi_approx/target
-rm -rf moonbit/hello_world/target moonbit/pi_approx/target
+rm -rf moonbit/hello_world/_build moonbit/pi_approx/_build
 rm -rf assemblyscript/node_modules
 """
 


### PR DESCRIPTION
## Summary
Updated the Moonbit build configuration to use release mode and corrected the output directory structure to match the current Moonbit compiler behavior.

## Key Changes
- Added `--release` flag to Moonbit build commands for both hello_world and pi_approx projects
- Updated build artifact paths from `target/wasm/release/build/src/src.wasm` to `_build/wasm/release/build/src/src.wasm` to reflect the correct output directory structure
- Updated cleanup script to remove `_build` directories instead of `target` directories for Moonbit projects
- Updated README documentation to reflect the new build flags (`--release --strip`) and updated binary sizes (hello_world: 22,884 → 21,103 bytes; pi_approx: 32,940 → 31,133 bytes)

## Implementation Details
The changes align with the current Moonbit compiler's directory structure and build process. The addition of the `--release` flag enables release mode optimizations, which results in smaller binary sizes as reflected in the updated benchmark numbers in the README.

https://claude.ai/code/session_01XrSowe1KSTtcLc5UnEAADG