### PR TITLE
Add O1 optimization level to CI E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,30 @@ jobs:
 
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o0
 
+  test-e2e-o1:
+    name: Test (E2E O1)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - uses: rui314/setup-mold@v1
+
+      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o1
+
   test-e2e-o3:
     name: Test (E2E O3)
     runs-on: ubuntu-latest
@@ -191,12 +215,12 @@ jobs:
   test:
     name: Test
     if: always()
-    needs: [test-core, test-e2e-o0, test-e2e-o3, test-e2e-os, check-wasm32]
+    needs: [test-core, test-e2e-o0, test-e2e-o1, test-e2e-o3, test-e2e-os, check-wasm32]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
         run: |
-          results="${{ needs.test-core.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check-wasm32.result }}"
+          results="${{ needs.test-core.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check-wasm32.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then
               echo "One or more jobs failed"

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -219,6 +219,16 @@ fn fixture_test_o2(path: &Path, content: &str) -> Result<(), Box<dyn std::error:
     Ok(())
 }
 
+/// Test function for O1 (development optimization)
+/// Skipped by default locally. Runs in CI or when WADO_FULL_TEST=1 is set.
+fn fixture_test_o1(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
+        return Ok(()); // Skip locally by default
+    }
+    run_fixture_test_with_opt(path, content, OptLevel::O1);
+    Ok(())
+}
+
 /// Test function for O3 (aggressive optimization)
 /// Skipped by default locally. Runs in CI or when WADO_FULL_TEST=1 is set.
 fn fixture_test_o3(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -243,6 +253,7 @@ datatest_mini::harness! {
     // Pattern matches .wado files directly in fixtures/ but not in subdirectories
     // (subdirectories contain helper modules that are imported, not run as tests)
     { test = fixture_test_o0, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
+    { test = fixture_test_o1, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
     { test = fixture_test_o2, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
     { test = fixture_test_o3, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
     { test = fixture_test_os, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },


### PR DESCRIPTION
O1 is skipped in local `cargo test` (same as O3/Os) and runs only
in CI or when WADO_FULL_TEST=1 is set.

https://claude.ai/code/session_01KfMVRgEb1cq5UfTN26eW51