### PR TITLE
Make github:cli/cli optional so mise install doesn't fail in restricted environments

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -16,8 +16,10 @@ wasmtime = "41"
 
 # Node.js - required for VS Code extension development
 node = "24"
-# GitHub CLI (use github backend; aqua backend's signer_workflow check fails)
-"github:cli/cli" = "latest"
+
+# Optional tools below are NOT in [tools] because mise doesn't support per-tool
+# optional flag. They are installed best-effort via `make on-task-started`.
+#   github:cli/cli = "latest"  # GitHub CLI
 
 [settings]
 # Automatically install missing tools when entering the directory

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ on-task-started:
 		echo "mise is already installed."; \
 		echo "Installing project tools..."; \
 		mise install; \
+		echo "Installing optional tools..."; \
+		mise install github:cli/cli@latest 2>&1 || echo "  [skip] github:cli/cli (install failed, non-fatal)"; \
 		echo ""; \
 		echo "Development environment ready."; \
 	fi


### PR DESCRIPTION
GitHub attestation verification fails in sandboxed/CI environments. Since mise
doesn't support per-tool optional flags, move gh CLI out of [tools] and install
it best-effort in `make on-task-started`.

https://claude.ai/code/session_01Mhi9PTio9WWFKK3QpsFTy2