### PR TITLE
Fix hello-run-wasmtime by adding missing wasmtime feature flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ hello-run:
 
 .PHONY: hello-run-wasmtime
 hello-run-wasmtime: hello
-	wasmtime run -S p3=y -W component-model-async=y -W component-model-async-stackful=y --invoke 'run()' example/hello.wasm
+	wasmtime run -S p3=y -W component-model=y -W component-model-gc=y -W component-model-async=y -W component-model-async-builtins=y -W component-model-async-stackful=y -W gc=y -W function-references=y -W simd=y -W wide-arithmetic=y -W threads=y --invoke 'run()' example/hello.wasm
 
 .PHONY: test
 test:


### PR DESCRIPTION
The Makefile target was missing several -W flags that the embedded
wasmtime runtime (runtime.rs) enables: gc, function-references, simd,
wide-arithmetic, threads, component-model, component-model-gc, and
component-model-async-builtins. Without gc=y, wasmtime fails with
"array indexed types not supported without the gc feature".

https://claude.ai/code/session_01LUuiiy98FhXDAN8T55Xwtt