### PR TITLE
Rewrite builtin::effect_wait as internal::effect_wait in Wado

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -399,7 +399,6 @@ fn i32_and(a: i32, b: i32) -> i32;
 | `array_set_u8`        | `array.set $type`        | Array       |
 | `memory_store8`       | `i32.store8`             | Memory      |
 | `memory_load8_u`      | `i32.load8_u`            | Memory      |
-| `effect_wait`         | (effect synchronization) | Effects     |
 | `unreachable`         | `unreachable`            | Control     |
 | `f32_abs`             | `f32.abs`                | Float math  |
 | `f64_abs`             | `f64.abs`                | Float math  |
@@ -866,9 +865,6 @@ builtin::waitable_set_new() -> i32
 builtin::waitable_join(set: i32, subtask: i32)
 builtin::waitable_set_wait(set: i32, outptr: i32) -> i32
 builtin::subtask_drop(subtask: i32)
-
-// Effect synchronization
-builtin::effect_wait()                // Wait for all pending effects to complete
 
 // Branch hinting (Wasm branch hinting proposal)
 builtin::likely(cond: bool) -> bool    // Hint: branch is usually taken

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -388,44 +388,44 @@ fn i32_and(a: i32, b: i32) -> i32;
 
 **Instruction Builtins:**
 
-| Function              | Wasm Instruction         | Category    |
-| --------------------- | ------------------------ | ----------- |
-| `i32_and`             | `i32.and`                | i32 ops     |
-| `i32_eqz`             | `i32.eqz`                | i32 ops     |
-| `i32_clz`             | `i32.clz`                | i32 ops     |
-| `i64_clz`             | `i64.clz`                | i64 ops     |
-| `array_len`           | `array.len`              | Array       |
-| `array_get_u8`        | `array.get_u $type`      | Array       |
-| `array_set_u8`        | `array.set $type`        | Array       |
-| `memory_store8`       | `i32.store8`             | Memory      |
-| `memory_load8_u`      | `i32.load8_u`            | Memory      |
-| `unreachable`         | `unreachable`            | Control     |
-| `f32_abs`             | `f32.abs`                | Float math  |
-| `f64_abs`             | `f64.abs`                | Float math  |
-| `f32_ceil`            | `f32.ceil`               | Float math  |
-| `f64_ceil`            | `f64.ceil`               | Float math  |
-| `f32_floor`           | `f32.floor`              | Float math  |
-| `f64_floor`           | `f64.floor`              | Float math  |
-| `f32_trunc`           | `f32.trunc`              | Float math  |
-| `f64_trunc`           | `f64.trunc`              | Float math  |
-| `f32_nearest`         | `f32.nearest`            | Float math  |
-| `f64_nearest`         | `f64.nearest`            | Float math  |
-| `f32_sqrt`            | `f32.sqrt`               | Float math  |
-| `f64_sqrt`            | `f64.sqrt`               | Float math  |
-| `f32_min`             | `f32.min`                | Float math  |
-| `f64_min`             | `f64.min`                | Float math  |
-| `f32_max`             | `f32.max`                | Float math  |
-| `f64_max`             | `f64.max`                | Float math  |
-| `f32_copysign`        | `f32.copysign`           | Float math  |
-| `f64_copysign`        | `f64.copysign`           | Float math  |
-| `i64_add128`          | `i64.add128`             | Wide arith  |
-| `i64_sub128`          | `i64.sub128`             | Wide arith  |
-| `i64_mul_wide_u`      | `i64.mul_wide_u`         | Wide arith  |
-| `i64_mul_wide_s`      | `i64.mul_wide_s`         | Wide arith  |
-| `i64_reinterpret_f64` | `i64.reinterpret_f64`    | Reinterpret |
-| `f64_reinterpret_i64` | `f64.reinterpret_i64`    | Reinterpret |
-| `i32_reinterpret_f32` | `i32.reinterpret_f32`    | Reinterpret |
-| `f32_reinterpret_i32` | `f32.reinterpret_i32`    | Reinterpret |
+| Function              | Wasm Instruction      | Category    |
+| --------------------- | --------------------- | ----------- |
+| `i32_and`             | `i32.and`             | i32 ops     |
+| `i32_eqz`             | `i32.eqz`             | i32 ops     |
+| `i32_clz`             | `i32.clz`             | i32 ops     |
+| `i64_clz`             | `i64.clz`             | i64 ops     |
+| `array_len`           | `array.len`           | Array       |
+| `array_get_u8`        | `array.get_u $type`   | Array       |
+| `array_set_u8`        | `array.set $type`     | Array       |
+| `memory_store8`       | `i32.store8`          | Memory      |
+| `memory_load8_u`      | `i32.load8_u`         | Memory      |
+| `unreachable`         | `unreachable`         | Control     |
+| `f32_abs`             | `f32.abs`             | Float math  |
+| `f64_abs`             | `f64.abs`             | Float math  |
+| `f32_ceil`            | `f32.ceil`            | Float math  |
+| `f64_ceil`            | `f64.ceil`            | Float math  |
+| `f32_floor`           | `f32.floor`           | Float math  |
+| `f64_floor`           | `f64.floor`           | Float math  |
+| `f32_trunc`           | `f32.trunc`           | Float math  |
+| `f64_trunc`           | `f64.trunc`           | Float math  |
+| `f32_nearest`         | `f32.nearest`         | Float math  |
+| `f64_nearest`         | `f64.nearest`         | Float math  |
+| `f32_sqrt`            | `f32.sqrt`            | Float math  |
+| `f64_sqrt`            | `f64.sqrt`            | Float math  |
+| `f32_min`             | `f32.min`             | Float math  |
+| `f64_min`             | `f64.min`             | Float math  |
+| `f32_max`             | `f32.max`             | Float math  |
+| `f64_max`             | `f64.max`             | Float math  |
+| `f32_copysign`        | `f32.copysign`        | Float math  |
+| `f64_copysign`        | `f64.copysign`        | Float math  |
+| `i64_add128`          | `i64.add128`          | Wide arith  |
+| `i64_sub128`          | `i64.sub128`          | Wide arith  |
+| `i64_mul_wide_u`      | `i64.mul_wide_u`      | Wide arith  |
+| `i64_mul_wide_s`      | `i64.mul_wide_s`      | Wide arith  |
+| `i64_reinterpret_f64` | `i64.reinterpret_f64` | Reinterpret |
+| `f64_reinterpret_i64` | `f64.reinterpret_i64` | Reinterpret |
+| `i32_reinterpret_f32` | `i32.reinterpret_f32` | Reinterpret |
+| `f32_reinterpret_i32` | `f32.reinterpret_i32` | Reinterpret |
 
 **Registry Usage:**
 

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -66,8 +66,6 @@ fn waitable_set_wait(set: i32, outptr: i32) -> i32;
 #[canonical("wasi", "subtask-drop")]
 fn subtask_drop(subtask: i32);
 
-/// Wait for all pending effects to complete
-fn effect_wait();
 /// Reinterpret an i32 value as a char (no validation, no-op at Wasm level).
 /// Used internally by the stdlib for trusted conversions (e.g., UTF-8 decoding).
 /// User code should use char::from_u32() or char::from_i32() instead.
@@ -385,10 +383,12 @@ fn f32_reinterpret_i32(i: i32) -> f32;
 /// Unconditional trap - marks unreachable code
 fn unreachable() -> !;
 /// Call stdout's write_via_stream indirectly (ambient, no effect required)
-fn call_indirect_stdout_write_via_stream(rx: i32);
+/// Returns the subtask handle for the async operation.
+fn call_indirect_stdout_write_via_stream(rx: i32) -> i32;
 
 /// Call stderr's write_via_stream indirectly (ambient, no effect required)
-fn call_indirect_stderr_write_via_stream(rx: i32);
+/// Returns the subtask handle for the async operation.
+fn call_indirect_stderr_write_via_stream(rx: i32) -> i32;
 /// Absolute value of f32
 /// Maps to Wasm f32.abs instruction
 fn f32_abs(x: f32) -> f32;

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -45,6 +45,18 @@ pub fn write_string_to_stream(tx: i32, message: String, add_newline: bool) {
     builtin::stream_drop_writable(tx);
 }
 
+/// Wait for a pending async subtask to complete.
+/// If the subtask is still pending (status bit 0 == 0), creates a waitable set,
+/// joins the subtask, waits for completion, and drops the subtask handle.
+pub fn effect_wait(subtask: i32) {
+    if builtin::i32_eqz(builtin::i32_and(subtask, 1)) {
+        let ws = builtin::waitable_set_new();
+        builtin::waitable_join(ws, subtask);
+        builtin::waitable_set_wait(ws, 2048);
+        builtin::subtask_drop(subtask);
+    }
+}
+
 /// Best-effort logging to stdout (ambient, no effect required)
 /// Writes message with newline to stdout. Waits for completion.
 pub fn log_stdout(message: String) {
@@ -52,9 +64,9 @@ pub fn log_stdout(message: String) {
     let rx = handles as i32;
     let tx = (handles >> 32) as i32;
 
-    builtin::call_indirect_stdout_write_via_stream(rx);
+    let subtask = builtin::call_indirect_stdout_write_via_stream(rx);
     write_string_to_stream(tx, message, true);
-    builtin::effect_wait();
+    effect_wait(subtask);
 }
 
 /// Best-effort logging to stderr (ambient, no effect required)
@@ -64,9 +76,9 @@ pub fn log_stderr(message: String) {
     let rx = handles as i32;
     let tx = (handles >> 32) as i32;
 
-    builtin::call_indirect_stderr_write_via_stream(rx);
+    let subtask = builtin::call_indirect_stderr_write_via_stream(rx);
     write_string_to_stream(tx, message, true);
-    builtin::effect_wait();
+    effect_wait(subtask);
 }
 
 /// Convert a Component Model list<string> to a GC Array<String>

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -52,7 +52,9 @@ pub fn effect_wait(subtask: i32) {
     if (subtask & 1) == 0 {
         let ws = builtin::waitable_set_new();
         builtin::waitable_join(ws, subtask);
-        builtin::waitable_set_wait(ws, 2048);
+        let ptr = builtin::realloc(0, 0, 4, 4);
+        builtin::waitable_set_wait(ws, ptr);
+        builtin::realloc(ptr, 4, 4, 0);
         builtin::subtask_drop(subtask);
     }
 }

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -49,7 +49,7 @@ pub fn write_string_to_stream(tx: i32, message: String, add_newline: bool) {
 /// If the subtask is still pending (status bit 0 == 0), creates a waitable set,
 /// joins the subtask, waits for completion, and drops the subtask handle.
 pub fn effect_wait(subtask: i32) {
-    if builtin::i32_eqz(builtin::i32_and(subtask, 1)) {
+    if (subtask & 1) == 0 {
         let ws = builtin::waitable_set_new();
         builtin::waitable_join(ws, subtask);
         builtin::waitable_set_wait(ws, 2048);

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -48,7 +48,7 @@ pub fn write_string_to_stream(tx: i32, message: String, add_newline: bool) {
 /// Wait for a pending async subtask to complete.
 /// If the subtask is still pending (status bit 0 == 0), creates a waitable set,
 /// joins the subtask, waits for completion, and drops the subtask handle.
-pub fn effect_wait(subtask: i32) {
+pub fn wait_for_subtask(subtask: i32) {
     if (subtask & 1) == 0 {
         let ws = builtin::waitable_set_new();
         builtin::waitable_join(ws, subtask);
@@ -68,7 +68,7 @@ pub fn log_stdout(message: String) {
 
     let subtask = builtin::call_indirect_stdout_write_via_stream(rx);
     write_string_to_stream(tx, message, true);
-    effect_wait(subtask);
+    wait_for_subtask(subtask);
 }
 
 /// Best-effort logging to stderr (ambient, no effect required)
@@ -80,7 +80,7 @@ pub fn log_stderr(message: String) {
 
     let subtask = builtin::call_indirect_stderr_write_via_stream(rx);
     write_string_to_stream(tx, message, true);
-    effect_wait(subtask);
+    wait_for_subtask(subtask);
 }
 
 /// Convert a Component Model list<string> to a GC Array<String>

--- a/wado-compiler/lib/core/stream.wado
+++ b/wado-compiler/lib/core/stream.wado
@@ -56,17 +56,3 @@ pub fn waitable_set_wait(set: i32, out_addr: i32) -> i32 {
 pub fn subtask_drop(subtask: i32) {
     builtin::subtask_drop(subtask);
 }
-/// Wait for a write-via-stream subtask to complete if pending
-/// This is used after calling Stdout::write_via_stream or similar effect functions
-/// The subtask parameter is the return value from write-via-stream
-pub fn wait_for_subtask(subtask: i32) {
-    // Check if subtask is pending: (status & 1) == 0
-    if builtin::i32_eqz(builtin::i32_and(subtask, 1)) {
-        let waitable_set = builtin::waitable_set_new();
-        builtin::waitable_join(waitable_set, subtask);
-        let ptr = builtin::realloc(0, 0, 4, 4);
-        builtin::waitable_set_wait(waitable_set, ptr);
-        builtin::realloc(ptr, 4, 4, 0);
-        builtin::subtask_drop(subtask);
-    }
-}

--- a/wado-compiler/lib/core/stream.wado
+++ b/wado-compiler/lib/core/stream.wado
@@ -59,13 +59,14 @@ pub fn subtask_drop(subtask: i32) {
 /// Wait for a write-via-stream subtask to complete if pending
 /// This is used after calling Stdout::write_via_stream or similar effect functions
 /// The subtask parameter is the return value from write-via-stream
-/// Scratch memory address (2048) is used for waitable-set-wait output
 pub fn wait_for_subtask(subtask: i32) {
     // Check if subtask is pending: (status & 1) == 0
     if builtin::i32_eqz(builtin::i32_and(subtask, 1)) {
         let waitable_set = builtin::waitable_set_new();
         builtin::waitable_join(waitable_set, subtask);
-        builtin::waitable_set_wait(waitable_set, 2048);
+        let ptr = builtin::realloc(0, 0, 4, 4);
+        builtin::waitable_set_wait(waitable_set, ptr);
+        builtin::realloc(ptr, 4, 4, 0);
         builtin::subtask_drop(subtask);
     }
 }

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -12632,59 +12632,6 @@ impl Codegen<'_> {
         // If no conversion needed, the raw return value (bool, resource handle) stays on stack
     }
 
-    /// Generate wait logic for pending effect subtasks
-    ///
-    /// This should be called at the end of functions that use Stdout/Stderr effects.
-    /// It waits for the subtask started by write-via-stream to complete.
-    fn generate_effect_wait(
-        &self,
-        func: &mut Function,
-        ctx: &FunctionContext,
-        builder: &CoreModuleBuilder,
-    ) {
-        // Check if we have a subtask to wait for
-        let subtask_local = match ctx.get_local("__subtask") {
-            Some(idx) => idx,
-            None => return, // No pending subtask
-        };
-
-        let waitable_set_new_idx = builder.func_idx("waitable-set-new");
-        let waitable_join_idx = builder.func_idx("waitable-join");
-        let waitable_set_wait_idx = builder.func_idx("waitable-set-wait");
-        let subtask_drop_idx = builder.func_idx("subtask-drop");
-        let waitable_set_local = ctx.get_local("__waitable_set").unwrap_or(subtask_local + 1);
-
-        // Check if subtask is pending
-        // If (status & 1) == 0, the operation is still pending and we need to wait
-        func.instruction(&Instruction::LocalGet(subtask_local));
-        func.instruction(&Instruction::I32Const(1));
-        func.instruction(&Instruction::I32And);
-        func.instruction(&Instruction::I32Eqz);
-        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
-
-        // Subtask is pending - need to wait for it
-        // Create waitable-set
-        func.instruction(&Instruction::Call(waitable_set_new_idx));
-        func.instruction(&Instruction::LocalSet(waitable_set_local));
-
-        // Join subtask to waitable-set
-        func.instruction(&Instruction::LocalGet(waitable_set_local));
-        func.instruction(&Instruction::LocalGet(subtask_local));
-        func.instruction(&Instruction::Call(waitable_join_idx));
-
-        // Wait for completion
-        func.instruction(&Instruction::LocalGet(waitable_set_local));
-        func.instruction(&Instruction::I32Const(2048)); // outptr
-        func.instruction(&Instruction::Call(waitable_set_wait_idx));
-        func.instruction(&Instruction::Drop); // drop wait result
-
-        // Drop subtask
-        func.instruction(&Instruction::LocalGet(subtask_local));
-        func.instruction(&Instruction::Call(subtask_drop_idx));
-
-        func.instruction(&Instruction::End); // end if
-    }
-
     /// Generate code for a builtin function call.
     /// Handles both intrinsics (inline Wasm instructions) and builtins with canonical mappings.
     /// Panics if the builtin is unknown.
@@ -12721,9 +12668,6 @@ impl Codegen<'_> {
                 self.generate_expr(func, &args[0], type_table, ctx, builder);
                 let result_type = self.type_id_to_valtype(type_table, expr.type_id);
                 func.instruction(&Instruction::TypedSelect(result_type));
-            }
-            "builtin::effect_wait" => {
-                self.generate_effect_wait(func, ctx, builder);
             }
             "builtin::array_len" => {
                 // Generate array argument and ensure it's non-null
@@ -13036,10 +12980,7 @@ impl Codegen<'_> {
                 let stdout_func = build_local_alias_name("cli", "Stdout", "write_via_stream");
                 let func_idx = builder.func_idx(&stdout_func);
                 func.instruction(&Instruction::Call(func_idx));
-                let subtask_local = ctx.get_local("__subtask").expect(
-                    "__subtask should be pre-allocated for functions with Stdout/Stderr effects",
-                );
-                func.instruction(&Instruction::LocalSet(subtask_local));
+                // Result (subtask handle i32) is left on the stack as the return value
             }
             "builtin::call_indirect_stderr_write_via_stream" => {
                 self.generate_args(func, args, type_table, ctx, builder);
@@ -13047,10 +12988,7 @@ impl Codegen<'_> {
                 let stderr_func = build_local_alias_name("cli", "Stderr", "write_via_stream");
                 let func_idx = builder.func_idx(&stderr_func);
                 func.instruction(&Instruction::Call(func_idx));
-                let subtask_local = ctx.get_local("__subtask").expect(
-                    "__subtask should be pre-allocated for functions with Stdout/Stderr effects",
-                );
-                func.instruction(&Instruction::LocalSet(subtask_local));
+                // Result (subtask handle i32) is left on the stack as the return value
             }
             // Builtins with canonical function mappings - generate regular function calls
             // These are declared with #[canonical(...)] in builtin.wado

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -7947,15 +7947,6 @@ impl<'a> EffectScratchAnalyzer<'a> {
                             }
                         }
                         ModuleSource::Core { name: module_name } if module_name == "builtin" => {
-                            // Check for async-requiring builtins
-                            if name == "effect_wait"
-                                || name == "waitable_set_new"
-                                || name == "waitable_set_wait"
-                                || name == "call_indirect_stdout_write_via_stream"
-                                || name == "call_indirect_stderr_write_via_stream"
-                            {
-                                self.needs_async = true;
-                            }
                             // future/stream create pair returns i64 that needs unpacking
                             if name == "future_create_pair" || name == "stream_create_pair" {
                                 self.needs_i64_temp = true;
@@ -8012,17 +8003,7 @@ impl<'a> EffectScratchAnalyzer<'a> {
                                 }
                             }
                         }
-                        ModuleSource::Core { name: module_name } if module_name == "builtin" => {
-                            // Check for async-requiring builtins
-                            if name == "effect_wait"
-                                || name == "waitable_set_new"
-                                || name == "waitable_set_wait"
-                                || name == "call_indirect_stdout_write_via_stream"
-                                || name == "call_indirect_stderr_write_via_stream"
-                            {
-                                self.needs_async = true;
-                            }
-                        }
+                        ModuleSource::Core { .. } => {}
                         _ => {}
                     }
                 }

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -281,7 +281,7 @@ pub fn analyze_project(project: &mut Project) {
         add_import_by_name(&mut imports, "task_return");
 
         // Waitable-set builtins (waitable_set_new, waitable_join, waitable_set_wait, subtask_drop)
-        // are added automatically via reachability from internal::effect_wait
+        // are added automatically via reachability from internal::wait_for_subtask
 
         // HTTP handler exports need future intrinsics for response creation
         // (trailers parameter to response.new is a future)

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -88,11 +88,6 @@ pub fn analyze_project(project: &mut Project) {
         FunctionId::Free(FreeFunctionName::from_strs(&["core", "internal"], name))
     };
 
-    // Helper to check if a core/builtin function is reachable
-    let core_builtin = |name: &str| -> FunctionId {
-        FunctionId::Free(FreeFunctionName::from_strs(&["core", "builtin"], name))
-    };
-
     // Derive builtin usage from reachable internal functions
     // f64_to_string/f32_to_string call the bundled f64_to_buffer/f32_to_buffer
     let needs_f64_to_buffer = reachable.contains(&core_internal("f64_to_string"));
@@ -285,15 +280,8 @@ pub fn analyze_project(project: &mut Project) {
         // TaskReturn is always needed for async exports
         add_import_by_name(&mut imports, "task_return");
 
-        // Waitable-set builtins only needed when effect_wait is called
-        // effect_wait is used by ambient logging functions (log_stdout, log_stderr)
-        // but NOT by regular println/eprintln which don't wait for completion
-        if reachable.contains(&core_builtin("effect_wait")) {
-            add_import_by_name(&mut imports, "waitable_set_new");
-            add_import_by_name(&mut imports, "waitable_join");
-            add_import_by_name(&mut imports, "waitable_set_wait");
-            add_import_by_name(&mut imports, "subtask_drop");
-        }
+        // Waitable-set builtins (waitable_set_new, waitable_join, waitable_set_wait, subtask_drop)
+        // are added automatically via reachability from internal::effect_wait
 
         // HTTP handler exports need future intrinsics for response creation
         // (trailers parameter to response.new is a future)

--- a/wado-compiler/tests/fixtures.golden/eprintln_then_trap.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/eprintln_then_trap.lowered.wado
@@ -13,9 +13,8 @@
 // wasi::waitable-set-new (waitable_set_new)
 // wasi::waitable-set-wait (waitable_set_wait)
 
-fn run() with Stderr {
-    core::cli::eprintln(move "error message");
-    core::builtin::effect_wait();
+fn run() {
+    core::internal::log_stderr(move "error message");
     core::builtin::unreachable();
 }
 

--- a/wado-compiler/tests/fixtures/eprintln_then_trap.wado
+++ b/wado-compiler/tests/fixtures/eprintln_then_trap.wado
@@ -1,11 +1,9 @@
 // Test eprintln followed by trap in same function
 
-use { Stderr } from "wasi:cli";
-use { eprintln } from "core:cli";
+use { log_stderr } from "core:internal";
 
-export fn run() with Stderr {
-    eprintln("error message");
-    builtin::effect_wait();
+export fn run() {
+    log_stderr("error message");
     builtin::unreachable();
 }
 


### PR DESCRIPTION
Move effect_wait from a compiler-generated builtin to a Wado function in
internal.wado, making the subtask handle flow explicit. call_indirect_*
builtins now return i32 subtask handles instead of storing them in hidden
__subtask locals.

https://claude.ai/code/session_01TtCoX5uVuw81pYuC11QCCU