### PR TITLE
Add WEP docs for WIR layer and CM adapter synthesis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Variant-Independent Types](./docs/wep-2026-02-09-variant-independent-types.md)
 - [Compile-Time Tuple Enumeration](./docs/wep-2026-02-10-compile-time-tuple-enumeration.md)
 - [Package Manifest (`wado.toml`)](./docs/wep-2026-02-14-package-manifest.md)
+- [Wasm IR (WIR) Layer](./docs/wep-2026-02-14-wir-layer.md)
 
 ### Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Compile-Time Tuple Enumeration](./docs/wep-2026-02-10-compile-time-tuple-enumeration.md)
 - [Package Manifest (`wado.toml`)](./docs/wep-2026-02-14-package-manifest.md)
 - [Wasm IR (WIR) Layer](./docs/wep-2026-02-14-wir-layer.md)
+- [TIR-Level CM Adapter Synthesis](./docs/wep-2026-02-15-cm-adapter-synthesis.md)
 
 ### Structure
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -131,19 +131,66 @@ Examples:
 | Global counter | `counter` | `<entry>//counter` |
 | Enum Ordering from prelude | `Ordering` | `core:prelude//Ordering` |
 
-`WirName` is used in:
+`WirName` is used on **definitions** (low frequency):
 
 - **Type definitions**: `WirStructType.name`, `WirVariantType.name`, `WirEnumType.name`, etc.
-- **Type references**: `WirTypeRef(WirName)`
 - **Function definitions**: `WirFunction.name`
-- **Function references**: `Call { func_name: WirName }`, `RefFunc { func_name: WirName }`
 - **Global definitions and references**: `WirGlobal.name`, `GlobalGet { name: WirName }`
+
+**Instructions** use `WirTypeId` / `WirFuncId` instead of `WirName` (see below).
 
 Not used for local-scope names (no module qualification needed):
 
 - Struct field names, enum/variant case names
 - Local variable names (`DeclareLocal`, `LocalGet`, `LocalSet`)
 - Block labels
+
+### Type and Function IDs
+
+WIR instructions reference types and functions via lightweight IDs (`WirTypeId`, `WirFuncId`) instead of embedding `WirName` in every instruction. GC instructions (struct access, array access, ref cast, etc.) and call instructions are extremely frequent — in a typical Wado program, every field access, every function call, and every type test requires a type or function reference. Using IDs avoids per-instruction string hashing during emission.
+
+```rust
+use std::rc::Rc;
+
+/// Lightweight reference to a type definition in WirModule.types.
+///
+/// - `index`: indexes into WirModule.types (not the Wasm type section)
+/// - `fq`: fully-qualified name shared via Rc<str> for Debug output
+///
+/// Eq and Hash use `index` only (O(1) integer operations).
+/// Debug prints the fq name (e.g., "core:prelude//Array<i32>").
+/// Clone is O(1) — Rc refcount increment (non-atomic, near zero cost).
+#[derive(Clone)]
+pub struct WirTypeId {
+    index: u32,
+    fq: Rc<str>,
+}
+
+/// Lightweight reference to a function.
+/// Same design as WirTypeId.
+#[derive(Clone)]
+pub struct WirFuncId {
+    index: u32,
+    fq: Rc<str>,
+}
+```
+
+For both types:
+
+- `PartialEq` / `Eq`: compares `index` only
+- `Hash`: hashes `index` only
+- `fmt::Debug`: prints `fq` (e.g., `core:prelude//Point` instead of `WirTypeId(17)`)
+- All references to the same type/function share the same `Rc<str>` allocation
+
+`tir_to_wir` creates name→ID maps during type and function registration. When generating instructions, it embeds the pre-resolved ID. `wir_emit` builds `WirTypeId.index → Wasm type index` and `WirFuncId.index → Wasm func index` tables once, then resolves every reference via O(1) integer indexing.
+
+| Property | `WirName` (definitions) | `WirTypeId` / `WirFuncId` (instructions) |
+| --- | --- | --- |
+| Eq / Hash | O(n) string hash | O(1) integer |
+| Clone | O(n) string copy | O(1) Rc refcount |
+| Debug | shows display name | shows fq name |
+| Stack size | 48 bytes (2× String) | 24 bytes (u32 + Rc\<str\>) |
+| Used in | Type/function definitions | Instructions (high frequency) |
 
 ### Metadata
 
@@ -334,9 +381,6 @@ pub struct WirFuncType {
     pub params: Vec<WirType>,
     pub results: Vec<WirType>,
 }
-
-/// Reference to a type (resolved to index during emission via fq name)
-pub struct WirTypeRef(pub WirName);
 ```
 
 ### WIR Type System
@@ -374,11 +418,11 @@ pub enum WirType {
     // Unit (no Wasm representation; zero-size)
     Unit,
     /// Named enum type (i32 at Wasm level)
-    Enum { type_name: WirName },
+    Enum { type_id: WirTypeId },
     /// Named flags type (i32 at Wasm level)
-    Flags { type_name: WirName },
+    Flags { type_id: WirTypeId },
     /// Reference to a named GC type
-    Ref { type_name: WirName, nullable: bool },
+    Ref { type_id: WirTypeId, nullable: bool },
     /// Abstract reference type (anyref, funcref, etc.)
     AbstractRef { heap_type: WirAbstractHeapType, nullable: bool },
 }
@@ -401,8 +445,8 @@ pub enum WirAbstractHeapType {
 pub struct WirFunction {
     /// Function name (display: "Point::sum", fq: "./geometry.wado/Point::sum")
     pub name: WirName,
-    /// Type reference (function signature — param types and result types)
-    pub type_ref: WirTypeRef,
+    /// Function type ID (references a WirTypeDef::Func in WirModule.types)
+    pub type_id: WirTypeId,
     /// Parameter names (types come from the referenced WirFuncType)
     pub param_names: Vec<String>,
     /// Body (None for imported functions)
@@ -574,32 +618,32 @@ pub enum WirInstr {
     F64ReinterpretI64(Box<WirInstr>),
 
     // === GC: Struct ===
-    /// struct.new with named type
-    StructNew { type_name: WirName, fields: Vec<WirInstr> },
-    /// struct.get with named type and field (field index resolved by emitter)
-    StructGet { type_name: WirName, field_name: String, expr: Box<WirInstr> },
-    /// struct.set with named type and field (field index resolved by emitter)
-    StructSet { type_name: WirName, field_name: String, expr: Box<WirInstr>, value: Box<WirInstr> },
+    /// struct.new with type ID
+    StructNew { type_id: WirTypeId, fields: Vec<WirInstr> },
+    /// struct.get with type ID and field name (field index resolved by emitter)
+    StructGet { type_id: WirTypeId, field_name: String, expr: Box<WirInstr> },
+    /// struct.set with type ID and field name (field index resolved by emitter)
+    StructSet { type_id: WirTypeId, field_name: String, expr: Box<WirInstr>, value: Box<WirInstr> },
 
     // === GC: Array ===
-    ArrayNew { type_name: WirName, init: Box<WirInstr>, len: Box<WirInstr> },
-    ArrayNewDefault { type_name: WirName, len: Box<WirInstr> },
-    ArrayNewData { type_name: WirName, data_index: u32, offset: Box<WirInstr>, len: Box<WirInstr> },
-    ArrayNewFixed { type_name: WirName, elements: Vec<WirInstr> },
-    ArrayGet { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr> },
-    ArrayGetS { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr> },
-    ArrayGetU { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr> },
-    ArraySet { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr>, value: Box<WirInstr> },
+    ArrayNew { type_id: WirTypeId, init: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayNewDefault { type_id: WirTypeId, len: Box<WirInstr> },
+    ArrayNewData { type_id: WirTypeId, data_index: u32, offset: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayNewFixed { type_id: WirTypeId, elements: Vec<WirInstr> },
+    ArrayGet { type_id: WirTypeId, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArrayGetS { type_id: WirTypeId, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArrayGetU { type_id: WirTypeId, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArraySet { type_id: WirTypeId, array: Box<WirInstr>, index: Box<WirInstr>, value: Box<WirInstr> },
     ArrayLen(Box<WirInstr>),
-    ArrayCopy { dest_type: WirName, src_type: WirName, dest: Box<WirInstr>, dest_offset: Box<WirInstr>, src: Box<WirInstr>, src_offset: Box<WirInstr>, len: Box<WirInstr> },
-    ArrayFill { type_name: WirName, array: Box<WirInstr>, offset: Box<WirInstr>, value: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayCopy { dest_type_id: WirTypeId, src_type_id: WirTypeId, dest: Box<WirInstr>, dest_offset: Box<WirInstr>, src: Box<WirInstr>, src_offset: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayFill { type_id: WirTypeId, array: Box<WirInstr>, offset: Box<WirInstr>, value: Box<WirInstr>, len: Box<WirInstr> },
 
     // === GC: Reference ===
     RefNull { heap_type: WirAbstractHeapType },
     RefIsNull(Box<WirInstr>),
     RefAsNonNull(Box<WirInstr>),
-    RefCast { type_name: WirName, nullable: bool, expr: Box<WirInstr> },
-    RefTest { type_name: WirName, nullable: bool, expr: Box<WirInstr> },
+    RefCast { type_id: WirTypeId, nullable: bool, expr: Box<WirInstr> },
+    RefTest { type_id: WirTypeId, nullable: bool, expr: Box<WirInstr> },
     RefEq(Box<WirInstr>, Box<WirInstr>),
     RefI31(Box<WirInstr>),
     I31GetS(Box<WirInstr>),
@@ -632,10 +676,10 @@ pub enum WirInstr {
     Select { condition: Box<WirInstr>, if_true: Box<WirInstr>, if_false: Box<WirInstr>, ty: Option<WirType> },
 
     // === Calls ===
-    Call { func_name: WirName, args: Vec<WirInstr> },
-    CallIndirect { type_name: WirName, table: u32, index: Box<WirInstr>, args: Vec<WirInstr> },
-    CallRef { type_name: WirName, func_ref: Box<WirInstr>, args: Vec<WirInstr> },
-    RefFunc { func_name: WirName },
+    Call { func_id: WirFuncId, args: Vec<WirInstr> },
+    CallIndirect { type_id: WirTypeId, table: u32, index: Box<WirInstr>, args: Vec<WirInstr> },
+    CallRef { type_id: WirTypeId, func_ref: Box<WirInstr>, args: Vec<WirInstr> },
+    RefFunc { func_id: WirFuncId },
 
     // === Memory ===
     MemorySize,
@@ -653,7 +697,7 @@ pub enum WirInstr {
 
     /// Deep copy of a value type (struct, array, variant, option, tuple).
     /// Lowered to field-by-field copy, array loop, etc. during emission.
-    ValueCopy { type_name: WirName, source_type: WirCopyType, expr: Box<WirInstr> },
+    ValueCopy { type_id: WirTypeId, source_type: WirCopyType, expr: Box<WirInstr> },
 
     /// Sequence of instructions (for statement blocks)
     Seq(Vec<WirInstr>),
@@ -703,33 +747,17 @@ pub struct WirComponent {
 
 ### Names and References
 
-WIR uses `WirName` for globally-scoped references and plain `String` for local-scope references. During emission, `WirName.fq` is resolved to indices via lookup tables. For unparse, `WirName.display` provides human-readable names.
+WIR uses three reference mechanisms depending on frequency and scope:
 
-| Scope | Reference type | Identity key | Display |
-| ----- | -------------- | ------------ | ------- |
-| Global | `WirName` | `fq` | `display` |
-| Local | `String` | name itself | name itself |
+| Scope | Reference type | Used in | Eq / Hash |
+| ----- | -------------- | ------- | --------- |
+| Types (in instructions) | `WirTypeId` | `StructGet`, `ArrayNew`, `RefCast`, `CallRef`, etc. | O(1) integer |
+| Functions (in instructions) | `WirFuncId` | `Call`, `RefFunc` | O(1) integer |
+| Definitions | `WirName` | `WirStructType.name`, `WirFunction.name`, `WirGlobal.name` | O(n) string |
+| Globals (in instructions) | `WirName` | `GlobalGet`, `GlobalSet` | O(n) string |
+| Local scope | `String` | `LocalGet`, `StructGet.field_name`, labels, case names | N/A |
 
-Global-scope references (use `WirName`):
-
-- **Types**: `WirTypeRef(WirName)` — in function signatures, instructions
-- **Functions**: `WirName` — in `Call`, `RefFunc`, `WirFunction.name`
-- **Globals**: `WirName` — in `GlobalGet`, `GlobalSet`
-
-Local-scope references (use `String`):
-
-- **Locals**: in `LocalGet`, `LocalSet`, `DeclareLocal`
-- **Fields**: in `StructGet`, `StructSet` (resolved to field index by emitter)
-- **Labels**: in `Block`, `Loop`
-- **Enum/variant cases**: in `WirEnumCase`, `WirVariantCase`
-
-```rust
-/// Type references carry both display and fq names
-pub struct WirTypeRef(pub WirName);
-
-/// Function references carry both display and fq names
-pub struct WirFuncRef(pub WirName);
-```
+Type and function references in instructions use `WirTypeId` / `WirFuncId` because they are high-frequency (every GC instruction and every call). Global variable references use `WirName` because they are comparatively rare. Local-scope names use plain `String` (no module qualification needed).
 
 ## Unparse Format
 
@@ -896,9 +924,10 @@ Wasm is a stack machine, but flat instruction sequences are hard to inspect and 
 
 ```rust
 // WIR (tree): readable, inspectable
+// Debug output shows fq names from WirTypeId (not integer indices)
 I32Add(
-    StructGet { type_name: "Point", field_name: "x", expr: LocalGet("self") },
-    StructGet { type_name: "Point", field_name: "y", expr: LocalGet("self") },
+    StructGet { type_id: <entry>//Point, field_name: "x", expr: LocalGet("self") },
+    StructGet { type_id: <entry>//Point, field_name: "y", expr: LocalGet("self") },
 )
 
 // Unparse: Wado-style field access
@@ -914,18 +943,22 @@ I32Add(
 
 Flattening trees to stack-machine instructions is trivial (post-order traversal). The reverse is not.
 
-### Why Named References (Not Indices)?
+### Why `WirTypeId` / `WirFuncId` with `Rc<str>` (Not Raw Indices or `WirName`)?
 
-Using names for all references keeps WIR independent of emission order and self-documenting:
+WIR instructions reference types and functions at very high frequency (every struct field access, every call, every ref cast). The reference design must balance three goals: emission speed, debuggability, and independence from emission order.
 
-- Global-scope names use `WirName` with both `display` (for unparse) and `fq` (for identity)
+Three alternatives were considered:
+
+1. **Raw `u32` index**: Fastest, but `Debug` output shows `WirTypeId(17)` — unreadable without a lookup table. Debugging the compiler requires constantly cross-referencing indices.
+2. **`WirName` (two owned `String`s)**: Most readable, but every clone copies two strings. In a program with thousands of instructions, this means thousands of string allocations. `Eq` and `Hash` require O(n) string operations.
+3. **`WirTypeId { index: u32, fq: Rc<str> }` (chosen)**: `Eq`/`Hash` are O(1) via integer comparison. `Debug` prints the fq name for readability. `Clone` is O(1) — just an `Rc` refcount increment (non-atomic, near zero cost). All references to the same type share one `Rc<str>` allocation.
+
+Additional design properties:
+
+- `WirTypeId.index` indexes into `WirModule.types`, not the Wasm type section — WIR remains independent of emission order
+- Type and function definitions retain full `WirName` (with `display` + `fq`) for unparse output
 - Local-scope names (locals, fields, labels) use plain `String`
-- Type registration order can change without invalidating WIR
-- Functions and globals can be reordered freely
 - Struct field indices are resolved from type definitions during emission
-- Unparse uses `display` names — no need to parse FQ names for readability
-
-The cost is a `fq`→index lookup during emission, which is O(1) with `IndexMap`.
 
 ### Why `ValueCopy` as a Compound Instruction?
 
@@ -1037,5 +1070,5 @@ This eliminates the current coupling between the optimizer and codegen via `need
 ### Risks
 
 - **Scope creep**: WIR should stay close to Wasm. Resist adding high-level abstractions.
-- **Name resolution overhead**: String-based name lookup during emission. Mitigated by single-pass name table construction.
+- **`WirTypeId` is not `Copy`**: `Rc<str>` prevents `Copy`. Mitigated by cheap `Clone` (non-atomic refcount increment) and instructions being heap-allocated (`Box<WirInstr>`) regardless.
 - **Incomplete migration**: If migration stalls midway, we'd have two code paths. Mitigated by the incremental approach where each step is a complete working state.

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -152,6 +152,8 @@ WIR preserves TIR metadata for debugging and unparse output, even when not neede
 ```rust
 /// Source location and origin metadata, carried through from TIR.
 pub struct WirMeta {
+    /// Which module this entity was defined in
+    pub module_source: Option<ModuleSource>,
     /// Source span in the original Wado source
     pub span: Option<Span>,
     /// Attributes (e.g., #[hidden])
@@ -159,7 +161,7 @@ pub struct WirMeta {
 }
 ```
 
-Note: `module_source` is not in `WirMeta`. It is part of `WirName.fq` — the entity's own name carries its module origin. This avoids duplicating module information.
+`module_source` is also encoded in `WirName.fq`, but kept as a separate `ModuleSource` value for programmatic use (e.g., `is_core()`, `is_wasi()`, grouping by module). Parsing `fq` strings to extract module origin would violate name.rs conventions.
 
 ```rust
 /// Generic instantiation origin (e.g., Array<i32> from Array<T>)
@@ -216,7 +218,7 @@ pub struct WirStructType {
     pub name: WirName,
     /// Fields with names and types
     pub fields: Vec<WirField>,
-    /// Metadata (span, attributes)
+    /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
     pub generic_origin: Option<WirGenericOrigin>,
@@ -244,7 +246,7 @@ pub struct WirVariantType {
     pub name: WirName,
     /// Cases with names and optional payload types
     pub cases: Vec<WirVariantCase>,
-    /// Metadata (span, attributes)
+    /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
     pub generic_origin: Option<WirGenericOrigin>,
@@ -280,7 +282,7 @@ pub struct WirEnumType {
     pub name: WirName,
     /// Cases with names and discriminant values
     pub cases: Vec<WirEnumCase>,
-    /// Metadata (span, attributes)
+    /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
     pub generic_origin: Option<WirGenericOrigin>,
@@ -304,7 +306,7 @@ pub struct WirFlagsType {
     pub name: WirName,
     /// Flag bits with names and positions
     pub bits: Vec<WirFlagBit>,
-    /// Metadata (span, attributes)
+    /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
 }
 
@@ -935,11 +937,11 @@ This eliminates the `ValType`/`StorageType` split at the WIR level — there is 
 
 ### Why Preserve TIR Metadata?
 
-WIR carries metadata (spans, attributes, generic origin, newtype origin) even though the emit phase does not need most of it. This is intentional:
+WIR carries metadata (module source, spans, attributes, generic origin, newtype origin) even though the emit phase does not need most of it. This is intentional:
 
-- **Unparse**: `wado dump --wir --unparse` can show `// from ./geometry.wado` comments (derived from `WirName.fq`), display newtype origins, and annotate generic instantiations.
+- **Unparse**: `wado dump --wir --unparse` can show `// from ./geometry.wado` comments (from `WirMeta.module_source`), display newtype origins, and annotate generic instantiations.
 - **Error messages**: If the emit phase detects a problem, it can report source locations via `WirMeta.span`.
-- **Debugging**: When investigating codegen issues, knowing where a type or function came from is critical. `WirName.fq` carries the module origin; `WirMeta.span` carries the source location.
+- **Debugging**: When investigating codegen issues, knowing where a type or function came from is critical. `WirMeta.module_source` provides structured access (`is_core()`, `is_wasi()`, etc.); `WirName.fq` provides the serialized identity.
 - **Newtypes**: Resolved by the WIR phase (a `Meters` field is `F64` in WIR), but `newtype_origin` records that it was `Meters` from `./physics.wado`. This avoids polluting the emit phase with newtype logic while keeping debug info.
 
 The metadata is lightweight (references and optional fields) and does not affect WIR→Wasm correctness.

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -350,12 +350,12 @@ pub enum WirAbstractHeapType {
 pub struct WirFunction {
     /// Function name (for name section and local references)
     pub name: String,
-    /// Type reference (function signature)
+    /// Type reference (function signature — param types and result types)
     pub type_ref: WirTypeRef,
-    /// Parameters (named)
-    pub params: Vec<WirLocal>,
+    /// Parameter names (types come from the referenced WirFuncType)
+    pub param_names: Vec<String>,
     /// Body (None for imported functions)
-    pub body: Option<WirBody>,
+    pub body: Option<Vec<WirInstr>>,
     /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin
@@ -363,20 +363,9 @@ pub struct WirFunction {
     /// Effect requirements (for unparse display)
     pub effects: Vec<String>,
 }
-
-pub struct WirBody {
-    /// Locals declared in the body (in declaration order)
-    /// Unlike raw Wasm, locals can be declared inline at first use.
-    pub locals: Vec<WirLocal>,
-    /// Function body instructions
-    pub code: Vec<WirInstr>,
-}
-
-pub struct WirLocal {
-    pub name: String,
-    pub ty: WirType,
-}
 ```
+
+Locals are declared via `DeclareLocal` instructions in the body. There is no separate locals list — the emit phase collects all `DeclareLocal`s and pre-allocates them as Wasm locals.
 
 ### Instructions
 
@@ -395,8 +384,8 @@ pub enum WirInstr {
     LocalTee { name: String, value: Box<WirInstr> },
 
     // === Globals ===
-    GlobalGet { index: u32 },
-    GlobalSet { index: u32, value: Box<WirInstr> },
+    GlobalGet { name: String },
+    GlobalSet { name: String, value: Box<WirInstr> },
 
     // === Constants ===
     I32Const(i32),
@@ -536,10 +525,10 @@ pub enum WirInstr {
     // === GC: Struct ===
     /// struct.new with named type
     StructNew { type_name: String, fields: Vec<WirInstr> },
-    /// struct.get with named type and field
-    StructGet { type_name: String, field_name: String, field_index: u32, expr: Box<WirInstr> },
-    /// struct.set with named type and field
-    StructSet { type_name: String, field_name: String, field_index: u32, expr: Box<WirInstr>, value: Box<WirInstr> },
+    /// struct.get with named type and field (field index resolved by emitter)
+    StructGet { type_name: String, field_name: String, expr: Box<WirInstr> },
+    /// struct.set with named type and field (field index resolved by emitter)
+    StructSet { type_name: String, field_name: String, expr: Box<WirInstr>, value: Box<WirInstr> },
 
     // === GC: Array ===
     ArrayNew { type_name: String, init: Box<WirInstr>, len: Box<WirInstr> },
@@ -663,7 +652,15 @@ pub struct WirComponent {
 
 ### Names and References
 
-WIR uses **string names** for type and function references, not numeric indices. During emission, names are resolved to indices via lookup tables built during the emission pass. This keeps WIR readable and decoupled from index allocation order.
+WIR uses **string names** for all references, not numeric indices. During emission, names are resolved to indices via lookup tables built during the emission pass. This keeps WIR readable and decoupled from index allocation order.
+
+All named references in WIR:
+
+- **Types**: `WirTypeRef(String)` — struct, variant, array, func type names
+- **Functions**: `WirFuncRef(String)` — function names in `Call`, `RefFunc`
+- **Locals**: `String` — local variable names in `LocalGet`, `LocalSet`, `DeclareLocal`
+- **Globals**: `String` — global variable names in `GlobalGet`, `GlobalSet`
+- **Fields**: `String` — struct field names in `StructGet`, `StructSet` (resolved to field index by emitter)
 
 ```rust
 /// Type references use the type's name
@@ -816,18 +813,18 @@ Wasm is a stack machine, but flat instruction sequences are hard to inspect and 
 ```rust
 // WIR (tree): readable, inspectable
 I32Add(
-    StructGet { type_name: "Point", field_name: "x", field_index: 0, expr: LocalGet("self") },
-    StructGet { type_name: "Point", field_name: "y", field_index: 1, expr: LocalGet("self") },
+    StructGet { type_name: "Point", field_name: "x", expr: LocalGet("self") },
+    StructGet { type_name: "Point", field_name: "y", expr: LocalGet("self") },
 )
 
 // Unparse: Wado-style field access
 // i32.add(self.x, self.y)
 
-// Wasm (flat): requires mental stack tracking
+// Wasm (emitted): field indices resolved from type definition
 // local.get $self
-// struct.get $Point 0
+// struct.get $Point 0   ;; "x" → index 0
 // local.get $self
-// struct.get $Point 1
+// struct.get $Point 1   ;; "y" → index 1
 // i32.add
 ```
 
@@ -835,10 +832,12 @@ Flattening trees to stack-machine instructions is trivial (post-order traversal)
 
 ### Why Named References (Not Indices)?
 
-Using names keeps WIR independent of emission order:
+Using names **uniformly** for all references keeps WIR independent of emission order and self-documenting:
 
+- Types, functions, globals, locals, struct fields — all referenced by name
 - Type registration order can change without invalidating WIR
-- Functions can be reordered freely
+- Functions and globals can be reordered freely
+- Struct field indices are resolved from type definitions during emission
 - WIR is self-documenting (no need for a separate name section to read it)
 
 The cost is a name→index lookup during emission, which is O(1) with `IndexMap`.

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -33,12 +33,12 @@ Introduce **WIR (Wasm IR)** — a tree-structured intermediate representation be
 ### New Pipeline
 
 ```
-lower → optimize → wasm_plan → codegen(emit) → wasm binary
-                       ↓
-                   WirModule
+lower → optimize → wasm_plan → tir_to_wir → wir_emit → wasm binary
+                                    ↓
+                                WirModule (inspectable via dump --wir)
 ```
 
-The `wasm_plan` phase is expanded to produce a `WirModule` — a complete description of the Wasm module in WIR form. Codegen becomes a mechanical WIR → Wasm binary translation.
+`tir_to_wir` translates the optimized Project into a `WirModule` — a complete description of the Wasm module in WIR form. `wir_emit` translates `WirModule` into Wasm binary bytes. `wasm_plan` remains unchanged and provides `ComponentPlan` metadata consumed by `tir_to_wir`.
 
 ### What WIR Is
 
@@ -841,75 +841,152 @@ fn "copy_array"(src: ref Array<i32>) -> ref Array<i32> {
 
 ## Migration Plan
 
-The migration is incremental. Each step produces a working compiler.
+### Strategy: Strangler Fig Pattern
 
-### Preparation: Extract Submodules from codegen.rs
+The migration builds a complete WIR pipeline **alongside** the existing codegen, without modifying `codegen.rs`. Both pipelines consume the same `&Project` after `wasm_plan`. E2E tests validate the new pipeline against the same fixtures. Once all tests pass, the old codegen is replaced and deleted.
 
-Before introducing WIR, split codegen.rs into manageable files:
+```
+                                  ┌→ codegen → wasm binary (existing, untouched)
+lower → optimize → wasm_plan ─────┤
+                                  └→ tir_to_wir → wir_emit → wasm binary (new, tested in parallel)
+```
 
-- [ ] **Step 0a**: Extract `type_registration.rs` — the 15+ type registration phases from `build_main_module()` (lines 700–1365). This is pure analysis + `wasm_encoder` type section building. ~700 lines.
-- [ ] **Step 0b**: Extract `value_copy.rs` — `generate_value_copy()`, `generate_struct_copy()`, `generate_array_copy()`, `generate_variant_copy()`, `generate_option_copy()`, `needs_value_copy()`. ~500 lines.
-- [ ] **Step 0c**: Extract `match_codegen.rs` — `generate_match_expr()`, `generate_match_arms()`, `generate_match_br_table()`, `generate_match_pattern_check()`, `generate_match_pattern_binding()`, `analyze_for_br_table()`. ~600 lines.
-- [ ] **Step 0d**: Extract `cm_codegen.rs` — `generate_cm_effect_call()`, `generate_cm_resource_method_call()`, CM payload lowering functions. ~700 lines.
-- [ ] **Step 0e**: Extract `scalarization.rs` — `collect_scalarization_candidates()`, `preallocate_scalarized_locals()`, related analysis. ~300 lines.
-- [ ] **Step 0f**: Move `effect_wait` from `builtin.wado` to `internal.wado` — `generate_effect_wait()` in codegen is not a single Wasm instruction nor an external import; it is a multi-instruction sequence (if/call to `waitable_set_new`, `waitable_join`, `waitable_set_wait`, `subtask_drop`). Refactor it into a Wado function `internal::effect_wait(subtask: i32)` that takes the subtask handle as a parameter. The compiler generates `Call(internal::effect_wait, __subtask)` instead of inline expansion. This removes ~50 lines of hard-coded codegen logic and makes `builtin.wado` strictly 1:1 Wasm instructions or `#[canonical]` imports.
+This is a departure from the original plan that required decomposing `codegen.rs` first (Phase 0). That approach was:
 
-After this step, codegen.rs is split into ~6 files but the architecture is unchanged. This is pure refactoring.
+- **High risk**: modifying `codegen.rs` while it is the only backend
+- **Big-bang**: each step must produce identical output or tests break
+- **Previously attempted and abandoned**
 
-### Phase 1: Define WIR Data Structures
+The strangler fig approach eliminates these risks:
+
+- **Zero risk to existing tests**: `codegen.rs` is never modified, so all tests always pass
+- **No Phase 0**: `codegen.rs` decomposition is unnecessary since we never modify it
+- **Living reference**: `codegen.rs` serves as the "correct answer" throughout development
+- **Incremental progress**: each feature added to `tir_to_wir` makes more WIR E2E tests pass
+- **Inspectable**: `wado dump --wir --unparse` provides visibility into the new pipeline at all times
+
+### Phase 1: Scaffolding and Inspection
+
+Set up the WIR data structures, unparse output, and dump integration. No code generation yet.
 
 - [ ] **Step 1a**: Create `wir.rs` with the WIR data structure definitions (types, instructions, module structure). No code uses it yet.
-- [ ] **Step 1b**: Create `wir_unparse.rs` for WIR → pseudo-Wado output. Hook into `wado dump --wir --unparse`.
-- [ ] **Step 1c**: Add `--wir` flag to the dump command. Pipeline: TIR → (existing codegen analysis) → WIR → display.
+- [ ] **Step 1b**: Create `wir_unparse.rs` for WIR → pseudo-Wado output.
+- [ ] **Step 1c**: Add `--wir` flag to the dump command (`wado dump --wir --unparse`). Initially outputs an empty `WirModule`.
+- [ ] **Step 1d**: Move `effect_wait` from `builtin.wado` to `internal.wado` — `generate_effect_wait()` in codegen is a multi-instruction sequence. Refactor it into a Wado function `internal::effect_wait(subtask: i32)`. This removes hard-coded codegen logic and simplifies future WIR translation. (This is the only change that touches existing code, and it is a semantic no-op.)
 
-### Phase 2: WIR Emission for Function Bodies
+After this phase: `wado dump --wir --unparse` works but shows an empty module.
 
-The core migration: replace TIR expression codegen with WIR generation.
+### Phase 2: Parallel E2E Test Infrastructure
 
-- [ ] **Step 2a**: Create `tir_to_wir.rs` — translates TIR expressions to WIR instructions. This extracts the logic from `generate_expr()` but produces WIR nodes instead of `wasm_encoder::Instruction`.
-- [ ] **Step 2b**: Create `wir_emit.rs` — translates WIR instructions to `wasm_encoder::Instruction`. This is a mechanical mapping (WIR names → Wasm indices, WIR tree → flat instruction sequence).
-- [ ] **Step 2c**: Wire it together: `tir_to_wir` produces `WirFunction` bodies, `wir_emit` produces `wasm_encoder::Function`. The old `generate_expr()` / `generate_function()` can be replaced incrementally (one TirExprKind at a time).
-- [ ] **Step 2d**: Delete the old `generate_expr()` once all expression kinds are covered by `tir_to_wir` + `wir_emit`.
+Set up the mechanism to run the same E2E test fixtures through the WIR pipeline.
 
-### Phase 3: WIR Emission for Type Section
+- [ ] **Step 2a**: Create `compile_with_wir(&Project) -> Vec<u8>` in a new module. This is the WIR pipeline entry point: calls `tir_to_wir` → `wir_emit` and returns Wasm bytes. Initially returns a minimal valid Wasm component (stub).
+- [ ] **Step 2b**: Create `tests/wir_e2e.rs` — a parallel E2E test harness that uses `compile_with_wir` instead of `Codegen::generate_wasm`. Same fixtures, same `__DATA__` specs. Gated by `WADO_WIR_TEST=1` so normal `make test` is unaffected.
+- [ ] **Step 2c**: Add a progress tracking mechanism — e.g., a test that counts how many fixtures pass vs. fail through the WIR pipeline, printed as a summary.
 
-- [ ] **Step 3a**: Move type layout decisions into WIR generation. The 15+ type registration phases produce `Vec<WirTypeDef>` (structs, variants, enums, flags, arrays, func types) instead of calling `wasm_encoder` directly.
-- [ ] **Step 3b**: `wir_emit` translates `WirTypeDef` → Wasm type section entries. This includes expanding `WirVariantType` into base struct + subtype structs, and skipping `WirEnumType`/`WirFlagsType` (no Wasm type section entry needed).
-- [ ] **Step 3c**: Delete the old type registration code in codegen.
+After this phase: `WADO_WIR_TEST=1 cargo test --test wir_e2e` runs but all tests fail. The scaffolding for incremental progress is in place.
 
-### Phase 4: WIR Emission for Module Structure
+### Phase 3: Core Translation
 
-- [ ] **Step 4a**: Move import/export/global/data section generation to produce WIR structures.
-- [ ] **Step 4b**: Move Component Model wrapper generation to produce `WirComponent`.
-- [ ] **Step 4c**: `wir_emit` translates the complete `WirModule` → Wasm binary.
+The main implementation work. Build `tir_to_wir` and `wir_emit` incrementally. Each feature added makes more E2E tests pass.
 
-### Phase 5: Merge wasm_plan into WIR Generation
+#### Step 3a: Type Registration
 
-At this point, `wasm_plan` and `tir_to_wir` are doing related work. Consolidate:
+Translate TIR type definitions to `Vec<WirTypeDef>`. Implement `wir_emit` type section generation.
 
-- [ ] **Step 5a**: Move `ComponentPlan` generation into WIR generation (it becomes `WirComponent`).
-- [ ] **Step 5b**: The pipeline becomes: `optimize → wir_gen → wir_emit`.
-- [ ] **Step 5c**: Delete the separate `wasm_plan` phase. Its analysis functions (topological sort, etc.) move into `wir_gen` or stay as utilities.
+- [ ] Struct types (fields, mutability, GC layout)
+- [ ] Variant types (base struct + case subtypes)
+- [ ] Enum types (i32 discriminant, no Wasm type entry)
+- [ ] Flags types (i32 bitfield, no Wasm type entry)
+- [ ] Array types (element type, mutability)
+- [ ] Tuple types (anonymous structs)
+- [ ] Closure types (funcref + captured environment struct)
+- [ ] Function types
+- [ ] Rec groups and topological sorting
 
-### Phase 6 (Future): Optimizer Migration
+#### Step 3b: Module Skeleton
+
+Translate module-level structure to `WirModule`.
+
+- [ ] Import section (WASI functions, bundled modules)
+- [ ] Global variables
+- [ ] Data section (string literals)
+- [ ] Element section (funcref tables)
+- [ ] Export section
+- [ ] Name section
+
+#### Step 3c: Function Bodies — Basics
+
+Implement `tir_to_wir` expression translation for core constructs.
+
+- [ ] Constants (i32, i64, f32, f64)
+- [ ] Local variables (get, set, tee, declare)
+- [ ] Arithmetic (i32, i64, f32, f64 — all operators)
+- [ ] Comparison and logical operators
+- [ ] Type casts and conversions
+- [ ] Block, Loop, If/Else, Br, BrIf, BrTable
+- [ ] Return, Unreachable, Nop, Drop
+- [ ] Function calls (direct)
+
+#### Step 3d: Function Bodies — GC and Compound
+
+- [ ] Struct construction (struct.new)
+- [ ] Field access (struct.get) and assignment (struct.set)
+- [ ] Array operations (new, get, set, len, copy, fill)
+- [ ] Reference operations (ref.null, ref.test, ref.cast, ref.eq)
+- [ ] Value copy (ValueCopy compound instruction)
+- [ ] Match expressions (pattern dispatch, br_table optimization)
+- [ ] Closure creation and call_ref
+- [ ] Global get/set
+
+#### Step 3e: Function Bodies — WASI and CM
+
+- [ ] CM effect calls (canonical lift/lower)
+- [ ] CM resource method calls
+- [ ] CM payload lowering (string, list, record, variant, option, result)
+- [ ] CM export glue functions
+- [ ] Async CM (subtask handling, waitable sets)
+
+#### Step 3f: Component Model Wrapper
+
+Translate `ComponentPlan` to `WirComponent` and emit the CM wrapper.
+
+- [ ] WASI interface imports
+- [ ] Bundled module instantiation (fts, libm)
+- [ ] Core module + component composition
+- [ ] World export declarations
+
+After this phase: all (or nearly all) E2E tests pass through the WIR pipeline.
+
+### Phase 4: Cutover
+
+Once all E2E tests pass via the WIR pipeline:
+
+- [ ] **Step 4a**: Verify behavioral equivalence across all fixtures and optimization levels.
+- [ ] **Step 4b**: Replace `Codegen::generate_wasm` calls in `compile_with_options` with `compile_with_wir`.
+- [ ] **Step 4c**: Delete `codegen.rs` and `copy_context.rs`.
+- [ ] **Step 4d**: Promote `tests/wir_e2e.rs` to be the primary `e2e.rs` (or remove it if identical).
+- [ ] **Step 4e**: Merge `wasm_plan` analysis into `tir_to_wir` where appropriate. The pipeline becomes: `optimize → tir_to_wir → wir_emit`.
+
+### Phase 5 (Future): Optimizer Migration
 
 After WIR is stable, migrate low-level optimizations from TIR to WIR:
 
-- [ ] **Step 6a**: Move constant folding to `wir_optimize`. Pattern: `I32Add(I32Const, I32Const)` → `I32Const`. No TIR dependency.
-- [ ] **Step 6b**: Move LICM to `wir_optimize`. Pattern: `Loop` + `StructGet` on non-modified locals. No TIR dependency.
-- [ ] **Step 6c**: Move ValueCopy analysis from `optimize_rewrite.rs` to `wir_gen`. Fresh value detection and copy type resolution happen during WIR generation instead of as a post-optimization rewrite. Remove `needed_copy_types`, `copy_source_types`, and `Move` from `TirFunction`.
-- [ ] **Step 6d**: Move `CopyContext` (scratch local pre-allocation) from codegen to `wir_emit`. WIR uses named locals, so pre-allocation is purely an emission concern.
-- [ ] **Step 6e**: Add peephole optimizations in `wir_optimize` (redundant `LocalSet`/`LocalGet` elimination, dead `Drop` removal, etc.).
+- [ ] **Step 5a**: Move constant folding to `wir_optimize`. Pattern: `I32Add(I32Const, I32Const)` → `I32Const`. No TIR dependency.
+- [ ] **Step 5b**: Move LICM to `wir_optimize`. Pattern: `Loop` + `StructGet` on non-modified locals. No TIR dependency.
+- [ ] **Step 5c**: Move ValueCopy analysis from `optimize_rewrite.rs` to `tir_to_wir`. Fresh value detection and copy type resolution happen during WIR generation instead of as a post-optimization rewrite. Remove `needed_copy_types`, `copy_source_types`, and `Move` from `TirFunction`.
+- [ ] **Step 5d**: Move `CopyContext` (scratch local pre-allocation) into `wir_emit`. WIR uses named locals, so pre-allocation is purely an emission concern.
+- [ ] **Step 5e**: Add peephole optimizations in `wir_optimize` (redundant `LocalSet`/`LocalGet` elimination, dead `Drop` removal, etc.).
 
 ### Final State
 
 ```
-lower → optimize → wir_gen → wir_emit → wasm binary
-                      ↓
-                  WirModule (inspectable via dump --wir)
+lower → optimize → tir_to_wir → wir_emit → wasm binary
+                        ↓
+                    WirModule (inspectable via dump --wir)
 ```
 
-- `wir_gen` (~5000 lines): TIR + Project → WirModule. All analysis, type layout, function translation, ValueCopy insertion.
+- `tir_to_wir` (~5000 lines): TIR + Project → WirModule. All analysis, type layout, function translation, ValueCopy insertion.
 - `wir_emit` (~2000 lines): WirModule → Wasm binary. Mechanical translation, index allocation, `wasm_encoder` calls, CopyContext local pre-allocation.
 - `wir.rs` (~500 lines): Data structure definitions.
 - `wir_unparse.rs` (~500 lines): WIR → pseudo-Wado for debugging.
@@ -917,13 +994,13 @@ lower → optimize → wir_gen → wir_emit → wasm binary
 #### Future State (with optimizer migration)
 
 ```
-lower → tir_optimize → wir_gen → wir_optimize → wir_emit → wasm binary
-                           ↓
-                       WirModule (inspectable via dump --wir)
+lower → tir_optimize → tir_to_wir → wir_optimize → wir_emit → wasm binary
+                             ↓
+                         WirModule (inspectable via dump --wir)
 ```
 
 - `tir_optimize`: Semantic optimizations (inlining, DCE, SROA, ref-elim, copy-prop). Operates on TIR with full TypeTable access.
-- `wir_gen`: TIR → WirModule. Includes ValueCopy insertion (freshness analysis + copy type resolution).
+- `tir_to_wir`: TIR → WirModule. Includes ValueCopy insertion (freshness analysis + copy type resolution).
 - `wir_optimize`: Wasm-level optimizations (constant folding, LICM, peephole). Operates on WIR where types are embedded in instruction names.
 - `wir_emit`: WirModule → Wasm binary. CopyContext, index allocation, `wasm_encoder` calls.
 
@@ -1018,8 +1095,8 @@ The metadata is lightweight (references and optional fields) and does not affect
 The current optimizer runs entirely on TIR. The long-term plan is to split optimizations into two levels:
 
 ```
-Current:  lower → optimize → wir_gen → wir_emit
-Future:   lower → tir_optimize → wir_gen → wir_optimize → wir_emit
+Current:  lower → optimize → tir_to_wir → wir_emit
+Future:   lower → tir_optimize → tir_to_wir → wir_optimize → wir_emit
 ```
 
 #### Responsibility Split
@@ -1042,7 +1119,7 @@ Future:   lower → tir_optimize → wir_gen → wir_optimize → wir_emit
 
 WIR does not need to carry `is_mut`, `address_taken_locals`, or `TypeTable` — those are only needed by semantic optimizations that stay on TIR. WIR-level optimizations rely on information already embedded in instruction names and structure.
 
-#### ValueCopy Belongs in `wir_gen`, Not the Optimizer
+#### ValueCopy Belongs in `tir_to_wir`, Not the Optimizer
 
 The current `optimize_rewrite.rs` performs three tasks that are not optimizations:
 
@@ -1052,10 +1129,10 @@ The current `optimize_rewrite.rs` performs three tasks that are not optimization
 
 These are **lowering concerns** — they implement Wasm GC value semantics, not performance optimizations. They are placed in the optimizer solely because they must run after inlining stabilizes function bodies.
 
-In the future pipeline, these move into `wir_gen`:
+In the future pipeline, these move into `tir_to_wir`:
 
-- `wir_gen` emits `ValueCopy { type_name, source_type, expr }` for non-fresh assignments to value types
-- `wir_gen` omits `ValueCopy` for fresh values (the TIR `Move` wrapper or WIR-level freshness analysis)
+- `tir_to_wir` emits `ValueCopy { type_name, source_type, expr }` for non-fresh assignments to value types
+- `tir_to_wir` omits `ValueCopy` for fresh values (the TIR `Move` wrapper or WIR-level freshness analysis)
 - The `ValueCopy` compound instruction carries its own `WirCopyType`, which `wir_emit` lowers to copy instructions
 - `CopyContext` (scratch local pre-allocation) moves entirely into `wir_emit`, since WIR uses named locals and index allocation is an emission concern
 
@@ -1082,4 +1159,4 @@ This eliminates the current coupling between the optimizer and codegen via `need
 
 - **Scope creep**: WIR should stay close to Wasm. Resist adding high-level abstractions.
 - **`WirTypeId` is not `Copy`**: `Rc<str>` prevents `Copy`. Mitigated by cheap `Clone` (non-atomic refcount increment) and instructions being heap-allocated (`Box<WirInstr>`) regardless.
-- **Incomplete migration**: If migration stalls midway, we'd have two code paths. Mitigated by the incremental approach where each step is a complete working state.
+- **Two code paths during migration**: The strangler fig approach intentionally maintains two pipelines (`codegen` and `tir_to_wir` + `wir_emit`) until cutover. This is safe because the existing pipeline is never modified — it always produces correct output. The new pipeline is tested independently via `wir_e2e.rs`. The risk is that migration stalls and the duplicate code persists indefinitely; mitigated by Phase 2's progress tracking which gives clear visibility into how close the WIR pipeline is to completion.

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -559,6 +559,12 @@ pub enum WirInstr {
     I64TruncF32U(Box<WirInstr>),
     I64ReinterpretF64(Box<WirInstr>),
 
+    // === Arithmetic (i128 via i64 pairs, Wasm 3.0) ===
+    I64Add128(Box<WirInstr>, Box<WirInstr>, Box<WirInstr>, Box<WirInstr>),
+    I64Sub128(Box<WirInstr>, Box<WirInstr>, Box<WirInstr>, Box<WirInstr>),
+    I64MulWideU(Box<WirInstr>, Box<WirInstr>),
+    I64MulWideS(Box<WirInstr>, Box<WirInstr>),
+
     // === Arithmetic (f32) ===
     F32Add(Box<WirInstr>, Box<WirInstr>),
     F32Sub(Box<WirInstr>, Box<WirInstr>),
@@ -683,7 +689,13 @@ pub enum WirInstr {
     MemorySize,
     MemoryGrow(Box<WirInstr>),
     I32Load { offset: u64, align: u32, addr: Box<WirInstr> },
+    I32Load8U { offset: u64, align: u32, addr: Box<WirInstr> },
+    I32Load8S { offset: u64, align: u32, addr: Box<WirInstr> },
+    I32Load16U { offset: u64, align: u32, addr: Box<WirInstr> },
+    I32Load16S { offset: u64, align: u32, addr: Box<WirInstr> },
     I32Store { offset: u64, align: u32, addr: Box<WirInstr>, value: Box<WirInstr> },
+    I32Store8 { offset: u64, align: u32, addr: Box<WirInstr>, value: Box<WirInstr> },
+    I32Store16 { offset: u64, align: u32, addr: Box<WirInstr>, value: Box<WirInstr> },
     I64Load { offset: u64, align: u32, addr: Box<WirInstr> },
     I64Store { offset: u64, align: u32, addr: Box<WirInstr>, value: Box<WirInstr> },
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -26,6 +26,8 @@ lower → optimize → wasm_plan → codegen → wasm binary
 
 `codegen` receives TIR + metadata and produces Wasm bytes in one monolithic pass. There is no inspectable intermediate form between TIR and binary.
 
+A complementary approach — [TIR-Level CM Adapter Synthesis](./wep-2026-02-15-cm-adapter-synthesis.md) — can reduce the CM-specific surface area of codegen independently and before WIR migration, by moving CM boundary logic into synthesized TIR functions that flow through the normal pipeline.
+
 ## Decision
 
 Introduce **WIR (Wasm IR)** — a tree-structured intermediate representation between TIR and Wasm binary. WIR is close to Wasm semantics but retains enough high-level information to be readable and debuggable.
@@ -940,6 +942,10 @@ Implement `tir_to_wir` expression translation for core constructs.
 - [ ] Global get/set
 
 #### Step 3e: Function Bodies — WASI and CM
+
+If [TIR-Level CM Adapter Synthesis](./wep-2026-02-15-cm-adapter-synthesis.md) is completed before this step, CM adapter functions are already ordinary TIR functions — `tir_to_wir` handles them like any other function, and this step is largely unnecessary. Only the raw CM call builtins (`builtin::cm_raw_call__*`) need WIR-level support.
+
+Without CM adapter synthesis, the following must be handled:
 
 - [ ] CM effect calls (canonical lift/lower)
 - [ ] CM resource method calls

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -125,13 +125,13 @@ pub struct WirName {
 
 Examples:
 
-| Entity | `display` | `fq` |
-| ------ | --------- | ---- |
-| Struct Point from entry | `Point` | `<entry>//Point` |
-| Array<i32> from prelude | `Array<i32>` | `core:prelude//Array<i32>` |
-| Method Point::sum | `Point::sum` | `./geometry.wado/Point::sum` |
-| Global counter | `counter` | `<entry>//counter` |
-| Enum Ordering from prelude | `Ordering` | `core:prelude//Ordering` |
+| Entity                     | `display`    | `fq`                         |
+| -------------------------- | ------------ | ---------------------------- |
+| Struct Point from entry    | `Point`      | `<entry>//Point`             |
+| Array<i32> from prelude    | `Array<i32>` | `core:prelude//Array<i32>`   |
+| Method Point::sum          | `Point::sum` | `./geometry.wado/Point::sum` |
+| Global counter             | `counter`    | `<entry>//counter`           |
+| Enum Ordering from prelude | `Ordering`   | `core:prelude//Ordering`     |
 
 `WirName` is used on **definitions** (low frequency):
 
@@ -186,13 +186,13 @@ For both types:
 
 `tir_to_wir` creates name→ID maps during type and function registration. When generating instructions, it embeds the pre-resolved ID. `wir_emit` builds `WirTypeId.index → Wasm type index` and `WirFuncId.index → Wasm func index` tables once, then resolves every reference via O(1) integer indexing.
 
-| Property | `WirName` (definitions) | `WirTypeId` / `WirFuncId` (instructions) |
-| --- | --- | --- |
-| Eq / Hash | O(n) string hash | O(1) integer |
-| Clone | O(n) string copy | O(1) Rc refcount |
-| Debug | shows display name | shows fq name |
-| Stack size | 48 bytes (2× String) | 24 bytes (u32 + Rc\<str\>) |
-| Used in | Type/function definitions | Instructions (high frequency) |
+| Property   | `WirName` (definitions)   | `WirTypeId` / `WirFuncId` (instructions) |
+| ---------- | ------------------------- | ---------------------------------------- |
+| Eq / Hash  | O(n) string hash          | O(1) integer                             |
+| Clone      | O(n) string copy          | O(1) Rc refcount                         |
+| Debug      | shows display name        | shows fq name                            |
+| Stack size | 48 bytes (2× String)      | 24 bytes (u32 + Rc\<str\>)               |
+| Used in    | Type/function definitions | Instructions (high frequency)            |
 
 ### Metadata
 
@@ -761,13 +761,13 @@ pub struct WirComponent {
 
 WIR uses three reference mechanisms depending on frequency and scope:
 
-| Scope | Reference type | Used in | Eq / Hash |
-| ----- | -------------- | ------- | --------- |
-| Types (in instructions) | `WirTypeId` | `StructGet`, `ArrayNew`, `RefCast`, `CallRef`, etc. | O(1) integer |
-| Functions (in instructions) | `WirFuncId` | `Call`, `RefFunc` | O(1) integer |
-| Definitions | `WirName` | `WirStructType.name`, `WirFunction.name`, `WirGlobal.name` | O(n) string |
-| Globals (in instructions) | `WirName` | `GlobalGet`, `GlobalSet` | O(n) string |
-| Local scope | `String` | `LocalGet`, `StructGet.field_name`, labels, case names | N/A |
+| Scope                       | Reference type | Used in                                                    | Eq / Hash    |
+| --------------------------- | -------------- | ---------------------------------------------------------- | ------------ |
+| Types (in instructions)     | `WirTypeId`    | `StructGet`, `ArrayNew`, `RefCast`, `CallRef`, etc.        | O(1) integer |
+| Functions (in instructions) | `WirFuncId`    | `Call`, `RefFunc`                                          | O(1) integer |
+| Definitions                 | `WirName`      | `WirStructType.name`, `WirFunction.name`, `WirGlobal.name` | O(n) string  |
+| Globals (in instructions)   | `WirName`      | `GlobalGet`, `GlobalSet`                                   | O(n) string  |
+| Local scope                 | `String`       | `LocalGet`, `StructGet.field_name`, labels, case names     | N/A          |
 
 Type and function references in instructions use `WirTypeId` / `WirFuncId` because they are high-frequency (every GC instruction and every call). Global variable references use `WirName` because they are comparatively rare. Local-scope names use plain `String` (no module qualification needed).
 
@@ -1067,20 +1067,20 @@ Wasm has only 4 numeric types: `i32`, `i64`, `f32`, `f64`. Wado has `bool`, `cha
 
 WIR keeps the Wado types and lets the emit phase lower them:
 
-| WIR Type      | As Wasm local (ValType) | As struct field (StorageType) |
-| ------------- | ----------------------- | ----------------------------- |
-| Bool          | i32                     | i8                            |
-| Char          | i32                     | i32                           |
-| I8            | i32                     | i8                            |
-| U8            | i32                     | i8                            |
-| I16           | i32                     | i16                           |
-| U16           | i32                     | i16                           |
-| I32, U32      | i32                     | i32                           |
-| I64, U64      | i64                     | i64                           |
-| F32           | f32                     | f32                           |
-| F64           | f64                     | f64                           |
-| Enum { .. }   | i32                     | i32                           |
-| Flags { .. }  | i32                     | i32                           |
+| WIR Type     | As Wasm local (ValType) | As struct field (StorageType) |
+| ------------ | ----------------------- | ----------------------------- |
+| Bool         | i32                     | i8                            |
+| Char         | i32                     | i32                           |
+| I8           | i32                     | i8                            |
+| U8           | i32                     | i8                            |
+| I16          | i32                     | i16                           |
+| U16          | i32                     | i16                           |
+| I32, U32     | i32                     | i32                           |
+| I64, U64     | i64                     | i64                           |
+| F32          | f32                     | f32                           |
+| F64          | f64                     | f64                           |
+| Enum { .. }  | i32                     | i32                           |
+| Flags { .. } | i32                     | i32                           |
 
 This eliminates the `ValType`/`StorageType` split at the WIR level — there is just `WirType`. The emit phase knows the context (local vs. struct field) and picks the right Wasm encoding. It also makes unparse output more readable: `bool` instead of `i32`, `Color` instead of `i32`.
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -850,8 +850,9 @@ Before introducing WIR, split codegen.rs into manageable files:
 - [ ] **Step 0a**: Extract `type_registration.rs` — the 15+ type registration phases from `build_main_module()` (lines 700–1365). This is pure analysis + `wasm_encoder` type section building. ~700 lines.
 - [ ] **Step 0b**: Extract `value_copy.rs` — `generate_value_copy()`, `generate_struct_copy()`, `generate_array_copy()`, `generate_variant_copy()`, `generate_option_copy()`, `needs_value_copy()`. ~500 lines.
 - [ ] **Step 0c**: Extract `match_codegen.rs` — `generate_match_expr()`, `generate_match_arms()`, `generate_match_br_table()`, `generate_match_pattern_check()`, `generate_match_pattern_binding()`, `analyze_for_br_table()`. ~600 lines.
-- [ ] **Step 0d**: Extract `cm_codegen.rs` — `generate_cm_effect_call()`, `generate_cm_resource_method_call()`, `generate_effect_wait()`, CM payload lowering functions. ~800 lines.
+- [ ] **Step 0d**: Extract `cm_codegen.rs` — `generate_cm_effect_call()`, `generate_cm_resource_method_call()`, CM payload lowering functions. ~700 lines.
 - [ ] **Step 0e**: Extract `scalarization.rs` — `collect_scalarization_candidates()`, `preallocate_scalarized_locals()`, related analysis. ~300 lines.
+- [ ] **Step 0f**: Move `effect_wait` from `builtin.wado` to `internal.wado` — `generate_effect_wait()` in codegen is not a single Wasm instruction nor an external import; it is a multi-instruction sequence (if/call to `waitable_set_new`, `waitable_join`, `waitable_set_wait`, `subtask_drop`). Refactor it into a Wado function `internal::effect_wait(subtask: i32)` that takes the subtask handle as a parameter. The compiler generates `Call(internal::effect_wait, __subtask)` instead of inline expansion. This removes ~50 lines of hard-coded codegen logic and makes `builtin.wado` strictly 1:1 Wasm instructions or `#[canonical]` imports.
 
 After this step, codegen.rs is split into ~6 files but the architecture is unchanged. This is pure refactoring.
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -46,9 +46,11 @@ WIR is a tree-structured IR that maps almost 1:1 to Wasm instructions, but with 
 
 1. **Named locals**: Variables are referenced by name, not pre-allocated indices. Locals can be declared inline (no pre-allocation pass needed).
 2. **Named types**: Struct, enum, and variant types retain their source-level names and field/case names.
-3. **Structured control flow**: Blocks, loops, if/else are tree nodes (not flat instruction sequences with labels).
-4. **Explicit value copy**: Copy operations are explicit WIR nodes rather than inline instruction sequences.
-5. **Unparse support**: WIR can be rendered as pseudo-Wado for inspection via `wado dump --wir --unparse`.
+3. **Wado-level primitive types**: WIR uses `Bool`, `Char`, `I8`, `U8`, `I16`, `U16`, etc. instead of Wasm's `i32`-for-everything. The emit phase lowers to Wasm `ValType`/`StorageType`. This avoids the `ValType`/`StorageType` split at the WIR level and provides better debug output.
+4. **Structured control flow**: Blocks, loops, if/else are tree nodes (not flat instruction sequences with labels).
+5. **Explicit value copy**: Copy operations are explicit WIR nodes rather than inline instruction sequences.
+6. **TIR metadata preserved**: Module source, source spans, attributes, generic instantiation info, and newtype origin are carried through for debugging and unparse. Newtypes are resolved (a `Meters` is `f64` at the WIR level), but their origin is recorded.
+7. **Unparse support**: WIR can be rendered as pseudo-Wado for inspection via `wado dump --wir --unparse`.
 
 ### What WIR Is Not
 
@@ -89,6 +91,38 @@ pub struct WirModule {
 }
 ```
 
+### Metadata
+
+WIR preserves TIR metadata for debugging and unparse output, even when not needed for code emission.
+
+```rust
+/// Source location and origin metadata, carried through from TIR.
+pub struct WirMeta {
+    /// Which module this entity was defined in
+    pub module_source: Option<ModuleSource>,
+    /// Source span in the original Wado source
+    pub span: Option<Span>,
+    /// Attributes (e.g., #[hidden])
+    pub attributes: Vec<WirAttribute>,
+}
+
+/// Generic instantiation origin (e.g., Array<i32> from Array<T>)
+pub struct WirGenericOrigin {
+    /// Base generic name (e.g., "Array", "Box")
+    pub base_name: String,
+    /// Type arguments used for instantiation (e.g., ["i32"])
+    pub type_args: Vec<String>,
+}
+
+/// Newtype origin — when a type was originally a newtype alias
+pub struct WirNewtypeOrigin {
+    /// Newtype name (e.g., "Meters")
+    pub name: String,
+    /// Module where the newtype was defined
+    pub module_source: ModuleSource,
+}
+```
+
 ### Type Definitions
 
 ```rust
@@ -111,52 +145,78 @@ pub struct WirStructType {
     pub supertype: Option<WirTypeRef>,
     /// Whether this is a final type (no further subtypes allowed)
     pub is_final: bool,
+    /// Metadata (module source, span, attributes)
+    pub meta: WirMeta,
+    /// Generic instantiation origin (None for non-generic types)
+    pub generic_origin: Option<WirGenericOrigin>,
+    /// If this type was a newtype in the source (resolved by WIR phase)
+    pub newtype_origin: Option<WirNewtypeOrigin>,
 }
 
 pub struct WirField {
     /// Source-level field name (e.g., "x", "repr", "tag")
     pub name: String,
-    /// Wasm storage type
-    pub storage_type: WirStorageType,
+    /// WIR type (uses Wado-level primitives, not Wasm ValType)
+    pub ty: WirType,
     /// Whether this field is mutable
     pub mutable: bool,
 }
 
 pub struct WirArrayType {
     pub name: String,
-    pub element_type: WirStorageType,
+    pub element_type: WirType,
     pub mutable: bool,
+    pub meta: WirMeta,
+    pub generic_origin: Option<WirGenericOrigin>,
 }
 
 pub struct WirFuncType {
     pub name: String,
-    pub params: Vec<WirValType>,
-    pub results: Vec<WirValType>,
+    pub params: Vec<WirType>,
+    pub results: Vec<WirType>,
 }
 
 /// Reference to a type by name (resolved to index during emission)
 pub struct WirTypeRef(pub String);
 ```
 
-### Value Types
+### WIR Type System
+
+WIR uses **Wado-level primitive types**, not Wasm's `ValType`/`StorageType` split. This preserves semantic information for debugging and simplifies the type representation. The emit phase lowers `WirType` to the appropriate Wasm `ValType` or `StorageType` depending on context (local vs. struct field).
 
 ```rust
-/// Wasm value type — mirrors wasm_encoder::ValType but with named type refs.
-pub enum WirValType {
+/// WIR type — Wado-level primitives + GC references.
+///
+/// Unlike Wasm's ValType (i32/i64/f32/f64 only), WIR preserves the full
+/// Wado type distinctions. The emit phase lowers these:
+///   - I8/I16/U8/U16/Bool/Char → i32 (locals) or i8/i16 (packed struct fields)
+///   - I32/U32 → i32
+///   - I64/U64 → i64
+///   - F32 → f32
+///   - F64 → f64
+pub enum WirType {
+    // Signed integers
+    I8,
+    I16,
     I32,
     I64,
+    // Unsigned integers
+    U8,
+    U16,
+    U32,
+    U64,
+    // Floats
     F32,
     F64,
+    // Other primitives
+    Bool,
+    Char,
+    // Unit (no Wasm representation; zero-size)
+    Unit,
     /// Reference to a named GC type
     Ref { type_name: String, nullable: bool },
     /// Abstract reference type (anyref, funcref, etc.)
     AbstractRef { heap_type: WirAbstractHeapType, nullable: bool },
-}
-
-pub enum WirStorageType {
-    Val(WirValType),
-    I8,
-    I16,
 }
 
 pub enum WirAbstractHeapType {
@@ -183,6 +243,12 @@ pub struct WirFunction {
     pub params: Vec<WirLocal>,
     /// Body (None for imported functions)
     pub body: Option<WirBody>,
+    /// Metadata (module source, span, attributes)
+    pub meta: WirMeta,
+    /// Generic instantiation origin
+    pub generic_origin: Option<WirGenericOrigin>,
+    /// Effect requirements (for unparse display)
+    pub effects: Vec<String>,
 }
 
 pub struct WirBody {
@@ -195,7 +261,7 @@ pub struct WirBody {
 
 pub struct WirLocal {
     pub name: String,
-    pub ty: WirValType,
+    pub ty: WirType,
 }
 ```
 
@@ -207,7 +273,7 @@ WIR instructions are tree-structured where operands are child nodes, not stack v
 pub enum WirInstr {
     // === Locals ===
     /// Declare a new local variable inline (not in Wasm; lowered to pre-allocated local)
-    DeclareLocal { name: String, ty: WirValType },
+    DeclareLocal { name: String, ty: WirType },
     /// local.get by name
     LocalGet { name: String },
     /// local.set by name
@@ -390,11 +456,11 @@ pub enum WirInstr {
 
     // === Control Flow ===
     /// Block with optional label and result type
-    Block { label: Option<String>, result: Option<WirValType>, body: Vec<WirInstr> },
+    Block { label: Option<String>, result: Option<WirType>, body: Vec<WirInstr> },
     /// Loop with optional label
     Loop { label: Option<String>, body: Vec<WirInstr> },
     /// If/else with optional result type
-    If { condition: Box<WirInstr>, result: Option<WirValType>, then_body: Vec<WirInstr>, else_body: Option<Vec<WirInstr>> },
+    If { condition: Box<WirInstr>, result: Option<WirType>, then_body: Vec<WirInstr>, else_body: Option<Vec<WirInstr>> },
     /// Branch to label
     Br { depth: u32 },
     /// Conditional branch
@@ -410,7 +476,7 @@ pub enum WirInstr {
     /// Drop a value
     Drop(Box<WirInstr>),
     /// Select between two values
-    Select { condition: Box<WirInstr>, if_true: Box<WirInstr>, if_false: Box<WirInstr>, ty: Option<WirValType> },
+    Select { condition: Box<WirInstr>, if_true: Box<WirInstr>, if_false: Box<WirInstr>, ty: Option<WirType> },
 
     // === Calls ===
     Call { func_name: String, args: Vec<WirInstr> },
@@ -499,19 +565,25 @@ pub struct WirFuncRef(pub String);
 WIR supports `--unparse` to output pseudo-Wado/WAT hybrid for debugging:
 
 ```
-// Type definitions
-type Point = struct { x: i32, y: i32 }
-type Array<i32> = struct { repr: array<i32>, used: i32 }
+// Type definitions with metadata
+type Point = struct { x: i32, y: i32 }  // from ./geometry.wado
+type Meters = f64  // newtype from ./physics.wado
+type Array<i32> = struct { repr: array<i32>, used: i32 }  // Array<T> with T=i32
 
-// Function
-fn "example"(a: i32, b: i32) -> i32 {
+// Function with module source and effects
+fn "example"(a: i32, b: i32) -> i32 {  // from <entry>
     let result: i32;
     result = i32.add(a, b);
     return result;
 }
 
+// Wado-level types in signatures (bool, char, u8 etc.)
+fn "is_ascii"(c: char) -> bool {  // from ./utils.wado
+    return i32.lt_u(c, 128);
+}
+
 // GC operations shown with type names
-fn "Point::sum"(self: ref Point) -> i32 {
+fn "Point::sum"(self: ref Point) -> i32 {  // from ./geometry.wado
     return i32.add(
         struct.get Point.x(self),
         struct.get Point.y(self),
@@ -628,6 +700,38 @@ Value copy involves complex dispatching (struct copy, array loop, variant tag ch
 - Preserves the semantic intent ("copy this value")
 - Allows the emitter to choose the most efficient lowering strategy
 - Keeps `tir_to_wir` focused on semantics, not emission details
+
+### Why Wado-Level Primitives (Not Wasm ValType)?
+
+Wasm has only 4 numeric types: `i32`, `i64`, `f32`, `f64`. Wado has `bool`, `char`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `f32`, `f64`. In the current codegen, all the small types and `bool`/`char` are collapsed to `i32` early, losing semantic information.
+
+WIR keeps the Wado types and lets the emit phase lower them:
+
+| WIR Type | As Wasm local (ValType) | As struct field (StorageType) |
+| -------- | ----------------------- | ----------------------------- |
+| Bool     | i32                     | i8                            |
+| Char     | i32                     | i32                           |
+| I8       | i32                     | i8                            |
+| U8       | i32                     | i8                            |
+| I16      | i32                     | i16                           |
+| U16      | i32                     | i16                           |
+| I32, U32 | i32                     | i32                           |
+| I64, U64 | i64                     | i64                           |
+| F32      | f32                     | f32                           |
+| F64      | f64                     | f64                           |
+
+This eliminates the `ValType`/`StorageType` split at the WIR level — there is just `WirType`. The emit phase knows the context (local vs. struct field) and picks the right Wasm encoding. It also makes unparse output more readable: `bool` instead of `i32`, `char` instead of `i32`.
+
+### Why Preserve TIR Metadata?
+
+WIR carries metadata (module source, spans, attributes, generic origin, newtype origin) even though the emit phase does not need most of it. This is intentional:
+
+- **Unparse**: `wado dump --wir --unparse` can show `// from ./geometry.wado` comments, display newtype origins, and annotate generic instantiations.
+- **Error messages**: If the emit phase detects a problem, it can report source locations.
+- **Debugging**: When investigating codegen issues, knowing where a type or function came from is critical.
+- **Newtypes**: Resolved by the WIR phase (a `Meters` field is `F64` in WIR), but `newtype_origin` records that it was `Meters` from `./physics.wado`. This avoids polluting the emit phase with newtype logic while keeping debug info.
+
+The metadata is lightweight (references and optional fields) and does not affect WIR→Wasm correctness.
 
 ### Why Not a Separate Optimization Pass on WIR?
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -55,7 +55,7 @@ WIR is a tree-structured IR that maps almost 1:1 to Wasm instructions, but with 
 ### What WIR Is Not
 
 - **Not a CFG**: WIR preserves Wasm's structured control flow (block/loop/if), not a control-flow graph.
-- **Not an optimization target**: WIR is a lowering target. Optimizations happen on TIR before WIR generation.
+- **Not a semantic optimization target**: Semantic optimizations (inlining, SROA, reference elimination) happen on TIR where richer type information is available. WIR may host low-level Wasm optimizations (constant folding, LICM, peephole) in the future.
 - **Not an abstraction over Wasm versions**: WIR targets specific Wasm features (GC, Component Model). It does not abstract away Wasm details.
 
 ## WIR Data Structures
@@ -852,6 +852,16 @@ At this point, `wasm_plan` and `tir_to_wir` are doing related work. Consolidate:
 - [ ] **Step 5b**: The pipeline becomes: `optimize → wir_gen → wir_emit`.
 - [ ] **Step 5c**: Delete the separate `wasm_plan` phase. Its analysis functions (topological sort, etc.) move into `wir_gen` or stay as utilities.
 
+### Phase 6 (Future): Optimizer Migration
+
+After WIR is stable, migrate low-level optimizations from TIR to WIR:
+
+- [ ] **Step 6a**: Move constant folding to `wir_optimize`. Pattern: `I32Add(I32Const, I32Const)` → `I32Const`. No TIR dependency.
+- [ ] **Step 6b**: Move LICM to `wir_optimize`. Pattern: `Loop` + `StructGet` on non-modified locals. No TIR dependency.
+- [ ] **Step 6c**: Move ValueCopy analysis from `optimize_rewrite.rs` to `wir_gen`. Fresh value detection and copy type resolution happen during WIR generation instead of as a post-optimization rewrite. Remove `needed_copy_types`, `copy_source_types`, and `Move` from `TirFunction`.
+- [ ] **Step 6d**: Move `CopyContext` (scratch local pre-allocation) from codegen to `wir_emit`. WIR uses named locals, so pre-allocation is purely an emission concern.
+- [ ] **Step 6e**: Add peephole optimizations in `wir_optimize` (redundant `LocalSet`/`LocalGet` elimination, dead `Drop` removal, etc.).
+
 ### Final State
 
 ```
@@ -860,10 +870,23 @@ lower → optimize → wir_gen → wir_emit → wasm binary
                   WirModule (inspectable via dump --wir)
 ```
 
-- `wir_gen` (~5000 lines): TIR + Project → WirModule. All analysis, type layout, function translation.
-- `wir_emit` (~2000 lines): WirModule → Wasm binary. Mechanical translation, index allocation, `wasm_encoder` calls.
+- `wir_gen` (~5000 lines): TIR + Project → WirModule. All analysis, type layout, function translation, ValueCopy insertion.
+- `wir_emit` (~2000 lines): WirModule → Wasm binary. Mechanical translation, index allocation, `wasm_encoder` calls, CopyContext local pre-allocation.
 - `wir.rs` (~500 lines): Data structure definitions.
 - `wir_unparse.rs` (~500 lines): WIR → pseudo-Wado for debugging.
+
+#### Future State (with optimizer migration)
+
+```
+lower → tir_optimize → wir_gen → wir_optimize → wir_emit → wasm binary
+                           ↓
+                       WirModule (inspectable via dump --wir)
+```
+
+- `tir_optimize`: Semantic optimizations (inlining, DCE, SROA, ref-elim, copy-prop). Operates on TIR with full TypeTable access.
+- `wir_gen`: TIR → WirModule. Includes ValueCopy insertion (freshness analysis + copy type resolution).
+- `wir_optimize`: Wasm-level optimizations (constant folding, LICM, peephole). Operates on WIR where types are embedded in instruction names.
+- `wir_emit`: WirModule → Wasm binary. CopyContext, index allocation, `wasm_encoder` calls.
 
 ## Design Rationale
 
@@ -946,11 +969,53 @@ WIR carries metadata (module source, spans, attributes, generic origin, newtype 
 
 The metadata is lightweight (references and optional fields) and does not affect WIR→Wasm correctness.
 
-### Why Not a Separate Optimization Pass on WIR?
+### Future: Optimizer on WIR
 
-WIR is intentionally a thin layer. Optimizations belong on TIR where semantic information is richer. WIR's purpose is debuggability and separation of concerns, not optimization.
+The current optimizer runs entirely on TIR. The long-term plan is to split optimizations into two levels:
 
-If Wasm-level optimizations become needed (peephole, etc.), they can be added as a `wir_opt` pass later without changing the architecture.
+```
+Current:  lower → optimize → wir_gen → wir_emit
+Future:   lower → tir_optimize → wir_gen → wir_optimize → wir_emit
+```
+
+#### Responsibility Split
+
+**`tir_optimize` (semantic optimizations)** — remains on TIR where richer type information is available:
+
+- Inlining: requires purity analysis (`effects.is_empty()`), return type checks (`ResolvedType::Never`), nested generics detection (`has_nested_generics()`), expression counting
+- SROA: requires `Let` + `StructLiteral` pattern matching, `is_mut` on let bindings, escape analysis
+- Reference elimination: requires `Let` + `Ref(Local)` pattern, `address_taken_locals`, field access tracking
+- Copy propagation: requires `Let` + `Local/Literal` pattern, `is_mut`, use counting
+- DCE: works on both TIR and WIR, but entry point analysis uses TIR metadata
+
+**`wir_optimize` (Wasm-level optimizations)** — operates on WIR where types are embedded in instructions:
+
+- Constant folding: `I32Add(I32Const(1), I32Const(2))` → `I32Const(3)`. Type is encoded in instruction names — no TypeTable needed.
+- LICM: `Loop { body }` + `StructGet` hoisting. Modified locals detectable from `LocalSet`. Loop structure is explicit.
+- Peephole: redundant `LocalSet`/`LocalGet` pairs, dead `Drop`, etc.
+
+#### Why This Split Works
+
+WIR does not need to carry `is_mut`, `address_taken_locals`, or `TypeTable` — those are only needed by semantic optimizations that stay on TIR. WIR-level optimizations rely on information already embedded in instruction names and structure.
+
+#### ValueCopy Belongs in `wir_gen`, Not the Optimizer
+
+The current `optimize_rewrite.rs` performs three tasks that are not optimizations:
+
+1. **Fresh value detection** (`is_fresh_value()`): classifies whether an expression produces a new value (literal, call result, constructor) vs. referencing an existing value (local, field access)
+2. **Copy type collection** (`collect_value_copy_types_in_*()`): determines which types need deep copy operations
+3. **Move insertion** (`insert_moves_in_*()`): wraps fresh values in `Move { expr }` to suppress unnecessary copies
+
+These are **lowering concerns** — they implement Wasm GC value semantics, not performance optimizations. They are placed in the optimizer solely because they must run after inlining stabilizes function bodies.
+
+In the future pipeline, these move into `wir_gen`:
+
+- `wir_gen` emits `ValueCopy { type_name, source_type, expr }` for non-fresh assignments to value types
+- `wir_gen` omits `ValueCopy` for fresh values (the TIR `Move` wrapper or WIR-level freshness analysis)
+- The `ValueCopy` compound instruction carries its own `WirCopyType`, which `wir_emit` lowers to copy instructions
+- `CopyContext` (scratch local pre-allocation) moves entirely into `wir_emit`, since WIR uses named locals and index allocation is an emission concern
+
+This eliminates the current coupling between the optimizer and codegen via `needed_copy_types` / `copy_source_types` / `Move` on `TirFunction`.
 
 ## Consequences
 
@@ -967,7 +1032,7 @@ If Wasm-level optimizations become needed (peephole, etc.), they can be added as
 - **Additional IR**: One more representation to maintain. Mitigated by WIR being close to Wasm (not a novel abstraction).
 - **Memory**: WIR trees allocate more than flat instruction streams. Acceptable since Wado programs are not extremely large.
 - **Migration effort**: Incremental migration spans multiple steps. Each step is independently shippable.
-- **No Wasm-level optimization**: Intentional. TIR optimization is sufficient for now.
+- **No Wasm-level optimization yet**: TIR optimization is sufficient for now. A `wir_optimize` pass can be added later without architectural changes.
 
 ### Risks
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -1,0 +1,659 @@
+# WEP: Wasm IR (WIR) Layer
+
+## Context
+
+`codegen.rs` is 14,000+ lines and mixes three concerns:
+
+1. **Type layout decisions**: Mapping TIR types to Wasm GC types, registering struct/variant/array/tuple/closure types across 15+ phases with topological sorting and deferred registration
+2. **Function-level analysis**: Pre-allocating locals, scalarization analysis, scratch local computation, copy context setup
+3. **Instruction emission**: Translating TIR expressions to Wasm instructions
+
+The existing `wasm_plan` phase (WEP 2026-02-03) moved Component Model analysis out of codegen, but the core problem remains: codegen is doing extensive TIR-to-Wasm translation and analysis that is tangled with low-level `wasm_encoder` API calls. This makes it hard to:
+
+- Debug the compiler (no way to inspect the "planned" Wasm output before encoding)
+- Test codegen logic (analysis and emission are inseparable)
+- Add optimizations at the Wasm level (peephole, register allocation)
+- Understand what the compiler is doing (TIR → binary is a black box)
+
+### Current Pipeline
+
+```
+lower → optimize → wasm_plan → codegen → wasm binary
+                       ↓
+                   ComponentPlan
+                   CmExportInfo
+```
+
+`codegen` receives TIR + metadata and produces Wasm bytes in one monolithic pass. There is no inspectable intermediate form between TIR and binary.
+
+## Decision
+
+Introduce **WIR (Wasm IR)** — a tree-structured intermediate representation between TIR and Wasm binary. WIR is close to Wasm semantics but retains enough high-level information to be readable and debuggable.
+
+### New Pipeline
+
+```
+lower → optimize → wasm_plan → codegen(emit) → wasm binary
+                       ↓
+                   WirModule
+```
+
+The `wasm_plan` phase is expanded to produce a `WirModule` — a complete description of the Wasm module in WIR form. Codegen becomes a mechanical WIR → Wasm binary translation.
+
+### What WIR Is
+
+WIR is a tree-structured IR that maps almost 1:1 to Wasm instructions, but with these ergonomic improvements over raw Wasm:
+
+1. **Named locals**: Variables are referenced by name, not pre-allocated indices. Locals can be declared inline (no pre-allocation pass needed).
+2. **Named types**: Struct, enum, and variant types retain their source-level names and field/case names.
+3. **Structured control flow**: Blocks, loops, if/else are tree nodes (not flat instruction sequences with labels).
+4. **Explicit value copy**: Copy operations are explicit WIR nodes rather than inline instruction sequences.
+5. **Unparse support**: WIR can be rendered as pseudo-Wado for inspection via `wado dump --wir --unparse`.
+
+### What WIR Is Not
+
+- **Not a CFG**: WIR preserves Wasm's structured control flow (block/loop/if), not a control-flow graph.
+- **Not an optimization target**: WIR is a lowering target. Optimizations happen on TIR before WIR generation.
+- **Not an abstraction over Wasm versions**: WIR targets specific Wasm features (GC, Component Model). It does not abstract away Wasm details.
+
+## WIR Data Structures
+
+### Module Level
+
+```rust
+/// A complete Wasm module in WIR form.
+/// Contains all information needed to emit a valid Wasm binary.
+pub struct WirModule {
+    /// Type section: all Wasm GC types (structs, arrays, function types)
+    pub types: Vec<WirTypeDef>,
+    /// Rec groups: which types form recursive groups
+    pub rec_groups: Vec<WirRecGroup>,
+    /// Import section
+    pub imports: Vec<WirImport>,
+    /// Function declarations with bodies
+    pub functions: Vec<WirFunction>,
+    /// Global variables
+    pub globals: Vec<WirGlobal>,
+    /// Export section
+    pub exports: Vec<WirExport>,
+    /// Element section (for funcref tables)
+    pub elements: Vec<WirElement>,
+    /// Data section (string literals, etc.)
+    pub data: Vec<WirData>,
+    /// Branch hints (from likely/unlikely)
+    pub branch_hints: Vec<WirBranchHint>,
+    /// Name section entries
+    pub names: WirNames,
+    /// Component Model wrapper info
+    pub component: WirComponent,
+}
+```
+
+### Type Definitions
+
+```rust
+/// A Wasm GC type definition.
+pub enum WirTypeDef {
+    /// Struct type with named fields
+    Struct(WirStructType),
+    /// Array type
+    Array(WirArrayType),
+    /// Function type
+    Func(WirFuncType),
+}
+
+pub struct WirStructType {
+    /// Source-level name (e.g., "Point", "Array<i32>", "__Closure_3")
+    pub name: String,
+    /// Fields with names and types
+    pub fields: Vec<WirField>,
+    /// Supertype index (for variant subtypes)
+    pub supertype: Option<WirTypeRef>,
+    /// Whether this is a final type (no further subtypes allowed)
+    pub is_final: bool,
+}
+
+pub struct WirField {
+    /// Source-level field name (e.g., "x", "repr", "tag")
+    pub name: String,
+    /// Wasm storage type
+    pub storage_type: WirStorageType,
+    /// Whether this field is mutable
+    pub mutable: bool,
+}
+
+pub struct WirArrayType {
+    pub name: String,
+    pub element_type: WirStorageType,
+    pub mutable: bool,
+}
+
+pub struct WirFuncType {
+    pub name: String,
+    pub params: Vec<WirValType>,
+    pub results: Vec<WirValType>,
+}
+
+/// Reference to a type by name (resolved to index during emission)
+pub struct WirTypeRef(pub String);
+```
+
+### Value Types
+
+```rust
+/// Wasm value type — mirrors wasm_encoder::ValType but with named type refs.
+pub enum WirValType {
+    I32,
+    I64,
+    F32,
+    F64,
+    /// Reference to a named GC type
+    Ref { type_name: String, nullable: bool },
+    /// Abstract reference type (anyref, funcref, etc.)
+    AbstractRef { heap_type: WirAbstractHeapType, nullable: bool },
+}
+
+pub enum WirStorageType {
+    Val(WirValType),
+    I8,
+    I16,
+}
+
+pub enum WirAbstractHeapType {
+    Any,
+    Eq,
+    Struct,
+    Array,
+    Func,
+    None,
+    NoFunc,
+    Extern,
+}
+```
+
+### Functions
+
+```rust
+pub struct WirFunction {
+    /// Function name (for name section and local references)
+    pub name: String,
+    /// Type reference (function signature)
+    pub type_ref: WirTypeRef,
+    /// Parameters (named)
+    pub params: Vec<WirLocal>,
+    /// Body (None for imported functions)
+    pub body: Option<WirBody>,
+}
+
+pub struct WirBody {
+    /// Locals declared in the body (in declaration order)
+    /// Unlike raw Wasm, locals can be declared inline at first use.
+    pub locals: Vec<WirLocal>,
+    /// Function body instructions
+    pub code: Vec<WirInstr>,
+}
+
+pub struct WirLocal {
+    pub name: String,
+    pub ty: WirValType,
+}
+```
+
+### Instructions
+
+WIR instructions are tree-structured where operands are child nodes, not stack values. This makes the structure inspectable and allows inline local declaration.
+
+```rust
+pub enum WirInstr {
+    // === Locals ===
+    /// Declare a new local variable inline (not in Wasm; lowered to pre-allocated local)
+    DeclareLocal { name: String, ty: WirValType },
+    /// local.get by name
+    LocalGet { name: String },
+    /// local.set by name
+    LocalSet { name: String, value: Box<WirInstr> },
+    /// local.tee by name
+    LocalTee { name: String, value: Box<WirInstr> },
+
+    // === Globals ===
+    GlobalGet { index: u32 },
+    GlobalSet { index: u32, value: Box<WirInstr> },
+
+    // === Constants ===
+    I32Const(i32),
+    I64Const(i64),
+    F32Const(f32),
+    F64Const(f64),
+
+    // === Arithmetic (i32) ===
+    I32Add(Box<WirInstr>, Box<WirInstr>),
+    I32Sub(Box<WirInstr>, Box<WirInstr>),
+    I32Mul(Box<WirInstr>, Box<WirInstr>),
+    I32DivS(Box<WirInstr>, Box<WirInstr>),
+    I32DivU(Box<WirInstr>, Box<WirInstr>),
+    I32RemS(Box<WirInstr>, Box<WirInstr>),
+    I32RemU(Box<WirInstr>, Box<WirInstr>),
+    I32And(Box<WirInstr>, Box<WirInstr>),
+    I32Or(Box<WirInstr>, Box<WirInstr>),
+    I32Xor(Box<WirInstr>, Box<WirInstr>),
+    I32Shl(Box<WirInstr>, Box<WirInstr>),
+    I32ShrS(Box<WirInstr>, Box<WirInstr>),
+    I32ShrU(Box<WirInstr>, Box<WirInstr>),
+    I32Eqz(Box<WirInstr>),
+    I32Eq(Box<WirInstr>, Box<WirInstr>),
+    I32Ne(Box<WirInstr>, Box<WirInstr>),
+    I32LtS(Box<WirInstr>, Box<WirInstr>),
+    I32LtU(Box<WirInstr>, Box<WirInstr>),
+    I32GtS(Box<WirInstr>, Box<WirInstr>),
+    I32GtU(Box<WirInstr>, Box<WirInstr>),
+    I32LeS(Box<WirInstr>, Box<WirInstr>),
+    I32LeU(Box<WirInstr>, Box<WirInstr>),
+    I32GeS(Box<WirInstr>, Box<WirInstr>),
+    I32GeU(Box<WirInstr>, Box<WirInstr>),
+    I32WrapI64(Box<WirInstr>),
+    I32Clz(Box<WirInstr>),
+    I32Ctz(Box<WirInstr>),
+    I32Popcnt(Box<WirInstr>),
+    I32TruncF64S(Box<WirInstr>),
+    I32TruncF64U(Box<WirInstr>),
+    I32TruncF32S(Box<WirInstr>),
+    I32TruncF32U(Box<WirInstr>),
+    I32ReinterpretF32(Box<WirInstr>),
+    I32Extend8S(Box<WirInstr>),
+    I32Extend16S(Box<WirInstr>),
+
+    // === Arithmetic (i64) ===
+    I64Add(Box<WirInstr>, Box<WirInstr>),
+    I64Sub(Box<WirInstr>, Box<WirInstr>),
+    I64Mul(Box<WirInstr>, Box<WirInstr>),
+    I64DivS(Box<WirInstr>, Box<WirInstr>),
+    I64DivU(Box<WirInstr>, Box<WirInstr>),
+    I64RemS(Box<WirInstr>, Box<WirInstr>),
+    I64RemU(Box<WirInstr>, Box<WirInstr>),
+    I64And(Box<WirInstr>, Box<WirInstr>),
+    I64Or(Box<WirInstr>, Box<WirInstr>),
+    I64Xor(Box<WirInstr>, Box<WirInstr>),
+    I64Shl(Box<WirInstr>, Box<WirInstr>),
+    I64ShrS(Box<WirInstr>, Box<WirInstr>),
+    I64ShrU(Box<WirInstr>, Box<WirInstr>),
+    I64Eqz(Box<WirInstr>),
+    I64Eq(Box<WirInstr>, Box<WirInstr>),
+    I64Ne(Box<WirInstr>, Box<WirInstr>),
+    I64LtS(Box<WirInstr>, Box<WirInstr>),
+    I64LtU(Box<WirInstr>, Box<WirInstr>),
+    I64GtS(Box<WirInstr>, Box<WirInstr>),
+    I64GtU(Box<WirInstr>, Box<WirInstr>),
+    I64LeS(Box<WirInstr>, Box<WirInstr>),
+    I64LeU(Box<WirInstr>, Box<WirInstr>),
+    I64GeS(Box<WirInstr>, Box<WirInstr>),
+    I64GeU(Box<WirInstr>, Box<WirInstr>),
+    I64ExtendI32S(Box<WirInstr>),
+    I64ExtendI32U(Box<WirInstr>),
+    I64Clz(Box<WirInstr>),
+    I64Ctz(Box<WirInstr>),
+    I64Popcnt(Box<WirInstr>),
+    I64TruncF64S(Box<WirInstr>),
+    I64TruncF64U(Box<WirInstr>),
+    I64TruncF32S(Box<WirInstr>),
+    I64TruncF32U(Box<WirInstr>),
+    I64ReinterpretF64(Box<WirInstr>),
+
+    // === Arithmetic (f32) ===
+    F32Add(Box<WirInstr>, Box<WirInstr>),
+    F32Sub(Box<WirInstr>, Box<WirInstr>),
+    F32Mul(Box<WirInstr>, Box<WirInstr>),
+    F32Div(Box<WirInstr>, Box<WirInstr>),
+    F32Neg(Box<WirInstr>),
+    F32Abs(Box<WirInstr>),
+    F32Ceil(Box<WirInstr>),
+    F32Floor(Box<WirInstr>),
+    F32Trunc(Box<WirInstr>),
+    F32Nearest(Box<WirInstr>),
+    F32Sqrt(Box<WirInstr>),
+    F32Min(Box<WirInstr>, Box<WirInstr>),
+    F32Max(Box<WirInstr>, Box<WirInstr>),
+    F32Copysign(Box<WirInstr>, Box<WirInstr>),
+    F32Eq(Box<WirInstr>, Box<WirInstr>),
+    F32Ne(Box<WirInstr>, Box<WirInstr>),
+    F32Lt(Box<WirInstr>, Box<WirInstr>),
+    F32Gt(Box<WirInstr>, Box<WirInstr>),
+    F32Le(Box<WirInstr>, Box<WirInstr>),
+    F32Ge(Box<WirInstr>, Box<WirInstr>),
+    F32ConvertI32S(Box<WirInstr>),
+    F32ConvertI32U(Box<WirInstr>),
+    F32ConvertI64S(Box<WirInstr>),
+    F32ConvertI64U(Box<WirInstr>),
+    F32DemoteF64(Box<WirInstr>),
+    F32ReinterpretI32(Box<WirInstr>),
+
+    // === Arithmetic (f64) ===
+    F64Add(Box<WirInstr>, Box<WirInstr>),
+    F64Sub(Box<WirInstr>, Box<WirInstr>),
+    F64Mul(Box<WirInstr>, Box<WirInstr>),
+    F64Div(Box<WirInstr>, Box<WirInstr>),
+    F64Neg(Box<WirInstr>),
+    F64Abs(Box<WirInstr>),
+    F64Ceil(Box<WirInstr>),
+    F64Floor(Box<WirInstr>),
+    F64Trunc(Box<WirInstr>),
+    F64Nearest(Box<WirInstr>),
+    F64Sqrt(Box<WirInstr>),
+    F64Min(Box<WirInstr>, Box<WirInstr>),
+    F64Max(Box<WirInstr>, Box<WirInstr>),
+    F64Copysign(Box<WirInstr>, Box<WirInstr>),
+    F64Eq(Box<WirInstr>, Box<WirInstr>),
+    F64Ne(Box<WirInstr>, Box<WirInstr>),
+    F64Lt(Box<WirInstr>, Box<WirInstr>),
+    F64Gt(Box<WirInstr>, Box<WirInstr>),
+    F64Le(Box<WirInstr>, Box<WirInstr>),
+    F64Ge(Box<WirInstr>, Box<WirInstr>),
+    F64ConvertI32S(Box<WirInstr>),
+    F64ConvertI32U(Box<WirInstr>),
+    F64ConvertI64S(Box<WirInstr>),
+    F64ConvertI64U(Box<WirInstr>),
+    F64PromoteF32(Box<WirInstr>),
+    F64ReinterpretI64(Box<WirInstr>),
+
+    // === GC: Struct ===
+    /// struct.new with named type
+    StructNew { type_name: String, fields: Vec<WirInstr> },
+    /// struct.get with named type and field
+    StructGet { type_name: String, field_name: String, field_index: u32, expr: Box<WirInstr> },
+    /// struct.set with named type and field
+    StructSet { type_name: String, field_name: String, field_index: u32, expr: Box<WirInstr>, value: Box<WirInstr> },
+
+    // === GC: Array ===
+    ArrayNew { type_name: String, init: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayNewDefault { type_name: String, len: Box<WirInstr> },
+    ArrayNewData { type_name: String, data_index: u32, offset: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayNewFixed { type_name: String, elements: Vec<WirInstr> },
+    ArrayGet { type_name: String, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArrayGetS { type_name: String, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArrayGetU { type_name: String, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArraySet { type_name: String, array: Box<WirInstr>, index: Box<WirInstr>, value: Box<WirInstr> },
+    ArrayLen(Box<WirInstr>),
+    ArrayCopy { dest_type: String, src_type: String, dest: Box<WirInstr>, dest_offset: Box<WirInstr>, src: Box<WirInstr>, src_offset: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayFill { type_name: String, array: Box<WirInstr>, offset: Box<WirInstr>, value: Box<WirInstr>, len: Box<WirInstr> },
+
+    // === GC: Reference ===
+    RefNull { heap_type: WirAbstractHeapType },
+    RefIsNull(Box<WirInstr>),
+    RefAsNonNull(Box<WirInstr>),
+    RefCast { type_name: String, nullable: bool, expr: Box<WirInstr> },
+    RefTest { type_name: String, nullable: bool, expr: Box<WirInstr> },
+    RefEq(Box<WirInstr>, Box<WirInstr>),
+    RefI31(Box<WirInstr>),
+    I31GetS(Box<WirInstr>),
+    I31GetU(Box<WirInstr>),
+    ExternInternalize(Box<WirInstr>),
+    ExternExternalize(Box<WirInstr>),
+
+    // === Control Flow ===
+    /// Block with optional label and result type
+    Block { label: Option<String>, result: Option<WirValType>, body: Vec<WirInstr> },
+    /// Loop with optional label
+    Loop { label: Option<String>, body: Vec<WirInstr> },
+    /// If/else with optional result type
+    If { condition: Box<WirInstr>, result: Option<WirValType>, then_body: Vec<WirInstr>, else_body: Option<Vec<WirInstr>> },
+    /// Branch to label
+    Br { depth: u32 },
+    /// Conditional branch
+    BrIf { depth: u32, condition: Box<WirInstr> },
+    /// Branch table (switch)
+    BrTable { index: Box<WirInstr>, targets: Vec<u32>, default: u32 },
+    /// Return from function
+    Return { value: Option<Box<WirInstr>> },
+    /// Unreachable trap
+    Unreachable,
+    /// No operation (for structure)
+    Nop,
+    /// Drop a value
+    Drop(Box<WirInstr>),
+    /// Select between two values
+    Select { condition: Box<WirInstr>, if_true: Box<WirInstr>, if_false: Box<WirInstr>, ty: Option<WirValType> },
+
+    // === Calls ===
+    Call { func_name: String, args: Vec<WirInstr> },
+    CallIndirect { type_name: String, table: u32, index: Box<WirInstr>, args: Vec<WirInstr> },
+    CallRef { type_name: String, func_ref: Box<WirInstr>, args: Vec<WirInstr> },
+    RefFunc { func_name: String },
+
+    // === Memory ===
+    MemorySize,
+    MemoryGrow(Box<WirInstr>),
+    I32Load { offset: u64, align: u32, addr: Box<WirInstr> },
+    I32Store { offset: u64, align: u32, addr: Box<WirInstr>, value: Box<WirInstr> },
+    I64Load { offset: u64, align: u32, addr: Box<WirInstr> },
+    I64Store { offset: u64, align: u32, addr: Box<WirInstr>, value: Box<WirInstr> },
+
+    // === Table ===
+    TableGet { table: u32, index: Box<WirInstr> },
+    TableSet { table: u32, index: Box<WirInstr>, value: Box<WirInstr> },
+
+    // === High-level compound instructions (lowered to sequences during emission) ===
+
+    /// Deep copy of a value type (struct, array, variant, option, tuple).
+    /// Lowered to field-by-field copy, array loop, etc. during emission.
+    ValueCopy { type_name: String, source_type: WirCopyType, expr: Box<WirInstr> },
+
+    /// Sequence of instructions (for statement blocks)
+    Seq(Vec<WirInstr>),
+}
+```
+
+### Copy Types
+
+```rust
+/// What kind of value copy to perform
+pub enum WirCopyType {
+    Struct { fields: Vec<WirCopyField> },
+    Array { element_copy: Option<Box<WirCopyType>> },
+    Variant { cases: Vec<WirCopyCase> },
+    Option { inner_copy: Box<WirCopyType> },
+    Tuple { field_copies: Vec<Option<WirCopyType>> },
+}
+
+pub struct WirCopyField {
+    pub index: u32,
+    pub needs_copy: bool,
+    pub copy_type: Option<WirCopyType>,
+}
+
+pub struct WirCopyCase {
+    pub index: u32,
+    pub name: String,
+    pub payload_copy: Option<WirCopyType>,
+}
+```
+
+### Component Model
+
+```rust
+/// Component Model wrapper information
+pub struct WirComponent {
+    /// WASI interfaces to import
+    pub wasi_imports: Vec<WirWasiImport>,
+    /// Bundled modules (fts, libm)
+    pub bundled_modules: Vec<WirBundledModule>,
+    /// World exports
+    pub world_exports: Vec<WirWorldExport>,
+    /// Memory module configuration
+    pub memory: WirMemoryConfig,
+}
+```
+
+### Names and References
+
+WIR uses **string names** for type and function references, not numeric indices. During emission, names are resolved to indices via lookup tables built during the emission pass. This keeps WIR readable and decoupled from index allocation order.
+
+```rust
+/// Type references use the type's name
+pub struct WirTypeRef(pub String);
+
+/// Function references use the function's name
+pub struct WirFuncRef(pub String);
+```
+
+## Unparse Format
+
+WIR supports `--unparse` to output pseudo-Wado/WAT hybrid for debugging:
+
+```
+// Type definitions
+type Point = struct { x: i32, y: i32 }
+type Array<i32> = struct { repr: array<i32>, used: i32 }
+
+// Function
+fn "example"(a: i32, b: i32) -> i32 {
+    let result: i32;
+    result = i32.add(a, b);
+    return result;
+}
+
+// GC operations shown with type names
+fn "Point::sum"(self: ref Point) -> i32 {
+    return i32.add(
+        struct.get Point.x(self),
+        struct.get Point.y(self),
+    );
+}
+
+// Value copy shown explicitly
+fn "copy_array"(src: ref Array<i32>) -> ref Array<i32> {
+    return value_copy Array<i32>(src);
+}
+```
+
+## Migration Plan
+
+The migration is incremental. Each step produces a working compiler.
+
+### Preparation: Extract Submodules from codegen.rs
+
+Before introducing WIR, split codegen.rs into manageable files:
+
+- [ ] **Step 0a**: Extract `type_registration.rs` — the 15+ type registration phases from `build_main_module()` (lines 700–1365). This is pure analysis + `wasm_encoder` type section building. ~700 lines.
+- [ ] **Step 0b**: Extract `value_copy.rs` — `generate_value_copy()`, `generate_struct_copy()`, `generate_array_copy()`, `generate_variant_copy()`, `generate_option_copy()`, `needs_value_copy()`. ~500 lines.
+- [ ] **Step 0c**: Extract `match_codegen.rs` — `generate_match_expr()`, `generate_match_arms()`, `generate_match_br_table()`, `generate_match_pattern_check()`, `generate_match_pattern_binding()`, `analyze_for_br_table()`. ~600 lines.
+- [ ] **Step 0d**: Extract `cm_codegen.rs` — `generate_cm_effect_call()`, `generate_cm_resource_method_call()`, `generate_effect_wait()`, CM payload lowering functions. ~800 lines.
+- [ ] **Step 0e**: Extract `scalarization.rs` — `collect_scalarization_candidates()`, `preallocate_scalarized_locals()`, related analysis. ~300 lines.
+
+After this step, codegen.rs is split into ~6 files but the architecture is unchanged. This is pure refactoring.
+
+### Phase 1: Define WIR Data Structures
+
+- [ ] **Step 1a**: Create `wir.rs` with the WIR data structure definitions (types, instructions, module structure). No code uses it yet.
+- [ ] **Step 1b**: Create `wir_unparse.rs` for WIR → pseudo-Wado output. Hook into `wado dump --wir --unparse`.
+- [ ] **Step 1c**: Add `--wir` flag to the dump command. Pipeline: TIR → (existing codegen analysis) → WIR → display.
+
+### Phase 2: WIR Emission for Function Bodies
+
+The core migration: replace TIR expression codegen with WIR generation.
+
+- [ ] **Step 2a**: Create `tir_to_wir.rs` — translates TIR expressions to WIR instructions. This extracts the logic from `generate_expr()` but produces WIR nodes instead of `wasm_encoder::Instruction`.
+- [ ] **Step 2b**: Create `wir_emit.rs` — translates WIR instructions to `wasm_encoder::Instruction`. This is a mechanical mapping (WIR names → Wasm indices, WIR tree → flat instruction sequence).
+- [ ] **Step 2c**: Wire it together: `tir_to_wir` produces `WirFunction` bodies, `wir_emit` produces `wasm_encoder::Function`. The old `generate_expr()` / `generate_function()` can be replaced incrementally (one TirExprKind at a time).
+- [ ] **Step 2d**: Delete the old `generate_expr()` once all expression kinds are covered by `tir_to_wir` + `wir_emit`.
+
+### Phase 3: WIR Emission for Type Section
+
+- [ ] **Step 3a**: Move type layout decisions into WIR generation. The 15+ type registration phases produce `Vec<WirTypeDef>` instead of calling `wasm_encoder` directly.
+- [ ] **Step 3b**: `wir_emit` translates `WirTypeDef` → `wasm_encoder` type section entries.
+- [ ] **Step 3c**: Delete the old type registration code in codegen.
+
+### Phase 4: WIR Emission for Module Structure
+
+- [ ] **Step 4a**: Move import/export/global/data section generation to produce WIR structures.
+- [ ] **Step 4b**: Move Component Model wrapper generation to produce `WirComponent`.
+- [ ] **Step 4c**: `wir_emit` translates the complete `WirModule` → Wasm binary.
+
+### Phase 5: Merge wasm_plan into WIR Generation
+
+At this point, `wasm_plan` and `tir_to_wir` are doing related work. Consolidate:
+
+- [ ] **Step 5a**: Move `ComponentPlan` generation into WIR generation (it becomes `WirComponent`).
+- [ ] **Step 5b**: The pipeline becomes: `optimize → wir_gen → wir_emit`.
+- [ ] **Step 5c**: Delete the separate `wasm_plan` phase. Its analysis functions (topological sort, etc.) move into `wir_gen` or stay as utilities.
+
+### Final State
+
+```
+lower → optimize → wir_gen → wir_emit → wasm binary
+                      ↓
+                  WirModule (inspectable via dump --wir)
+```
+
+- `wir_gen` (~5000 lines): TIR + Project → WirModule. All analysis, type layout, function translation.
+- `wir_emit` (~2000 lines): WirModule → Wasm binary. Mechanical translation, index allocation, `wasm_encoder` calls.
+- `wir.rs` (~500 lines): Data structure definitions.
+- `wir_unparse.rs` (~500 lines): WIR → pseudo-Wado for debugging.
+
+## Design Rationale
+
+### Why Tree-Structured (Not Flat Instructions)?
+
+Wasm is a stack machine, but flat instruction sequences are hard to inspect and manipulate. WIR uses trees where operands are children:
+
+```rust
+// WIR (tree): readable, inspectable
+I32Add(
+    StructGet { type_name: "Point", field_name: "x", expr: LocalGet("self") },
+    StructGet { type_name: "Point", field_name: "y", expr: LocalGet("self") },
+)
+
+// Wasm (flat): requires mental stack tracking
+// local.get $self
+// struct.get $Point 0
+// local.get $self
+// struct.get $Point 1
+// i32.add
+```
+
+Flattening trees to stack-machine instructions is trivial (post-order traversal). The reverse is not.
+
+### Why Named References (Not Indices)?
+
+Using names keeps WIR independent of emission order:
+
+- Type registration order can change without invalidating WIR
+- Functions can be reordered freely
+- WIR is self-documenting (no need for a separate name section to read it)
+
+The cost is a name→index lookup during emission, which is O(1) with `IndexMap`.
+
+### Why `ValueCopy` as a Compound Instruction?
+
+Value copy involves complex dispatching (struct copy, array loop, variant tag check, etc.). Keeping it as a single WIR node:
+
+- Preserves the semantic intent ("copy this value")
+- Allows the emitter to choose the most efficient lowering strategy
+- Keeps `tir_to_wir` focused on semantics, not emission details
+
+### Why Not a Separate Optimization Pass on WIR?
+
+WIR is intentionally a thin layer. Optimizations belong on TIR where semantic information is richer. WIR's purpose is debuggability and separation of concerns, not optimization.
+
+If Wasm-level optimizations become needed (peephole, etc.), they can be added as a `wir_opt` pass later without changing the architecture.
+
+## Consequences
+
+### Benefits
+
+- **Debuggability**: `wado dump --wir --unparse` shows exactly what Wasm will be generated, with readable names
+- **Testability**: WIR generation and WIR emission can be tested independently
+- **Maintainability**: codegen.rs (14k lines) splits into focused modules (~5k + ~2k + ~1k)
+- **Extensibility**: New Wasm features (SIMD, stack switching) are added as WIR nodes, not interleaved with encoding logic
+- **Golden testing**: WIR output can be used for golden file testing (more stable than binary Wasm)
+
+### Trade-offs
+
+- **Additional IR**: One more representation to maintain. Mitigated by WIR being close to Wasm (not a novel abstraction).
+- **Memory**: WIR trees allocate more than flat instruction streams. Acceptable since Wado programs are not extremely large.
+- **Migration effort**: Incremental migration spans multiple steps. Each step is independently shippable.
+- **No Wasm-level optimization**: Intentional. TIR optimization is sufficient for now.
+
+### Risks
+
+- **Scope creep**: WIR should stay close to Wasm. Resist adding high-level abstractions.
+- **Name resolution overhead**: String-based name lookup during emission. Mitigated by single-pass name table construction.
+- **Incomplete migration**: If migration stalls midway, we'd have two code paths. Mitigated by the incremental approach where each step is a complete working state.

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -98,6 +98,53 @@ pub struct WirModule {
 }
 ```
 
+### Names
+
+WIR entities at global scope (types, functions, globals) use `WirName` to carry both a short display name and a fully-qualified identity name. Local-scope names (locals, struct fields, enum/variant cases) remain plain `String`.
+
+```rust
+/// A globally-scoped name in WIR.
+///
+/// Carries both forms needed by different consumers:
+/// - `display`: short name for unparse and error messages
+/// - `fq`: module-qualified name for unique identity
+///
+/// The `tir_to_wir` phase constructs WirNames from name.rs objects
+/// (StructName, FunctionId, etc.). WIR itself does not import name.rs types.
+pub struct WirName {
+    /// Short display name (e.g., "Point", "Array<i32>", "Point::sum")
+    /// Used by unparse and error messages.
+    pub display: String,
+    /// Fully-qualified name (e.g., "core:prelude//Point", "./geometry.wado/Point::sum")
+    /// Used as the unique identity key for name→index resolution during emission.
+    pub fq: String,
+}
+```
+
+Examples:
+
+| Entity | `display` | `fq` |
+| ------ | --------- | ---- |
+| Struct Point from entry | `Point` | `<entry>//Point` |
+| Array<i32> from prelude | `Array<i32>` | `core:prelude//Array<i32>` |
+| Method Point::sum | `Point::sum` | `./geometry.wado/Point::sum` |
+| Global counter | `counter` | `<entry>//counter` |
+| Enum Ordering from prelude | `Ordering` | `core:prelude//Ordering` |
+
+`WirName` is used in:
+
+- **Type definitions**: `WirStructType.name`, `WirVariantType.name`, `WirEnumType.name`, etc.
+- **Type references**: `WirTypeRef(WirName)`
+- **Function definitions**: `WirFunction.name`
+- **Function references**: `Call { func_name: WirName }`, `RefFunc { func_name: WirName }`
+- **Global definitions and references**: `WirGlobal.name`, `GlobalGet { name: WirName }`
+
+Not used for local-scope names (no module qualification needed):
+
+- Struct field names, enum/variant case names
+- Local variable names (`DeclareLocal`, `LocalGet`, `LocalSet`)
+- Block labels
+
 ### Metadata
 
 WIR preserves TIR metadata for debugging and unparse output, even when not needed for code emission.
@@ -105,14 +152,16 @@ WIR preserves TIR metadata for debugging and unparse output, even when not neede
 ```rust
 /// Source location and origin metadata, carried through from TIR.
 pub struct WirMeta {
-    /// Which module this entity was defined in
-    pub module_source: Option<ModuleSource>,
     /// Source span in the original Wado source
     pub span: Option<Span>,
     /// Attributes (e.g., #[hidden])
     pub attributes: Vec<WirAttribute>,
 }
+```
 
+Note: `module_source` is not in `WirMeta`. It is part of `WirName.fq` — the entity's own name carries its module origin. This avoids duplicating module information.
+
+```rust
 /// Generic instantiation origin (e.g., Array<i32> from Array<T>)
 pub struct WirGenericOrigin {
     /// Base generic name (e.g., "Array", "Box")
@@ -163,11 +212,11 @@ pub enum WirTypeDef {
 
 ```rust
 pub struct WirStructType {
-    /// Source-level name (e.g., "Point", "Array<i32>", "__Closure_3")
-    pub name: String,
+    /// Name (display: "Point", fq: "core:prelude//Point")
+    pub name: WirName,
     /// Fields with names and types
     pub fields: Vec<WirField>,
-    /// Metadata (module source, span, attributes)
+    /// Metadata (span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
     pub generic_origin: Option<WirGenericOrigin>,
@@ -191,11 +240,11 @@ Variants are sum types with payloads. At the Wasm level, they expand to a subtyp
 
 ```rust
 pub struct WirVariantType {
-    /// Source-level name (e.g., "Shape", "Result<i32, String>")
-    pub name: String,
+    /// Name (display: "Shape", fq: "./shapes.wado//Shape")
+    pub name: WirName,
     /// Cases with names and optional payload types
     pub cases: Vec<WirVariantCase>,
-    /// Metadata (module source, span, attributes)
+    /// Metadata (span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
     pub generic_origin: Option<WirGenericOrigin>,
@@ -227,11 +276,11 @@ Enums are discriminated values without payloads. They have no Wasm type section 
 
 ```rust
 pub struct WirEnumType {
-    /// Source-level name (e.g., "Color", "Ordering")
-    pub name: String,
+    /// Name (display: "Color", fq: "./colors.wado//Color")
+    pub name: WirName,
     /// Cases with names and discriminant values
     pub cases: Vec<WirEnumCase>,
-    /// Metadata (module source, span, attributes)
+    /// Metadata (span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
     pub generic_origin: Option<WirGenericOrigin>,
@@ -251,11 +300,11 @@ Flags are bitfield types. Like enums, they have no Wasm type section entry — v
 
 ```rust
 pub struct WirFlagsType {
-    /// Source-level name
-    pub name: String,
+    /// Name (display: "Permissions", fq: "./perms.wado//Permissions")
+    pub name: WirName,
     /// Flag bits with names and positions
     pub bits: Vec<WirFlagBit>,
-    /// Metadata (module source, span, attributes)
+    /// Metadata (span, attributes)
     pub meta: WirMeta,
 }
 
@@ -271,7 +320,7 @@ pub struct WirFlagBit {
 
 ```rust
 pub struct WirArrayType {
-    pub name: String,
+    pub name: WirName,
     pub element_type: WirType,
     pub mutable: bool,
     pub meta: WirMeta,
@@ -279,13 +328,13 @@ pub struct WirArrayType {
 }
 
 pub struct WirFuncType {
-    pub name: String,
+    pub name: WirName,
     pub params: Vec<WirType>,
     pub results: Vec<WirType>,
 }
 
-/// Reference to a type by name (resolved to index during emission)
-pub struct WirTypeRef(pub String);
+/// Reference to a type (resolved to index during emission via fq name)
+pub struct WirTypeRef(pub WirName);
 ```
 
 ### WIR Type System
@@ -323,11 +372,11 @@ pub enum WirType {
     // Unit (no Wasm representation; zero-size)
     Unit,
     /// Named enum type (i32 at Wasm level)
-    Enum { type_name: String },
+    Enum { type_name: WirName },
     /// Named flags type (i32 at Wasm level)
-    Flags { type_name: String },
+    Flags { type_name: WirName },
     /// Reference to a named GC type
-    Ref { type_name: String, nullable: bool },
+    Ref { type_name: WirName, nullable: bool },
     /// Abstract reference type (anyref, funcref, etc.)
     AbstractRef { heap_type: WirAbstractHeapType, nullable: bool },
 }
@@ -348,8 +397,8 @@ pub enum WirAbstractHeapType {
 
 ```rust
 pub struct WirFunction {
-    /// Function name (for name section and local references)
-    pub name: String,
+    /// Function name (display: "Point::sum", fq: "./geometry.wado/Point::sum")
+    pub name: WirName,
     /// Type reference (function signature — param types and result types)
     pub type_ref: WirTypeRef,
     /// Parameter names (types come from the referenced WirFuncType)
@@ -384,8 +433,8 @@ pub enum WirInstr {
     LocalTee { name: String, value: Box<WirInstr> },
 
     // === Globals ===
-    GlobalGet { name: String },
-    GlobalSet { name: String, value: Box<WirInstr> },
+    GlobalGet { name: WirName },
+    GlobalSet { name: WirName, value: Box<WirInstr> },
 
     // === Constants ===
     I32Const(i32),
@@ -524,31 +573,31 @@ pub enum WirInstr {
 
     // === GC: Struct ===
     /// struct.new with named type
-    StructNew { type_name: String, fields: Vec<WirInstr> },
+    StructNew { type_name: WirName, fields: Vec<WirInstr> },
     /// struct.get with named type and field (field index resolved by emitter)
-    StructGet { type_name: String, field_name: String, expr: Box<WirInstr> },
+    StructGet { type_name: WirName, field_name: String, expr: Box<WirInstr> },
     /// struct.set with named type and field (field index resolved by emitter)
-    StructSet { type_name: String, field_name: String, expr: Box<WirInstr>, value: Box<WirInstr> },
+    StructSet { type_name: WirName, field_name: String, expr: Box<WirInstr>, value: Box<WirInstr> },
 
     // === GC: Array ===
-    ArrayNew { type_name: String, init: Box<WirInstr>, len: Box<WirInstr> },
-    ArrayNewDefault { type_name: String, len: Box<WirInstr> },
-    ArrayNewData { type_name: String, data_index: u32, offset: Box<WirInstr>, len: Box<WirInstr> },
-    ArrayNewFixed { type_name: String, elements: Vec<WirInstr> },
-    ArrayGet { type_name: String, array: Box<WirInstr>, index: Box<WirInstr> },
-    ArrayGetS { type_name: String, array: Box<WirInstr>, index: Box<WirInstr> },
-    ArrayGetU { type_name: String, array: Box<WirInstr>, index: Box<WirInstr> },
-    ArraySet { type_name: String, array: Box<WirInstr>, index: Box<WirInstr>, value: Box<WirInstr> },
+    ArrayNew { type_name: WirName, init: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayNewDefault { type_name: WirName, len: Box<WirInstr> },
+    ArrayNewData { type_name: WirName, data_index: u32, offset: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayNewFixed { type_name: WirName, elements: Vec<WirInstr> },
+    ArrayGet { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArrayGetS { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArrayGetU { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr> },
+    ArraySet { type_name: WirName, array: Box<WirInstr>, index: Box<WirInstr>, value: Box<WirInstr> },
     ArrayLen(Box<WirInstr>),
-    ArrayCopy { dest_type: String, src_type: String, dest: Box<WirInstr>, dest_offset: Box<WirInstr>, src: Box<WirInstr>, src_offset: Box<WirInstr>, len: Box<WirInstr> },
-    ArrayFill { type_name: String, array: Box<WirInstr>, offset: Box<WirInstr>, value: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayCopy { dest_type: WirName, src_type: WirName, dest: Box<WirInstr>, dest_offset: Box<WirInstr>, src: Box<WirInstr>, src_offset: Box<WirInstr>, len: Box<WirInstr> },
+    ArrayFill { type_name: WirName, array: Box<WirInstr>, offset: Box<WirInstr>, value: Box<WirInstr>, len: Box<WirInstr> },
 
     // === GC: Reference ===
     RefNull { heap_type: WirAbstractHeapType },
     RefIsNull(Box<WirInstr>),
     RefAsNonNull(Box<WirInstr>),
-    RefCast { type_name: String, nullable: bool, expr: Box<WirInstr> },
-    RefTest { type_name: String, nullable: bool, expr: Box<WirInstr> },
+    RefCast { type_name: WirName, nullable: bool, expr: Box<WirInstr> },
+    RefTest { type_name: WirName, nullable: bool, expr: Box<WirInstr> },
     RefEq(Box<WirInstr>, Box<WirInstr>),
     RefI31(Box<WirInstr>),
     I31GetS(Box<WirInstr>),
@@ -581,10 +630,10 @@ pub enum WirInstr {
     Select { condition: Box<WirInstr>, if_true: Box<WirInstr>, if_false: Box<WirInstr>, ty: Option<WirType> },
 
     // === Calls ===
-    Call { func_name: String, args: Vec<WirInstr> },
-    CallIndirect { type_name: String, table: u32, index: Box<WirInstr>, args: Vec<WirInstr> },
-    CallRef { type_name: String, func_ref: Box<WirInstr>, args: Vec<WirInstr> },
-    RefFunc { func_name: String },
+    Call { func_name: WirName, args: Vec<WirInstr> },
+    CallIndirect { type_name: WirName, table: u32, index: Box<WirInstr>, args: Vec<WirInstr> },
+    CallRef { type_name: WirName, func_ref: Box<WirInstr>, args: Vec<WirInstr> },
+    RefFunc { func_name: WirName },
 
     // === Memory ===
     MemorySize,
@@ -602,7 +651,7 @@ pub enum WirInstr {
 
     /// Deep copy of a value type (struct, array, variant, option, tuple).
     /// Lowered to field-by-field copy, array loop, etc. during emission.
-    ValueCopy { type_name: String, source_type: WirCopyType, expr: Box<WirInstr> },
+    ValueCopy { type_name: WirName, source_type: WirCopyType, expr: Box<WirInstr> },
 
     /// Sequence of instructions (for statement blocks)
     Seq(Vec<WirInstr>),
@@ -652,22 +701,32 @@ pub struct WirComponent {
 
 ### Names and References
 
-WIR uses **string names** for all references, not numeric indices. During emission, names are resolved to indices via lookup tables built during the emission pass. This keeps WIR readable and decoupled from index allocation order.
+WIR uses `WirName` for globally-scoped references and plain `String` for local-scope references. During emission, `WirName.fq` is resolved to indices via lookup tables. For unparse, `WirName.display` provides human-readable names.
 
-All named references in WIR:
+| Scope | Reference type | Identity key | Display |
+| ----- | -------------- | ------------ | ------- |
+| Global | `WirName` | `fq` | `display` |
+| Local | `String` | name itself | name itself |
 
-- **Types**: `WirTypeRef(String)` — struct, variant, array, func type names
-- **Functions**: `WirFuncRef(String)` — function names in `Call`, `RefFunc`
-- **Locals**: `String` — local variable names in `LocalGet`, `LocalSet`, `DeclareLocal`
-- **Globals**: `String` — global variable names in `GlobalGet`, `GlobalSet`
-- **Fields**: `String` — struct field names in `StructGet`, `StructSet` (resolved to field index by emitter)
+Global-scope references (use `WirName`):
+
+- **Types**: `WirTypeRef(WirName)` — in function signatures, instructions
+- **Functions**: `WirName` — in `Call`, `RefFunc`, `WirFunction.name`
+- **Globals**: `WirName` — in `GlobalGet`, `GlobalSet`
+
+Local-scope references (use `String`):
+
+- **Locals**: in `LocalGet`, `LocalSet`, `DeclareLocal`
+- **Fields**: in `StructGet`, `StructSet` (resolved to field index by emitter)
+- **Labels**: in `Block`, `Loop`
+- **Enum/variant cases**: in `WirEnumCase`, `WirVariantCase`
 
 ```rust
-/// Type references use the type's name
-pub struct WirTypeRef(pub String);
+/// Type references carry both display and fq names
+pub struct WirTypeRef(pub WirName);
 
-/// Function references use the function's name
-pub struct WirFuncRef(pub String);
+/// Function references carry both display and fq names
+pub struct WirFuncRef(pub WirName);
 ```
 
 ## Unparse Format
@@ -832,15 +891,16 @@ Flattening trees to stack-machine instructions is trivial (post-order traversal)
 
 ### Why Named References (Not Indices)?
 
-Using names **uniformly** for all references keeps WIR independent of emission order and self-documenting:
+Using names for all references keeps WIR independent of emission order and self-documenting:
 
-- Types, functions, globals, locals, struct fields — all referenced by name
+- Global-scope names use `WirName` with both `display` (for unparse) and `fq` (for identity)
+- Local-scope names (locals, fields, labels) use plain `String`
 - Type registration order can change without invalidating WIR
 - Functions and globals can be reordered freely
 - Struct field indices are resolved from type definitions during emission
-- WIR is self-documenting (no need for a separate name section to read it)
+- Unparse uses `display` names — no need to parse FQ names for readability
 
-The cost is a name→index lookup during emission, which is O(1) with `IndexMap`.
+The cost is a `fq`→index lookup during emission, which is O(1) with `IndexMap`.
 
 ### Why `ValueCopy` as a Compound Instruction?
 
@@ -875,11 +935,11 @@ This eliminates the `ValType`/`StorageType` split at the WIR level — there is 
 
 ### Why Preserve TIR Metadata?
 
-WIR carries metadata (module source, spans, attributes, generic origin, newtype origin) even though the emit phase does not need most of it. This is intentional:
+WIR carries metadata (spans, attributes, generic origin, newtype origin) even though the emit phase does not need most of it. This is intentional:
 
-- **Unparse**: `wado dump --wir --unparse` can show `// from ./geometry.wado` comments, display newtype origins, and annotate generic instantiations.
-- **Error messages**: If the emit phase detects a problem, it can report source locations.
-- **Debugging**: When investigating codegen issues, knowing where a type or function came from is critical.
+- **Unparse**: `wado dump --wir --unparse` can show `// from ./geometry.wado` comments (derived from `WirName.fq`), display newtype origins, and annotate generic instantiations.
+- **Error messages**: If the emit phase detects a problem, it can report source locations via `WirMeta.span`.
+- **Debugging**: When investigating codegen issues, knowing where a type or function came from is critical. `WirName.fq` carries the module origin; `WirMeta.span` carries the source location.
 - **Newtypes**: Resolved by the WIR phase (a `Meters` field is `F64` in WIR), but `newtype_origin` records that it was `Meters` from `./physics.wado`. This avoids polluting the emit phase with newtype logic while keeping debug info.
 
 The metadata is lightweight (references and optional fields) and does not affect WIR→Wasm correctness.

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -874,7 +874,6 @@ Set up the WIR data structures, unparse output, and dump integration. No code ge
 - [ ] **Step 1a**: Create `wir.rs` with the WIR data structure definitions (types, instructions, module structure). No code uses it yet.
 - [ ] **Step 1b**: Create `wir_unparse.rs` for WIR → pseudo-Wado output.
 - [ ] **Step 1c**: Add `--wir` flag to the dump command (`wado dump --wir --unparse`). Initially outputs an empty `WirModule`.
-- [ ] **Step 1d**: Move `effect_wait` from `builtin.wado` to `internal.wado` — `generate_effect_wait()` in codegen is a multi-instruction sequence. Refactor it into a Wado function `internal::effect_wait(subtask: i32)`. This removes hard-coded codegen logic and simplifies future WIR translation. (This is the only change that touches existing code, and it is a semantic no-op.)
 
 After this phase: `wado dump --wir --unparse` works but shows an empty module.
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -331,8 +331,6 @@ pub struct WirEnumType {
     pub cases: Vec<WirEnumCase>,
     /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
-    /// Generic instantiation origin (None for non-generic types)
-    pub generic_origin: Option<WirGenericOrigin>,
 }
 
 pub struct WirEnumCase {

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -45,8 +45,8 @@ The `wasm_plan` phase is expanded to produce a `WirModule` — a complete descri
 WIR is a tree-structured IR that maps almost 1:1 to Wasm instructions, but with these ergonomic improvements over raw Wasm:
 
 1. **Named locals**: Variables are referenced by name, not pre-allocated indices. Locals can be declared inline (no pre-allocation pass needed).
-2. **Named types**: Struct, enum, and variant types retain their source-level names and field/case names.
-3. **Wado-level primitive types**: WIR uses `Bool`, `Char`, `I8`, `U8`, `I16`, `U16`, etc. instead of Wasm's `i32`-for-everything. The emit phase lowers to Wasm `ValType`/`StorageType`. This avoids the `ValType`/`StorageType` split at the WIR level and provides better debug output.
+2. **Named types**: Struct, variant, enum, and flags types retain their source-level names and field/case names. These are Wado-level type definitions, not Wasm type section entries — the emit phase expands them (e.g., a variant becomes N+1 Wasm struct types).
+3. **Wado-level value types**: WIR uses `Bool`, `Char`, `I8`, `U8`, `I16`, `U16`, `Enum { type_name }`, `Flags { type_name }`, etc. instead of Wasm's `i32`-for-everything. The emit phase lowers to Wasm `ValType`/`StorageType`. This avoids the `ValType`/`StorageType` split at the WIR level and provides better debug output.
 4. **Structured control flow**: Blocks, loops, if/else are tree nodes (not flat instruction sequences with labels).
 5. **Explicit value copy**: Copy operations are explicit WIR nodes rather than inline instruction sequences.
 6. **TIR metadata preserved**: Module source, source spans, attributes, generic instantiation info, and newtype origin are carried through for debugging and unparse. Newtypes are resolved (a `Meters` is `f64` at the WIR level), but their origin is recorded.
@@ -66,7 +66,14 @@ WIR is a tree-structured IR that maps almost 1:1 to Wasm instructions, but with 
 /// A complete Wasm module in WIR form.
 /// Contains all information needed to emit a valid Wasm binary.
 pub struct WirModule {
-    /// Type section: all Wasm GC types (structs, arrays, function types)
+    /// Type definitions: Wado-level types (struct, variant, enum, flags, array, func).
+    /// Not a 1:1 mapping to the Wasm type section — the emit phase expands these:
+    ///   Struct → 1 Wasm struct type
+    ///   Variant → N+1 Wasm struct types (base + case subtypes)
+    ///   Enum → none (i32 discriminant)
+    ///   Flags → none (i32 bitfield)
+    ///   Array → 1 Wasm array type
+    ///   Func → 1 Wasm func type
     pub types: Vec<WirTypeDef>,
     /// Rec groups: which types form recursive groups
     pub rec_groups: Vec<WirRecGroup>,
@@ -125,26 +132,41 @@ pub struct WirNewtypeOrigin {
 
 ### Type Definitions
 
+WIR type definitions are at the Wado source level, not the Wasm type section level. The emit phase expands them into actual Wasm type section entries.
+
 ```rust
-/// A Wasm GC type definition.
+/// A Wado-level type definition.
+/// The emit phase expands these into Wasm type section entries:
+///   Struct → 1 Wasm struct type
+///   Variant → N+1 Wasm struct types (base with discriminant field + case subtypes)
+///   Enum → none (represented as i32)
+///   Flags → none (represented as i32 bitfield)
+///   Array → 1 Wasm array type
+///   Func → 1 Wasm func type
 pub enum WirTypeDef {
     /// Struct type with named fields
     Struct(WirStructType),
+    /// Variant type (sum type with payloads)
+    Variant(WirVariantType),
+    /// Enum type (discriminated values without payloads)
+    Enum(WirEnumType),
+    /// Flags type (bitfield)
+    Flags(WirFlagsType),
     /// Array type
     Array(WirArrayType),
     /// Function type
     Func(WirFuncType),
 }
+```
 
+#### Struct
+
+```rust
 pub struct WirStructType {
     /// Source-level name (e.g., "Point", "Array<i32>", "__Closure_3")
     pub name: String,
     /// Fields with names and types
     pub fields: Vec<WirField>,
-    /// Supertype index (for variant subtypes)
-    pub supertype: Option<WirTypeRef>,
-    /// Whether this is a final type (no further subtypes allowed)
-    pub is_final: bool,
     /// Metadata (module source, span, attributes)
     pub meta: WirMeta,
     /// Generic instantiation origin (None for non-generic types)
@@ -154,14 +176,100 @@ pub struct WirStructType {
 }
 
 pub struct WirField {
-    /// Source-level field name (e.g., "x", "repr", "tag")
+    /// Source-level field name (e.g., "x", "repr", "discriminant")
     pub name: String,
     /// WIR type (uses Wado-level primitives, not Wasm ValType)
     pub ty: WirType,
     /// Whether this field is mutable
     pub mutable: bool,
 }
+```
 
+#### Variant
+
+Variants are sum types with payloads. At the Wasm level, they expand to a subtype hierarchy: a base struct with a `discriminant` field, and per-case subtypes that add payload fields.
+
+```rust
+pub struct WirVariantType {
+    /// Source-level name (e.g., "Shape", "Result<i32, String>")
+    pub name: String,
+    /// Cases with names and optional payload types
+    pub cases: Vec<WirVariantCase>,
+    /// Metadata (module source, span, attributes)
+    pub meta: WirMeta,
+    /// Generic instantiation origin (None for non-generic types)
+    pub generic_origin: Option<WirGenericOrigin>,
+    /// If this type was a newtype in the source (resolved by WIR phase)
+    pub newtype_origin: Option<WirNewtypeOrigin>,
+}
+
+pub struct WirVariantCase {
+    /// Case name (e.g., "Circle", "Ok")
+    pub name: String,
+    /// Case index (discriminant value)
+    pub index: u32,
+    /// Payload field types (empty for unit cases like "Point" or "None")
+    pub payload: Vec<WirType>,
+}
+```
+
+The emit phase generates:
+
+- Base struct: `(type $Shape (struct (field $discriminant i32)))`
+- Case subtypes: `(type $Shape::Circle (sub $Shape (struct (field $discriminant i32) (field $0 f64))))`
+- Unit case subtypes: `(type $Shape::Point (sub $Shape (struct (field $discriminant i32))))`
+
+For NullableRef variants (2 cases, 1 unit, payload is non-nullable ref), the emit phase may use a nullable reference instead of a subtype hierarchy.
+
+#### Enum
+
+Enums are discriminated values without payloads. They have no Wasm type section entry — values are i32 discriminants.
+
+```rust
+pub struct WirEnumType {
+    /// Source-level name (e.g., "Color", "Ordering")
+    pub name: String,
+    /// Cases with names and discriminant values
+    pub cases: Vec<WirEnumCase>,
+    /// Metadata (module source, span, attributes)
+    pub meta: WirMeta,
+    /// Generic instantiation origin (None for non-generic types)
+    pub generic_origin: Option<WirGenericOrigin>,
+}
+
+pub struct WirEnumCase {
+    /// Case name (e.g., "Red", "Less")
+    pub name: String,
+    /// Discriminant value
+    pub discriminant: i32,
+}
+```
+
+#### Flags
+
+Flags are bitfield types. Like enums, they have no Wasm type section entry — values are i32 bitfields.
+
+```rust
+pub struct WirFlagsType {
+    /// Source-level name
+    pub name: String,
+    /// Flag bits with names and positions
+    pub bits: Vec<WirFlagBit>,
+    /// Metadata (module source, span, attributes)
+    pub meta: WirMeta,
+}
+
+pub struct WirFlagBit {
+    /// Flag name
+    pub name: String,
+    /// Bit position (0-indexed)
+    pub position: u32,
+}
+```
+
+#### Array and Func
+
+```rust
 pub struct WirArrayType {
     pub name: String,
     pub element_type: WirType,
@@ -194,6 +302,7 @@ WIR uses **Wado-level primitive types**, not Wasm's `ValType`/`StorageType` spli
 ///   - I64/U64 → i64
 ///   - F32 → f32
 ///   - F64 → f64
+///   - Enum/Flags → i32
 pub enum WirType {
     // Signed integers
     I8,
@@ -213,6 +322,10 @@ pub enum WirType {
     Char,
     // Unit (no Wasm representation; zero-size)
     Unit,
+    /// Named enum type (i32 at Wasm level)
+    Enum { type_name: String },
+    /// Named flags type (i32 at Wasm level)
+    Flags { type_name: String },
     /// Reference to a named GC type
     Ref { type_name: String, nullable: bool },
     /// Abstract reference type (anyref, funcref, etc.)
@@ -562,13 +675,27 @@ pub struct WirFuncRef(pub String);
 
 ## Unparse Format
 
-WIR supports `--unparse` to output pseudo-Wado/WAT hybrid for debugging:
+WIR supports `--unparse` to output pseudo-Wado for debugging. The unparse output should look as close to Wado source as possible, using named field access and Wado-level type definitions rather than raw Wasm instructions.
 
 ```
-// Type definitions with metadata
-type Point = struct { x: i32, y: i32 }  // from ./geometry.wado
+// Struct definition
+struct Point { x: i32, y: i32 }  // from ./geometry.wado
+
+// Variant definition (source-level, not expanded to Wasm struct hierarchy)
+variant Shape {  // from ./shapes.wado
+    Circle(f64),
+    Rectangle(f64, f64),
+    Point,
+}
+
+// Enum definition (no Wasm type — i32 discriminant)
+enum Color { Red = 0, Green = 1, Blue = 2 }  // from ./colors.wado
+
+// Newtype (resolved to base type, origin recorded)
 type Meters = f64  // newtype from ./physics.wado
-type Array<i32> = struct { repr: array<i32>, used: i32 }  // Array<T> with T=i32
+
+// Generic instantiation
+struct Array<i32> { repr: array<i32>, used: i32 }  // Array<T> with T=i32
 
 // Function with module source and effects
 fn "example"(a: i32, b: i32) -> i32 {  // from <entry>
@@ -582,11 +709,22 @@ fn "is_ascii"(c: char) -> bool {  // from ./utils.wado
     return i32.lt_u(c, 128);
 }
 
-// GC operations shown with type names
+// Named field access (Wado-style, not struct.get)
 fn "Point::sum"(self: ref Point) -> i32 {  // from ./geometry.wado
-    return i32.add(
-        struct.get Point.x(self),
-        struct.get Point.y(self),
+    return i32.add(self.x, self.y);
+}
+
+// Named field assignment (Wado-style, not struct.set)
+fn "Point::reset"(self: ref mut Point) {  // from ./geometry.wado
+    self.x = 0;
+    self.y = 0;
+}
+
+// Enum type in signatures
+fn "Color::is_primary"(self: Color) -> bool {  // from ./colors.wado
+    return i32.or(
+        i32.eq(self, 0),  // Red
+        i32.eq(self, 2),  // Blue
     );
 }
 
@@ -595,6 +733,15 @@ fn "copy_array"(src: ref Array<i32>) -> ref Array<i32> {
     return value_copy Array<i32>(src);
 }
 ```
+
+### Unparse Principles
+
+- **Type definitions**: Use Wado syntax (`struct`, `variant`, `enum`) not Wasm GC syntax
+- **Field access**: Use `self.x` not `struct.get Point.x(self)`
+- **Field assignment**: Use `self.x = value` not `struct.set Point.x(self, value)`
+- **Enum/flags values**: Show discriminant as i32 constant (since the Wasm level is i32)
+- **Variant construction**: Show `Shape::Circle(5.0)` or `struct.new Shape::Circle(0, 5.0)` depending on context
+- **Instructions**: Use WAT-style mnemonics for arithmetic (`i32.add`, `f64.mul`, etc.)
 
 ## Migration Plan
 
@@ -629,8 +776,8 @@ The core migration: replace TIR expression codegen with WIR generation.
 
 ### Phase 3: WIR Emission for Type Section
 
-- [ ] **Step 3a**: Move type layout decisions into WIR generation. The 15+ type registration phases produce `Vec<WirTypeDef>` instead of calling `wasm_encoder` directly.
-- [ ] **Step 3b**: `wir_emit` translates `WirTypeDef` → `wasm_encoder` type section entries.
+- [ ] **Step 3a**: Move type layout decisions into WIR generation. The 15+ type registration phases produce `Vec<WirTypeDef>` (structs, variants, enums, flags, arrays, func types) instead of calling `wasm_encoder` directly.
+- [ ] **Step 3b**: `wir_emit` translates `WirTypeDef` → Wasm type section entries. This includes expanding `WirVariantType` into base struct + subtype structs, and skipping `WirEnumType`/`WirFlagsType` (no Wasm type section entry needed).
 - [ ] **Step 3c**: Delete the old type registration code in codegen.
 
 ### Phase 4: WIR Emission for Module Structure
@@ -669,9 +816,12 @@ Wasm is a stack machine, but flat instruction sequences are hard to inspect and 
 ```rust
 // WIR (tree): readable, inspectable
 I32Add(
-    StructGet { type_name: "Point", field_name: "x", expr: LocalGet("self") },
-    StructGet { type_name: "Point", field_name: "y", expr: LocalGet("self") },
+    StructGet { type_name: "Point", field_name: "x", field_index: 0, expr: LocalGet("self") },
+    StructGet { type_name: "Point", field_name: "y", field_index: 1, expr: LocalGet("self") },
 )
+
+// Unparse: Wado-style field access
+// i32.add(self.x, self.y)
 
 // Wasm (flat): requires mental stack tracking
 // local.get $self
@@ -695,32 +845,34 @@ The cost is a name→index lookup during emission, which is O(1) with `IndexMap`
 
 ### Why `ValueCopy` as a Compound Instruction?
 
-Value copy involves complex dispatching (struct copy, array loop, variant tag check, etc.). Keeping it as a single WIR node:
+Value copy involves complex dispatching (struct copy, array loop, variant discriminant check, etc.). Keeping it as a single WIR node:
 
 - Preserves the semantic intent ("copy this value")
 - Allows the emitter to choose the most efficient lowering strategy
 - Keeps `tir_to_wir` focused on semantics, not emission details
 
-### Why Wado-Level Primitives (Not Wasm ValType)?
+### Why Wado-Level Value Types (Not Wasm ValType)?
 
-Wasm has only 4 numeric types: `i32`, `i64`, `f32`, `f64`. Wado has `bool`, `char`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `f32`, `f64`. In the current codegen, all the small types and `bool`/`char` are collapsed to `i32` early, losing semantic information.
+Wasm has only 4 numeric types: `i32`, `i64`, `f32`, `f64`. Wado has `bool`, `char`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `f32`, `f64`, plus enum and flags types — all of which collapse to `i32` at the Wasm level. In the current codegen, this collapse happens early, losing semantic information.
 
 WIR keeps the Wado types and lets the emit phase lower them:
 
-| WIR Type | As Wasm local (ValType) | As struct field (StorageType) |
-| -------- | ----------------------- | ----------------------------- |
-| Bool     | i32                     | i8                            |
-| Char     | i32                     | i32                           |
-| I8       | i32                     | i8                            |
-| U8       | i32                     | i8                            |
-| I16      | i32                     | i16                           |
-| U16      | i32                     | i16                           |
-| I32, U32 | i32                     | i32                           |
-| I64, U64 | i64                     | i64                           |
-| F32      | f32                     | f32                           |
-| F64      | f64                     | f64                           |
+| WIR Type      | As Wasm local (ValType) | As struct field (StorageType) |
+| ------------- | ----------------------- | ----------------------------- |
+| Bool          | i32                     | i8                            |
+| Char          | i32                     | i32                           |
+| I8            | i32                     | i8                            |
+| U8            | i32                     | i8                            |
+| I16           | i32                     | i16                           |
+| U16           | i32                     | i16                           |
+| I32, U32      | i32                     | i32                           |
+| I64, U64      | i64                     | i64                           |
+| F32           | f32                     | f32                           |
+| F64           | f64                     | f64                           |
+| Enum { .. }   | i32                     | i32                           |
+| Flags { .. }  | i32                     | i32                           |
 
-This eliminates the `ValType`/`StorageType` split at the WIR level — there is just `WirType`. The emit phase knows the context (local vs. struct field) and picks the right Wasm encoding. It also makes unparse output more readable: `bool` instead of `i32`, `char` instead of `i32`.
+This eliminates the `ValType`/`StorageType` split at the WIR level — there is just `WirType`. The emit phase knows the context (local vs. struct field) and picks the right Wasm encoding. It also makes unparse output more readable: `bool` instead of `i32`, `Color` instead of `i32`.
 
 ### Why Preserve TIR Metadata?
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -205,6 +205,21 @@ The adapter functions use builtins to perform low-level operations. Some already
 | `internal::gc_array_to_memory` | Copy bytes from GC array to linear memory |
 | `internal::wait_for_subtask` | Wait for async subtask completion |
 
+#### internal.wado scope
+
+`internal.wado` provides CM helper functions only for types where lowering/lifting involves real work (allocation, memory copy). Scalar types (i32, i64, f32, f64, etc.) are lowered/lifted inline by the synthesizer using `builtin::i32_load` / `builtin::i32_store` directly — wrapping these in `internal::cm_lower_i32()` etc. would be trivial identity functions with no benefit.
+
+| Type | Lowering | Lifting | Provider |
+| --- | --- | --- | --- |
+| i32, i64, f32, f64 | identity (flat param) / `builtin::*_store` (memory) | `builtin::*_load` | synthesizer inline |
+| bool | `value as i32` | `i32_load8_u(addr) != 0` | synthesizer inline |
+| char | `value as i32` | `char::from_u32_unchecked` | synthesizer inline |
+| String | alloc + copy → `(ptr, len)` | copy from linear memory → GC string | `internal::cm_lower_string`, `internal::memory_to_gc_string` |
+| Array\<u8\> | alloc + copy → `(ptr, len)` | copy from linear memory → GC array | `internal::cm_lower_array_u8`, `internal::memory_to_gc_array` |
+| list\<T\>, option\<T\>, result\<T, E\>, record, variant | recursive | recursive | synthesizer generates TIR (calls leaf helpers above) |
+
+Per-type converter functions (e.g., `cm_list_string_to_array`, `cm_option_string_to_option`) will be deleted once the synthesizer handles their types generically.
+
 #### New builtins to add
 
 | Function | Wasm instruction | Purpose |

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -4,7 +4,7 @@
 
 The compiler's Component Model (CM) boundary logic — lifting GC values to linear memory, lowering linear memory to GC values, calling lowered WASI imports, wrapping exports for `canon lift` — is currently spread across multiple layers:
 
-- `codegen.rs`: `generate_cm_effect_call` (~140 lines), `generate_cm_resource_method_call` (~250 lines), `generate_effect_wait` (~50 lines), `emit_option_string_lowering` (~40 lines), `emit_field_size_payload_lowering` (~65 lines), plus scattered CM glue throughout function emission
+- `codegen.rs`: `generate_cm_effect_call` (~140 lines), `generate_cm_resource_method_call` (~250 lines), `emit_option_string_lowering` (~40 lines), `emit_field_size_payload_lowering` (~65 lines), plus scattered CM glue throughout function emission
 - `component_model.rs`: `CmCallConvention` and its `from_return_type` logic (~350 lines), deriving ABI conventions from WASI return types via pattern matching on `Type` variants
 - `internal.wado`: hand-written CM converter functions (`cm_lower_string`, `cm_list_string_to_array`, etc.) — each covers one specific type shape (~130 lines)
 - `wasm_plan.rs`: `CmExportInfo` with pre-computed scratch locals and required imports for export glue
@@ -174,11 +174,9 @@ fn __cm_adapter__write_via_stream(stream: i32, data: String) {
     let subtask = builtin::cm_raw_call(stream, data_ptr, data_len);
 
     // Wait for completion
-    builtin::effect_wait(subtask);
+    internal::wait_for_subtask(subtask);
 }
 ```
-
-The `builtin::effect_wait` call expands to `waitable_set_new` + `waitable_join` + `waitable_set_wait` + `subtask_drop`, which is already in `builtin.wado` (or can be moved to `internal.wado` as a Wado-level function).
 
 ### Required Builtins
 
@@ -196,7 +194,7 @@ The adapter functions use builtins to perform low-level operations. Some already
 | `internal::cm_lower_list_u8` | Lower Array\<u8\> to (ptr, len) |
 | `internal::memory_to_gc_array` | Copy bytes from linear memory to GC array |
 | `internal::gc_array_to_memory` | Copy bytes from GC array to linear memory |
-| `builtin::effect_wait` | Wait for async subtask completion |
+| `internal::wait_for_subtask` | Wait for async subtask completion |
 
 #### New builtins to add
 
@@ -366,7 +364,6 @@ After cm_adapter_gen is complete:
 | --- | --- | --- | --- |
 | codegen.rs | `generate_cm_effect_call` | ~140 | Deleted — adapter handles CM calls |
 | codegen.rs | `generate_cm_resource_method_call` | ~250 | Deleted — adapter handles resource calls |
-| codegen.rs | `generate_effect_wait` | ~50 | Deleted — adapter calls `builtin::effect_wait` |
 | codegen.rs | `emit_option_string_lowering` | ~40 | Deleted — adapter generates inline |
 | codegen.rs | `emit_field_size_payload_lowering` | ~65 | Deleted — adapter generates inline |
 | codegen.rs | `wado_type_to_cm_val_type` | ~50 | Moved to cm_abi.rs |
@@ -375,7 +372,7 @@ After cm_adapter_gen is complete:
 | internal.wado | `cm_option_string_to_option` | ~15 | Deleted — adapter generates inline |
 | internal.wado | `cm_option_own_resource_to_option` | ~10 | Deleted — adapter generates inline |
 | internal.wado | `cm_list_tuple_string_string_to_array` | ~25 | Deleted — adapter generates inline |
-| Total removed | | ~1015 | |
+| Total removed | | ~965 | |
 
 New code:
 
@@ -386,7 +383,7 @@ New code:
 | builtin.wado additions | Memory load/store builtins | ~50 |
 | Total added | | ~750 |
 
-Net: **~250 lines reduction**, plus elimination of the per-type hand-coding pattern.
+Net: **~215 lines reduction**, plus elimination of the per-type hand-coding pattern.
 
 ### What Stays
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -87,7 +87,7 @@ cm_adapter_gen synthesizes a TIR function:
 // Synthesized adapter: wasi:http/types/[method]fields.get
 fn __cm_adapter__fields_get(self_handle: i32, name: String) -> Array<Array<u8>> {
     // 1. Lower params: String → (ptr, len) in linear memory
-    let name_packed = builtin::cm_lower_string(name);
+    let name_packed = internal::cm_lower_string(name);
     let name_ptr = name_packed as i32;
     let name_len = (name_packed >> 32) as i32;
 
@@ -95,20 +95,28 @@ fn __cm_adapter__fields_get(self_handle: i32, name: String) -> Array<Array<u8>> 
     let outptr = builtin::realloc(0, 0, 4, 8);
 
     // 3. Call lowered WASI function (flat ABI)
-    builtin::cm_raw_call(self_handle, name_ptr, name_len, outptr);
+    builtin::cm_raw_call__wasi_http_types_fields_get(self_handle, name_ptr, name_len, outptr);
 
-    // 4. Lift result: read (base_ptr, count) from outptr
+    // 4. Free lowered param memory (callee has consumed it)
+    builtin::realloc(name_ptr, name_len, 1, 0);
+
+    // 5. Lift result: read (base_ptr, count) from outptr
     let base_ptr = builtin::i32_load(outptr);
     let count = builtin::i32_load(outptr + 4);
 
-    // 5. Build Array<Array<u8>> from linear memory
+    // 6. Build Array<Array<u8>> from linear memory
     let result: Array<Array<u8>> = Array::<Array<u8>>::with_capacity(count);
     for let mut i = 0; i < count; i += 1 {
         let elem_ptr = builtin::i32_load(base_ptr + i * 8);
         let elem_len = builtin::i32_load(base_ptr + i * 8 + 4);
-        let bytes = builtin::memory_to_gc_array(elem_ptr, elem_len);
+        let bytes = internal::memory_to_gc_array(elem_ptr, elem_len);
         result.append(bytes);
     }
+
+    // 7. Free result linear memory (outer list + outptr)
+    builtin::realloc(base_ptr, count * 8, 4, 0);
+    builtin::realloc(outptr, 8, 4, 0);
+
     return result;
 }
 ```
@@ -139,8 +147,8 @@ fn __cm_export__handle(method_ptr: i32, method_len: i32,
                        /* ... flat params ... */
                        outptr: i32) {
     // 1. Lift params from flat ABI
-    let method = builtin::memory_to_gc_string(method_ptr, method_len);
-    let path = builtin::memory_to_gc_string(path_ptr, path_len);
+    let method = internal::memory_to_gc_string(method_ptr, method_len);
+    let path = internal::memory_to_gc_string(path_ptr, path_len);
     let request = Request { method, path, /* ... */ };
 
     // 2. Call user function
@@ -166,15 +174,16 @@ For async WASI functions (e.g., `Stdout::write_via_stream`):
 
 ```wado
 fn __cm_adapter__write_via_stream(stream: i32, data: String) {
-    let data_packed = builtin::cm_lower_string(data);
+    let data_packed = internal::cm_lower_string(data);
     let data_ptr = data_packed as i32;
     let data_len = (data_packed >> 32) as i32;
 
-    // Call lowered function — returns subtask handle
-    let subtask = builtin::cm_raw_call(stream, data_ptr, data_len);
+    // Call lowered async function — returns subtask handle
+    let subtask = builtin::cm_raw_call__wasi_cli_stdout_write_via_stream(stream, data_ptr, data_len);
 
-    // Wait for completion
+    // Wait for completion, then free lowered param memory
     internal::wait_for_subtask(subtask);
+    builtin::realloc(data_ptr, data_len, 1, 0);
 }
 ```
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -193,49 +193,49 @@ The adapter functions use builtins to perform low-level operations. Some already
 
 #### Existing (in builtin.wado / internal.wado)
 
-| Function | Purpose |
-| --- | --- |
-| `builtin::realloc` | Allocate linear memory |
-| `builtin::memory_load32` | Read i32 from linear memory |
-| `builtin::memory_store8` | Write byte to linear memory |
-| `builtin::memory_load8_u` | Read byte from linear memory |
-| `internal::cm_lower_string` | Lower String to (ptr, len) packed as i64 |
-| `internal::cm_lower_list_u8` | Lower Array\<u8\> to (ptr, len) |
+| Function                       | Purpose                                   |
+| ------------------------------ | ----------------------------------------- |
+| `builtin::realloc`             | Allocate linear memory                    |
+| `builtin::memory_load32`       | Read i32 from linear memory               |
+| `builtin::memory_store8`       | Write byte to linear memory               |
+| `builtin::memory_load8_u`      | Read byte from linear memory              |
+| `internal::cm_lower_string`    | Lower String to (ptr, len) packed as i64  |
+| `internal::cm_lower_list_u8`   | Lower Array\<u8\> to (ptr, len)           |
 | `internal::memory_to_gc_array` | Copy bytes from linear memory to GC array |
 | `internal::gc_array_to_memory` | Copy bytes from GC array to linear memory |
-| `internal::wait_for_subtask` | Wait for async subtask completion |
+| `internal::wait_for_subtask`   | Wait for async subtask completion         |
 
 #### internal.wado scope
 
 `internal.wado` provides CM helper functions only for types where lowering/lifting involves real work (allocation, memory copy). Scalar types (i32, i64, f32, f64, etc.) are lowered/lifted inline by the synthesizer using `builtin::i32_load` / `builtin::i32_store` directly — wrapping these in `internal::cm_lower_i32()` etc. would be trivial identity functions with no benefit.
 
-| Type | Lowering | Lifting | Provider |
-| --- | --- | --- | --- |
-| i32, i64, f32, f64 | identity (flat param) / `builtin::*_store` (memory) | `builtin::*_load` | synthesizer inline |
-| bool | `value as i32` | `i32_load8_u(addr) != 0` | synthesizer inline |
-| char | `value as i32` | `char::from_u32_unchecked` | synthesizer inline |
-| String | alloc + copy → `(ptr, len)` | copy from linear memory → GC string | `internal::cm_lower_string`, `internal::memory_to_gc_string` |
-| Array\<u8\> | alloc + copy → `(ptr, len)` | copy from linear memory → GC array | `internal::cm_lower_array_u8`, `internal::memory_to_gc_array` |
-| list\<T\>, option\<T\>, result\<T, E\>, record, variant | recursive | recursive | synthesizer generates TIR (calls leaf helpers above) |
+| Type                                                    | Lowering                                            | Lifting                             | Provider                                                      |
+| ------------------------------------------------------- | --------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------- |
+| i32, i64, f32, f64                                      | identity (flat param) / `builtin::*_store` (memory) | `builtin::*_load`                   | synthesizer inline                                            |
+| bool                                                    | `value as i32`                                      | `i32_load8_u(addr) != 0`            | synthesizer inline                                            |
+| char                                                    | `value as i32`                                      | `char::from_u32_unchecked`          | synthesizer inline                                            |
+| String                                                  | alloc + copy → `(ptr, len)`                         | copy from linear memory → GC string | `internal::cm_lower_string`, `internal::memory_to_gc_string`  |
+| Array\<u8\>                                             | alloc + copy → `(ptr, len)`                         | copy from linear memory → GC array  | `internal::cm_lower_array_u8`, `internal::memory_to_gc_array` |
+| list\<T\>, option\<T\>, result\<T, E\>, record, variant | recursive                                           | recursive                           | synthesizer generates TIR (calls leaf helpers above)          |
 
 Per-type converter functions (e.g., `cm_list_string_to_array`, `cm_option_string_to_option`) will be deleted once the synthesizer handles their types generically.
 
 #### New builtins to add
 
-| Function | Wasm instruction | Purpose |
-| --- | --- | --- |
-| `builtin::i32_load` | `i32.load` | Read i32 from linear memory at offset |
-| `builtin::i32_store` | `i32.store` | Write i32 to linear memory at offset |
-| `builtin::i64_load` | `i64.load` | Read i64 from linear memory at offset |
-| `builtin::i64_store` | `i64.store` | Write i64 to linear memory at offset |
-| `builtin::f32_load` | `f32.load` | Read f32 from linear memory at offset |
-| `builtin::f32_store` | `f32.store` | Write f32 to linear memory at offset |
-| `builtin::f64_load` | `f64.load` | Read f64 from linear memory at offset |
-| `builtin::f64_store` | `f64.store` | Write f64 to linear memory at offset |
-| `builtin::i32_load8_u` | `i32.load8_u` | Read byte from linear memory (zero-extended) |
-| `builtin::i32_load16_u` | `i32.load16_u` | Read u16 from linear memory |
-| `builtin::i32_store8` | `i32.store8` | Write byte to linear memory |
-| `builtin::i32_store16` | `i32.store16` | Write u16 to linear memory |
+| Function                | Wasm instruction | Purpose                                      |
+| ----------------------- | ---------------- | -------------------------------------------- |
+| `builtin::i32_load`     | `i32.load`       | Read i32 from linear memory at offset        |
+| `builtin::i32_store`    | `i32.store`      | Write i32 to linear memory at offset         |
+| `builtin::i64_load`     | `i64.load`       | Read i64 from linear memory at offset        |
+| `builtin::i64_store`    | `i64.store`      | Write i64 to linear memory at offset         |
+| `builtin::f32_load`     | `f32.load`       | Read f32 from linear memory at offset        |
+| `builtin::f32_store`    | `f32.store`      | Write f32 to linear memory at offset         |
+| `builtin::f64_load`     | `f64.load`       | Read f64 from linear memory at offset        |
+| `builtin::f64_store`    | `f64.store`      | Write f64 to linear memory at offset         |
+| `builtin::i32_load8_u`  | `i32.load8_u`    | Read byte from linear memory (zero-extended) |
+| `builtin::i32_load16_u` | `i32.load16_u`   | Read u16 from linear memory                  |
+| `builtin::i32_store8`   | `i32.store8`     | Write byte to linear memory                  |
+| `builtin::i32_store16`  | `i32.store16`    | Write u16 to linear memory                   |
 
 Note: `builtin::memory_load32` already exists but should be aliased to `builtin::i32_load` for consistency. The naming convention `builtin::i32_load` matches the Wasm instruction name.
 
@@ -391,28 +391,28 @@ This replaces the ad-hoc size/align constants scattered throughout `CmCallConven
 
 After cm_adapter_gen is complete:
 
-| Location | Code | Lines | Fate |
-| --- | --- | --- | --- |
-| codegen.rs | `generate_cm_effect_call` | ~140 | Deleted — adapter handles CM calls |
-| codegen.rs | `generate_cm_resource_method_call` | ~250 | Deleted — adapter handles resource calls |
-| codegen.rs | `emit_option_string_lowering` | ~40 | Deleted — adapter generates inline |
-| codegen.rs | `emit_field_size_payload_lowering` | ~65 | Deleted — adapter generates inline |
-| codegen.rs | `wado_type_to_cm_val_type` | ~50 | Moved to cm_abi.rs |
-| component_model.rs | `CmCallConvention` + `from_return_type` | ~350 | Deleted — type-driven synthesis replaces pattern matching |
-| internal.wado | `cm_list_string_to_array` | ~20 | Deleted — adapter generates inline |
-| internal.wado | `cm_option_string_to_option` | ~15 | Deleted — adapter generates inline |
-| internal.wado | `cm_option_own_resource_to_option` | ~10 | Deleted — adapter generates inline |
-| internal.wado | `cm_list_tuple_string_string_to_array` | ~25 | Deleted — adapter generates inline |
-| Total removed | | ~965 | |
+| Location           | Code                                    | Lines | Fate                                                      |
+| ------------------ | --------------------------------------- | ----- | --------------------------------------------------------- |
+| codegen.rs         | `generate_cm_effect_call`               | ~140  | Deleted — adapter handles CM calls                        |
+| codegen.rs         | `generate_cm_resource_method_call`      | ~250  | Deleted — adapter handles resource calls                  |
+| codegen.rs         | `emit_option_string_lowering`           | ~40   | Deleted — adapter generates inline                        |
+| codegen.rs         | `emit_field_size_payload_lowering`      | ~65   | Deleted — adapter generates inline                        |
+| codegen.rs         | `wado_type_to_cm_val_type`              | ~50   | Moved to cm_abi.rs                                        |
+| component_model.rs | `CmCallConvention` + `from_return_type` | ~350  | Deleted — type-driven synthesis replaces pattern matching |
+| internal.wado      | `cm_list_string_to_array`               | ~20   | Deleted — adapter generates inline                        |
+| internal.wado      | `cm_option_string_to_option`            | ~15   | Deleted — adapter generates inline                        |
+| internal.wado      | `cm_option_own_resource_to_option`      | ~10   | Deleted — adapter generates inline                        |
+| internal.wado      | `cm_list_tuple_string_string_to_array`  | ~25   | Deleted — adapter generates inline                        |
+| Total removed      |                                         | ~965  |                                                           |
 
 New code:
 
-| Module | Purpose | Lines (est.) |
-| --- | --- | --- |
-| cm_adapter_gen.rs | Type-driven adapter synthesis | ~500 |
-| cm_abi.rs | Canonical ABI layout computation | ~200 |
-| builtin.wado additions | Memory load/store builtins | ~50 |
-| Total added | | ~750 |
+| Module                 | Purpose                          | Lines (est.) |
+| ---------------------- | -------------------------------- | ------------ |
+| cm_adapter_gen.rs      | Type-driven adapter synthesis    | ~500         |
+| cm_abi.rs              | Canonical ABI layout computation | ~200         |
+| builtin.wado additions | Memory load/store builtins       | ~50          |
+| Total added            |                                  | ~750         |
 
 Net: **~215 lines reduction**, plus elimination of the per-type hand-coding pattern.
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -95,7 +95,7 @@ fn __cm_adapter__fields_get(self_handle: i32, name: String) -> Array<Array<u8>> 
     let outptr = builtin::realloc(0, 0, 4, 8);
 
     // 3. Call lowered WASI function (flat ABI)
-    builtin::cm_raw_call__wasi_http_types_fields_get(self_handle, name_ptr, name_len, outptr);
+    cm_raw_call Fields::get(self_handle, name_ptr, name_len, outptr);
 
     // 4. Free lowered param memory (callee has consumed it)
     builtin::realloc(name_ptr, name_len, 1, 0);
@@ -179,7 +179,7 @@ fn __cm_adapter__write_via_stream(stream: i32, data: String) {
     let data_len = (data_packed >> 32) as i32;
 
     // Call lowered async function — returns subtask handle
-    let subtask = builtin::cm_raw_call__wasi_cli_stdout_write_via_stream(stream, data_ptr, data_len);
+    let subtask = cm_raw_call Stdout::write_via_stream(stream, data_ptr, data_len);
 
     // Wait for completion, then free lowered param memory
     internal::wait_for_subtask(subtask);
@@ -226,14 +226,21 @@ Note: `builtin::memory_load32` already exists but should be aliased to `builtin:
 
 #### Raw CM calls
 
-Each lowered WASI function is represented as a builtin with a generated name:
+Raw CM calls are represented as a dedicated TIR node `CmRawCall` rather than builtin functions. This avoids polluting the builtin namespace and produces more readable unparse output:
 
 ```
-builtin::cm_raw_call__wasi_cli_stdout_get_stdout
-builtin::cm_raw_call__wasi_http_types_fields_get
+// TIR node
+TirExprKind::CmRawCall {
+    target: "Fields::get",                                    // effect::op reference
+    local_name: "wasi:http/types/[method]fields.get",         // resolved import name
+    args: [self_handle, name_ptr, name_len, outptr],          // flat ABI args
+}
+
+// Unparse output
+cm_raw_call Fields::get(self_handle, name_ptr, name_len, outptr)
 ```
 
-These map directly to imported core functions in the Component Model. Codegen emits them as `call` instructions targeting the imported function index.
+Codegen resolves the `local_name` to the imported function index. No builtin entity is needed per WASI function.
 
 ### Type-Driven Synthesis
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -1,0 +1,454 @@
+# WEP: TIR-Level CM Adapter Synthesis
+
+## Context
+
+The compiler's Component Model (CM) boundary logic — lifting GC values to linear memory, lowering linear memory to GC values, calling lowered WASI imports, wrapping exports for `canon lift` — is currently spread across multiple layers:
+
+- `codegen.rs`: `generate_cm_effect_call` (~140 lines), `generate_cm_resource_method_call` (~250 lines), `generate_effect_wait` (~50 lines), `emit_option_string_lowering` (~40 lines), `emit_field_size_payload_lowering` (~65 lines), plus scattered CM glue throughout function emission
+- `component_model.rs`: `CmCallConvention` and its `from_return_type` logic (~350 lines), deriving ABI conventions from WASI return types via pattern matching on `Type` variants
+- `internal.wado`: hand-written CM converter functions (`cm_lower_string`, `cm_list_string_to_array`, etc.) — each covers one specific type shape (~130 lines)
+- `wasm_plan.rs`: `CmExportInfo` with pre-computed scratch locals and required imports for export glue
+
+This architecture has two problems:
+
+### Per-type hand-coding
+
+Every new WASI return type shape requires adding a new `cm_*` function in `internal.wado`, a new match arm in `CmCallConvention::from_return_type`, and sometimes new codegen logic. For example, `list<tuple<string, string>>` required `cm_list_tuple_string_string_to_array` — a dedicated function for a single WASI call. This does not scale to arbitrary WIT types from third-party components.
+
+### Codegen complexity
+
+Codegen emits raw Wasm instructions for CM boundary crossing: `i32.load`, `i32.store`, `memory.grow`, `realloc` calls, outptr allocation, discriminant dispatch. This mixes two abstraction levels — Wado semantics and CM ABI mechanics — in the same function. The resulting code is hard to test, hard to debug (no intermediate representation between TIR and Wasm binary), and hard to optimize (the optimizer never sees CM glue code).
+
+### Relationship to WIR
+
+The WIR layer (WEP 2026-02-14) will replace codegen with a structured `tir_to_wir → wir_emit` pipeline. CM adapter synthesis can be done **before** WIR: it transforms `EffectCall` TIR nodes into ordinary `Call` nodes targeting synthesized adapter functions, reducing the surface area of CM-specific logic that `tir_to_wir` must handle.
+
+## Decision
+
+Introduce a **cm_adapter_gen** phase that synthesizes CM adapter functions as TIR, inserted between resolve and lower. Adapter functions express lifting, lowering, and boundary calls using Wado's own type system and builtins. They flow through the normal lower → optimize → codegen pipeline.
+
+### Pipeline Position
+
+```
+parse → desugar → modules → symbols → tir (resolve)
+                                        ↓
+                                   cm_adapter_gen  ← NEW
+                                        ↓
+                                      lower → optimize → wasm_plan → codegen
+```
+
+The phase runs after type resolution (all types are concrete, WASI registry is built) and before lower (so adapter functions go through match desugaring, closure capture, monomorphization, and optimization).
+
+### What cm_adapter_gen Does
+
+For each WASI import function used by the program:
+
+1. **Synthesize an adapter function** that:
+   - Accepts Wado-typed parameters (String, Array, structs, etc.)
+   - Lowers parameters to CM flat ABI (linear memory via builtins)
+   - Calls the lowered WASI function (flat i32/i64 params)
+   - Lifts the result from CM flat ABI back to Wado types
+   - Returns the Wado-typed result
+
+2. **Rewrite `EffectCall` nodes** to ordinary `Call` nodes targeting the adapter function.
+
+For each export function:
+
+3. **Synthesize an export adapter function** that:
+   - Accepts flat CM parameters (i32/i64 values, pointers)
+   - Lifts parameters to Wado types
+   - Calls the user's export function
+   - Lowers the result to flat CM ABI
+   - Returns flat values or writes to outptr
+
+### Import Adapter Example
+
+Given a WASI function:
+
+```wit
+// wasi:http/types.fields.get: func(self: borrow<fields>, name: string) -> list<list<u8>>
+```
+
+Currently represented as:
+
+```
+TirExprKind::EffectCall {
+    effect_name: "Fields",
+    op_name: "get",
+    args: [self_handle, name],
+    cm_convention: Some(CmCallConvention { outptr_alloc: Some((8, 4)), ... }),
+    cm_local_name: Some("wasi:http/types/[method]fields.get"),
+}
+```
+
+cm_adapter_gen synthesizes a TIR function:
+
+```wado
+// Synthesized adapter: wasi:http/types/[method]fields.get
+fn __cm_adapter__fields_get(self_handle: i32, name: String) -> Array<Array<u8>> {
+    // 1. Lower params: String → (ptr, len) in linear memory
+    let name_packed = builtin::cm_lower_string(name);
+    let name_ptr = name_packed as i32;
+    let name_len = (name_packed >> 32) as i32;
+
+    // 2. Allocate outptr for list<list<u8>> return
+    let outptr = builtin::realloc(0, 0, 4, 8);
+
+    // 3. Call lowered WASI function (flat ABI)
+    builtin::cm_raw_call(self_handle, name_ptr, name_len, outptr);
+
+    // 4. Lift result: read (base_ptr, count) from outptr
+    let base_ptr = builtin::i32_load(outptr);
+    let count = builtin::i32_load(outptr + 4);
+
+    // 5. Build Array<Array<u8>> from linear memory
+    let result: Array<Array<u8>> = Array::<Array<u8>>::with_capacity(count);
+    for let mut i = 0; i < count; i += 1 {
+        let elem_ptr = builtin::i32_load(base_ptr + i * 8);
+        let elem_len = builtin::i32_load(base_ptr + i * 8 + 4);
+        let bytes = builtin::memory_to_gc_array(elem_ptr, elem_len);
+        result.append(bytes);
+    }
+    return result;
+}
+```
+
+And the `EffectCall` becomes:
+
+```
+TirExprKind::Call {
+    func: FunctionRef::Resolved("__cm_adapter__fields_get"),
+    args: [self_handle, name],
+}
+```
+
+### Export Adapter Example
+
+Given a user export:
+
+```wado
+export fn handle(request: Request) -> Result<Response, ErrorCode> { ... }
+```
+
+cm_adapter_gen synthesizes:
+
+```wado
+// Synthesized export adapter
+fn __cm_export__handle(method_ptr: i32, method_len: i32,
+                       path_ptr: i32, path_len: i32,
+                       /* ... flat params ... */
+                       outptr: i32) {
+    // 1. Lift params from flat ABI
+    let method = builtin::memory_to_gc_string(method_ptr, method_len);
+    let path = builtin::memory_to_gc_string(path_ptr, path_len);
+    let request = Request { method, path, /* ... */ };
+
+    // 2. Call user function
+    let result = handle(request);
+
+    // 3. Lower Result<Response, ErrorCode> to outptr
+    match result {
+        Ok(response) => {
+            builtin::i32_store(outptr, 0);  // discriminant = Ok
+            // lower response fields to outptr + 4...
+        },
+        Err(code) => {
+            builtin::i32_store(outptr, 1);  // discriminant = Err
+            builtin::i32_store(outptr + 4, code as i32);
+        },
+    }
+}
+```
+
+### Async Adapter Example
+
+For async WASI functions (e.g., `Stdout::write_via_stream`):
+
+```wado
+fn __cm_adapter__write_via_stream(stream: i32, data: String) {
+    let data_packed = builtin::cm_lower_string(data);
+    let data_ptr = data_packed as i32;
+    let data_len = (data_packed >> 32) as i32;
+
+    // Call lowered function — returns subtask handle
+    let subtask = builtin::cm_raw_call(stream, data_ptr, data_len);
+
+    // Wait for completion
+    builtin::effect_wait(subtask);
+}
+```
+
+The `builtin::effect_wait` call expands to `waitable_set_new` + `waitable_join` + `waitable_set_wait` + `subtask_drop`, which is already in `builtin.wado` (or can be moved to `internal.wado` as a Wado-level function).
+
+### Required Builtins
+
+The adapter functions use builtins to perform low-level operations. Some already exist, others need to be added:
+
+#### Existing (in builtin.wado / internal.wado)
+
+| Function | Purpose |
+| --- | --- |
+| `builtin::realloc` | Allocate linear memory |
+| `builtin::memory_load32` | Read i32 from linear memory |
+| `builtin::memory_store8` | Write byte to linear memory |
+| `builtin::memory_load8_u` | Read byte from linear memory |
+| `internal::cm_lower_string` | Lower String to (ptr, len) packed as i64 |
+| `internal::cm_lower_list_u8` | Lower Array\<u8\> to (ptr, len) |
+| `internal::memory_to_gc_array` | Copy bytes from linear memory to GC array |
+| `internal::gc_array_to_memory` | Copy bytes from GC array to linear memory |
+| `builtin::effect_wait` | Wait for async subtask completion |
+
+#### New builtins to add
+
+| Function | Wasm instruction | Purpose |
+| --- | --- | --- |
+| `builtin::i32_load` | `i32.load` | Read i32 from linear memory at offset |
+| `builtin::i32_store` | `i32.store` | Write i32 to linear memory at offset |
+| `builtin::i64_load` | `i64.load` | Read i64 from linear memory at offset |
+| `builtin::i64_store` | `i64.store` | Write i64 to linear memory at offset |
+| `builtin::f32_load` | `f32.load` | Read f32 from linear memory at offset |
+| `builtin::f32_store` | `f32.store` | Write f32 to linear memory at offset |
+| `builtin::f64_load` | `f64.load` | Read f64 from linear memory at offset |
+| `builtin::f64_store` | `f64.store` | Write f64 to linear memory at offset |
+| `builtin::i32_load8_u` | `i32.load8_u` | Read byte from linear memory (zero-extended) |
+| `builtin::i32_load16_u` | `i32.load16_u` | Read u16 from linear memory |
+| `builtin::i32_store8` | `i32.store8` | Write byte to linear memory |
+| `builtin::i32_store16` | `i32.store16` | Write u16 to linear memory |
+
+Note: `builtin::memory_load32` already exists but should be aliased to `builtin::i32_load` for consistency. The naming convention `builtin::i32_load` matches the Wasm instruction name.
+
+#### Raw CM calls
+
+Each lowered WASI function is represented as a builtin with a generated name:
+
+```
+builtin::cm_raw_call__wasi_cli_stdout_get_stdout
+builtin::cm_raw_call__wasi_http_types_fields_get
+```
+
+These map directly to imported core functions in the Component Model. Codegen emits them as `call` instructions targeting the imported function index.
+
+### Type-Driven Synthesis
+
+The core of cm_adapter_gen is a **type-driven recursive synthesizer** that generates lift/lower TIR expressions for any Canonical ABI type:
+
+```rust
+// cm_adapter_gen.rs
+impl CmAdapterGen {
+    /// Synthesize TIR expressions to lift a CM value from linear memory
+    fn synthesize_lift(&self, ty: &ResolvedType, addr: TirExpr) -> TirExpr {
+        match ty {
+            // Primitives: single load
+            ResolvedType::I32 | ResolvedType::U32 =>
+                builtin_call("i32_load", vec![addr]),
+            ResolvedType::I64 | ResolvedType::U64 =>
+                builtin_call("i64_load", vec![addr]),
+            ResolvedType::F32 =>
+                builtin_call("f32_load", vec![addr]),
+            ResolvedType::F64 =>
+                builtin_call("f64_load", vec![addr]),
+            ResolvedType::Bool =>
+                // i32.load8_u, then != 0
+                ne(builtin_call("i32_load8_u", vec![addr]), i32_const(0)),
+
+            // String: read (ptr, len), copy from linear memory
+            ResolvedType::String => {
+                let ptr = builtin_call("i32_load", vec![addr.clone()]);
+                let len = builtin_call("i32_load", vec![add(addr, i32_const(4))]);
+                internal_call("memory_to_gc_string", vec![ptr, len])
+            }
+
+            // Array<T>: read (ptr, count), lift each element
+            ResolvedType::Array(elem_ty) => {
+                let base = builtin_call("i32_load", vec![addr.clone()]);
+                let count = builtin_call("i32_load", vec![add(addr, i32_const(4))]);
+                let elem_size = self.cm_size(elem_ty);
+                // Generate loop: for i in 0..count, lift element at base + i * elem_size
+                self.synthesize_lift_list(elem_ty, base, count, elem_size)
+            }
+
+            // Option<T>: read discriminant, conditionally lift payload
+            ResolvedType::Option(inner_ty) => {
+                let disc = builtin_call("i32_load8_u", vec![addr.clone()]);
+                let payload_offset = self.cm_align(inner_ty);  // padding after discriminant
+                // if disc == 0 { None } else { Some(lift(inner, addr + offset)) }
+                self.synthesize_lift_option(inner_ty, disc, addr, payload_offset)
+            }
+
+            // Result<T, E>: read discriminant, lift Ok or Err
+            ResolvedType::Result(ok_ty, err_ty) => {
+                let disc = builtin_call("i32_load", vec![addr.clone()]);
+                let payload_offset = 4;  // after i32 discriminant
+                // match disc { 0 => Ok(lift(ok, addr+4)), 1 => Err(lift(err, addr+4)) }
+                self.synthesize_lift_result(ok_ty, err_ty, disc, addr, payload_offset)
+            }
+
+            // Record/struct: lift each field at its offset
+            ResolvedType::Record(fields) => {
+                self.synthesize_lift_record(fields, addr)
+            }
+
+            // Enum: load discriminant
+            ResolvedType::Enum(_) =>
+                builtin_call("i32_load", vec![addr]),
+
+            // Variant: load discriminant, lift payload per case
+            ResolvedType::Variant(cases) => {
+                self.synthesize_lift_variant(cases, addr)
+            }
+
+            // Resource handle: just an i32
+            ResolvedType::Resource =>
+                builtin_call("i32_load", vec![addr]),
+        }
+    }
+
+    /// Synthesize TIR expressions to lower a Wado value to linear memory
+    fn synthesize_lower(&self, ty: &ResolvedType, value: TirExpr, addr: TirExpr) -> TirExpr {
+        // Symmetric to synthesize_lift: store primitives, recurse for composites
+        // ...
+    }
+}
+```
+
+### Canonical ABI Layout Computation
+
+A pure `cm_abi.rs` module computes sizes, alignments, and field offsets for Canonical ABI types:
+
+```rust
+// cm_abi.rs
+
+/// Canonical ABI size in bytes
+pub fn cm_size(ty: &ResolvedType) -> u32 {
+    match ty {
+        ResolvedType::Bool | ResolvedType::U8 | ResolvedType::I8 => 1,
+        ResolvedType::U16 | ResolvedType::I16 => 2,
+        ResolvedType::I32 | ResolvedType::U32 | ResolvedType::F32 |
+        ResolvedType::Char | ResolvedType::Enum(_) | ResolvedType::Resource => 4,
+        ResolvedType::I64 | ResolvedType::U64 | ResolvedType::F64 => 8,
+        ResolvedType::String | ResolvedType::Array(_) => 8,  // (ptr, len)
+        ResolvedType::Option(inner) => {
+            let payload = cm_size(inner);
+            let align = cm_align(inner);
+            align_to(1, align) + payload  // disc + padding + payload
+        }
+        ResolvedType::Result(ok, err) => {
+            4 + max(cm_size(ok), cm_size(err))  // disc(i32) + max(ok, err)
+        }
+        ResolvedType::Record(fields) => {
+            // Sum of fields with alignment padding
+            layout_record(fields).size
+        }
+        ResolvedType::Variant(cases) => {
+            4 + cases.iter().map(|c| cm_size(&c.payload)).max().unwrap_or(0)
+        }
+        // Tuple is a record
+        ResolvedType::Tuple(elems) => {
+            layout_tuple(elems).size
+        }
+    }
+}
+
+/// Canonical ABI alignment in bytes
+pub fn cm_align(ty: &ResolvedType) -> u32 { ... }
+
+/// Compute field offsets for a record/struct
+pub fn layout_record(fields: &[CmField]) -> CmLayout { ... }
+```
+
+This replaces the ad-hoc size/align constants scattered throughout `CmCallConvention` (e.g., `outptr_alloc: Some((8, 4))` for string, `Some((12, 4))` for option\<string\>).
+
+### What Gets Removed
+
+After cm_adapter_gen is complete:
+
+| Location | Code | Lines | Fate |
+| --- | --- | --- | --- |
+| codegen.rs | `generate_cm_effect_call` | ~140 | Deleted — adapter handles CM calls |
+| codegen.rs | `generate_cm_resource_method_call` | ~250 | Deleted — adapter handles resource calls |
+| codegen.rs | `generate_effect_wait` | ~50 | Deleted — adapter calls `builtin::effect_wait` |
+| codegen.rs | `emit_option_string_lowering` | ~40 | Deleted — adapter generates inline |
+| codegen.rs | `emit_field_size_payload_lowering` | ~65 | Deleted — adapter generates inline |
+| codegen.rs | `wado_type_to_cm_val_type` | ~50 | Moved to cm_abi.rs |
+| component_model.rs | `CmCallConvention` + `from_return_type` | ~350 | Deleted — type-driven synthesis replaces pattern matching |
+| internal.wado | `cm_list_string_to_array` | ~20 | Deleted — adapter generates inline |
+| internal.wado | `cm_option_string_to_option` | ~15 | Deleted — adapter generates inline |
+| internal.wado | `cm_option_own_resource_to_option` | ~10 | Deleted — adapter generates inline |
+| internal.wado | `cm_list_tuple_string_string_to_array` | ~25 | Deleted — adapter generates inline |
+| Total removed | | ~1015 | |
+
+New code:
+
+| Module | Purpose | Lines (est.) |
+| --- | --- | --- |
+| cm_adapter_gen.rs | Type-driven adapter synthesis | ~500 |
+| cm_abi.rs | Canonical ABI layout computation | ~200 |
+| builtin.wado additions | Memory load/store builtins | ~50 |
+| Total added | | ~750 |
+
+Net: **~250 lines reduction**, plus elimination of the per-type hand-coding pattern.
+
+### What Stays
+
+- `WasiRegistry` in component_model.rs — still needed to know which WASI functions exist and their signatures
+- `ComponentPlan` in wasm_plan.rs — still needed for component wrapper construction
+- `CmExportInfo` in wasm_plan.rs — absorbed into cm_adapter_gen (export adapter synthesis replaces scratch local pre-computation)
+- Component wrapper encoding in codegen — still emits the outer Component Model structure (`ComponentBuilder` calls)
+
+## Migration Plan
+
+### Phase 1: Builtins and Infrastructure
+
+- [ ] Add `builtin::i32_load`, `builtin::i32_store`, `builtin::i64_load`, `builtin::i64_store`, `builtin::f32_load`, `builtin::f32_store`, `builtin::f64_load`, `builtin::f64_store` and sub-word variants to `builtin.wado` and codegen's builtin dispatch.
+- [ ] Create `cm_abi.rs` with Canonical ABI size/align/layout computation.
+- [ ] Add unit tests for `cm_abi.rs` against known Canonical ABI layouts.
+
+### Phase 2: Import Adapters (Incremental)
+
+Migrate one WASI interface at a time, validating via existing E2E tests.
+
+- [ ] Create `cm_adapter_gen.rs` scaffolding: the phase entry point, TIR function synthesis helpers.
+- [ ] Implement `synthesize_lift` and `synthesize_lower` for primitives (i32, i64, f32, f64, bool, char).
+- [ ] Implement `synthesize_lift` and `synthesize_lower` for String.
+- [ ] Migrate `wasi:cli/Stdout` and `wasi:cli/Stderr` (simplest: void return, String param). Validate with E2E tests.
+- [ ] Implement `synthesize_lift` for `list<T>`, `option<T>`, `result<T, E>`.
+- [ ] Migrate `wasi:cli/Environment` (returns `list<tuple<string, string>>`). This replaces `cm_list_tuple_string_string_to_array`.
+- [ ] Migrate `wasi:http/types` resource methods. This replaces `generate_cm_resource_method_call`.
+- [ ] Migrate remaining WASI interfaces.
+- [ ] Delete `CmCallConvention` and per-type converters in `internal.wado`.
+
+### Phase 3: Export Adapters
+
+- [ ] Implement export adapter synthesis for `wasi:cli/run` (simplest export).
+- [ ] Implement export adapter synthesis for `wasi:http/incoming-handler` (complex: async, Result return).
+- [ ] Delete `CmExportInfo` scratch local logic — adapters declare their own locals.
+- [ ] Delete export-related CM glue from codegen.
+
+### Phase 4: Cleanup
+
+- [ ] Remove `TirExprKind::EffectCall` — all effect calls are now ordinary `Call`s to adapters.
+- [ ] Remove `cm_convention` and `cm_local_name` fields from TIR.
+- [ ] Inline or remove `CmCallConvention`.
+- [ ] Verify all E2E tests pass, including HTTP serve tests.
+
+## Consequences
+
+### Benefits
+
+- **Extensibility**: Any Canonical ABI type is supported by the recursive synthesizer — no per-type hand-coding.
+- **Optimization**: Adapter functions go through lower → optimize, so the optimizer can inline small adapters, eliminate dead branches in match arms, and propagate constants.
+- **Debuggability**: `wado dump --tir --unparse` and `wado dump --lower --unparse` show the full CM glue as Wado code.
+- **Independence from WIR**: This can be implemented and shipped before WIR migration begins. It reduces the CM surface area that `tir_to_wir` must handle (Step 3e in WIR WEP).
+- **Simpler codegen**: Codegen no longer needs to know about CM lifting/lowering. It just compiles adapter functions like any other function.
+- **Simpler `tir_to_wir`**: When WIR migration begins, CM adapters are already ordinary TIR functions — no special CM translation logic needed in `tir_to_wir`.
+
+### Trade-offs
+
+- **TIR growth**: The synthesized adapter functions add to the TIR function count. Mitigated by dead code elimination (unused adapters are removed) and by adapter functions being small.
+- **Builtin surface area**: More builtins (`builtin::i32_load`, etc.) increase the builtin dispatch table. These are trivial 1:1 mappings to Wasm instructions.
+- **Two-phase migration**: During migration, some WASI calls use adapters while others still use the old `generate_cm_effect_call` path. Each interface is migrated independently, so the codebase is always in a working state.
+
+### Risks
+
+- **Canonical ABI correctness**: The layout computation must match the Component Model specification exactly. Mitigated by unit tests against known layouts and by validating against wasmtime's runtime behavior via E2E tests.
+- **Performance regression in adapter code**: Synthesized TIR may produce suboptimal Wasm compared to hand-written codegen. Mitigated by the optimizer (which sees adapter functions) and by golden fixture comparison.


### PR DESCRIPTION
## Summary

This PR adds two new Wado Enhancement Proposals (WEPs) that define the architecture for major compiler improvements:

1. **WEP 2026-02-14: Wasm IR (WIR) Layer** — Introduces an intermediate representation between TIR and Wasm binary to improve debuggability, testability, and optimization opportunities
2. **WEP 2026-02-15: TIR-Level CM Adapter Synthesis** — Proposes synthesizing Component Model boundary adapters as TIR functions to reduce codegen complexity

## Key Changes

- **docs/wep-2026-02-14-wir-layer.md** (1,167 lines)
  - Defines WIR as a tree-structured IR that maps 1:1 to Wasm instructions with ergonomic improvements (named locals, named types, Wado-level value types, structured control flow)
  - Specifies complete WIR data structures: `WirModule`, `WirTypeDef`, `WirFunction`, `WirInstr`, type system, and metadata preservation
  - Details the new pipeline: `tir_to_wir → wir_emit` replacing monolithic codegen
  - Describes unparse format for debugging via `dump --wir`
  - Outlines strangler fig migration strategy to build WIR alongside existing codegen without modifying it
  - Includes implementation phases, testing strategy, and rollout plan

- **docs/wep-2026-02-15-cm-adapter-synthesis.md** (482 lines)
  - Proposes synthesizing CM adapter functions as TIR to eliminate per-type hand-coding in `internal.wado`
  - Shows concrete examples of import and export adapters
  - Specifies required builtins for memory operations and lifting/lowering
  - Describes type-driven recursive synthesis for arbitrary Canonical ABI types
  - Explains how this reduces codegen surface area before WIR migration

- **AGENTS.md**
  - Added references to both new WEPs in the WEP index

## Notable Details

- WIR uses lightweight `WirTypeId` and `WirFuncId` (O(1) integer-based) for high-frequency instruction references, while definitions use `WirName` (fully-qualified strings)
- Metadata (source spans, attributes, generic origins, newtype origins) is preserved through WIR for debugging and unparse
- CM adapter synthesis runs between resolve and lower, allowing adapters to flow through normal optimization pipeline
- Both proposals are designed to work together: CM adapters reduce what `tir_to_wir` must handle, and WIR provides the structured IR needed for future Wasm-level optimizations

https://claude.ai/code/session_01BMr6arVpKqesuTiYbx7tY8