### PR TITLE
Update Wado agent guidelines for sub-agents and symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,8 @@ Wado is designed with the following Wasm features:
 - When referring to WAT, use folded style syntax.
 - Do not commit changes unless the user requests so. When commit, no need to explain the implementation details.
 - If you find a compiler bug, limitation, or awkward behavior, fix it. Such a problem must be treated as the highest priority.
+- Use sub-agents only for research tasks (searching, reading, exploring). Never use sub-agents for editing files.
+- `CLAUDE.md` is a symlink to `AGENTS.md`. Editing either one is sufficient.
 
 ## Rules for Rust
 


### PR DESCRIPTION
## Summary
Updated the Wado agent guidelines in AGENTS.md to clarify best practices for sub-agent usage and document the relationship between AGENTS.md and CLAUDE.md.

## Key Changes
- Added guidance that sub-agents should only be used for research tasks (searching, reading, exploring), never for editing files
- Documented that CLAUDE.md is a symlink to AGENTS.md, so editing either file is sufficient

## Details
These additions to the Wado design principles help establish clearer boundaries for agent behavior and clarify the documentation structure for maintainers.

https://claude.ai/code/session_01U9rY4aFCi1ZKcbcbnmnXNx