### PR TITLE
Fix waitable_set_wait output buffer size to 8 bytes

### DIFF
--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -57,8 +57,11 @@ fn waitable_set_new() -> i32;
 #[canonical("wasi", "waitable-join")]
 fn waitable_join(set: i32, subtask: i32);
 
-/// Wait on a waitable set, returns when any task completes
-/// Writes completion info to outptr
+/// Wait on a waitable set, returns event ordinal when any task completes.
+/// Writes 8 bytes (POINTER_PAIR) to outptr:
+///   outptr+0: handle (u32) - waitable handle or 0
+///   outptr+4: result (u32) - packed status code
+/// Caller must allocate 8 bytes with 4-byte alignment.
 #[canonical("wasi", "waitable-set-wait")]
 fn waitable_set_wait(set: i32, outptr: i32) -> i32;
 

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -52,9 +52,9 @@ pub fn wait_for_subtask(subtask: i32) {
     if (subtask & 1) == 0 {
         let ws = builtin::waitable_set_new();
         builtin::waitable_join(ws, subtask);
-        let ptr = builtin::realloc(0, 0, 4, 4);
+        let ptr = builtin::realloc(0, 0, 4, 8);
         builtin::waitable_set_wait(ws, ptr);
-        builtin::realloc(ptr, 4, 4, 0);
+        builtin::realloc(ptr, 8, 4, 0);
         builtin::subtask_drop(subtask);
     }
 }


### PR DESCRIPTION
## Summary
This PR corrects the buffer allocation and deallocation sizes for the `waitable_set_wait` function output parameter to match the documented interface specification.

## Key Changes
- Updated `builtin.wado` documentation for `waitable_set_wait` to clarify that it writes 8 bytes (POINTER_PAIR) to the output pointer, containing:
  - 4 bytes for handle (u32) at offset 0
  - 4 bytes for result/status code (u32) at offset 4
  - Requires 4-byte alignment
- Fixed `internal.wado` buffer allocation in `wait_for_subtask`:
  - Changed `realloc(0, 0, 4, 4)` to `realloc(0, 0, 4, 8)` to allocate 8 bytes instead of 4
  - Changed `realloc(ptr, 4, 4, 0)` to `realloc(ptr, 8, 4, 0)` to deallocate the correct 8-byte size

## Details
The `waitable_set_wait` function requires an 8-byte output buffer to store both the waitable handle and the packed status code. The previous implementation was only allocating 4 bytes, which would cause a buffer overflow. This fix ensures the buffer size matches the actual data being written by the function.

https://claude.ai/code/session_01AjrXyv43STy8HkSQKnSEof