### PR TITLE
Add Component Model ABI support and adapter synthesis framework

### DIFF
--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -406,13 +406,13 @@ After cm_adapter_gen is complete:
 
 New code (actual for Phases 1–2, estimated for Phases 3–4):
 
-| Module                    | Purpose                                | Lines    |
-| ------------------------- | -------------------------------------- | -------- |
-| cm_abi.rs                 | Canonical ABI layout computation       | 719      |
-| cm_adapter_gen.rs         | Type-driven adapter synthesis          | 678      |
-| builtin.wado additions    | Memory load/store builtins             | ~50      |
-| CmRawCall visitor changes | Match arms across 14 files             | ~160     |
-| Total added               |                                        | ~1600    |
+| Module                    | Purpose                          | Lines |
+| ------------------------- | -------------------------------- | ----- |
+| cm_abi.rs                 | Canonical ABI layout computation | 719   |
+| cm_adapter_gen.rs         | Type-driven adapter synthesis    | 678   |
+| builtin.wado additions    | Memory load/store builtins       | ~50   |
+| CmRawCall visitor changes | Match arms across 14 files       | ~160  |
+| Total added               |                                  | ~1600 |
 
 The actual code is larger than the original ~750 line estimate, mainly because `cm_abi.rs` is more thorough than expected (719 lines with 37 tests covering all type shapes, consistency checks, and edge cases like nested options/results). The adapter gen module will grow further as composite type lift/lower is added.
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -25,19 +25,19 @@ The WIR layer (WEP 2026-02-14) will replace codegen with a structured `tir_to_wi
 
 ## Decision
 
-Introduce a **cm_adapter_gen** phase that synthesizes CM adapter functions as TIR, inserted between resolve and lower. Adapter functions express lifting, lowering, and boundary calls using Wado's own type system and builtins. They flow through the normal lower → optimize → codegen pipeline.
+Introduce a **cm_adapter_gen** phase that synthesizes CM adapter functions as TIR, inserted between effect_check and monomorphize. Adapter functions express lifting, lowering, and boundary calls using Wado's own type system and builtins. They flow through the normal monomorphize → lower → optimize → codegen pipeline.
 
 ### Pipeline Position
 
 ```
-parse → desugar → modules → symbols → tir (resolve)
-                                        ↓
-                                   cm_adapter_gen  ← NEW
-                                        ↓
-                                      lower → optimize → wasm_plan → codegen
+parse → desugar → modules → symbols → tir (resolve) → effect_check
+                                                            ↓
+                                                       cm_adapter_gen  ← NEW
+                                                            ↓
+                                       monomorphize → lower → optimize → wasm_plan → codegen
 ```
 
-The phase runs after type resolution (all types are concrete, WASI registry is built) and before lower (so adapter functions go through match desugaring, closure capture, monomorphization, and optimization).
+The phase runs after effect checking (all effects are validated) and before monomorphize (so adapter functions go through monomorphization, match desugaring, optimization, and codegen like any other function).
 
 ### What cm_adapter_gen Does
 
@@ -196,9 +196,9 @@ The adapter functions use builtins to perform low-level operations. Some already
 | Function                       | Purpose                                   |
 | ------------------------------ | ----------------------------------------- |
 | `builtin::realloc`             | Allocate linear memory                    |
-| `builtin::memory_load32`       | Read i32 from linear memory               |
-| `builtin::memory_store8`       | Write byte to linear memory               |
-| `builtin::memory_load8_u`      | Read byte from linear memory              |
+| `builtin::i32_load`            | Read i32 from linear memory               |
+| `builtin::i32_store8`          | Write byte to linear memory               |
+| `builtin::i32_load8_u`         | Read byte from linear memory              |
 | `internal::cm_lower_string`    | Lower String to (ptr, len) packed as i64  |
 | `internal::cm_lower_list_u8`   | Lower Array\<u8\> to (ptr, len)           |
 | `internal::memory_to_gc_array` | Copy bytes from linear memory to GC array |
@@ -220,7 +220,9 @@ The adapter functions use builtins to perform low-level operations. Some already
 
 Per-type converter functions (e.g., `cm_list_string_to_array`, `cm_option_string_to_option`) will be deleted once the synthesizer handles their types generically.
 
-#### New builtins to add
+#### Memory load/store builtins (added in Phase 1)
+
+All memory load/store builtins use Wasm instruction names for consistency. The old `memory_load32`, `memory_store8`, `memory_load8_u` aliases were removed in favor of these.
 
 | Function                | Wasm instruction | Purpose                                      |
 | ----------------------- | ---------------- | -------------------------------------------- |
@@ -237,8 +239,6 @@ Per-type converter functions (e.g., `cm_list_string_to_array`, `cm_option_string
 | `builtin::i32_store8`   | `i32.store8`     | Write byte to linear memory                  |
 | `builtin::i32_store16`  | `i32.store16`    | Write u16 to linear memory                   |
 
-Note: `builtin::memory_load32` already exists but should be aliased to `builtin::i32_load` for consistency. The naming convention `builtin::i32_load` matches the Wasm instruction name.
-
 #### Raw CM calls
 
 Raw CM calls are represented as a dedicated TIR node `CmRawCall` rather than builtin functions. This avoids polluting the builtin namespace and produces more readable unparse output:
@@ -246,16 +246,15 @@ Raw CM calls are represented as a dedicated TIR node `CmRawCall` rather than bui
 ```
 // TIR node
 TirExprKind::CmRawCall {
-    target: "Fields::get",                                    // effect::op reference
     local_name: "wasi:http/types/[method]fields.get",         // resolved import name
     args: [self_handle, name_ptr, name_len, outptr],          // flat ABI args
 }
 
 // Unparse output
-cm_raw_call Fields::get(self_handle, name_ptr, name_len, outptr)
+cm_raw_call wasi:http/types/[method]fields.get(self_handle, name_ptr, name_len, outptr)
 ```
 
-Codegen resolves the `local_name` to the imported function index. No builtin entity is needed per WASI function.
+The `local_name` field is the only identifier needed — codegen resolves it to the imported function index via `try_func_idx`. The original design included a separate `target` field for `effect::op` reference, but this was dropped as redundant; the adapter function name (`__cm_adapter__Effect_method`) is sufficient for human readability and the `local_name` is what codegen needs.
 
 ### Type-Driven Synthesis
 
@@ -405,16 +404,19 @@ After cm_adapter_gen is complete:
 | internal.wado      | `cm_list_tuple_string_string_to_array`  | ~25   | Deleted — adapter generates inline                        |
 | Total removed      |                                         | ~965  |                                                           |
 
-New code:
+New code (actual for Phases 1–2, estimated for Phases 3–4):
 
-| Module                 | Purpose                          | Lines (est.) |
-| ---------------------- | -------------------------------- | ------------ |
-| cm_adapter_gen.rs      | Type-driven adapter synthesis    | ~500         |
-| cm_abi.rs              | Canonical ABI layout computation | ~200         |
-| builtin.wado additions | Memory load/store builtins       | ~50          |
-| Total added            |                                  | ~750         |
+| Module                    | Purpose                                | Lines    |
+| ------------------------- | -------------------------------------- | -------- |
+| cm_abi.rs                 | Canonical ABI layout computation       | 719      |
+| cm_adapter_gen.rs         | Type-driven adapter synthesis          | 678      |
+| builtin.wado additions    | Memory load/store builtins             | ~50      |
+| CmRawCall visitor changes | Match arms across 14 files             | ~160     |
+| Total added               |                                        | ~1600    |
 
-Net: **~215 lines reduction**, plus elimination of the per-type hand-coding pattern.
+The actual code is larger than the original ~750 line estimate, mainly because `cm_abi.rs` is more thorough than expected (719 lines with 37 tests covering all type shapes, consistency checks, and edge cases like nested options/results). The adapter gen module will grow further as composite type lift/lower is added.
+
+Net line change will depend on how much codegen/component_model CM logic is deleted in Phases 3–4.
 
 ### What Stays
 
@@ -425,21 +427,24 @@ Net: **~215 lines reduction**, plus elimination of the per-type hand-coding patt
 
 ## Migration Plan
 
-### Phase 1: Builtins and Infrastructure
+### Phase 1: Builtins and Infrastructure (done)
 
-- [ ] Add `builtin::i32_load`, `builtin::i32_store`, `builtin::i64_load`, `builtin::i64_store`, `builtin::f32_load`, `builtin::f32_store`, `builtin::f64_load`, `builtin::f64_store` and sub-word variants to `builtin.wado` and codegen's builtin dispatch.
-- [ ] Create `cm_abi.rs` with Canonical ABI size/align/layout computation.
-- [ ] Add unit tests for `cm_abi.rs` against known Canonical ABI layouts.
+- [x] Add `builtin::i32_load`, `builtin::i32_store`, `builtin::i64_load`, `builtin::i64_store`, `builtin::f32_load`, `builtin::f32_store`, `builtin::f64_load`, `builtin::f64_store` and sub-word variants to `builtin.wado` and codegen's builtin dispatch.
+- [x] Create `cm_abi.rs` (719 lines) with Canonical ABI size/align/layout computation: `cm_size`, `cm_align`, `layout_record`, `layout_tuple`, `layout_option`, `layout_result`, `cm_flat_types`.
+- [x] Add 37 unit tests for `cm_abi.rs` against known Canonical ABI layouts.
 
 ### Phase 2: Import Adapters (Incremental)
 
 Migrate one WASI interface at a time, validating via existing E2E tests.
 
-- [ ] Create `cm_adapter_gen.rs` scaffolding: the phase entry point, TIR function synthesis helpers.
-- [ ] Implement `synthesize_lift` and `synthesize_lower` for primitives (i32, i64, f32, f64, bool, char).
-- [ ] Implement `synthesize_lift` and `synthesize_lower` for String.
+- [x] Add `TirExprKind::CmRawCall { local_name, args }` variant to TIR and handle in all 14 visitor/transform files (codegen, lower, monomorphize, effect_check, unparse, and all optimizer passes).
+- [x] Create `cm_adapter_gen.rs` scaffolding (678 lines): the phase entry point (`generate_adapters`), TIR function synthesis helpers (`builtin_call`, `internal_call`, `i32_const`, `i64_const`, `local_ref`, `binary`, `cast`, `let_stmt`, `expr_stmt`, `return_stmt`, `cm_raw_call`), effect call collector. 19 unit tests.
+- [x] Wire `cm_adapter_gen` into pipeline between `effect_check` and `monomorphize` (currently no-op scaffolding that scans effect calls without transforming).
+- [x] Implement `synthesize_lift` and `synthesize_lower` for primitives (i32, i64, f32, f64, bool, char, i8/u8, i16/u16).
+- [x] Implement `synthesize_lift` for String (via `memory_to_gc_string`). `synthesize_lower` for String not yet implemented (needs `cm_lower_string` integration).
+- [ ] Implement `synthesize_lower` for String.
 - [ ] Migrate `wasi:cli/Stdout` and `wasi:cli/Stderr` (simplest: void return, String param). Validate with E2E tests.
-- [ ] Implement `synthesize_lift` for `list<T>`, `option<T>`, `result<T, E>`.
+- [ ] Implement `synthesize_lift` and `synthesize_lower` for `list<T>`, `option<T>`, `result<T, E>`.
 - [ ] Migrate `wasi:cli/Environment` (returns `list<tuple<string, string>>`). This replaces `cm_list_tuple_string_string_to_array`.
 - [ ] Migrate `wasi:http/types` resource methods. This replaces `generate_cm_resource_method_call`.
 - [ ] Migrate remaining WASI interfaces.
@@ -458,6 +463,37 @@ Migrate one WASI interface at a time, validating via existing E2E tests.
 - [ ] Remove `cm_convention` and `cm_local_name` fields from TIR.
 - [ ] Inline or remove `CmCallConvention`.
 - [ ] Verify all E2E tests pass, including HTTP serve tests.
+
+## Implementation Notes
+
+### CmRawCall visitor coverage
+
+Adding a new `TirExprKind` variant requires updating 14 files with match arms. The pattern varies per file:
+
+- **Grouped with EffectCall**: Most optimizer passes group `CmRawCall` with `EffectCall` since they share the same `args` structure. This is the common case for passes that recurse into arguments.
+- **Standalone handling**: codegen, unparse, effect_check, and optimize_dce need separate match arms because they have variant-specific logic (e.g., codegen resolves `local_name` to a function index, unparse formats differently).
+- **Reconstruction**: optimize_inline must reconstruct `CmRawCall` when inlining, remapping local indices.
+
+### TIR construction gotchas
+
+Discovered during implementation:
+
+- `IntLiteral.value` is `u64`, not `i64`. Signed constants need `as u64` cast.
+- `TirBinaryOp::NotEq`, not `NotEqual`.
+- `TirStmtKind` has no `While` or `For` — loops are lowered to `Loop` with `Break`/`Continue`.
+- `TirStmtKind::Break` has `{ label, value }` fields, not a unit variant.
+- `Switch` and `Match` have different arm types: `Switch { arms: Vec<TirBlock>, default: TirBlock }` vs `Match { arms: Vec<TirMatchArm> }`.
+- `module_source()` returns `ModuleSource` directly, not `Option<ModuleSource>`.
+
+These are documented here to help future TIR-synthesizing phases avoid the same issues.
+
+### Pipeline position
+
+The original WEP placed cm_adapter_gen "between resolve and lower". The actual position is between `effect_check` and `monomorphize`. This is because:
+
+1. Effect checking must run first to validate effect declarations.
+2. Adapter functions need monomorphization (they may use generic builtins).
+3. Placing before monomorphize means adapters flow through all downstream phases: monomorphize → lower → optimize → wasm_plan → codegen.
 
 ## Consequences
 

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -108,15 +108,6 @@ fn array_copy<T>(dst: builtin::array<T>, dst_offset: i32, src: builtin::array<T>
 /// Fill a builtin::array<T> with a value
 /// Fills `len` elements starting at `offset` with `value`
 fn array_fill<T>(arr: builtin::array<T>, offset: i32, value: T, len: i32);
-/// Store a byte to linear memory
-fn memory_store8(addr: i32, value: i32);
-
-/// Load a byte from linear memory (zero-extended to i32)
-fn memory_load8_u(addr: i32) -> i32;
-
-/// Load a 32-bit value from linear memory
-fn memory_load32(addr: i32) -> i32;
-
 /// Load i32 from linear memory (Wasm i32.load)
 fn i32_load(addr: i32) -> i32;
 

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -117,6 +117,42 @@ fn memory_load8_u(addr: i32) -> i32;
 /// Load a 32-bit value from linear memory
 fn memory_load32(addr: i32) -> i32;
 
+/// Load i32 from linear memory (Wasm i32.load)
+fn i32_load(addr: i32) -> i32;
+
+/// Store i32 to linear memory (Wasm i32.store)
+fn i32_store(addr: i32, value: i32);
+
+/// Load i64 from linear memory (Wasm i64.load)
+fn i64_load(addr: i32) -> i64;
+
+/// Store i64 to linear memory (Wasm i64.store)
+fn i64_store(addr: i32, value: i64);
+
+/// Load f32 from linear memory (Wasm f32.load)
+fn f32_load(addr: i32) -> f32;
+
+/// Store f32 to linear memory (Wasm f32.store)
+fn f32_store(addr: i32, value: f32);
+
+/// Load f64 from linear memory (Wasm f64.load)
+fn f64_load(addr: i32) -> f64;
+
+/// Store f64 to linear memory (Wasm f64.store)
+fn f64_store(addr: i32, value: f64);
+
+/// Load byte from linear memory, zero-extended to i32 (Wasm i32.load8_u)
+fn i32_load8_u(addr: i32) -> i32;
+
+/// Load u16 from linear memory, zero-extended to i32 (Wasm i32.load16_u)
+fn i32_load16_u(addr: i32) -> i32;
+
+/// Store low byte of i32 to linear memory (Wasm i32.store8)
+fn i32_store8(addr: i32, value: i32);
+
+/// Store low 16 bits of i32 to linear memory (Wasm i32.store16)
+fn i32_store16(addr: i32, value: i32);
+
 /// Allocate/reallocate memory in linear memory
 /// Standard WASI realloc signature
 #[canonical("mem", "realloc")]

--- a/wado-compiler/lib/core/cli.wado
+++ b/wado-compiler/lib/core/cli.wado
@@ -26,10 +26,10 @@ pub fn write_to_stream(tx: i32, message: String, add_newline: bool) {
     let ptr = builtin::realloc(0, 0, 1, alloc_size);
     for (let mut i = 0; i < len; i = i + 1) {
         let byte = builtin::array_get_u8(msg_bytes, i);
-        builtin::memory_store8(ptr + i, byte);
+        builtin::i32_store8(ptr + i, byte);
     }
     if add_newline {
-        builtin::memory_store8(ptr + len, '\n');
+        builtin::i32_store8(ptr + len, '\n');
     }
     builtin::stream_write(tx, ptr, alloc_size);
     builtin::stream_drop_writable(tx);

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -14,7 +14,7 @@
 pub fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {
     let arr = builtin::array_new::<u8>(len);
     for (let mut i = 0; i < len; i += 1) {
-        builtin::array_set_u8(arr, i, builtin::memory_load8_u(ptr + i));
+        builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i));
     }
     return arr;
 }
@@ -22,7 +22,7 @@ pub fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {
 /// Copy bytes from a GC array to linear memory
 pub fn gc_array_to_memory(arr: builtin::array<u8>, ptr: i32, len: i32) {
     for (let mut i = 0; i < len; i += 1) {
-        builtin::memory_store8(ptr + i, builtin::array_get_u8(arr, i));
+        builtin::i32_store8(ptr + i, builtin::array_get_u8(arr, i));
     }
 }
 
@@ -35,7 +35,7 @@ pub fn write_string_to_stream(tx: i32, message: String, add_newline: bool) {
     let ptr = builtin::realloc(0, 0, 1, alloc_size);
     gc_array_to_memory(msg_bytes, ptr, len);
     if add_newline {
-        builtin::memory_store8(ptr + len, '\n');
+        builtin::i32_store8(ptr + len, '\n');
     }
     builtin::stream_write(tx, ptr, alloc_size);
 
@@ -91,16 +91,16 @@ pub fn log_stderr(message: String) {
 ///   base_ptr[i*8+0..i*8+4]: str_ptr - pointer to UTF-8 bytes
 ///   base_ptr[i*8+4..i*8+8]: str_len - length in bytes
 pub fn cm_list_string_to_array(outptr: i32) -> Array<String> {
-    let base_ptr = builtin::memory_load32(outptr);
-    let count = builtin::memory_load32(outptr + 4);
+    let base_ptr = builtin::i32_load(outptr);
+    let count = builtin::i32_load(outptr + 4);
 
     // Create Array<String> with capacity
     let mut result = Array::<String>::with_capacity(count);
 
     // Convert each CM string to a GC string
     for (let mut i = 0; i < count; i += 1) {
-        let str_ptr = builtin::memory_load32(base_ptr + i * 8);
-        let str_len = builtin::memory_load32(base_ptr + i * 8 + 4);
+        let str_ptr = builtin::i32_load(base_ptr + i * 8);
+        let str_len = builtin::i32_load(base_ptr + i * 8 + 4);
 
         let arr = memory_to_gc_array(str_ptr, str_len);
 
@@ -116,7 +116,7 @@ pub fn cm_list_string_to_array(outptr: i32) -> Array<String> {
 ///   outptr[4..7]: str_ptr (if some)
 ///   outptr[8..11]: str_len (if some)
 pub fn cm_option_string_to_option(outptr: i32) -> Option<String> {
-    let discriminant = builtin::memory_load8_u(outptr);
+    let discriminant = builtin::i32_load8_u(outptr);
 
     if discriminant == 0 {
         // None
@@ -124,8 +124,8 @@ pub fn cm_option_string_to_option(outptr: i32) -> Option<String> {
     }
 
     // Some - read string pointer and length
-    let str_ptr = builtin::memory_load32(outptr + 4);
-    let str_len = builtin::memory_load32(outptr + 8);
+    let str_ptr = builtin::i32_load(outptr + 4);
+    let str_len = builtin::i32_load(outptr + 8);
     let arr = memory_to_gc_array(str_ptr, str_len);
 
     return String::internal_from_utf8_raw(arr, str_len);
@@ -136,13 +136,13 @@ pub fn cm_option_string_to_option(outptr: i32) -> Option<String> {
 ///   outptr[0]: discriminant (0 = none, 1 = some)
 ///   outptr[4..7]: handle (i32, if some)
 pub fn cm_option_own_resource_to_option(outptr: i32) -> Option<i32> {
-    let discriminant = builtin::memory_load8_u(outptr);
+    let discriminant = builtin::i32_load8_u(outptr);
 
     if discriminant == 0 {
         return null;
     }
 
-    let handle = builtin::memory_load32(outptr + 4);
+    let handle = builtin::i32_load(outptr + 4);
     return Option::<i32>::Some(handle);
 }
 pub fn panic(message: String) -> ! {
@@ -192,8 +192,8 @@ pub fn cm_lower_array_u8(arr: Array<u8>) -> i64 {
 ///   base_ptr[i*16+8..i*16+12]: str2_ptr
 ///   base_ptr[i*16+12..i*16+16]: str2_len
 pub fn cm_list_tuple_string_string_to_array(outptr: i32) -> Array<[String, String]> {
-    let base_ptr = builtin::memory_load32(outptr);
-    let count = builtin::memory_load32(outptr + 4);
+    let base_ptr = builtin::i32_load(outptr);
+    let count = builtin::i32_load(outptr + 4);
 
     // Create Array<[String, String]> with capacity
     let mut result = Array::<[String, String]>::with_capacity(count);
@@ -203,13 +203,13 @@ pub fn cm_list_tuple_string_string_to_array(outptr: i32) -> Array<[String, Strin
         let tuple_offset = base_ptr + i * 16;
 
         // Read first string
-        let str1_ptr = builtin::memory_load32(tuple_offset);
-        let str1_len = builtin::memory_load32(tuple_offset + 4);
+        let str1_ptr = builtin::i32_load(tuple_offset);
+        let str1_len = builtin::i32_load(tuple_offset + 4);
         let arr1 = memory_to_gc_array(str1_ptr, str1_len);
 
         // Read second string
-        let str2_ptr = builtin::memory_load32(tuple_offset + 8);
-        let str2_len = builtin::memory_load32(tuple_offset + 12);
+        let str2_ptr = builtin::i32_load(tuple_offset + 8);
+        let str2_len = builtin::i32_load(tuple_offset + 12);
         let arr2 = memory_to_gc_array(str2_ptr, str2_len);
 
         result.append([String::internal_from_utf8_raw(arr1, str1_len), String::internal_from_utf8_raw(arr2, str2_len)]);

--- a/wado-compiler/lib/core/prelude/format.wado
+++ b/wado-compiler/lib/core/prelude/format.wado
@@ -132,7 +132,7 @@ impl Formatter {
         // Padding needed — create temporary string for alignment
         let arr = builtin::array_new::<u8>(len);
         for let mut i = 0; i < len; i += 1 {
-            builtin::array_set_u8(arr, i, builtin::memory_load8_u(ptr + i));
+            builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i));
         }
         let s = String::internal_from_utf8_raw(arr, len);
         self.pad(s);

--- a/wado-compiler/lib/core/prelude/int128.wado
+++ b/wado-compiler/lib/core/prelude/int128.wado
@@ -199,7 +199,7 @@ impl u128 {
             let rem: u128 = result[1];
             let digit_u64: u64 = rem.low();
             let digit: i32 = (digit_u64 as i64) as i32;
-            builtin::memory_store8(ptr + pos, ('0' as i32) + digit);
+            builtin::i32_store8(ptr + pos, ('0' as i32) + digit);
             temp = result[0];
         }
 
@@ -207,7 +207,7 @@ impl u128 {
         let len: i32 = 39 - pos;
         let arr = builtin::array_new::<u8>(len);
         for (let mut i: i32 = 0; i < len; i += 1) {
-            let byte: i32 = builtin::memory_load8_u(ptr + pos + i);
+            let byte: i32 = builtin::i32_load8_u(ptr + pos + i);
             builtin::array_set_u8(arr, i, byte);
         }
 

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -13,7 +13,7 @@ pub global __PRIMITIVES_MODULE_LOADED: bool = true;
 fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {
     let arr = builtin::array_new::<u8>(len);
     for let mut i = 0; i < len; i += 1 {
-        builtin::array_set_u8(arr, i, builtin::memory_load8_u(ptr + i));
+        builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i));
     }
     return arr;
 }

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -98,7 +98,7 @@ impl String {
             self.grow(new_used);
         }
         for let mut i = 0; i < len; i += 1 {
-            builtin::array_set_u8(self.repr, self.used + i, builtin::memory_load8_u(ptr + i));
+            builtin::array_set_u8(self.repr, self.used + i, builtin::i32_load8_u(ptr + i));
         }
         self.used = new_used;
     }

--- a/wado-compiler/src/cm_abi.rs
+++ b/wado-compiler/src/cm_abi.rs
@@ -1,0 +1,719 @@
+//! Canonical ABI layout computation for the WebAssembly Component Model.
+//!
+//! This module provides pure functions for computing sizes, alignments, and
+//! field offsets according to the Canonical ABI specification. It operates on
+//! AST `Type`s (which is what `WasiRegistry` stores for WASI function signatures).
+//!
+//! Reference: <https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md>
+
+use crate::ast::{GenericType, NamedType, Type};
+use crate::token::Span;
+
+/// Round `offset` up to the next multiple of `align`.
+pub fn align_to(offset: u32, align: u32) -> u32 {
+    debug_assert!(align.is_power_of_two(), "alignment must be a power of two");
+    (offset + align - 1) & !(align - 1)
+}
+
+/// Canonical ABI size in bytes for a given type.
+pub fn cm_size(ty: &Type) -> u32 {
+    match ty {
+        Type::Named(named) => cm_size_named(&named.name),
+        Type::Generic(generic) => cm_size_generic(generic),
+        Type::Tuple(elems) => {
+            if elems.is_empty() {
+                return 0; // unit type
+            }
+            let layout = layout_tuple(elems);
+            layout.size
+        }
+        Type::Reference(_) | Type::MutReference(_) => 4, // resource handle
+        _ => 0,
+    }
+}
+
+/// Canonical ABI alignment in bytes for a given type.
+pub fn cm_align(ty: &Type) -> u32 {
+    match ty {
+        Type::Named(named) => cm_align_named(&named.name),
+        Type::Generic(generic) => cm_align_generic(generic),
+        Type::Tuple(elems) => {
+            if elems.is_empty() {
+                return 1; // unit type
+            }
+            elems.iter().map(cm_align).max().unwrap_or(1)
+        }
+        Type::Reference(_) | Type::MutReference(_) => 4, // resource handle
+        _ => 1,
+    }
+}
+
+/// Layout information for a composite type (record, tuple).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CmLayout {
+    /// Total size in bytes (including trailing padding for alignment).
+    pub size: u32,
+    /// Alignment in bytes.
+    pub align: u32,
+    /// Byte offset of each field/element.
+    pub offsets: Vec<u32>,
+}
+
+/// Compute the layout for a record (struct with named fields).
+pub fn layout_record(fields: &[(&str, &Type)]) -> CmLayout {
+    let types: Vec<&Type> = fields.iter().map(|(_, ty)| *ty).collect();
+    compute_layout(&types)
+}
+
+/// Compute the layout for a tuple (positional elements).
+pub fn layout_tuple(elements: &[Type]) -> CmLayout {
+    let types: Vec<&Type> = elements.iter().collect();
+    compute_layout(&types)
+}
+
+/// Core layout computation: given a list of field types, compute offsets.
+fn compute_layout(types: &[&Type]) -> CmLayout {
+    let mut offset: u32 = 0;
+    let mut max_align: u32 = 1;
+    let mut offsets = Vec::with_capacity(types.len());
+
+    for ty in types {
+        let field_align = cm_align(ty);
+        let field_size = cm_size(ty);
+
+        // Align offset for this field
+        offset = align_to(offset, field_align);
+        offsets.push(offset);
+
+        offset += field_size;
+        max_align = max_align.max(field_align);
+    }
+
+    // Trailing padding to satisfy overall alignment
+    let size = align_to(offset, max_align);
+
+    CmLayout {
+        size,
+        align: max_align,
+        offsets,
+    }
+}
+
+/// Canonical ABI size for named (primitive) types.
+fn cm_size_named(name: &str) -> u32 {
+    match name {
+        "bool" | "u8" | "i8" => 1,
+        "u16" | "i16" => 2,
+        "i32" | "u32" | "f32" | "char" => 4,
+        "i64" | "u64" | "f64" => 8,
+        "String" => 8, // (ptr: i32, len: i32)
+        "()" => 0,     // unit
+        // Unknown named types (enums, resources) are i32 handles
+        _ => 4,
+    }
+}
+
+/// Canonical ABI alignment for named (primitive) types.
+fn cm_align_named(name: &str) -> u32 {
+    match name {
+        "bool" | "u8" | "i8" => 1,
+        "u16" | "i16" => 2,
+        "i32" | "u32" | "f32" | "char" => 4,
+        "i64" | "u64" | "f64" => 8,
+        "String" => 4, // (ptr: i32, len: i32) — aligned to i32
+        "()" => 1,     // unit
+        // Unknown named types (enums, resources) are i32 handles
+        _ => 4,
+    }
+}
+
+/// Canonical ABI size for generic types.
+fn cm_size_generic(generic: &GenericType) -> u32 {
+    match generic.name.as_str() {
+        // list<T> is (ptr: i32, len: i32)
+        "Array" => 8,
+        // option<T>: discriminant byte + padding + payload
+        "Option" if generic.args.len() == 1 => {
+            let inner = &generic.args[0];
+            let payload_align = cm_align(inner);
+            let payload_size = cm_size(inner);
+            // discriminant (1 byte) + padding to payload alignment + payload
+            let payload_offset = align_to(1, payload_align);
+            align_to(payload_offset + payload_size, cm_align_option(inner))
+        }
+        // result<T, E>: discriminant (i32) + max(ok_size, err_size)
+        "Result" if generic.args.len() == 2 => {
+            let ok_size = cm_size(&generic.args[0]);
+            let err_size = cm_size(&generic.args[1]);
+            let payload_size = ok_size.max(err_size);
+            let payload_align = cm_align(&generic.args[0]).max(cm_align(&generic.args[1]));
+            let payload_offset = align_to(4, payload_align); // after i32 discriminant
+            align_to(
+                payload_offset + payload_size,
+                cm_align_result(&generic.args[0], &generic.args[1]),
+            )
+        }
+        // Tuple<T, U, ...>
+        "Tuple" => {
+            let layout = layout_tuple(&generic.args);
+            layout.size
+        }
+        // Stream<T>, Future<T> are i32 handles
+        "Stream" | "Future" => 4,
+        // Own<T>, Borrow<T> are i32 handles
+        "Own" | "Borrow" => 4,
+        _ => 4,
+    }
+}
+
+/// Canonical ABI alignment for generic types.
+fn cm_align_generic(generic: &GenericType) -> u32 {
+    match generic.name.as_str() {
+        "Array" => 4, // (ptr: i32, len: i32) — aligned to i32
+        "Option" if generic.args.len() == 1 => cm_align_option(&generic.args[0]),
+        "Result" if generic.args.len() == 2 => cm_align_result(&generic.args[0], &generic.args[1]),
+        "Tuple" => generic.args.iter().map(cm_align).max().unwrap_or(1),
+        "Stream" | "Future" | "Own" | "Borrow" => 4,
+        _ => 4,
+    }
+}
+
+/// Alignment for option<T>: max(1, align(T))
+fn cm_align_option(inner: &Type) -> u32 {
+    1_u32.max(cm_align(inner))
+}
+
+/// Alignment for result<T, E>: max(4, align(T), align(E))
+/// The discriminant is i32 (4 bytes), so alignment is at least 4.
+fn cm_align_result(ok: &Type, err: &Type) -> u32 {
+    4_u32.max(cm_align(ok)).max(cm_align(err))
+}
+
+/// Layout for option<T>: discriminant offset + payload offset.
+pub fn layout_option(inner: &Type) -> CmLayout {
+    let payload_align = cm_align(inner);
+    let payload_size = cm_size(inner);
+    let overall_align = cm_align_option(inner);
+
+    // discriminant at offset 0 (1 byte)
+    let payload_offset = align_to(1, payload_align);
+    let size = align_to(payload_offset + payload_size, overall_align);
+
+    CmLayout {
+        size,
+        align: overall_align,
+        offsets: vec![0, payload_offset], // [discriminant, payload]
+    }
+}
+
+/// Layout for result<T, E>: discriminant (i32) + payload.
+pub fn layout_result(ok: &Type, err: &Type) -> CmLayout {
+    let payload_align = cm_align(ok).max(cm_align(err));
+    let payload_size = cm_size(ok).max(cm_size(err));
+    let overall_align = cm_align_result(ok, err);
+
+    // discriminant at offset 0 (i32 = 4 bytes)
+    let payload_offset = align_to(4, payload_align);
+    let size = align_to(payload_offset + payload_size, overall_align);
+
+    CmLayout {
+        size,
+        align: overall_align,
+        offsets: vec![0, payload_offset], // [discriminant, payload]
+    }
+}
+
+/// Compute the flat (core Wasm) parameter types for a Canonical ABI type.
+///
+/// This is used for lowered function signatures: compound types are flattened
+/// into sequences of core value types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmValType {
+    I32,
+    I64,
+    F32,
+    F64,
+}
+
+/// Flatten a type into its core Wasm value types for the flat ABI.
+///
+/// Compound types like String and list<T> are lowered to (i32, i32) pairs.
+/// Simple types map to their corresponding core value type.
+pub fn cm_flat_types(ty: &Type) -> Vec<CmValType> {
+    let mut out = Vec::new();
+    flatten_type(ty, &mut out);
+    out
+}
+
+fn flatten_type(ty: &Type, out: &mut Vec<CmValType>) {
+    match ty {
+        Type::Named(named) => match named.name.as_str() {
+            "bool" | "u8" | "i8" | "u16" | "i16" | "i32" | "u32" | "char" => {
+                out.push(CmValType::I32);
+            }
+            "i64" | "u64" => out.push(CmValType::I64),
+            "f32" => out.push(CmValType::F32),
+            "f64" => out.push(CmValType::F64),
+            "String" => {
+                out.push(CmValType::I32); // ptr
+                out.push(CmValType::I32); // len
+            }
+            "()" => {} // unit — no values
+            // Resource handles, enums — i32
+            _ => out.push(CmValType::I32),
+        },
+        Type::Generic(generic) => match generic.name.as_str() {
+            "Array" => {
+                out.push(CmValType::I32); // ptr
+                out.push(CmValType::I32); // len
+            }
+            "Stream" | "Future" | "Own" | "Borrow" => out.push(CmValType::I32),
+            // Option, Result, Tuple — not flattened inline, passed via outptr
+            // (exceeds MAX_FLAT_RESULTS=1 in most cases)
+            _ => out.push(CmValType::I32),
+        },
+        Type::Reference(_) | Type::MutReference(_) => out.push(CmValType::I32),
+        Type::Tuple(elems) => {
+            if elems.is_empty() {
+                return; // unit
+            }
+            for elem in elems {
+                flatten_type(elem, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Helper: create a `Type::Named` with a dummy span. Useful for tests.
+pub fn named_type(name: &str) -> Type {
+    Type::Named(NamedType {
+        name: name.to_string(),
+        span: Span::new(0, 0, 1, 1),
+    })
+}
+
+/// Helper: create a `Type::Generic` with a dummy span. Useful for tests.
+pub fn generic_type(name: &str, args: Vec<Type>) -> Type {
+    Type::Generic(GenericType {
+        name: name.to_string(),
+        args,
+        span: Span::new(0, 0, 1, 1),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // Size tests
+    // ========================================================================
+
+    #[test]
+    fn test_primitive_sizes() {
+        assert_eq!(cm_size(&named_type("bool")), 1);
+        assert_eq!(cm_size(&named_type("u8")), 1);
+        assert_eq!(cm_size(&named_type("i8")), 1);
+        assert_eq!(cm_size(&named_type("u16")), 2);
+        assert_eq!(cm_size(&named_type("i16")), 2);
+        assert_eq!(cm_size(&named_type("i32")), 4);
+        assert_eq!(cm_size(&named_type("u32")), 4);
+        assert_eq!(cm_size(&named_type("f32")), 4);
+        assert_eq!(cm_size(&named_type("char")), 4);
+        assert_eq!(cm_size(&named_type("i64")), 8);
+        assert_eq!(cm_size(&named_type("u64")), 8);
+        assert_eq!(cm_size(&named_type("f64")), 8);
+    }
+
+    #[test]
+    fn test_string_size() {
+        // String = list<u8> = (ptr: i32, len: i32)
+        assert_eq!(cm_size(&named_type("String")), 8);
+        assert_eq!(cm_align(&named_type("String")), 4);
+    }
+
+    #[test]
+    fn test_list_size() {
+        // list<T> = (ptr: i32, len: i32) regardless of T
+        let list_i32 = generic_type("Array", vec![named_type("i32")]);
+        assert_eq!(cm_size(&list_i32), 8);
+        assert_eq!(cm_align(&list_i32), 4);
+
+        let list_string = generic_type("Array", vec![named_type("String")]);
+        assert_eq!(cm_size(&list_string), 8);
+        assert_eq!(cm_align(&list_string), 4);
+    }
+
+    #[test]
+    fn test_unit_size() {
+        assert_eq!(cm_size(&named_type("()")), 0);
+        assert_eq!(cm_size(&Type::Tuple(vec![])), 0);
+    }
+
+    // ========================================================================
+    // Alignment tests
+    // ========================================================================
+
+    #[test]
+    fn test_primitive_alignments() {
+        assert_eq!(cm_align(&named_type("bool")), 1);
+        assert_eq!(cm_align(&named_type("u8")), 1);
+        assert_eq!(cm_align(&named_type("i16")), 2);
+        assert_eq!(cm_align(&named_type("i32")), 4);
+        assert_eq!(cm_align(&named_type("f32")), 4);
+        assert_eq!(cm_align(&named_type("i64")), 8);
+        assert_eq!(cm_align(&named_type("f64")), 8);
+    }
+
+    // ========================================================================
+    // align_to tests
+    // ========================================================================
+
+    #[test]
+    fn test_align_to() {
+        assert_eq!(align_to(0, 4), 0);
+        assert_eq!(align_to(1, 4), 4);
+        assert_eq!(align_to(3, 4), 4);
+        assert_eq!(align_to(4, 4), 4);
+        assert_eq!(align_to(5, 4), 8);
+        assert_eq!(align_to(0, 1), 0);
+        assert_eq!(align_to(7, 1), 7);
+        assert_eq!(align_to(1, 8), 8);
+        assert_eq!(align_to(9, 8), 16);
+    }
+
+    // ========================================================================
+    // Option layout tests
+    // ========================================================================
+
+    #[test]
+    fn test_option_i32() {
+        // option<i32>: disc(1 byte) + 3 padding + i32(4 bytes) = 8 bytes, align 4
+        let opt = generic_type("Option", vec![named_type("i32")]);
+        assert_eq!(cm_size(&opt), 8);
+        assert_eq!(cm_align(&opt), 4);
+
+        let layout = layout_option(&named_type("i32"));
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]); // disc at 0, payload at 4
+    }
+
+    #[test]
+    fn test_option_bool() {
+        // option<bool>: disc(1 byte) + bool(1 byte) = 2 bytes, align 1
+        let opt = generic_type("Option", vec![named_type("bool")]);
+        assert_eq!(cm_size(&opt), 2);
+        assert_eq!(cm_align(&opt), 1);
+
+        let layout = layout_option(&named_type("bool"));
+        assert_eq!(layout.size, 2);
+        assert_eq!(layout.align, 1);
+        assert_eq!(layout.offsets, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_option_string() {
+        // option<string>: disc(1 byte) + 3 padding + string(8 bytes) = 12 bytes, align 4
+        let opt = generic_type("Option", vec![named_type("String")]);
+        assert_eq!(cm_size(&opt), 12);
+        assert_eq!(cm_align(&opt), 4);
+
+        let layout = layout_option(&named_type("String"));
+        assert_eq!(layout.size, 12);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]); // disc at 0, payload at 4
+    }
+
+    #[test]
+    fn test_option_i64() {
+        // option<i64>: disc(1 byte) + 7 padding + i64(8 bytes) = 16 bytes, align 8
+        let opt = generic_type("Option", vec![named_type("i64")]);
+        assert_eq!(cm_size(&opt), 16);
+        assert_eq!(cm_align(&opt), 8);
+
+        let layout = layout_option(&named_type("i64"));
+        assert_eq!(layout.size, 16);
+        assert_eq!(layout.align, 8);
+        assert_eq!(layout.offsets, vec![0, 8]);
+    }
+
+    #[test]
+    fn test_option_resource() {
+        // option<own<resource>>: disc(1 byte) + 3 padding + handle(4 bytes) = 8 bytes, align 4
+        let own_resource = generic_type("Own", vec![named_type("Fields")]);
+        let opt = generic_type("Option", vec![own_resource]);
+        assert_eq!(cm_size(&opt), 8);
+        assert_eq!(cm_align(&opt), 4);
+    }
+
+    // ========================================================================
+    // Result layout tests
+    // ========================================================================
+
+    #[test]
+    fn test_result_unit_unit() {
+        // result<(), ()>: disc(4 bytes) + max(0, 0) = 4 bytes, align 4
+        let result = generic_type("Result", vec![named_type("()"), named_type("()")]);
+        assert_eq!(cm_size(&result), 4);
+        assert_eq!(cm_align(&result), 4);
+
+        let layout = layout_result(&named_type("()"), &named_type("()"));
+        assert_eq!(layout.size, 4);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]); // disc at 0, payload at 4
+    }
+
+    #[test]
+    fn test_result_i32_i32() {
+        // result<i32, i32>: disc(4 bytes) + max(4, 4) = 8 bytes, align 4
+        let result = generic_type("Result", vec![named_type("i32"), named_type("i32")]);
+        assert_eq!(cm_size(&result), 8);
+        assert_eq!(cm_align(&result), 4);
+
+        let layout = layout_result(&named_type("i32"), &named_type("i32"));
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_result_resource_enum() {
+        // result<Resource, ErrorCode>: disc(4) + max(4, 4) = 8 bytes, align 4
+        // Resource and ErrorCode are both i32 handles/discriminants
+        let result = generic_type(
+            "Result",
+            vec![named_type("IncomingBody"), named_type("ErrorCode")],
+        );
+        assert_eq!(cm_size(&result), 8);
+        assert_eq!(cm_align(&result), 4);
+    }
+
+    #[test]
+    fn test_result_string_i32() {
+        // result<string, i32>: disc(4) + max(string=8, i32=4) = 12 bytes, align 4
+        let result = generic_type("Result", vec![named_type("String"), named_type("i32")]);
+        assert_eq!(cm_size(&result), 12);
+        assert_eq!(cm_align(&result), 4);
+    }
+
+    // ========================================================================
+    // Tuple layout tests
+    // ========================================================================
+
+    #[test]
+    fn test_tuple_i32_i32() {
+        // tuple<i32, i32>: 4 + 4 = 8 bytes, align 4
+        let tuple = Type::Tuple(vec![named_type("i32"), named_type("i32")]);
+        assert_eq!(cm_size(&tuple), 8);
+        assert_eq!(cm_align(&tuple), 4);
+
+        let layout = layout_tuple(&[named_type("i32"), named_type("i32")]);
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_tuple_string_string() {
+        // tuple<string, string>: string(8) + string(8) = 16 bytes, align 4
+        let layout = layout_tuple(&[named_type("String"), named_type("String")]);
+        assert_eq!(layout.size, 16);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 8]);
+    }
+
+    #[test]
+    fn test_tuple_bool_i32() {
+        // tuple<bool, i32>: bool(1) + 3 padding + i32(4) = 8 bytes, align 4
+        let layout = layout_tuple(&[named_type("bool"), named_type("i32")]);
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_tuple_i32_bool() {
+        // tuple<i32, bool>: i32(4) + bool(1) = 5, padded to 8 bytes, align 4
+        let layout = layout_tuple(&[named_type("i32"), named_type("bool")]);
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_tuple_u8_u16_u32() {
+        // tuple<u8, u16, u32>: u8(1) + 1 padding + u16(2) + u32(4) = 8 bytes, align 4
+        let layout = layout_tuple(&[named_type("u8"), named_type("u16"), named_type("u32")]);
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 2, 4]);
+    }
+
+    // ========================================================================
+    // Nested type tests
+    // ========================================================================
+
+    #[test]
+    fn test_list_option_string() {
+        // list<option<string>> is still just (ptr, len) = 8 bytes
+        let inner = generic_type("Option", vec![named_type("String")]);
+        let list = generic_type("Array", vec![inner]);
+        assert_eq!(cm_size(&list), 8);
+        assert_eq!(cm_align(&list), 4);
+    }
+
+    #[test]
+    fn test_option_list_u8() {
+        // option<list<u8>>: disc(1) + 3 padding + list(8) = 12 bytes, align 4
+        let inner = generic_type("Array", vec![named_type("u8")]);
+        let opt = generic_type("Option", vec![inner]);
+        assert_eq!(cm_size(&opt), 12);
+        assert_eq!(cm_align(&opt), 4);
+    }
+
+    #[test]
+    fn test_result_option_string_i32() {
+        // result<option<string>, i32>:
+        //   option<string> size = 12, align = 4
+        //   i32 size = 4, align = 4
+        //   disc(4) + max(12, 4) = 16 bytes, align 4
+        let opt_string = generic_type("Option", vec![named_type("String")]);
+        let result = generic_type("Result", vec![opt_string, named_type("i32")]);
+        assert_eq!(cm_size(&result), 16);
+        assert_eq!(cm_align(&result), 4);
+    }
+
+    // ========================================================================
+    // Flat type tests
+    // ========================================================================
+
+    #[test]
+    fn test_flat_primitives() {
+        assert_eq!(cm_flat_types(&named_type("i32")), vec![CmValType::I32]);
+        assert_eq!(cm_flat_types(&named_type("i64")), vec![CmValType::I64]);
+        assert_eq!(cm_flat_types(&named_type("f32")), vec![CmValType::F32]);
+        assert_eq!(cm_flat_types(&named_type("f64")), vec![CmValType::F64]);
+        assert_eq!(cm_flat_types(&named_type("bool")), vec![CmValType::I32]);
+        assert_eq!(cm_flat_types(&named_type("char")), vec![CmValType::I32]);
+        assert_eq!(cm_flat_types(&named_type("u8")), vec![CmValType::I32]);
+    }
+
+    #[test]
+    fn test_flat_string() {
+        assert_eq!(
+            cm_flat_types(&named_type("String")),
+            vec![CmValType::I32, CmValType::I32]
+        );
+    }
+
+    #[test]
+    fn test_flat_list() {
+        let list = generic_type("Array", vec![named_type("i32")]);
+        assert_eq!(cm_flat_types(&list), vec![CmValType::I32, CmValType::I32]);
+    }
+
+    #[test]
+    fn test_flat_unit() {
+        assert_eq!(cm_flat_types(&named_type("()")), vec![]);
+        assert_eq!(cm_flat_types(&Type::Tuple(vec![])), vec![]);
+    }
+
+    #[test]
+    fn test_flat_tuple() {
+        let tuple = Type::Tuple(vec![named_type("i32"), named_type("f64")]);
+        assert_eq!(cm_flat_types(&tuple), vec![CmValType::I32, CmValType::F64]);
+    }
+
+    // ========================================================================
+    // Record layout tests
+    // ========================================================================
+
+    #[test]
+    fn test_record_simple() {
+        // record { x: i32, y: i32 }
+        let layout = layout_record(&[("x", &named_type("i32")), ("y", &named_type("i32"))]);
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_record_mixed_alignment() {
+        // record { flag: bool, value: i64 }
+        // flag(1) + 7 padding + i64(8) = 16 bytes, align 8
+        let bool_ty = named_type("bool");
+        let i64_ty = named_type("i64");
+        let layout = layout_record(&[("flag", &bool_ty), ("value", &i64_ty)]);
+        assert_eq!(layout.size, 16);
+        assert_eq!(layout.align, 8);
+        assert_eq!(layout.offsets, vec![0, 8]);
+    }
+
+    #[test]
+    fn test_record_with_string() {
+        // record { name: string, age: i32 }
+        // string(8) + i32(4) = 12 bytes, align 4
+        let str_ty = named_type("String");
+        let i32_ty = named_type("i32");
+        let layout = layout_record(&[("name", &str_ty), ("age", &i32_ty)]);
+        assert_eq!(layout.size, 12);
+        assert_eq!(layout.align, 4);
+        assert_eq!(layout.offsets, vec![0, 8]);
+    }
+
+    // ========================================================================
+    // Consistency with existing CmCallConvention
+    // ========================================================================
+
+    #[test]
+    fn test_consistency_string_return() {
+        // CmCallConvention uses outptr_alloc: Some((8, 4)) for String return
+        assert_eq!(cm_size(&named_type("String")), 8);
+        assert_eq!(cm_align(&named_type("String")), 4);
+    }
+
+    #[test]
+    fn test_consistency_option_string_return() {
+        // CmCallConvention uses outptr_alloc: Some((12, 4)) for option<string>
+        let layout = layout_option(&named_type("String"));
+        assert_eq!(layout.size, 12);
+        assert_eq!(layout.align, 4);
+    }
+
+    #[test]
+    fn test_consistency_option_own_resource() {
+        // CmCallConvention uses outptr_alloc: Some((8, 4)) for option<own<resource>>
+        let own_resource = generic_type("Own", vec![named_type("Fields")]);
+        let layout = layout_option(&own_resource);
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+    }
+
+    #[test]
+    fn test_consistency_result_resource_enum() {
+        // CmCallConvention uses outptr_alloc: Some((8, 4)) for result<resource, enum>
+        let layout = layout_result(&named_type("IncomingBody"), &named_type("ErrorCode"));
+        assert_eq!(layout.size, 8);
+        assert_eq!(layout.align, 4);
+    }
+
+    #[test]
+    fn test_consistency_list_return() {
+        // CmCallConvention uses outptr_alloc: Some((8, 4)) for list<T>
+        let list = generic_type("Array", vec![named_type("String")]);
+        assert_eq!(cm_size(&list), 8);
+        assert_eq!(cm_align(&list), 4);
+    }
+
+    #[test]
+    fn test_consistency_tuple_return() {
+        // CmCallConvention::for_tuple_return computes size/align for tuple<i32, u64>
+        // i32(4) + 4 padding + u64(8) = 16 bytes, align 8
+        let layout = layout_tuple(&[named_type("i32"), named_type("u64")]);
+        assert_eq!(layout.size, 16);
+        assert_eq!(layout.align, 8);
+        assert_eq!(layout.offsets, vec![0, 8]);
+    }
+}

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -1,0 +1,678 @@
+//! CM Adapter Synthesis phase.
+//!
+//! Generates TIR adapter functions for Component Model boundary crossing.
+//! Each adapter handles lifting Wado values to CM flat ABI (lowering params)
+//! and lifting CM flat ABI values back to Wado types (lifting results).
+//!
+//! Pipeline position: after effect_check, before monomorphize.
+//! This ensures adapter functions go through monomorphization, lowering,
+//! and optimization.
+//!
+//! See `docs/wep-2026-02-15-cm-adapter-synthesis.md` for design details.
+
+use indexmap::IndexSet;
+
+use crate::ast::Type;
+use crate::cm_abi;
+use crate::name::ModuleSource;
+use crate::project::Project;
+use crate::tir::{
+    TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind, TypeId, TypeTable,
+};
+use crate::token::Span;
+
+/// Synthetic span used for all generated adapter code.
+fn synth_span() -> Span {
+    Span::new(0, 0, 1, 1)
+}
+
+// ============================================================================
+// TIR construction helpers
+// ============================================================================
+
+/// Create a call to a builtin function (e.g., `builtin::i32_load`).
+pub fn builtin_call(name: &str, args: Vec<TirExpr>, return_type: TypeId) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::Call {
+            func: crate::tir::FunctionRef::External {
+                module_source: ModuleSource::core("builtin"),
+                name: name.to_string(),
+                monomorph_info: None,
+                method_info: None,
+            },
+            type_args: vec![],
+            args,
+        },
+        return_type,
+        synth_span(),
+    )
+}
+
+/// Create a call to an internal function (e.g., `internal::cm_lower_string`).
+pub fn internal_call(name: &str, args: Vec<TirExpr>, return_type: TypeId) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::Call {
+            func: crate::tir::FunctionRef::External {
+                module_source: ModuleSource::core("internal"),
+                name: name.to_string(),
+                monomorph_info: None,
+                method_info: None,
+            },
+            type_args: vec![],
+            args,
+        },
+        return_type,
+        synth_span(),
+    )
+}
+
+/// Create an i32 literal expression.
+pub fn i32_const(value: i32) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::IntLiteral {
+            value: value as u64,
+            repr: value.to_string(),
+        },
+        TypeTable::I32,
+        synth_span(),
+    )
+}
+
+/// Create an i64 literal expression.
+pub fn i64_const(value: i64) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::IntLiteral {
+            value: value as u64,
+            repr: value.to_string(),
+        },
+        TypeTable::I64,
+        synth_span(),
+    )
+}
+
+/// Create a local variable reference.
+pub fn local_ref(index: u32, name: &str, type_id: TypeId) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::Local {
+            index,
+            name: name.to_string(),
+        },
+        type_id,
+        synth_span(),
+    )
+}
+
+/// Create a binary expression.
+pub fn binary(
+    op: crate::tir::TirBinaryOp,
+    left: TirExpr,
+    right: TirExpr,
+    ty: TypeId,
+) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::Binary {
+            op,
+            left: Box::new(left),
+            right: Box::new(right),
+        },
+        ty,
+        synth_span(),
+    )
+}
+
+/// Create a cast expression.
+pub fn cast(expr: TirExpr, target_type: TypeId) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::Cast {
+            expr: Box::new(expr),
+            target_type,
+        },
+        target_type,
+        synth_span(),
+    )
+}
+
+/// Create a let statement.
+pub fn let_stmt(name: &str, local_index: u32, type_id: TypeId, value: TirExpr) -> TirStmt {
+    TirStmt::new(
+        TirStmtKind::Let {
+            name: name.to_string(),
+            local_index,
+            is_mut: false,
+            is_reactive: false,
+            type_id,
+            value,
+        },
+        synth_span(),
+    )
+}
+
+/// Create an expression statement.
+pub fn expr_stmt(expr: TirExpr) -> TirStmt {
+    TirStmt::new(TirStmtKind::Expr(expr), synth_span())
+}
+
+/// Create a return statement.
+pub fn return_stmt(value: Option<TirExpr>) -> TirStmt {
+    TirStmt::new(TirStmtKind::Return { value }, synth_span())
+}
+
+/// Create a `CmRawCall` expression targeting a lowered WASI import.
+pub fn cm_raw_call(local_name: &str, args: Vec<TirExpr>, return_type: TypeId) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::CmRawCall {
+            local_name: local_name.to_string(),
+            args,
+        },
+        return_type,
+        synth_span(),
+    )
+}
+
+// ============================================================================
+// Lift / Lower synthesis
+// ============================================================================
+
+/// Synthesize a TIR expression that loads a CM value from linear memory.
+///
+/// For primitives, this is a single `builtin::i32_load` (or similar).
+/// For String, this reads (ptr, len) and calls `memory_to_gc_string`.
+pub fn synthesize_lift(ty: &Type, addr: TirExpr) -> TirExpr {
+    match ty {
+        Type::Named(named) => match named.name.as_str() {
+            "i32" | "u32" => builtin_call("i32_load", vec![addr], TypeTable::I32),
+            "i64" | "u64" => builtin_call("i64_load", vec![addr], TypeTable::I64),
+            "f32" => builtin_call("f32_load", vec![addr], TypeTable::F32),
+            "f64" => builtin_call("f64_load", vec![addr], TypeTable::F64),
+            "i8" | "u8" => builtin_call("i32_load8_u", vec![addr], TypeTable::I32),
+            "i16" | "u16" => builtin_call("i32_load16_u", vec![addr], TypeTable::I32),
+            "bool" => {
+                let raw = builtin_call("i32_load8_u", vec![addr], TypeTable::I32);
+                binary(
+                    crate::tir::TirBinaryOp::NotEq,
+                    raw,
+                    i32_const(0),
+                    TypeTable::BOOL,
+                )
+            }
+            "char" => builtin_call("i32_load", vec![addr], TypeTable::CHAR),
+            "String" => {
+                let ptr = builtin_call("i32_load", vec![addr.clone()], TypeTable::I32);
+                let len = builtin_call(
+                    "i32_load",
+                    vec![binary(
+                        crate::tir::TirBinaryOp::Add,
+                        addr,
+                        i32_const(4),
+                        TypeTable::I32,
+                    )],
+                    TypeTable::I32,
+                );
+                // Return type uses I32 as placeholder; caller must fix up
+                // to the actual String TypeId from the type table.
+                internal_call("memory_to_gc_string", vec![ptr, len], TypeTable::I32)
+            }
+            _ => panic!("synthesize_lift: unsupported type `{}`", named.name),
+        },
+        Type::Tuple(elems) if elems.is_empty() => {
+            TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span())
+        }
+        _ => panic!("synthesize_lift: unsupported type {ty:?}"),
+    }
+}
+
+/// Synthesize TIR statements that store a Wado value into linear memory.
+///
+/// For primitives, this is a single `builtin::i32_store` (or similar).
+pub fn synthesize_lower(ty: &Type, value: TirExpr, addr: TirExpr) -> Vec<TirStmt> {
+    match ty {
+        Type::Named(named) => match named.name.as_str() {
+            "i32" | "u32" => vec![expr_stmt(builtin_call(
+                "i32_store", vec![addr, value], TypeTable::UNIT,
+            ))],
+            "i64" | "u64" => vec![expr_stmt(builtin_call(
+                "i64_store", vec![addr, value], TypeTable::UNIT,
+            ))],
+            "f32" => vec![expr_stmt(builtin_call(
+                "f32_store", vec![addr, value], TypeTable::UNIT,
+            ))],
+            "f64" => vec![expr_stmt(builtin_call(
+                "f64_store", vec![addr, value], TypeTable::UNIT,
+            ))],
+            "i8" | "u8" => vec![expr_stmt(builtin_call(
+                "i32_store8", vec![addr, value], TypeTable::UNIT,
+            ))],
+            "i16" | "u16" => vec![expr_stmt(builtin_call(
+                "i32_store16", vec![addr, value], TypeTable::UNIT,
+            ))],
+            "bool" => {
+                let as_i32 = cast(value, TypeTable::I32);
+                vec![expr_stmt(builtin_call(
+                    "i32_store8", vec![addr, as_i32], TypeTable::UNIT,
+                ))]
+            }
+            "char" => {
+                let as_i32 = cast(value, TypeTable::I32);
+                vec![expr_stmt(builtin_call(
+                    "i32_store", vec![addr, as_i32], TypeTable::UNIT,
+                ))]
+            }
+            _ => panic!("synthesize_lower: unsupported type `{}`", named.name),
+        },
+        Type::Tuple(elems) if elems.is_empty() => vec![],
+        _ => panic!("synthesize_lower: unsupported type {ty:?}"),
+    }
+}
+
+// ============================================================================
+// Flat ABI parameter/result computation
+// ============================================================================
+
+/// Compute the flat ABI parameter types for a WASI function parameter.
+pub fn flatten_param_type(ty: &Type) -> Vec<TypeId> {
+    match ty {
+        Type::Named(named) => match named.name.as_str() {
+            "i32" | "u32" | "bool" | "char" | "i8" | "u8" | "i16" | "u16" => {
+                vec![TypeTable::I32]
+            }
+            "i64" | "u64" => vec![TypeTable::I64],
+            "f32" => vec![TypeTable::F32],
+            "f64" => vec![TypeTable::F64],
+            "String" => vec![TypeTable::I32, TypeTable::I32],
+            _ => vec![TypeTable::I32],
+        },
+        Type::Generic(g) if g.name == "Stream" => vec![TypeTable::I32],
+        Type::Reference(_) | Type::MutReference(_) => vec![TypeTable::I32],
+        Type::Tuple(elems) if elems.is_empty() => vec![],
+        _ => {
+            let flat = cm_abi::cm_flat_types(ty);
+            flat.iter()
+                .map(|t| match t {
+                    cm_abi::CmValType::I32 => TypeTable::I32,
+                    cm_abi::CmValType::I64 => TypeTable::I64,
+                    cm_abi::CmValType::F32 => TypeTable::F32,
+                    cm_abi::CmValType::F64 => TypeTable::F64,
+                })
+                .collect()
+        }
+    }
+}
+
+// ============================================================================
+// Adapter function generation
+// ============================================================================
+
+/// Adapter function name prefix.
+const ADAPTER_PREFIX: &str = "__cm_adapter__";
+
+/// Build the adapter function name for a WASI import.
+pub fn adapter_func_name(effect_name: &str, method_name: &str) -> String {
+    format!("{ADAPTER_PREFIX}{effect_name}_{method_name}")
+}
+
+/// Phase entry point: generate CM adapter functions.
+///
+/// Currently a no-op scaffolding that enumerates effect calls without
+/// transforming them. As WASI interfaces are migrated, this will:
+/// 1. Synthesize adapter TIR functions for each used WASI import
+/// 2. Rewrite `Call` nodes targeting effect modules to call the adapters
+pub fn generate_adapters(project: Project) -> Project {
+    let mut _seen_effects: IndexSet<String> = IndexSet::new();
+    for module in project.tir_modules.values() {
+        for func_rc in &module.functions {
+            let func = func_rc.borrow();
+            if let Some(body) = &func.body {
+                collect_effect_calls_in_block(body, &mut _seen_effects);
+            }
+        }
+    }
+    project
+}
+
+fn collect_effect_calls_in_block(block: &TirBlock, effects: &mut IndexSet<String>) {
+    for stmt in &block.stmts {
+        collect_effect_calls_in_stmt(stmt, effects);
+    }
+}
+
+fn collect_effect_calls_in_stmt(stmt: &TirStmt, effects: &mut IndexSet<String>) {
+    match &stmt.kind {
+        TirStmtKind::Let { value, .. } | TirStmtKind::Expr(value) => {
+            collect_effect_calls_in_expr(value, effects);
+        }
+        TirStmtKind::Return { value } => {
+            if let Some(v) = value {
+                collect_effect_calls_in_expr(v, effects);
+            }
+        }
+        TirStmtKind::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            collect_effect_calls_in_expr(condition, effects);
+            collect_effect_calls_in_block(then_block, effects);
+            if let Some(blk) = else_block {
+                collect_effect_calls_in_block(blk, effects);
+            }
+        }
+        TirStmtKind::Loop { body }
+        | TirStmtKind::LabeledBlock { block: body, .. } => {
+            collect_effect_calls_in_block(body, effects);
+        }
+        TirStmtKind::IfPattern {
+            scrutinee,
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_effect_calls_in_expr(scrutinee, effects);
+            collect_effect_calls_in_block(then_block, effects);
+            if let Some(blk) = else_block {
+                collect_effect_calls_in_block(blk, effects);
+            }
+        }
+        TirStmtKind::Break { value, .. } => {
+            if let Some(v) = value {
+                collect_effect_calls_in_expr(v, effects);
+            }
+        }
+        TirStmtKind::Continue | TirStmtKind::LetPattern { .. } => {}
+    }
+}
+
+fn collect_effect_calls_in_expr(expr: &TirExpr, effects: &mut IndexSet<String>) {
+    match &expr.kind {
+        TirExprKind::Call { func, args, .. } => {
+            let module_source = func.module_source();
+            if module_source.is_effect_like() {
+                if let Some(effect_name) = module_source.effect_name() {
+                    let method_name = func.name();
+                    effects.insert(format!("{effect_name}::{method_name}"));
+                }
+            }
+            for arg in args {
+                collect_effect_calls_in_expr(arg, effects);
+            }
+        }
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. }
+        | TirExprKind::StaticCall { args, .. } => {
+            for arg in args {
+                collect_effect_calls_in_expr(arg, effects);
+            }
+        }
+        TirExprKind::MethodCall {
+            receiver, args, ..
+        } => {
+            collect_effect_calls_in_expr(receiver, effects);
+            for arg in args {
+                collect_effect_calls_in_expr(arg, effects);
+            }
+        }
+        TirExprKind::IndirectCall { callee, args } => {
+            collect_effect_calls_in_expr(callee, effects);
+            for arg in args {
+                collect_effect_calls_in_expr(arg, effects);
+            }
+        }
+        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
+            collect_effect_calls_in_block(block, effects);
+        }
+        TirExprKind::Binary { left, right, .. } => {
+            collect_effect_calls_in_expr(left, effects);
+            collect_effect_calls_in_expr(right, effects);
+        }
+        TirExprKind::Unary { expr: inner, .. }
+        | TirExprKind::Cast { expr: inner, .. }
+        | TirExprKind::FieldAccess { expr: inner, .. }
+        | TirExprKind::OptionSome { value: inner }
+        | TirExprKind::Move { expr: inner } => {
+            collect_effect_calls_in_expr(inner, effects);
+        }
+        TirExprKind::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            collect_effect_calls_in_expr(condition, effects);
+            collect_effect_calls_in_block(then_branch, effects);
+            if let Some(blk) = else_branch {
+                collect_effect_calls_in_block(blk, effects);
+            }
+        }
+        TirExprKind::Index { expr: e, index }
+        | TirExprKind::Assign { target: e, value: index } => {
+            collect_effect_calls_in_expr(e, effects);
+            collect_effect_calls_in_expr(index, effects);
+        }
+        TirExprKind::Switch {
+            scrutinee,
+            arms,
+            default,
+            ..
+        } => {
+            collect_effect_calls_in_expr(scrutinee, effects);
+            for arm in arms {
+                collect_effect_calls_in_block(arm, effects);
+            }
+            collect_effect_calls_in_block(default, effects);
+        }
+        TirExprKind::Match { expr: scrutinee, arms } => {
+            collect_effect_calls_in_expr(scrutinee, effects);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    collect_effect_calls_in_expr(guard, effects);
+                }
+                collect_effect_calls_in_expr(&arm.body, effects);
+            }
+        }
+        TirExprKind::Closure { body, .. } => {
+            collect_effect_calls_in_expr(body, effects);
+        }
+        TirExprKind::ClosureToCanonical { functor, .. } => {
+            collect_effect_calls_in_expr(functor, effects);
+        }
+        TirExprKind::StructLiteral { fields, .. } => {
+            for field in fields {
+                collect_effect_calls_in_expr(&field.value, effects);
+            }
+        }
+        TirExprKind::GlobalVarSet { value, .. } => {
+            collect_effect_calls_in_expr(value, effects);
+        }
+        TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::Local { .. }
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::Capture { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Global { .. }
+        | TirExprKind::EnumConstruct { .. } => {}
+        // Catch-all for any remaining leaf or rare variants
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::NamedType;
+
+    fn named_type(name: &str) -> Type {
+        Type::Named(NamedType {
+            name: name.to_string(),
+            span: Span::new(0, 0, 1, 1),
+        })
+    }
+
+    #[test]
+    fn flatten_param_i32() {
+        assert_eq!(flatten_param_type(&named_type("i32")), vec![TypeTable::I32]);
+    }
+
+    #[test]
+    fn flatten_param_i64() {
+        assert_eq!(flatten_param_type(&named_type("i64")), vec![TypeTable::I64]);
+    }
+
+    #[test]
+    fn flatten_param_f64() {
+        assert_eq!(flatten_param_type(&named_type("f64")), vec![TypeTable::F64]);
+    }
+
+    #[test]
+    fn flatten_param_string() {
+        assert_eq!(
+            flatten_param_type(&named_type("String")),
+            vec![TypeTable::I32, TypeTable::I32]
+        );
+    }
+
+    #[test]
+    fn flatten_param_bool() {
+        assert_eq!(
+            flatten_param_type(&named_type("bool")),
+            vec![TypeTable::I32]
+        );
+    }
+
+    #[test]
+    fn flatten_param_unit() {
+        assert!(flatten_param_type(&Type::Tuple(vec![])).is_empty());
+    }
+
+    #[test]
+    fn adapter_name() {
+        assert_eq!(
+            adapter_func_name("Stdout", "write_via_stream"),
+            "__cm_adapter__Stdout_write_via_stream"
+        );
+    }
+
+    #[test]
+    fn lift_i32() {
+        let expr = synthesize_lift(&named_type("i32"), i32_const(100));
+        assert!(matches!(expr.kind, TirExprKind::Call { .. }));
+        assert_eq!(expr.type_id, TypeTable::I32);
+    }
+
+    #[test]
+    fn lift_bool() {
+        let expr = synthesize_lift(&named_type("bool"), i32_const(100));
+        assert!(matches!(expr.kind, TirExprKind::Binary { .. }));
+        assert_eq!(expr.type_id, TypeTable::BOOL);
+    }
+
+    #[test]
+    fn lift_string() {
+        let expr = synthesize_lift(&named_type("String"), i32_const(100));
+        assert!(matches!(expr.kind, TirExprKind::Call { .. }));
+    }
+
+    #[test]
+    fn lower_i32() {
+        let stmts = synthesize_lower(&named_type("i32"), i32_const(42), i32_const(100));
+        assert_eq!(stmts.len(), 1);
+    }
+
+    #[test]
+    fn lower_bool() {
+        let value = TirExpr::new(
+            TirExprKind::BoolLiteral(true),
+            TypeTable::BOOL,
+            synth_span(),
+        );
+        let stmts = synthesize_lower(&named_type("bool"), value, i32_const(100));
+        assert_eq!(stmts.len(), 1);
+    }
+
+    #[test]
+    fn lower_unit() {
+        let value = TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span());
+        let stmts = synthesize_lower(&Type::Tuple(vec![]), value, i32_const(100));
+        assert!(stmts.is_empty());
+    }
+
+    #[test]
+    fn helpers_i32_const() {
+        let expr = i32_const(42);
+        assert_eq!(expr.type_id, TypeTable::I32);
+        match &expr.kind {
+            TirExprKind::IntLiteral { value, .. } => assert_eq!(*value, 42),
+            other => panic!("expected IntLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn helpers_i64_const() {
+        let expr = i64_const(123);
+        assert_eq!(expr.type_id, TypeTable::I64);
+        match &expr.kind {
+            TirExprKind::IntLiteral { value, .. } => assert_eq!(*value, 123),
+            other => panic!("expected IntLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn helpers_builtin_call() {
+        let call = builtin_call("i32_load", vec![i32_const(0)], TypeTable::I32);
+        match &call.kind {
+            TirExprKind::Call { func, args, .. } => {
+                assert_eq!(func.name(), "i32_load");
+                assert_eq!(args.len(), 1);
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn helpers_internal_call() {
+        let call = internal_call("cm_lower_string", vec![i32_const(0)], TypeTable::I64);
+        match &call.kind {
+            TirExprKind::Call { func, args, .. } => {
+                assert_eq!(func.name(), "cm_lower_string");
+                assert_eq!(args.len(), 1);
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn helpers_cm_raw_call() {
+        let call = cm_raw_call(
+            "wasi:cli/Stdout::write_via_stream",
+            vec![i32_const(0), i32_const(1), i32_const(2)],
+            TypeTable::I32,
+        );
+        match &call.kind {
+            TirExprKind::CmRawCall { local_name, args } => {
+                assert_eq!(local_name, "wasi:cli/Stdout::write_via_stream");
+                assert_eq!(args.len(), 3);
+            }
+            other => panic!("expected CmRawCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn helpers_let_stmt() {
+        let stmt = let_stmt("x", 0, TypeTable::I32, i32_const(42));
+        match &stmt.kind {
+            TirStmtKind::Let {
+                name,
+                local_index,
+                type_id,
+                ..
+            } => {
+                assert_eq!(name, "x");
+                assert_eq!(*local_index, 0);
+                assert_eq!(*type_id, TypeTable::I32);
+            }
+            other => panic!("expected Let, got {other:?}"),
+        }
+    }
+}

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -4,7 +4,7 @@
 //! Each adapter handles lifting Wado values to CM flat ABI (lowering params)
 //! and lifting CM flat ABI values back to Wado types (lifting results).
 //!
-//! Pipeline position: after effect_check, before monomorphize.
+//! Pipeline position: after `effect_check`, before monomorphize.
 //! This ensures adapter functions go through monomorphization, lowering,
 //! and optimization.
 //!
@@ -16,9 +16,7 @@ use crate::ast::Type;
 use crate::cm_abi;
 use crate::name::ModuleSource;
 use crate::project::Project;
-use crate::tir::{
-    TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind, TypeId, TypeTable,
-};
+use crate::tir::{TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind, TypeId, TypeTable};
 use crate::token::Span;
 
 /// Synthetic span used for all generated adapter code.
@@ -103,12 +101,7 @@ pub fn local_ref(index: u32, name: &str, type_id: TypeId) -> TirExpr {
 }
 
 /// Create a binary expression.
-pub fn binary(
-    op: crate::tir::TirBinaryOp,
-    left: TirExpr,
-    right: TirExpr,
-    ty: TypeId,
-) -> TirExpr {
+pub fn binary(op: crate::tir::TirBinaryOp, left: TirExpr, right: TirExpr, ty: TypeId) -> TirExpr {
     TirExpr::new(
         TirExprKind::Binary {
             op,
@@ -228,33 +221,49 @@ pub fn synthesize_lower(ty: &Type, value: TirExpr, addr: TirExpr) -> Vec<TirStmt
     match ty {
         Type::Named(named) => match named.name.as_str() {
             "i32" | "u32" => vec![expr_stmt(builtin_call(
-                "i32_store", vec![addr, value], TypeTable::UNIT,
+                "i32_store",
+                vec![addr, value],
+                TypeTable::UNIT,
             ))],
             "i64" | "u64" => vec![expr_stmt(builtin_call(
-                "i64_store", vec![addr, value], TypeTable::UNIT,
+                "i64_store",
+                vec![addr, value],
+                TypeTable::UNIT,
             ))],
             "f32" => vec![expr_stmt(builtin_call(
-                "f32_store", vec![addr, value], TypeTable::UNIT,
+                "f32_store",
+                vec![addr, value],
+                TypeTable::UNIT,
             ))],
             "f64" => vec![expr_stmt(builtin_call(
-                "f64_store", vec![addr, value], TypeTable::UNIT,
+                "f64_store",
+                vec![addr, value],
+                TypeTable::UNIT,
             ))],
             "i8" | "u8" => vec![expr_stmt(builtin_call(
-                "i32_store8", vec![addr, value], TypeTable::UNIT,
+                "i32_store8",
+                vec![addr, value],
+                TypeTable::UNIT,
             ))],
             "i16" | "u16" => vec![expr_stmt(builtin_call(
-                "i32_store16", vec![addr, value], TypeTable::UNIT,
+                "i32_store16",
+                vec![addr, value],
+                TypeTable::UNIT,
             ))],
             "bool" => {
                 let as_i32 = cast(value, TypeTable::I32);
                 vec![expr_stmt(builtin_call(
-                    "i32_store8", vec![addr, as_i32], TypeTable::UNIT,
+                    "i32_store8",
+                    vec![addr, as_i32],
+                    TypeTable::UNIT,
                 ))]
             }
             "char" => {
                 let as_i32 = cast(value, TypeTable::I32);
                 vec![expr_stmt(builtin_call(
-                    "i32_store", vec![addr, as_i32], TypeTable::UNIT,
+                    "i32_store",
+                    vec![addr, as_i32],
+                    TypeTable::UNIT,
                 ))]
             }
             _ => panic!("synthesize_lower: unsupported type `{}`", named.name),
@@ -356,8 +365,7 @@ fn collect_effect_calls_in_stmt(stmt: &TirStmt, effects: &mut IndexSet<String>) 
                 collect_effect_calls_in_block(blk, effects);
             }
         }
-        TirStmtKind::Loop { body }
-        | TirStmtKind::LabeledBlock { block: body, .. } => {
+        TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
             collect_effect_calls_in_block(body, effects);
         }
         TirStmtKind::IfPattern {
@@ -385,11 +393,11 @@ fn collect_effect_calls_in_expr(expr: &TirExpr, effects: &mut IndexSet<String>) 
     match &expr.kind {
         TirExprKind::Call { func, args, .. } => {
             let module_source = func.module_source();
-            if module_source.is_effect_like() {
-                if let Some(effect_name) = module_source.effect_name() {
-                    let method_name = func.name();
-                    effects.insert(format!("{effect_name}::{method_name}"));
-                }
+            if module_source.is_effect_like()
+                && let Some(effect_name) = module_source.effect_name()
+            {
+                let method_name = func.name();
+                effects.insert(format!("{effect_name}::{method_name}"));
             }
             for arg in args {
                 collect_effect_calls_in_expr(arg, effects);
@@ -402,9 +410,7 @@ fn collect_effect_calls_in_expr(expr: &TirExpr, effects: &mut IndexSet<String>) 
                 collect_effect_calls_in_expr(arg, effects);
             }
         }
-        TirExprKind::MethodCall {
-            receiver, args, ..
-        } => {
+        TirExprKind::MethodCall { receiver, args, .. } => {
             collect_effect_calls_in_expr(receiver, effects);
             for arg in args {
                 collect_effect_calls_in_expr(arg, effects);
@@ -442,7 +448,10 @@ fn collect_effect_calls_in_expr(expr: &TirExpr, effects: &mut IndexSet<String>) 
             }
         }
         TirExprKind::Index { expr: e, index }
-        | TirExprKind::Assign { target: e, value: index } => {
+        | TirExprKind::Assign {
+            target: e,
+            value: index,
+        } => {
             collect_effect_calls_in_expr(e, effects);
             collect_effect_calls_in_expr(index, effects);
         }
@@ -458,7 +467,10 @@ fn collect_effect_calls_in_expr(expr: &TirExpr, effects: &mut IndexSet<String>) 
             }
             collect_effect_calls_in_block(default, effects);
         }
-        TirExprKind::Match { expr: scrutinee, arms } => {
+        TirExprKind::Match {
+            expr: scrutinee,
+            arms,
+        } => {
             collect_effect_calls_in_expr(scrutinee, effects);
             for arm in arms {
                 if let Some(guard) = &arm.guard {

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -12697,23 +12697,7 @@ impl Codegen<'_> {
                 let u8_array_idx = self.get_array_type_index(TypeTable::U8);
                 func.instruction(&Instruction::ArraySet(u8_array_idx));
             }
-            "builtin::memory_store8" => {
-                self.generate_args(func, args, type_table, ctx, builder);
-                func.instruction(&Instruction::I32Store8(MemArg {
-                    offset: 0,
-                    align: 0,
-                    memory_index: 0,
-                }));
-            }
-            "builtin::memory_load8_u" => {
-                self.generate_args(func, args, type_table, ctx, builder);
-                func.instruction(&Instruction::I32Load8U(MemArg {
-                    offset: 0,
-                    align: 0,
-                    memory_index: 0,
-                }));
-            }
-            "builtin::memory_load32" | "builtin::i32_load" => {
+            "builtin::i32_load" => {
                 self.generate_args(func, args, type_table, ctx, builder);
                 func.instruction(&Instruction::I32Load(MemArg {
                     offset: 0,

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -7255,6 +7255,15 @@ impl Codegen<'_> {
                 }
             }
 
+            // === Raw CM Call (used inside synthesized adapter functions) ===
+            TirExprKind::CmRawCall { local_name, args } => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                let func_idx = builder
+                    .try_func_idx(local_name)
+                    .unwrap_or_else(|| panic!("unknown CM raw call target: {local_name}"));
+                func.instruction(&Instruction::Call(func_idx));
+            }
+
             // === Method Call ===
             TirExprKind::MethodCall {
                 receiver,
@@ -12052,7 +12061,8 @@ impl Codegen<'_> {
             // Argument lists
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. } => {
+            | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.preallocate_scalarized_locals_in_expr(arg, type_table, ctx, builder);
                 }

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -12703,11 +12703,99 @@ impl Codegen<'_> {
                     memory_index: 0,
                 }));
             }
-            "builtin::memory_load32" => {
+            "builtin::memory_load32" | "builtin::i32_load" => {
                 self.generate_args(func, args, type_table, ctx, builder);
                 func.instruction(&Instruction::I32Load(MemArg {
                     offset: 0,
                     align: 2,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i32_store" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i64_load" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I64Load(MemArg {
+                    offset: 0,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i64_store" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I64Store(MemArg {
+                    offset: 0,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::f32_load" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::F32Load(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::f32_store" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::F32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::f64_load" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::F64Load(MemArg {
+                    offset: 0,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::f64_store" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::F64Store(MemArg {
+                    offset: 0,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i32_load8_u" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I32Load8U(MemArg {
+                    offset: 0,
+                    align: 0,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i32_load16_u" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I32Load16U(MemArg {
+                    offset: 0,
+                    align: 1,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i32_store8" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I32Store8(MemArg {
+                    offset: 0,
+                    align: 0,
+                    memory_index: 0,
+                }));
+            }
+            "builtin::i32_store16" => {
+                self.generate_args(func, args, type_table, ctx, builder);
+                func.instruction(&Instruction::I32Store16(MemArg {
+                    offset: 0,
+                    align: 1,
                     memory_index: 0,
                 }));
             }

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -231,6 +231,13 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
                     self.check_expr(arg)?;
                 }
             }
+            TirExprKind::CmRawCall { args, .. } => {
+                // CmRawCall is used inside synthesized adapter functions;
+                // no effect checking needed (adapter functions are always effectful)
+                for arg in args {
+                    self.check_expr(arg)?;
+                }
+            }
             TirExprKind::IndirectCall { callee, args } => {
                 self.check_expr(callee)?;
                 for arg in args {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -73,6 +73,7 @@ pub mod ast;
 pub mod bind;
 pub mod builtin_registry;
 pub mod bundled;
+pub mod cm_abi;
 pub mod codegen;
 pub mod comment;
 pub mod compiler_host;

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -74,6 +74,7 @@ pub mod bind;
 pub mod builtin_registry;
 pub mod bundled;
 pub mod cm_abi;
+pub mod cm_adapter_gen;
 pub mod codegen;
 pub mod comment;
 pub mod compiler_host;
@@ -314,6 +315,12 @@ pub async fn compile_with_options<H: CompilerHost>(
         let _span = logger.span("effect-check");
         check_effects(&project.tir_modules, &logger)?;
     }
+
+    // === Phase 7b: CM Adapter Synthesis (Project -> Project) ===
+    let project = {
+        let _span = logger.span("cm-adapter-gen");
+        cm_adapter_gen::generate_adapters(project)
+    };
 
     // === Phase 8: Monomorphize (Project -> Project) ===
     let mut project = {

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -3140,8 +3140,7 @@ impl BoxLowerer {
             TirExprKind::GlobalVarSet { value, .. } => {
                 self.transform_expr(value, address_taken, type_table);
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.transform_expr(arg, address_taken, type_table);
                 }
@@ -5428,8 +5427,7 @@ impl ClosureLowerer {
             | TirExprKind::Move { expr: inner } => {
                 self.collect_fn_param_specs_expr(inner, func_by_name, type_table, requests);
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.collect_fn_param_specs_expr(arg, func_by_name, type_table, requests);
                 }
@@ -6763,8 +6761,7 @@ impl ClosureLowerer {
                 // Check if this call has closure arguments that need fn-param specialization
                 self.try_transform_fn_param_call(func, args, type_table);
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.transform_expr(arg, type_table);
                 }

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -557,7 +557,8 @@ fn lower_wide_int_in_expr(expr: &mut TirExpr, type_table: &Rc<RefCell<TypeTable>
         TirExprKind::Call { args, .. }
         | TirExprKind::MethodCall { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 lower_wide_int_in_expr(arg, type_table);
             }
@@ -1779,7 +1780,8 @@ impl<'a> PatternLowerer<'a> {
             TirExprKind::Call { args, .. }
             | TirExprKind::MethodCall { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. } => {
+            | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.lower_expr(arg, type_table);
                 }
@@ -3138,7 +3140,8 @@ impl BoxLowerer {
             TirExprKind::GlobalVarSet { value, .. } => {
                 self.transform_expr(value, address_taken, type_table);
             }
-            TirExprKind::EffectCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.transform_expr(arg, address_taken, type_table);
                 }
@@ -3764,6 +3767,7 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
                     self.collect_closures_in_expr(arg);
@@ -3969,6 +3973,7 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 // Arguments are in argument position
                 for arg in args {
@@ -4362,7 +4367,8 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. } => {
+            | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     Self::collect_locals_from_expr(arg, locals);
                 }
@@ -5159,7 +5165,8 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. } => args
+            | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => args
                 .iter()
                 .any(|a| self.fn_param_in_struct_field_expr(a, fn_param_indices)),
             TirExprKind::MethodCall { receiver, args, .. } => {
@@ -5421,7 +5428,8 @@ impl ClosureLowerer {
             | TirExprKind::Move { expr: inner } => {
                 self.collect_fn_param_specs_expr(inner, func_by_name, type_table, requests);
             }
-            TirExprKind::EffectCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.collect_fn_param_specs_expr(arg, func_by_name, type_table, requests);
                 }
@@ -5605,7 +5613,8 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. } => {
+            | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.count_closures_in_expr(arg, counter);
                 }
@@ -6179,6 +6188,17 @@ impl ClosureLowerer {
                 expr.type_id,
                 expr.span,
             ),
+            TirExprKind::CmRawCall { local_name, args } => TirExpr::new(
+                TirExprKind::CmRawCall {
+                    local_name: local_name.clone(),
+                    args: args
+                        .iter()
+                        .map(|a| self.specialize_expr(a, param_to_functor, type_table))
+                        .collect(),
+                },
+                expr.type_id,
+                expr.span,
+            ),
             TirExprKind::Block(block) => TirExpr::new(
                 TirExprKind::Block(self.specialize_function_body(
                     block,
@@ -6743,7 +6763,8 @@ impl ClosureLowerer {
                 // Check if this call has closure arguments that need fn-param specialization
                 self.try_transform_fn_param_call(func, args, type_table);
             }
-            TirExprKind::EffectCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.transform_expr(arg, type_table);
                 }
@@ -7078,6 +7099,7 @@ impl ClosureLowerer {
             // Recurse into all expression kinds
             TirExprKind::Call { args, .. }
             | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
                     self.transform_remaining_closures_expr(arg);
@@ -7358,6 +7380,7 @@ impl StringCollector {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
                     self.collect_expr(arg);
@@ -7654,6 +7677,7 @@ impl<'a> ScratchLocalAnalyzer<'a> {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
                     self.analyze_expr(arg);
@@ -7895,6 +7919,12 @@ impl<'a> EffectScratchAnalyzer<'a> {
                         self.needs_err_disc = true;
                     }
                 }
+                for arg in args {
+                    self.analyze_expr(arg);
+                }
+            }
+            TirExprKind::CmRawCall { args, .. } => {
+                // CmRawCall args are already flat ABI - just recurse
                 for arg in args {
                     self.analyze_expr(arg);
                 }

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -763,8 +763,7 @@ impl Monomorphizer {
                     self.rewrite_types_in_expr(arg, type_table);
                 }
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.rewrite_types_in_expr(arg, type_table);
                 }
@@ -1625,8 +1624,7 @@ impl Monomorphizer {
                     );
                 }
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.collect_func_instantiation_sites_in_expr(
                         arg,
@@ -2316,8 +2314,7 @@ impl Monomorphizer {
                     }
                 }
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.substitute_types_in_expr(arg, substitution, type_table);
                 }

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -763,7 +763,8 @@ impl Monomorphizer {
                     self.rewrite_types_in_expr(arg, type_table);
                 }
             }
-            TirExprKind::EffectCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.rewrite_types_in_expr(arg, type_table);
                 }
@@ -1624,7 +1625,8 @@ impl Monomorphizer {
                     );
                 }
             }
-            TirExprKind::EffectCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.collect_func_instantiation_sites_in_expr(
                         arg,
@@ -2314,7 +2316,8 @@ impl Monomorphizer {
                     }
                 }
             }
-            TirExprKind::EffectCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.substitute_types_in_expr(arg, substitution, type_table);
                 }
@@ -2684,6 +2687,7 @@ impl Monomorphizer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
                     Self::update_local_expr_types_in_expr(arg, local_types);
@@ -3014,7 +3018,9 @@ impl Monomorphizer {
                     self.rewrite_function_calls_in_expr(arg, type_table);
                 }
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::StaticCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. }
+            | TirExprKind::CmRawCall { args, .. }
+            | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
                     self.rewrite_function_calls_in_expr(arg, type_table);
                 }

--- a/wado-compiler/src/optimize_const_fold.rs
+++ b/wado-compiler/src/optimize_const_fold.rs
@@ -102,7 +102,8 @@ fn fold_constants_in_expr(expr: &mut TirExpr, type_table: &TypeTable) -> bool {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 changed |= fold_constants_in_expr(arg, type_table);
             }

--- a/wado-compiler/src/optimize_copy_prop.rs
+++ b/wado-compiler/src/optimize_copy_prop.rs
@@ -200,7 +200,8 @@ fn collect_assigned_in_expr(expr: &TirExpr, assigned: &mut IndexSet<u32>) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_assigned_in_expr(arg, assigned);
             }
@@ -413,7 +414,8 @@ fn collect_usage_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_usage_in_expr(arg, usage, in_loop, in_condition);
             }
@@ -733,7 +735,8 @@ fn substitute_in_expr(expr: &mut TirExpr, substitutions: &IndexMap<u32, CopySour
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 substitute_in_expr(arg, substitutions);
             }
@@ -969,7 +972,8 @@ fn collect_copy_bindings_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_copy_bindings_in_expr(arg, bindings, block_local_assigned);
             }
@@ -1168,7 +1172,8 @@ fn remove_copy_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u32>)
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 remove_copy_bindings_in_expr(arg, dead_locals);
             }

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -846,6 +846,11 @@ fn analyze_expr(
                 analyze_expr(arg, current_module, type_table, analysis);
             }
         }
+        TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                analyze_expr(arg, current_module, type_table, analysis);
+            }
+        }
         TirExprKind::StaticCall { func, args } => {
             let func_name = func.name();
             // Static method call - func_name already contains "StructName::method_name"
@@ -1508,7 +1513,8 @@ fn collect_types_from_expr(
             collect_types_from_expr(expr, type_table, reachable);
             collect_type_transitive(*target_type, type_table, reachable);
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_types_from_expr(arg, type_table, reachable);
             }

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -1513,8 +1513,7 @@ fn collect_types_from_expr(
             collect_types_from_expr(expr, type_table, reachable);
             collect_type_transitive(*target_type, type_table, reachable);
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_types_from_expr(arg, type_table, reachable);
             }

--- a/wado-compiler/src/optimize_inline.rs
+++ b/wado-compiler/src/optimize_inline.rs
@@ -74,7 +74,8 @@ fn count_expr(expr: &TirExpr) -> usize {
         | TirExprKind::Null => 0,
         // Closure and effect-related expressions
         TirExprKind::Capture { .. } | TirExprKind::EnumConstruct { .. } => 0,
-        TirExprKind::EffectCall { args, .. } => args.iter().map(count_expr).sum(),
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => args.iter().map(count_expr).sum(),
         TirExprKind::IndirectCall { callee, args } => {
             count_expr(callee) + args.iter().map(count_expr).sum::<usize>()
         }
@@ -377,7 +378,8 @@ fn expr_has_complex_generic_types(expr: &TirExpr, type_table: &TypeTable) -> boo
         TirExprKind::Call { args, .. }
         | TirExprKind::MethodCall { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => args
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => args
             .iter()
             .any(|a| expr_has_complex_generic_types(a, type_table)),
         TirExprKind::IndirectCall { callee, args } => {
@@ -649,7 +651,8 @@ fn collect_callees_from_expr(expr: &TirExpr, callees: &mut IndexSet<String>) {
         TirExprKind::ClosureToCanonical { functor, .. } => {
             collect_callees_from_expr(functor, callees);
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_callees_from_expr(arg, callees);
             }
@@ -2181,6 +2184,13 @@ fn remap_expr(
             cm_convention: cm_convention.clone(),
             cm_local_name: cm_local_name.clone(),
         },
+        TirExprKind::CmRawCall { local_name, args } => TirExprKind::CmRawCall {
+            local_name: local_name.clone(),
+            args: args
+                .iter()
+                .map(|a| remap_expr(a, param_to_local, local_offset, param_count, source_module))
+                .collect(),
+        },
         TirExprKind::FieldAccess {
             expr: inner,
             field_index,
@@ -2902,7 +2912,8 @@ fn inline_calls_in_expr(
                 *expr = inlined_expr;
             }
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 inline_calls_in_expr(
                     arg,

--- a/wado-compiler/src/optimize_inline.rs
+++ b/wado-compiler/src/optimize_inline.rs
@@ -74,8 +74,9 @@ fn count_expr(expr: &TirExpr) -> usize {
         | TirExprKind::Null => 0,
         // Closure and effect-related expressions
         TirExprKind::Capture { .. } | TirExprKind::EnumConstruct { .. } => 0,
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => args.iter().map(count_expr).sum(),
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            args.iter().map(count_expr).sum()
+        }
         TirExprKind::IndirectCall { callee, args } => {
             count_expr(callee) + args.iter().map(count_expr).sum::<usize>()
         }
@@ -651,8 +652,7 @@ fn collect_callees_from_expr(expr: &TirExpr, callees: &mut IndexSet<String>) {
         TirExprKind::ClosureToCanonical { functor, .. } => {
             collect_callees_from_expr(functor, callees);
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_callees_from_expr(arg, callees);
             }
@@ -2912,8 +2912,7 @@ fn inline_calls_in_expr(
                 *expr = inlined_expr;
             }
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 inline_calls_in_expr(
                     arg,

--- a/wado-compiler/src/optimize_licm.rs
+++ b/wado-compiler/src/optimize_licm.rs
@@ -352,7 +352,8 @@ fn collect_modified_vars_in_expr(expr: &TirExpr, modified: &mut IndexSet<u32>) {
                 collect_modified_vars_in_expr(arg, modified);
             }
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_modified_vars_in_expr(arg, modified);
             }
@@ -661,7 +662,8 @@ fn collect_licm_ref_bindings_in_expr(
                 collect_licm_ref_bindings_in_expr(arg, type_table, bindings);
             }
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_licm_ref_bindings_in_expr(arg, type_table, bindings);
             }
@@ -1087,7 +1089,8 @@ fn find_hoist_candidates_in_expr(
                 );
             }
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 find_hoist_candidates_in_expr(
                     arg,
@@ -1500,7 +1503,8 @@ fn replace_hoisted_in_expr(
                 replace_hoisted_in_expr(arg, candidates, ref_bindings);
             }
         }
-        TirExprKind::EffectCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 replace_hoisted_in_expr(arg, candidates, ref_bindings);
             }

--- a/wado-compiler/src/optimize_licm.rs
+++ b/wado-compiler/src/optimize_licm.rs
@@ -352,8 +352,7 @@ fn collect_modified_vars_in_expr(expr: &TirExpr, modified: &mut IndexSet<u32>) {
                 collect_modified_vars_in_expr(arg, modified);
             }
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_modified_vars_in_expr(arg, modified);
             }
@@ -662,8 +661,7 @@ fn collect_licm_ref_bindings_in_expr(
                 collect_licm_ref_bindings_in_expr(arg, type_table, bindings);
             }
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_licm_ref_bindings_in_expr(arg, type_table, bindings);
             }
@@ -1089,8 +1087,7 @@ fn find_hoist_candidates_in_expr(
                 );
             }
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 find_hoist_candidates_in_expr(
                     arg,
@@ -1503,8 +1500,7 @@ fn replace_hoisted_in_expr(
                 replace_hoisted_in_expr(arg, candidates, ref_bindings);
             }
         }
-        TirExprKind::EffectCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 replace_hoisted_in_expr(arg, candidates, ref_bindings);
             }

--- a/wado-compiler/src/optimize_ref_elim.rs
+++ b/wado-compiler/src/optimize_ref_elim.rs
@@ -115,7 +115,8 @@ fn track_local_uses_in_expr(expr: &TirExpr, local_index: u32) -> (bool, u32) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             let mut total = 0;
             let mut all_ok = true;
             for arg in args {
@@ -348,7 +349,8 @@ fn replace_ref_field_access_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 replace_ref_field_access_in_expr(arg, ref_local, target_local, target_name);
             }
@@ -684,7 +686,8 @@ fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) 
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_ref_bindings_in_expr(arg, bindings);
             }
@@ -889,7 +892,8 @@ fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 remove_dead_ref_bindings_in_expr(arg, dead_locals);
             }

--- a/wado-compiler/src/optimize_rewrite.rs
+++ b/wado-compiler/src/optimize_rewrite.rs
@@ -151,7 +151,8 @@ fn simplify_labeled_blocks_in_expr(expr: &mut TirExpr) -> bool {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 changed |= simplify_labeled_blocks_in_expr(arg);
             }
@@ -375,6 +376,7 @@ fn is_fresh_value(expr: &TirExpr) -> bool {
         | TirExprKind::StaticCall { .. }
         | TirExprKind::MethodCall { .. }
         | TirExprKind::EffectCall { .. }
+        | TirExprKind::CmRawCall { .. }
         | TirExprKind::IndirectCall { .. } => true,
 
         // ClosureToCanonical creates a fresh closure struct
@@ -517,7 +519,8 @@ fn insert_moves_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             // Wrap arguments in Move if they are fresh values (argument passing is assignment)
             for arg in args.iter_mut() {
                 insert_moves_in_expr(arg, type_table);
@@ -786,7 +789,8 @@ fn collect_value_copy_types_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_value_copy_types_in_expr(arg, type_table, copy_types);
             }

--- a/wado-compiler/src/optimize_sroa.rs
+++ b/wado-compiler/src/optimize_sroa.rs
@@ -435,7 +435,8 @@ fn check_escape_in_expr(expr: &TirExpr, candidates: &IndexSet<u32>, escaped: &mu
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 check_escape_in_expr(arg, candidates, escaped);
             }
@@ -783,7 +784,8 @@ fn rewrite_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. } => {
+        | TirExprKind::EffectCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 rewrite_expr(arg, safe_set, field_map, info_map, candidate_mut);
             }

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1164,6 +1164,17 @@ pub enum TirExprKind {
         /// Full local alias name for CM call (e.g., "`wasi:cli/Environment::get_arguments`")
         cm_local_name: Option<String>,
     },
+    /// Raw Component Model call to a lowered WASI import.
+    ///
+    /// Used inside synthesized CM adapter functions to call the flat-ABI WASI function
+    /// directly, bypassing the normal effect call mechanism. Args are already lowered
+    /// to flat CM types (i32, i64, f32, f64).
+    CmRawCall {
+        /// Full WASI local alias name (e.g., "wasi:cli/stdout@0.3.0/write-via-stream")
+        local_name: String,
+        /// Flat ABI arguments (already lowered to core Wasm types)
+        args: Vec<TirExpr>,
+    },
     MethodCall {
         receiver: Box<TirExpr>,
         /// Method reference (resolved TIR function or external)

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -2750,6 +2750,18 @@ impl<'a> TirUnparser<'a> {
                 }
                 self.output.push(')');
             }
+            TirExprKind::CmRawCall { local_name, args } => {
+                self.output.push_str("cm_raw_call ");
+                self.output.push_str(local_name);
+                self.output.push('(');
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_expr(arg);
+                }
+                self.output.push(')');
+            }
             TirExprKind::MethodCall {
                 receiver,
                 func,


### PR DESCRIPTION
## Summary

This PR introduces foundational support for WebAssembly Component Model (CM) boundary crossing by adding:
1. A pure Canonical ABI layout computation module (`cm_abi.rs`)
2. A CM adapter synthesis phase (`cm_adapter_gen.rs`) that generates TIR adapter functions
3. Integration points throughout the compiler pipeline to support CM operations

## Key Changes

### New Modules
- **`cm_abi.rs`**: Pure functions for computing Canonical ABI sizes, alignments, and field offsets according to the WebAssembly Component Model specification. Supports:
  - Primitive types (bool, i8-i64, f32, f64, char)
  - Compound types (String, tuples, records)
  - Generic types (Array, Option, Result, Stream, Future, Own, Borrow)
  - Layout computation with proper padding and alignment
  - Flat ABI type flattening for lowered function signatures

- **`cm_adapter_gen.rs`**: Scaffolding for synthesizing CM adapter functions as TIR. Currently enumerates effect calls without transformation; provides:
  - TIR construction helpers (builtin calls, internal calls, literals, locals, etc.)
  - Lift/lower synthesis for moving values between Wado types and linear memory
  - Flat ABI parameter/result computation
  - Adapter function naming and collection infrastructure

### TIR Extensions
- Added `TirExprKind::CmRawCall` variant for raw Component Model calls to lowered WASI imports
- Integrated CmRawCall handling throughout the compiler pipeline:
  - Codegen: generates direct function calls
  - Lower: handles wide int lowering and pattern lowering
  - Monomorphize: type rewriting support
  - Optimizations: DCE, LICM, SROA, copy propagation, ref elimination, const folding, inlining
  - Effect checking: validates CmRawCall expressions
  - Unparsing: debug output support

### Builtin API Updates
- Renamed memory access builtins for clarity:
  - `memory_store8` → `i32_store8`
  - `memory_load8_u` → `i32_load8_u`
  - `memory_load32` → `i32_load`
- Added new memory access builtins:
  - `i32_load`, `i32_store` (32-bit operations)
  - `i64_load`, `i64_store` (64-bit operations)
  - `f32_load`, `f32_store` (32-bit float operations)
  - `f64_load`, `f64_store` (64-bit float operations)
  - `i32_load16_u`, `i32_store16` (16-bit operations)

### Pipeline Integration
- Inserted `cm_adapter_gen` phase between `effect_check` and `monomorphize`
- Updated `internal.wado` and other core library files to use renamed builtins
- Codegen now handles CmRawCall expressions with proper function index resolution

### Documentation
- Updated WEP 2026-02-15 design document to reflect correct pipeline position (after effect_check, before monomorphize)
- Clarified that adapter functions flow through normal monomorphize → lower → optimize → codegen pipeline

## Implementation Details

The CM ABI module provides:
- `align_to()`: Alignment helper using bit manipulation
- `cm_size()` / `cm_align()`: Type-based size and alignment queries
- `layout_record()` / `layout_tuple()`: Composite type layout with field offsets
- `layout_option()` / `layout_result()`: Special handling for discriminated unions
- `cm_flat_types()`: Flattening for core Wasm value types

The adapter synthesis module provides:
- Helper functions for constructing TIR expressions and statements
- `synthesize_lift()`: Load CM values from linear memory
- `synthesize_lower()`: Store Wado values to linear memory
- `flatten_param_type()`: Compute flat ABI parameter types
- `generate_adapters()`: Phase entry point (currently scaffolding)

All

https://claude.ai/code/session_01MpCsoN8L2UbpJt4Ua6KGXA