### PR TITLE
Inline generic list lifting in CM adapters with proper monomorphization

### DIFF
--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -218,7 +218,7 @@ The adapter functions use builtins to perform low-level operations. Some already
 | Array\<u8\>                                             | alloc + copy → `(ptr, len)`                         | copy from linear memory → GC array  | `internal::cm_lower_array_u8`, `internal::memory_to_gc_array` |
 | list\<T\>, option\<T\>, result\<T, E\>, record, variant | recursive                                           | recursive                           | synthesizer generates TIR (calls leaf helpers above)          |
 
-Per-type converter functions (e.g., `cm_list_string_to_array`, `cm_option_string_to_option`) will be deleted once the synthesizer handles their types generically.
+All per-type converter functions (`cm_list_string_to_array`, `cm_option_string_to_option`, etc.) have been deleted. The synthesizer handles all types generically using inline TIR with proper monomorphization info.
 
 #### Memory load/store builtins (added in Phase 1)
 
@@ -390,21 +390,21 @@ This replaces the ad-hoc size/align constants scattered throughout `CmCallConven
 
 After cm_adapter_gen is complete:
 
-| Location           | Code                                   | Lines | Fate                                                          |
-| ------------------ | -------------------------------------- | ----- | ------------------------------------------------------------- |
-| codegen.rs         | `generate_cm_effect_call`              | ~155  | **Deleted** — adapter handles CM calls                        |
-| codegen.rs         | `generate_cm_resource_method_call`     | ~264  | **Deleted** — adapter handles resource calls                  |
-| codegen.rs         | `emit_option_string_lowering`          | ~40   | Deleted — adapter generates inline                            |
-| codegen.rs         | `emit_field_size_payload_lowering`     | ~65   | Deleted — adapter generates inline                            |
-| codegen.rs         | `wado_type_to_cm_val_type`             | ~50   | Moved to cm_abi.rs                                            |
-| component_model.rs | `CmCallConvention` struct + impl       | ~360  | **Deleted** — type-driven synthesis replaces pattern matching |
-| component_model.rs | `CmConverterKind` enum + impl          | ~50   | **Deleted** — call graph analysis replaces converter tracking |
-| wasm_plan.rs       | `CmConverterRequirements` + tests      | ~110  | **Deleted** — call graph analysis replaces converter tracking |
-| internal.wado      | `cm_option_string_to_option`           | ~26   | **Deleted** — adapter generates inline                        |
-| internal.wado      | `cm_option_own_resource_to_option`     | ~16   | **Deleted** — adapter generates inline                        |
-| internal.wado      | `cm_list_string_to_array`              | ~30   | Pending — used by adapter `result_converter` pattern          |
-| internal.wado      | `cm_list_tuple_string_string_to_array` | ~38   | Pending — used by adapter `result_converter` pattern          |
-| Total removed      |                                        | ~1021 | (bold = deleted in Phase 2)                                   |
+| Location           | Code                                   | Lines | Fate                                                              |
+| ------------------ | -------------------------------------- | ----- | ----------------------------------------------------------------- |
+| codegen.rs         | `generate_cm_effect_call`              | ~155  | **Deleted** — adapter handles CM calls                            |
+| codegen.rs         | `generate_cm_resource_method_call`     | ~264  | **Deleted** — adapter handles resource calls                      |
+| codegen.rs         | `emit_option_string_lowering`          | ~40   | Deleted — adapter generates inline                                |
+| codegen.rs         | `emit_field_size_payload_lowering`     | ~65   | Deleted — adapter generates inline                                |
+| codegen.rs         | `wado_type_to_cm_val_type`             | ~50   | Moved to cm_abi.rs                                                |
+| component_model.rs | `CmCallConvention` struct + impl       | ~360  | **Deleted** — type-driven synthesis replaces pattern matching     |
+| component_model.rs | `CmConverterKind` enum + impl          | ~50   | **Deleted** — call graph analysis replaces converter tracking     |
+| wasm_plan.rs       | `CmConverterRequirements` + tests      | ~110  | **Deleted** — call graph analysis replaces converter tracking     |
+| internal.wado      | `cm_option_string_to_option`           | ~26   | **Deleted** — adapter generates inline                            |
+| internal.wado      | `cm_option_own_resource_to_option`     | ~16   | **Deleted** — adapter generates inline                            |
+| internal.wado      | `cm_list_string_to_array`              | ~30   | **Deleted** — adapter generates inline with generic Array methods |
+| internal.wado      | `cm_list_tuple_string_string_to_array` | ~38   | **Deleted** — adapter generates inline with generic Array methods |
+| Total removed      |                                        | ~1089 | (bold = deleted)                                                  |
 
 New code (actual for Phases 1–2):
 
@@ -463,7 +463,7 @@ Migrate one WASI interface at a time, validating via existing E2E tests.
 - [x] Delete `CmConverterRequirements` struct and `get_cm_converter_for_type` from wasm_plan.rs.
 - [x] Simplify DCE converter tracking: rely on call graph analysis instead of `CmConverterRequirements`.
 - [x] Delete unused per-type converters from internal.wado: `cm_option_string_to_option`, `cm_option_own_resource_to_option`.
-- [ ] Implement `synthesize_lift` and `synthesize_lower` for `list<T>`, `option<T>`, `result<T, E>` generically — currently uses per-type `result_converter` functions for complex list types like `list<list<u8>>`.
+- [x] Implement `synthesize_lift` for `list<T>` generically — adapter synthesis now provides proper `MonomorphInfo` and `LocalMethodName` on `StaticCall`/`MethodCall` nodes for `Array::<T>::with_capacity()` and `.append()`, enabling the monomorphizer to instantiate these generic methods. `list_converter_for_type` workaround deleted along with `cm_list_string_to_array` and `cm_list_tuple_string_string_to_array` from internal.wado.
 - [ ] Migrate remaining WASI interfaces not yet covered by adapter synthesis (e.g., `wasi:clocks`).
 
 ### Phase 3: Export Adapters
@@ -541,7 +541,7 @@ The original WEP placed cm_adapter_gen "between resolve and lower". The actual p
 
 ### Known Limitations
 
-- **Array method calls in synthesized adapters**: The adapter synthesizer currently cannot call `Array<T>` methods (e.g., `Array::<T>::with_capacity()`, `arr.append()`) in synthesized TIR because these methods require monomorphized generic resolution that happens after adapter synthesis. The workaround is to delegate list lifting to pre-written `result_converter` functions in `internal.wado` (e.g., `cm_list_string_to_array`). This must be resolved in the next phase to enable fully generic `list<T>` lifting/lowering without per-type converters.
+- ~~**Array method calls in synthesized adapters**~~: Resolved. The adapter synthesizer now provides proper `MonomorphInfo` and `LocalMethodName` on `StaticCall`/`MethodCall` TIR nodes. The monomorphizer's collection phase (Phase 8) picks up the instantiation sites, and a new `StaticCall` rewrite path in Phase 12 renames calls to their monomorphized names. A `wasi_type_to_type_id` helper converts WASI AST types to `TypeId`s during adapter synthesis so the receiver and type arguments carry correct types.
 
 ### Risks
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -411,14 +411,15 @@ New code (actual for Phases 1–2):
 | Module                    | Purpose                          | Lines |
 | ------------------------- | -------------------------------- | ----- |
 | cm_abi.rs                 | Canonical ABI layout computation | 813   |
-| cm_adapter_gen.rs         | Type-driven adapter synthesis    | 2826  |
+| cm_adapter_gen.rs         | Type-driven adapter synthesis    | 2909  |
 | builtin.wado additions    | Memory load/store builtins       | ~50   |
 | CmRawCall visitor changes | Match arms across 14 files       | ~160  |
-| Total added               |                                  | ~3849 |
+| monomorphize.rs additions | StaticCall rewrite in Phase 12   | ~20   |
+| Total added               |                                  | ~3952 |
 
-The adapter gen module grew significantly in Phase 2 (from 1664 to 2826 lines) as resource method adapter synthesis was added, including variant/enum lifting with discriminant dispatch, nested struct lifting (`FieldSizePayload`, `DnsErrorPayload`, `TlsAlertReceivedPayload`), and `Option<own<resource>>` lifting.
+The adapter gen module grew significantly in Phase 2 (from 1664 to 2909 lines) as resource method adapter synthesis was added, including variant/enum lifting with discriminant dispatch, nested struct lifting (`FieldSizePayload`, `DnsErrorPayload`, `TlsAlertReceivedPayload`), `Option<own<resource>>` lifting, and generic `list<T>` lifting with proper monomorphization support.
 
-Net impact: ~3849 lines added, ~1021 lines removed (with ~68 lines still pending removal). The new code is more general and eliminates per-type hand-coding.
+Net impact: ~3952 lines added, ~1089 lines removed. The new code is more general and eliminates per-type hand-coding.
 
 ### What Stays
 

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -89,44 +89,6 @@ pub fn log_stderr(message: String) {
     wait_for_subtask(subtask);
 }
 
-/// Convert a Component Model list<string> to a GC Array<String>
-/// The outptr points to the CM list representation in linear memory:
-///   outptr[0..4]: base_ptr - pointer to array of (ptr, len) pairs
-///   outptr[4..8]: count - number of strings
-/// Each string in the array is represented as:
-///   base_ptr[i*8+0..i*8+4]: str_ptr - pointer to UTF-8 bytes
-///   base_ptr[i*8+4..i*8+8]: str_len - length in bytes
-pub fn cm_list_string_to_array(outptr: i32) -> Array<String> {
-    let base_ptr = builtin::i32_load(outptr);
-    let count = builtin::i32_load(outptr + 4);
-
-    // Create Array<String> with capacity
-    let mut result = Array::<String>::with_capacity(count);
-
-    // Convert each CM string to a GC string
-    for (let mut i = 0; i < count; i += 1) {
-        let str_ptr = builtin::i32_load(base_ptr + i * 8);
-        let str_len = builtin::i32_load(base_ptr + i * 8 + 4);
-
-        let arr = memory_to_gc_array(str_ptr, str_len);
-
-        result.append(String::internal_from_utf8_raw(arr, str_len));
-
-        // Free this string's linear memory
-        builtin::realloc(str_ptr, str_len, 1, 0);
-    }
-
-    // Free the list element array (count * 8 bytes, each element is ptr+len pair)
-    if count > 0 {
-        builtin::realloc(base_ptr, count * 8, 4, 0);
-    }
-
-    // Free the outptr itself (8 bytes: base_ptr + count)
-    builtin::realloc(outptr, 8, 4, 0);
-
-    return result;
-}
-
 pub fn panic(message: String) -> ! {
     log_stderr(message);
     builtin::unreachable();
@@ -164,51 +126,5 @@ pub fn cm_lower_array_u8(arr: Array<u8>) -> i64 {
     return cm_lower_list_u8(data, len);
 }
 
-/// Convert a Component Model list<tuple<string, string>> to a GC Array<[String, String]>
-/// The outptr points to the CM list representation in linear memory:
-///   outptr[0..4]: base_ptr - pointer to array of tuples
-///   outptr[4..8]: count - number of tuples
-/// Each tuple is 16 bytes:
-///   base_ptr[i*16+0..i*16+4]: str1_ptr
-///   base_ptr[i*16+4..i*16+8]: str1_len
-///   base_ptr[i*16+8..i*16+12]: str2_ptr
-///   base_ptr[i*16+12..i*16+16]: str2_len
-pub fn cm_list_tuple_string_string_to_array(outptr: i32) -> Array<[String, String]> {
-    let base_ptr = builtin::i32_load(outptr);
-    let count = builtin::i32_load(outptr + 4);
 
-    // Create Array<[String, String]> with capacity
-    let mut result = Array::<[String, String]>::with_capacity(count);
-
-    // Convert each CM tuple to a GC tuple
-    for (let mut i = 0; i < count; i += 1) {
-        let tuple_offset = base_ptr + i * 16;
-
-        // Read first string
-        let str1_ptr = builtin::i32_load(tuple_offset);
-        let str1_len = builtin::i32_load(tuple_offset + 4);
-        let arr1 = memory_to_gc_array(str1_ptr, str1_len);
-
-        // Read second string
-        let str2_ptr = builtin::i32_load(tuple_offset + 8);
-        let str2_len = builtin::i32_load(tuple_offset + 12);
-        let arr2 = memory_to_gc_array(str2_ptr, str2_len);
-
-        result.append([String::internal_from_utf8_raw(arr1, str1_len), String::internal_from_utf8_raw(arr2, str2_len)]);
-
-        // Free both strings' linear memory
-        builtin::realloc(str1_ptr, str1_len, 1, 0);
-        builtin::realloc(str2_ptr, str2_len, 1, 0);
-    }
-
-    // Free the list element array (count * 16 bytes per tuple)
-    if count > 0 {
-        builtin::realloc(base_ptr, count * 16, 4, 0);
-    }
-
-    // Free the outptr itself (8 bytes: base_ptr + count)
-    builtin::realloc(outptr, 8, 4, 0);
-
-    return result;
-}
 

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -18,11 +18,11 @@ use indexmap::{IndexMap, IndexSet};
 use crate::ast::Type;
 use crate::cm_abi;
 use crate::component_model::{WasiFunctionInfo, WasiRegistry};
-use crate::name::ModuleSource;
+use crate::name::{LocalMethodName, ModuleSource};
 use crate::project::Project;
 use crate::tir::{
-    FunctionRef, TirBlock, TirExpr, TirExprKind, TirFunction, TirParam, TirStmt, TirStmtKind,
-    TypeId, TypeTable,
+    FunctionRef, MonomorphInfo, TirBlock, TirExpr, TirExprKind, TirFunction, TirParam, TirStmt,
+    TirStmtKind, TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -31,6 +31,55 @@ use crate::token::Span;
 pub struct LiftContext<'a> {
     pub wasi_registry: &'a WasiRegistry,
     pub type_table: &'a RefCell<TypeTable>,
+}
+
+/// Convert a WASI AST `Type` to a `TypeId` in the type table.
+///
+/// This is needed for synthesized adapter code that calls generic methods
+/// (e.g., `Array::<String>::with_capacity()`). The monomorphizer requires
+/// concrete `TypeId`s in `MonomorphInfo::type_args` to instantiate generic methods.
+pub fn wasi_type_to_type_id(ty: &Type, type_table: &mut TypeTable) -> TypeId {
+    match ty {
+        Type::Named(named) => match named.name.as_str() {
+            "i8" => TypeTable::I8,
+            "i16" => TypeTable::I16,
+            "i32" => TypeTable::I32,
+            "i64" => TypeTable::I64,
+            "u8" => TypeTable::U8,
+            "u16" => TypeTable::U16,
+            "u32" => TypeTable::U32,
+            "u64" => TypeTable::U64,
+            "f32" => TypeTable::F32,
+            "f64" => TypeTable::F64,
+            "bool" => TypeTable::BOOL,
+            "char" => TypeTable::CHAR,
+            "String" => type_table.make_struct(
+                "String".to_string(),
+                ModuleSource::core("prelude/string.wado"),
+            ),
+            // Resource types and other named types are i32 handles
+            _ => TypeTable::I32,
+        },
+        Type::Generic(g) => match g.name.as_str() {
+            "Array" if g.args.len() == 1 => {
+                let elem_type = wasi_type_to_type_id(&g.args[0], type_table);
+                type_table.make_array(elem_type)
+            }
+            "Option" if g.args.len() == 1 => {
+                let inner_type = wasi_type_to_type_id(&g.args[0], type_table);
+                type_table.make_option(inner_type)
+            }
+            _ => TypeTable::UNIT,
+        },
+        Type::Tuple(types) => {
+            let resolved: Vec<TypeId> = types
+                .iter()
+                .map(|t| wasi_type_to_type_id(t, type_table))
+                .collect();
+            type_table.make_tuple(resolved)
+        }
+        _ => TypeTable::UNIT,
+    }
 }
 
 /// Synthetic span used for all generated adapter code.
@@ -242,25 +291,39 @@ pub fn assign(target: TirExpr, value: TirExpr) -> TirExpr {
     )
 }
 
-/// Create a method call expression.
-pub fn method_call(
-    receiver: TirExpr,
+/// Create a static call to a generic struct method with proper monomorphization info.
+///
+/// For example, `Array::<String>::with_capacity(n)` needs:
+/// - `method_info` with `struct_name: "Array"`, `method_name: "with_capacity"`
+/// - `monomorph_info` with `generic_name: "Array::with_capacity"`, `type_args: [String]`
+///
+/// Without these, the monomorphizer won't instantiate the generic method.
+fn generic_static_call(
+    struct_name: &str,
     method_name: &str,
-    method_module_source: ModuleSource,
+    module_source: ModuleSource,
     type_args: Vec<TypeId>,
     args: Vec<TirExpr>,
     return_type: TypeId,
 ) -> TirExpr {
-    TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: crate::tir::FunctionRef::External {
-                module_source: method_module_source,
-                name: method_name.to_string(),
-                monomorph_info: None,
-                method_info: None,
-            },
+    let info = LocalMethodName::new(struct_name.to_string(), None, method_name.to_string());
+    let mangled_name = info.to_mangled_name();
+    let monomorph_info = if type_args.is_empty() {
+        None
+    } else {
+        Some(MonomorphInfo {
+            generic_name: mangled_name.clone(),
             type_args,
+        })
+    };
+    TirExpr::new(
+        TirExprKind::StaticCall {
+            func: FunctionRef::External {
+                module_source,
+                name: mangled_name,
+                monomorph_info,
+                method_info: Some(info),
+            },
             args,
         },
         return_type,
@@ -268,21 +331,31 @@ pub fn method_call(
     )
 }
 
-/// Create a static call expression (e.g., `Array::<T>::with_capacity(n)`).
-pub fn static_call(
+/// Create a method call on a generic struct with proper monomorphization info.
+///
+/// For example, `arr.append(elem)` where `arr: Array<String>` needs:
+/// - `method_info` with `struct_name: "Array"`, `method_name: "append"`
+/// - The receiver's `type_id` must be the concrete `Array<String>` `TypeId`
+fn generic_method_call(
+    receiver: TirExpr,
+    struct_name: &str,
     method_name: &str,
-    module_source: ModuleSource,
+    method_module_source: ModuleSource,
     args: Vec<TirExpr>,
     return_type: TypeId,
 ) -> TirExpr {
+    let info = LocalMethodName::new(struct_name.to_string(), None, method_name.to_string());
+    let mangled_name = info.to_mangled_name();
     TirExpr::new(
-        TirExprKind::StaticCall {
-            func: crate::tir::FunctionRef::External {
-                module_source,
-                name: method_name.to_string(),
+        TirExprKind::MethodCall {
+            receiver: Box::new(receiver),
+            func: FunctionRef::External {
+                module_source: method_module_source,
+                name: mangled_name,
                 monomorph_info: None,
-                method_info: None,
+                method_info: Some(info),
             },
+            type_args: vec![],
             args,
         },
         return_type,
@@ -407,7 +480,7 @@ fn synthesize_lift_inner(
         },
         Type::Generic(g) => match g.name.as_str() {
             "Array" if g.args.len() == 1 => {
-                synthesize_lift_list(&g.args[0], addr, next_local, stmts, local_types)
+                synthesize_lift_list(&g.args[0], addr, next_local, stmts, local_types, ctx)
             }
             "Option" if g.args.len() == 1 => {
                 synthesize_lift_option_inner(&g.args[0], addr, next_local, stmts, local_types, ctx)
@@ -427,7 +500,9 @@ fn synthesize_lift_inner(
         Type::Tuple(elems) if elems.is_empty() => {
             TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span())
         }
-        Type::Tuple(elems) => synthesize_lift_tuple(elems, addr, next_local, stmts, local_types),
+        Type::Tuple(elems) => {
+            synthesize_lift_tuple(elems, addr, next_local, stmts, local_types, ctx)
+        }
         Type::Reference(_) | Type::MutReference(_) => {
             builtin_call("i32_load", vec![addr], TypeTable::I32)
         }
@@ -656,8 +731,21 @@ fn synthesize_lift_list(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     local_types: &mut Vec<TypeId>,
+    ctx: Option<&LiftContext<'_>>,
 ) -> TirExpr {
     let elem_size = cm_abi::cm_size(elem_ty);
+
+    // Resolve TypeIds for the element type and Array<ElemType>.
+    // These are needed by the monomorphizer to instantiate Array::with_capacity and .append().
+    let (elem_type_id, array_type_id) = if let Some(ctx) = ctx {
+        let mut tt = ctx.type_table.borrow_mut();
+        let elem_tid = wasi_type_to_type_id(elem_ty, &mut tt);
+        let array_tid = tt.make_array(elem_tid);
+        (elem_tid, array_tid)
+    } else {
+        // Fallback: use placeholder types (existing behavior for callers without context)
+        (TypeTable::I32, TypeTable::I32)
+    };
 
     let base_local = alloc_local(next_local, local_types, TypeTable::I32);
     stmts.push(let_stmt(
@@ -679,16 +767,18 @@ fn synthesize_lift_list(
         ),
     ));
 
-    let result_local = alloc_local(next_local, local_types, TypeTable::I32);
+    let result_local = alloc_local(next_local, local_types, array_type_id);
     stmts.push(let_mut_stmt(
         "__result",
         result_local,
-        TypeTable::I32,
-        static_call(
+        array_type_id,
+        generic_static_call(
+            "Array",
             "with_capacity",
             ModuleSource::core("prelude"),
+            vec![elem_type_id],
             vec![local_ref(count_local, "__count", TypeTable::I32)],
-            TypeTable::I32,
+            array_type_id,
         ),
     ));
 
@@ -727,23 +817,24 @@ fn synthesize_lift_list(
         ),
     ));
 
-    // Lift element
+    // Lift element (recursive: inner lists, options, etc. will also get proper types)
     let mut elem_lift_stmts: Vec<TirStmt> = Vec::new();
-    let lifted_elem = synthesize_lift(
+    let lifted_elem = synthesize_lift_inner(
         elem_ty,
         local_ref(elem_addr_local, "__elem_addr", TypeTable::I32),
         next_local,
         &mut elem_lift_stmts,
         local_types,
+        ctx,
     );
     loop_stmts.extend(elem_lift_stmts);
 
     // __result.append(lifted_elem)
-    loop_stmts.push(expr_stmt(method_call(
-        local_ref(result_local, "__result", TypeTable::I32),
+    loop_stmts.push(expr_stmt(generic_method_call(
+        local_ref(result_local, "__result", array_type_id),
+        "Array",
         "append",
         ModuleSource::core("prelude"),
-        vec![],
         vec![lifted_elem],
         TypeTable::UNIT,
     )));
@@ -856,7 +947,6 @@ fn synthesize_lift_option_inner(
 /// Lift a `result<T, E>` from linear memory at `addr`.
 ///
 /// Layout: discriminant i32 at offset 0, payload at aligned offset.
-
 #[allow(clippy::cast_possible_wrap)]
 fn synthesize_lift_result_inner(
     ok_ty: &Type,
@@ -970,19 +1060,31 @@ fn synthesize_lift_tuple(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     local_types: &mut Vec<TypeId>,
+    ctx: Option<&LiftContext<'_>>,
 ) -> TirExpr {
     let layout = cm_abi::layout_tuple(elems);
     let mut elem_exprs = Vec::new();
     for (i, elem_ty) in elems.iter().enumerate() {
         let elem_addr = binary_add(addr.clone(), i32_const(layout.offsets[i] as i32));
-        let lifted = synthesize_lift(elem_ty, elem_addr, next_local, stmts, local_types);
+        let lifted = synthesize_lift_inner(elem_ty, elem_addr, next_local, stmts, local_types, ctx);
         elem_exprs.push(lifted);
     }
+    // Resolve the tuple TypeId if we have a type table context.
+    let tuple_type_id = if let Some(ctx) = ctx {
+        let mut tt = ctx.type_table.borrow_mut();
+        let elem_type_ids: Vec<TypeId> = elems
+            .iter()
+            .map(|t| wasi_type_to_type_id(t, &mut tt))
+            .collect();
+        tt.make_tuple(elem_type_ids)
+    } else {
+        TypeTable::I32
+    };
     TirExpr::new(
         TirExprKind::TupleLiteral {
             elements: elem_exprs,
         },
-        TypeTable::I32,
+        tuple_type_id,
         synth_span(),
     )
 }
@@ -1214,36 +1316,6 @@ const ASYNC_OUTPTR: i32 = 2048;
 
 /// Canonical ABI: maximum number of flat return values before outptr is used.
 const MAX_FLAT_RESULTS: usize = 1;
-
-/// Returns the internal.wado converter function name for list types that need
-/// pre-compiled generic array operations, or `None` if the type can be lifted inline.
-///
-/// List types require `Array::<T>::with_capacity()` and `.append()` which are generic
-/// methods needing monomorphization. Since adapter synthesis runs after the resolver,
-/// we delegate to internal.wado converter functions for these types.
-fn list_converter_for_type(ty: &Type) -> Option<&'static str> {
-    match ty {
-        Type::Generic(g) if g.name == "Array" && g.args.len() == 1 => {
-            match &g.args[0] {
-                Type::Named(n) if n.name == "String" => Some("cm_list_string_to_array"),
-                Type::Named(n) if n.name == "u8" => None, // u8 lists use memory_to_gc_array inline
-                Type::Tuple(elems) if elems.len() == 2 => {
-                    // list<tuple<string, string>> → cm_list_tuple_string_string_to_array
-                    if elems
-                        .iter()
-                        .all(|e| matches!(e, Type::Named(n) if n.name == "String"))
-                    {
-                        Some("cm_list_tuple_string_string_to_array")
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            }
-        }
-        _ => None,
-    }
-}
 
 /// Check whether a return type needs lifting from a flat i32 discriminant to a GC struct.
 /// This is true for Result types where all payloads are empty (unit), so the raw call
@@ -1678,46 +1750,34 @@ fn synthesize_adapter(
         let return_type = func_info.return_type.as_ref().unwrap();
         let resolved = wasi_registry.resolve_type(return_type);
 
-        // Check if this return type needs a pre-compiled internal converter function.
-        // List types require generic Array<T> operations (with_capacity, append) which
-        // need monomorphization. Since adapters are synthesized after resolution,
-        // we delegate to internal.wado converter functions for these types.
-        if let Some(converter_name) = list_converter_for_type(&resolved) {
-            let converter_call = internal_call(
-                converter_name,
-                vec![local_ref(outptr_local, "__outptr", TypeTable::I32)],
-                TypeTable::I32,
-            );
-            body_stmts.push(return_stmt(Some(converter_call)));
-        } else {
-            // Inline lifting for all other types (primitives, string, option, result, tuple, etc.)
-            let lift_ctx = LiftContext {
-                wasi_registry,
-                type_table,
-            };
-            let lifted = synthesize_lift_with_context(
-                &resolved,
+        // Inline lifting for all types, including list<T> which uses
+        // Array::<T>::with_capacity() and .append() with proper monomorphization info.
+        let lift_ctx = LiftContext {
+            wasi_registry,
+            type_table,
+        };
+        let lifted = synthesize_lift_with_context(
+            &resolved,
+            local_ref(outptr_local, "__outptr", TypeTable::I32),
+            &mut next_local,
+            &mut body_stmts,
+            &mut local_types,
+            &lift_ctx,
+        );
+
+        // Free the outptr
+        body_stmts.push(expr_stmt(builtin_call(
+            "realloc",
+            vec![
                 local_ref(outptr_local, "__outptr", TypeTable::I32),
-                &mut next_local,
-                &mut body_stmts,
-                &mut local_types,
-                &lift_ctx,
-            );
+                i32_const(alloc_size as i32),
+                i32_const(alloc_align as i32),
+                i32_const(0),
+            ],
+            TypeTable::I32,
+        )));
 
-            // Free the outptr
-            body_stmts.push(expr_stmt(builtin_call(
-                "realloc",
-                vec![
-                    local_ref(outptr_local, "__outptr", TypeTable::I32),
-                    i32_const(alloc_size as i32),
-                    i32_const(alloc_align as i32),
-                    i32_const(0),
-                ],
-                TypeTable::I32,
-            )));
-
-            body_stmts.push(return_stmt(Some(lifted)));
-        }
+        body_stmts.push(return_stmt(Some(lifted)));
         adapter_return_type = TypeTable::I32; // placeholder, fixed up at call site
     } else if func_info.return_type.is_some() {
         let return_type = func_info.return_type.as_ref().unwrap();

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -3016,9 +3016,48 @@ impl Monomorphizer {
                     self.rewrite_function_calls_in_expr(arg, type_table);
                 }
             }
-            TirExprKind::EffectCall { args, .. }
-            | TirExprKind::CmRawCall { args, .. }
-            | TirExprKind::StaticCall { args, .. } => {
+            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+                for arg in args {
+                    self.rewrite_function_calls_in_expr(arg, type_table);
+                }
+            }
+            TirExprKind::StaticCall {
+                func: static_func,
+                args,
+            } => {
+                // Check if this is a monomorphized static call that needs rewriting.
+                // This handles calls like `Array::with_capacity` in adapter functions
+                // where monomorph_info carries the type_args for instantiation lookup.
+                if let FunctionRef::External {
+                    monomorph_info: Some(monomorph),
+                    method_info: Some(info),
+                    ..
+                } = static_func
+                    && !monomorph.type_args.is_empty()
+                {
+                    let generic_method_name = MethodName::format_local(
+                        &info.base_struct_name,
+                        info.trait_name.as_deref(),
+                        &info.method_name,
+                    );
+                    let key = InstantiationKey {
+                        name: generic_method_name.clone(),
+                        type_args: monomorph.type_args.clone(),
+                        method_info: Some(info.clone()),
+                    };
+                    if let Some(mangled) = self.function_instantiated.get(&key) {
+                        let original_method_info = static_func.method_info();
+                        *static_func = FunctionRef::External {
+                            module_source: self.entry_module_source.clone(),
+                            name: mangled.clone(),
+                            monomorph_info: Some(MonomorphInfo {
+                                generic_name: generic_method_name,
+                                type_args: key.type_args.clone(),
+                            }),
+                            method_info: original_method_info,
+                        };
+                    }
+                }
                 for arg in args {
                     self.rewrite_function_calls_in_expr(arg, type_table);
                 }

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -91,7 +91,7 @@ pub fn analyze_project(project: &mut Project) {
     let needs_f64_to_buffer = reachable.contains(&core_internal("f64_to_string"));
     let needs_f32_to_buffer = reachable.contains(&core_internal("f32_to_string"));
 
-    // CM converter functions (cm_list_string_to_array, cm_lower_string, etc.)
+    // CM helper functions (cm_lower_string, memory_to_gc_string, etc.)
     // are called from synthesized CM adapter functions, which are part of the TIR
     // and discovered through normal call graph analysis.
 

--- a/wado-compiler/tests/fixtures.golden/cli_args.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/cli_args.lowered.wado
@@ -34,6 +34,44 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
 fn __cm_adapter__Environment_get_arguments() -> Array<String> {
     let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
     cm_raw_call wasi:cli/Environment::get_arguments(__outptr);
-    return core::internal::cm_list_string_to_array(__outptr);
+    let __base: i32 = core::builtin::i32_load(__outptr);
+    let __count: i32 = core::builtin::i32_load((__outptr + 4));
+    let mut __result: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(__count), used: 0 };
+    let mut __i: i32 = 0;
+    loop {
+        if (__i >= __count) {
+            break;
+        }
+        let __elem_addr: i32 = (__base + (__i * 8));
+        __result."Array<String>::append"(__inline_memory_to_gc_string_1: {
+            let ptr: i32 = core::builtin::i32_load(__elem_addr);
+            let len: i32 = core::builtin::i32_load((__elem_addr + 4));
+            let arr: builtin::array<u8> = core::internal::memory_to_gc_array(ptr, len);
+            break __inline_memory_to_gc_string_1: String { repr: arr, used: len };
+        });
+        core::builtin::realloc(core::builtin::i32_load(__elem_addr), core::builtin::i32_load((__elem_addr + 4)), 1, 0);
+        __i = (__i + 1);
+    }
+    if (__count > 0) {
+        core::builtin::realloc(__base, (__count * 8), 4, 0);
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result;
+}
+
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
 }
 

--- a/wado-compiler/tests/fixtures.golden/treemap-compact.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-compact.lowered.wado
@@ -639,6 +639,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "TreeMap<String,i32>::get"(self: &TreeMap<String,i32>, key: String) -> Option<i32> {
     let index: i32 = self."TreeMap<String,i32>::find_index"(key);
     if (index >= 0) {
@@ -758,22 +774,6 @@ pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> 
         }
     }
     return result;
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 pub fn "TreeMap<String,i32>::remove"(self: &mut TreeMap<String,i32>, key: String) -> bool {

--- a/wado-compiler/tests/fixtures.golden/treemap-ordering.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-ordering.lowered.wado
@@ -581,6 +581,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
     if (index >= self.used) {
         core::internal::panic(move "index out of bounds");
@@ -660,22 +676,6 @@ pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> 
         }
     }
     return result;
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 fn "TreeMap<String,i32>::insert"(self: &mut TreeMap<String,i32>, key: String, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/treemap-reinsert-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-reinsert-order.lowered.wado
@@ -528,6 +528,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
     if (index >= self.used) {
         core::internal::panic(move "index out of bounds");
@@ -607,22 +623,6 @@ pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> 
         }
     }
     return result;
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 pub fn "TreeMap<String,i32>::remove"(self: &mut TreeMap<String,i32>, key: String) -> bool {

--- a/wado-compiler/tests/fixtures.golden/treemap-remove-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-remove-order.lowered.wado
@@ -564,6 +564,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> String {
     if (index >= self.used) {
         core::internal::panic(move "index out of bounds");
@@ -588,22 +604,6 @@ pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> 
         }
     }
     return result;
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 fn "ArrayIter<TreeMapEntry<String,i32>>^Iterator::next"(self: &mut ArrayIter<TreeMapEntry<String,i32>>) -> Option<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-update-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-update-order.lowered.wado
@@ -352,6 +352,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
     if (index >= self.used) {
         core::internal::panic(move "index out of bounds");
@@ -431,22 +447,6 @@ pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> 
         }
     }
     return result;
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 fn "TreeMap<String,i32>::insert"(self: &mut TreeMap<String,i32>, key: String, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/treemap_btree.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree.lowered.wado
@@ -230,6 +230,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "TreeMap<String,i32>::compact"(self: &mut TreeMap<String,i32>) {
     let __pattern_temp_0: Option<&mut BTreeNode<String,i32>> = self.root;
     if __is_not_null(__pattern_temp_0) {
@@ -338,22 +354,6 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
         core::internal::panic(move "index out of bounds");
     }
     return core::builtin::array_get::<String>(self.repr, index);
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 fn "Array<bool>^IndexValue::index_value"(self: &Array<bool>, index: i32) -> bool {

--- a/wado-compiler/tests/fixtures.golden/treemap_btree2.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree2.lowered.wado
@@ -238,6 +238,22 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
 }
 
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
 fn "TreeMap<String,i32>::compact"(self: &mut TreeMap<String,i32>) {
     let __pattern_temp_0: Option<&mut BTreeNode<String,i32>> = self.root;
     if __is_not_null(__pattern_temp_0) {
@@ -346,22 +362,6 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
         core::internal::panic(move "index out of bounds");
     }
     return core::builtin::array_get::<String>(self.repr, index);
-}
-
-pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
-    let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let mut new_capacity: i32 = (capacity * 2);
-        if (capacity == 0) {
-            new_capacity = 4;
-        }
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
-        self.repr = new_repr;
-    }
-    core::builtin::array_set::<String>(self.repr, used, value);
-    self.used = (used + 1);
 }
 
 fn "Array<bool>^IndexValue::index_value"(self: &Array<bool>, index: i32) -> bool {

--- a/wado-compiler/tests/fixtures.golden/wasi_cli.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_cli.lowered.wado
@@ -56,12 +56,94 @@ fn __cm_adapter__Stderr_write_via_stream(data: i32) {
 fn __cm_adapter__Environment_get_arguments() -> Array<String> {
     let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
     cm_raw_call wasi:cli/Environment::get_arguments(__outptr);
-    return core::internal::cm_list_string_to_array(__outptr);
+    let __base: i32 = core::builtin::i32_load(__outptr);
+    let __count: i32 = core::builtin::i32_load((__outptr + 4));
+    let mut __result: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(__count), used: 0 };
+    let mut __i: i32 = 0;
+    loop {
+        if (__i >= __count) {
+            break;
+        }
+        let __elem_addr: i32 = (__base + (__i * 8));
+        __result."Array<String>::append"(__inline_memory_to_gc_string_1: {
+            let ptr: i32 = core::builtin::i32_load(__elem_addr);
+            let len: i32 = core::builtin::i32_load((__elem_addr + 4));
+            let arr: builtin::array<u8> = core::internal::memory_to_gc_array(ptr, len);
+            break __inline_memory_to_gc_string_1: String { repr: arr, used: len };
+        });
+        core::builtin::realloc(core::builtin::i32_load(__elem_addr), core::builtin::i32_load((__elem_addr + 4)), 1, 0);
+        __i = (__i + 1);
+    }
+    if (__count > 0) {
+        core::builtin::realloc(__base, (__count * 8), 4, 0);
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result;
 }
 
 fn __cm_adapter__Environment_get_environment() -> Array<[String, String]> {
     let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
     cm_raw_call wasi:cli/Environment::get_environment(__outptr);
-    return core::internal::cm_list_tuple_string_string_to_array(__outptr);
+    let __base: i32 = core::builtin::i32_load(__outptr);
+    let __count: i32 = core::builtin::i32_load((__outptr + 4));
+    let mut __result: Array<[String, String]> = move Array<Tuple<String,String>> { repr: core::builtin::array_new::<[String, String]>(__count), used: 0 };
+    let mut __i: i32 = 0;
+    loop {
+        if (__i >= __count) {
+            break;
+        }
+        let __elem_addr: i32 = (__base + (__i * 16));
+        __result."Array<Tuple<String,String>>::append"(move [__inline_memory_to_gc_string_1: {
+            let ptr: i32 = core::builtin::i32_load((__elem_addr + 0));
+            let len: i32 = core::builtin::i32_load(((__elem_addr + 0) + 4));
+            let arr: builtin::array<u8> = core::internal::memory_to_gc_array(ptr, len);
+            break __inline_memory_to_gc_string_1: String { repr: arr, used: len };
+        }, __inline_memory_to_gc_string_2: {
+            let ptr: i32 = core::builtin::i32_load((__elem_addr + 8));
+            let len: i32 = core::builtin::i32_load(((__elem_addr + 8) + 4));
+            let arr: builtin::array<u8> = core::internal::memory_to_gc_array(ptr, len);
+            break __inline_memory_to_gc_string_2: String { repr: arr, used: len };
+        }]);
+        core::builtin::realloc(core::builtin::i32_load((__elem_addr + 0)), core::builtin::i32_load(((__elem_addr + 0) + 4)), 1, 0);
+        core::builtin::realloc(core::builtin::i32_load((__elem_addr + 8)), core::builtin::i32_load(((__elem_addr + 8) + 4)), 1, 0);
+        __i = (__i + 1);
+    }
+    if (__count > 0) {
+        core::builtin::realloc(__base, (__count * 16), 4, 0);
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result;
+}
+
+pub fn "Array<Tuple<String,String>>::append"(self: &mut Array<[String, String]>, value: [String, String]) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
+        core::builtin::array_copy::<[String, String]>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<[String, String]>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
+pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let mut new_capacity: i32 = (capacity * 2);
+        if (capacity == 0) {
+            new_capacity = 4;
+        }
+        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+        core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<String>(self.repr, used, value);
+    self.used = (used + 1);
 }
 


### PR DESCRIPTION
## Summary

This PR eliminates the need for pre-compiled generic converter functions (`cm_list_string_to_array`, `cm_list_tuple_string_string_to_array`) by generating inline TIR code for lifting list types in Component Model adapters. The synthesizer now generates proper monomorphization info for generic method calls like `Array::<T>::with_capacity()` and `.append()`, allowing the monomorphizer to instantiate these methods correctly.

## Key Changes

- **New `wasi_type_to_type_id()` function**: Converts WASI AST `Type` to concrete `TypeId` values needed by the monomorphizer to instantiate generic methods with proper type arguments.

- **Refactored generic method call generation**:
  - `generic_static_call()`: Creates static calls to generic struct methods (e.g., `Array::<String>::with_capacity()`) with `MonomorphInfo` containing type arguments
  - `generic_method_call()`: Creates instance method calls (e.g., `arr.append(elem)`) with proper `LocalMethodName` and mangled names
  - Both functions now set `method_info` on `FunctionRef::External` to enable monomorphizer lookup

- **Enhanced `synthesize_lift_list()` and `synthesize_lift_tuple()`**: 
  - Now accept optional `LiftContext` parameter to access the type table
  - Resolve concrete `TypeId`s for element and container types
  - Pass context recursively to nested lifting calls for proper type propagation

- **Updated monomorphizer**: Added special handling in `rewrite_function_calls_in_expr()` for `StaticCall` expressions with `monomorph_info` to rewrite generic method references to their instantiated implementations.

- **Removed converter functions**: Deleted `cm_list_string_to_array()` and `cm_list_tuple_string_string_to_array()` from `internal.wado` and the `list_converter_for_type()` dispatch logic from `cm_adapter_gen.rs`.

- **Generated synthetic methods**: The monomorphizer now instantiates `Array<T>::append()` methods inline in adapter output for concrete types like `Array<String>` and `Array<[String, String]>`.

## Implementation Details

- Adapter synthesis now generates complete inline TIR for all list lifting operations, including proper loop structure, element lifting, and array append calls
- The `LiftContext` carries both the WASI registry and type table, enabling type resolution during synthesis
- Monomorphization info uses mangled method names (e.g., `"Array<String>::append"`) to match the generic method lookup key
- Fallback behavior preserves existing code paths for callers without context (backward compatibility)

https://claude.ai/code/session_01CpHZYEzqobYtBiwyr5TZuX