### PR TITLE
Remove dead TirExprKind::EffectCall variant

### DIFF
--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -465,7 +465,7 @@ Migrate one WASI interface at a time, validating via existing E2E tests.
 - [x] Simplify DCE converter tracking: rely on call graph analysis instead of `CmConverterRequirements`.
 - [x] Delete unused per-type converters from internal.wado: `cm_option_string_to_option`, `cm_option_own_resource_to_option`.
 - [x] Implement `synthesize_lift` for `list<T>` generically — adapter synthesis now provides proper `MonomorphInfo` and `LocalMethodName` on `StaticCall`/`MethodCall` nodes for `Array::<T>::with_capacity()` and `.append()`, enabling the monomorphizer to instantiate these generic methods. `list_converter_for_type` workaround deleted along with `cm_list_string_to_array` and `cm_list_tuple_string_string_to_array` from internal.wado.
-- [ ] Migrate remaining WASI interfaces not yet covered by adapter synthesis (e.g., `wasi:clocks`).
+- [x] Migrate remaining WASI interfaces not yet covered by adapter synthesis (e.g., `wasi:clocks`). Verified: all WASI interfaces (cli, clocks, random, http, sockets) are handled by the generic adapter synthesizer. The old codegen paths (`generate_cm_effect_call`, `generate_cm_resource_method_call`) were already deleted; clocks E2E tests pass at all optimization levels.
 
 ### Phase 3: Export Adapters
 
@@ -474,9 +474,9 @@ Migrate one WASI interface at a time, validating via existing E2E tests.
 - [ ] Delete `CmExportInfo` scratch local logic — adapters declare their own locals.
 - [ ] Delete export-related CM glue from codegen.
 
-### Phase 4: Cleanup (partially done)
+### Phase 4: Cleanup (done)
 
-- [ ] Remove `TirExprKind::EffectCall` — all effect calls are now ordinary `Call`s to adapters.
+- [x] Remove `TirExprKind::EffectCall` — variant was dead code (resolver creates `Call` nodes for all WASI operations; `EffectCall` was never constructed). Removed from `TirExprKind` enum and all 15 files with match arms (effect_check, cm_adapter_gen, codegen, unparse, lower, monomorphize, and 8 optimizer passes).
 - [x] Remove `cm_convention` and `cm_local_name` fields from TIR.
 - [x] Delete `CmCallConvention`, `CmConverterKind`, and `CmConverterRequirements`.
 - [x] Delete unused per-type converter functions from `internal.wado`.
@@ -488,9 +488,11 @@ Migrate one WASI interface at a time, validating via existing E2E tests.
 
 Adding a new `TirExprKind` variant requires updating 14 files with match arms. The pattern varies per file:
 
-- **Grouped with EffectCall**: Most optimizer passes group `CmRawCall` with `EffectCall` since they share the same `args` structure. This is the common case for passes that recurse into arguments.
-- **Standalone handling**: codegen, unparse, effect_check, and optimize_dce need separate match arms because they have variant-specific logic (e.g., codegen resolves `local_name` to a function index, unparse formats differently).
+- **Grouped with Call/StaticCall**: Most optimizer passes group `CmRawCall` with `Call` and `StaticCall` since they share the same `args` structure. This is the common case for passes that recurse into arguments.
+- **Standalone handling**: codegen, unparse, and optimize_dce need separate match arms because they have variant-specific logic (e.g., codegen resolves `local_name` to a function index, unparse formats differently).
 - **Reconstruction**: optimize_inline must reconstruct `CmRawCall` when inlining, remapping local indices.
+
+Note: `TirExprKind::EffectCall` was removed in Phase 4. It was a dead variant — the resolver creates `Call` nodes for all WASI operations (both sync and async), and `cm_adapter_gen` identifies effect calls via `ModuleSource::is_effect_like()`. The `EffectCall` variant was never constructed in the current codebase.
 
 ### TIR construction gotchas
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -467,20 +467,20 @@ Migrate one WASI interface at a time, validating via existing E2E tests.
 - [x] Implement `synthesize_lift` for `list<T>` generically — adapter synthesis now provides proper `MonomorphInfo` and `LocalMethodName` on `StaticCall`/`MethodCall` nodes for `Array::<T>::with_capacity()` and `.append()`, enabling the monomorphizer to instantiate these generic methods. `list_converter_for_type` workaround deleted along with `cm_list_string_to_array` and `cm_list_tuple_string_string_to_array` from internal.wado.
 - [x] Migrate remaining WASI interfaces not yet covered by adapter synthesis (e.g., `wasi:clocks`). Verified: all WASI interfaces (cli, clocks, random, http, sockets) are handled by the generic adapter synthesizer. The old codegen paths (`generate_cm_effect_call`, `generate_cm_resource_method_call`) were already deleted; clocks E2E tests pass at all optimization levels.
 
-### Phase 3: Export Adapters
-
-- [ ] Implement export adapter synthesis for `wasi:cli/run` (simplest export).
-- [ ] Implement export adapter synthesis for `wasi:http/incoming-handler` (complex: async, Result return).
-- [ ] Delete `CmExportInfo` scratch local logic — adapters declare their own locals.
-- [ ] Delete export-related CM glue from codegen.
-
-### Phase 4: Cleanup (done)
+### Phase 3: Cleanup (done)
 
 - [x] Remove `TirExprKind::EffectCall` — variant was dead code (resolver creates `Call` nodes for all WASI operations; `EffectCall` was never constructed). Removed from `TirExprKind` enum and all 15 files with match arms (effect_check, cm_adapter_gen, codegen, unparse, lower, monomorphize, and 8 optimizer passes).
 - [x] Remove `cm_convention` and `cm_local_name` fields from TIR.
 - [x] Delete `CmCallConvention`, `CmConverterKind`, and `CmConverterRequirements`.
 - [x] Delete unused per-type converter functions from `internal.wado`.
 - [x] Verify all E2E tests (3425), HTTP tests (8), and unit tests (229) pass.
+
+### Phase 4: Export Adapters
+
+- [ ] Implement export adapter synthesis for `wasi:cli/run` (simplest export).
+- [ ] Implement export adapter synthesis for `wasi:http/incoming-handler` (complex: async, Result return).
+- [ ] Delete `CmExportInfo` scratch local logic — adapters declare their own locals.
+- [ ] Delete export-related CM glue from codegen.
 
 ## Implementation Notes
 

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -2118,59 +2118,6 @@ fn rewrite_calls_in_expr(
     adapters: &IndexMap<String, Rc<RefCell<TirFunction>>>,
     entry_source: &ModuleSource,
 ) {
-    // Check if this is an EffectCall that should be rewritten to target an adapter
-    if let TirExprKind::EffectCall {
-        effect_name,
-        op_name,
-        ..
-    } = &expr.kind
-    {
-        let qualified = format!("{effect_name}::{op_name}");
-        if let Some(adapter_rc) = adapters.get(&qualified) {
-            // Collect args before replacing (need to move them out)
-            let mut taken_args: Vec<TirExpr> = Vec::new();
-            if let TirExprKind::EffectCall { args, .. } = &mut expr.kind {
-                taken_args = std::mem::take(args);
-            }
-
-            // Fix up adapter function types from the call site
-            {
-                let mut adapter = adapter_rc.borrow_mut();
-                if adapter.return_type != expr.type_id {
-                    adapter.return_type = expr.type_id;
-                    fixup_return_type_in_body(&mut adapter, expr.type_id);
-                }
-                for (i, arg) in taken_args.iter().enumerate() {
-                    if i < adapter.params.len() && adapter.params[i].type_id != arg.type_id {
-                        let local_idx = adapter.params[i].local_index as usize;
-                        adapter.params[i].type_id = arg.type_id;
-                        if local_idx < adapter.local_types.len() {
-                            adapter.local_types[local_idx] = arg.type_id;
-                        }
-                    }
-                }
-            }
-
-            // Replace EffectCall with Call targeting the adapter
-            expr.kind = TirExprKind::Call {
-                func: FunctionRef::Resolved {
-                    func: adapter_rc.clone(),
-                    module_source: entry_source.clone(),
-                },
-                args: taken_args,
-                type_args: vec![],
-            };
-
-            // Recurse into args of the new Call
-            if let TirExprKind::Call { args, .. } = &mut expr.kind {
-                for arg in args {
-                    rewrite_calls_in_expr(arg, adapters, entry_source);
-                }
-            }
-            return;
-        }
-    }
-
     // Check if this is an effect-like Call that should be rewritten
     let is_effect_call = matches!(&expr.kind, TirExprKind::Call { func, .. }
         if func.module_source().is_effect_like() && func.module_source().effect_name().is_some());
@@ -2301,7 +2248,6 @@ fn rewrite_calls_in_expr(
     // Recurse into sub-expressions
     match &mut expr.kind {
         TirExprKind::Call { args, .. }
-        | TirExprKind::EffectCall { args, .. }
         | TirExprKind::CmRawCall { args, .. }
         | TirExprKind::StaticCall { args, .. } => {
             for arg in args {
@@ -2474,21 +2420,6 @@ fn collect_effect_calls_in_expr(
                 if wasi_registry.get_function(&qualified).is_some() {
                     effects.insert(qualified);
                 }
-            }
-            for arg in args {
-                collect_effect_calls_in_expr(arg, effects, wasi_registry);
-            }
-        }
-        TirExprKind::EffectCall {
-            effect_name,
-            op_name,
-            args,
-            ..
-        } => {
-            // Collect async WASI calls (e.g., Stdout::write_via_stream)
-            let qualified = format!("{effect_name}::{op_name}");
-            if wasi_registry.get_function(&qualified).is_some() {
-                effects.insert(qualified);
             }
             for arg in args {
                 collect_effect_calls_in_expr(arg, effects, wasi_registry);

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -7235,19 +7235,6 @@ impl Codegen<'_> {
                 }
             }
 
-            // === Effect Operation Call ===
-            // All WASI effect calls are rewritten to adapter function Calls
-            // by cm_adapter_gen. No EffectCall nodes should reach codegen.
-            TirExprKind::EffectCall {
-                effect_name,
-                op_name,
-                ..
-            } => {
-                panic!(
-                    "EffectCall {effect_name}::{op_name} should have been rewritten to a CM adapter call"
-                );
-            }
-
             // === Raw CM Call (used inside synthesized adapter functions) ===
             TirExprKind::CmRawCall { local_name, args } => {
                 self.generate_args(func, args, type_table, ctx, builder);
@@ -12126,7 +12113,6 @@ impl Codegen<'_> {
             // Argument lists
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.preallocate_scalarized_locals_in_expr(arg, type_table, ctx, builder);

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -216,21 +216,6 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
                     self.check_expr(arg)?;
                 }
             }
-            TirExprKind::EffectCall {
-                effect_name, args, ..
-            } => {
-                // Effect calls require the effect
-                if !self.current_effects.contains(effect_name) {
-                    self.logger.error(EffectError {
-                        callee: effect_name.clone(),
-                        missing_effect: effect_name.clone(),
-                        span: expr.span,
-                    })?;
-                }
-                for arg in args {
-                    self.check_expr(arg)?;
-                }
-            }
             TirExprKind::CmRawCall { args, .. } => {
                 // CmRawCall is used inside synthesized adapter functions;
                 // no effect checking needed (adapter functions are always effectful)

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -557,7 +557,6 @@ fn lower_wide_int_in_expr(expr: &mut TirExpr, type_table: &Rc<RefCell<TypeTable>
         TirExprKind::Call { args, .. }
         | TirExprKind::MethodCall { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 lower_wide_int_in_expr(arg, type_table);
@@ -1780,7 +1779,6 @@ impl<'a> PatternLowerer<'a> {
             TirExprKind::Call { args, .. }
             | TirExprKind::MethodCall { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.lower_expr(arg, type_table);
@@ -3142,7 +3140,7 @@ impl BoxLowerer {
             TirExprKind::GlobalVarSet { value, .. } => {
                 self.transform_expr(value, address_taken, type_table);
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.transform_expr(arg, address_taken, type_table);
                 }
@@ -3767,7 +3765,6 @@ impl ClosureLowerer {
                 self.collect_closures_in_expr(inner);
             }
             TirExprKind::Call { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
@@ -3973,7 +3970,6 @@ impl ClosureLowerer {
                 }
             }
             TirExprKind::Call { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 // Arguments are in argument position
@@ -4369,7 +4365,6 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     Self::collect_locals_from_expr(arg, locals);
@@ -5167,7 +5162,6 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. } => args
                 .iter()
                 .any(|a| self.fn_param_in_struct_field_expr(a, fn_param_indices)),
@@ -5430,7 +5424,7 @@ impl ClosureLowerer {
             | TirExprKind::Move { expr: inner } => {
                 self.collect_fn_param_specs_expr(inner, func_by_name, type_table, requests);
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.collect_fn_param_specs_expr(arg, func_by_name, type_table, requests);
                 }
@@ -5614,7 +5608,6 @@ impl ClosureLowerer {
             }
             TirExprKind::Call { args, .. }
             | TirExprKind::StaticCall { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.count_closures_in_expr(arg, counter);
@@ -6165,22 +6158,6 @@ impl ClosureLowerer {
                                 type_table,
                             )
                         })
-                        .collect(),
-                },
-                expr.type_id,
-                expr.span,
-            ),
-            TirExprKind::EffectCall {
-                effect_name,
-                op_name,
-                args,
-            } => TirExpr::new(
-                TirExprKind::EffectCall {
-                    effect_name: effect_name.clone(),
-                    op_name: op_name.clone(),
-                    args: args
-                        .iter()
-                        .map(|a| self.specialize_expr(a, param_to_functor, type_table))
                         .collect(),
                 },
                 expr.type_id,
@@ -6761,7 +6738,7 @@ impl ClosureLowerer {
                 // Check if this call has closure arguments that need fn-param specialization
                 self.try_transform_fn_param_call(func, args, type_table);
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.transform_expr(arg, type_table);
                 }
@@ -7095,7 +7072,6 @@ impl ClosureLowerer {
             }
             // Recurse into all expression kinds
             TirExprKind::Call { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
@@ -7376,7 +7352,6 @@ impl StringCollector {
                 self.collect_expr(inner);
             }
             TirExprKind::Call { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
@@ -7673,7 +7648,6 @@ impl<'a> ScratchLocalAnalyzer<'a> {
                 }
             }
             TirExprKind::Call { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
@@ -7931,11 +7905,6 @@ impl<'a> EffectScratchAnalyzer<'a> {
 
     fn analyze_expr(&mut self, expr: &TirExpr) {
         match &expr.kind {
-            TirExprKind::EffectCall { args, .. } => {
-                for arg in args {
-                    self.analyze_expr(arg);
-                }
-            }
             TirExprKind::CmRawCall { args, .. } => {
                 // CmRawCall args are already flat ABI - just recurse
                 for arg in args {

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -763,7 +763,7 @@ impl Monomorphizer {
                     self.rewrite_types_in_expr(arg, type_table);
                 }
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.rewrite_types_in_expr(arg, type_table);
                 }
@@ -1624,7 +1624,7 @@ impl Monomorphizer {
                     );
                 }
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.collect_func_instantiation_sites_in_expr(
                         arg,
@@ -2315,7 +2315,7 @@ impl Monomorphizer {
                     }
                 }
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.substitute_types_in_expr(arg, substitution, type_table);
                 }
@@ -2684,7 +2684,6 @@ impl Monomorphizer {
                 }
             }
             TirExprKind::Call { args, .. }
-            | TirExprKind::EffectCall { args, .. }
             | TirExprKind::CmRawCall { args, .. }
             | TirExprKind::StaticCall { args, .. } => {
                 for arg in args {
@@ -3016,7 +3015,7 @@ impl Monomorphizer {
                     self.rewrite_function_calls_in_expr(arg, type_table);
                 }
             }
-            TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+            TirExprKind::CmRawCall { args, .. } => {
                 for arg in args {
                     self.rewrite_function_calls_in_expr(arg, type_table);
                 }

--- a/wado-compiler/src/optimize_const_fold.rs
+++ b/wado-compiler/src/optimize_const_fold.rs
@@ -102,7 +102,6 @@ fn fold_constants_in_expr(expr: &mut TirExpr, type_table: &TypeTable) -> bool {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 changed |= fold_constants_in_expr(arg, type_table);

--- a/wado-compiler/src/optimize_copy_prop.rs
+++ b/wado-compiler/src/optimize_copy_prop.rs
@@ -200,7 +200,6 @@ fn collect_assigned_in_expr(expr: &TirExpr, assigned: &mut IndexSet<u32>) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_assigned_in_expr(arg, assigned);
@@ -414,7 +413,6 @@ fn collect_usage_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_usage_in_expr(arg, usage, in_loop, in_condition);
@@ -735,7 +733,6 @@ fn substitute_in_expr(expr: &mut TirExpr, substitutions: &IndexMap<u32, CopySour
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 substitute_in_expr(arg, substitutions);
@@ -972,7 +969,6 @@ fn collect_copy_bindings_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_copy_bindings_in_expr(arg, bindings, block_local_assigned);
@@ -1172,7 +1168,6 @@ fn remove_copy_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u32>)
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 remove_copy_bindings_in_expr(arg, dead_locals);

--- a/wado-compiler/src/optimize_copy_prop.rs
+++ b/wado-compiler/src/optimize_copy_prop.rs
@@ -200,7 +200,7 @@ fn collect_assigned_in_expr(expr: &TirExpr, assigned: &mut IndexSet<u32>) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_assigned_in_expr(arg, assigned);
@@ -414,7 +414,7 @@ fn collect_usage_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_usage_in_expr(arg, usage, in_loop, in_condition);
@@ -735,7 +735,7 @@ fn substitute_in_expr(expr: &mut TirExpr, substitutions: &IndexMap<u32, CopySour
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 substitute_in_expr(arg, substitutions);
@@ -972,7 +972,7 @@ fn collect_copy_bindings_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_copy_bindings_in_expr(arg, bindings, block_local_assigned);
@@ -1172,7 +1172,7 @@ fn remove_copy_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u32>)
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 remove_copy_bindings_in_expr(arg, dead_locals);

--- a/wado-compiler/src/optimize_dce.rs
+++ b/wado-compiler/src/optimize_dce.rs
@@ -497,7 +497,6 @@ fn analyze_expr(
 
             // Detect effect calls: Effects have a single-element path with PascalCase name
             // (e.g., ["Stdout"], ["Stderr"], ["MonotonicClock"])
-            // Effect calls are represented as Call in TIR, not as EffectCall
             // Check using the original module path to detect effect-style paths
             let module_path = original_callee_module.to_path();
             if module_path.len() == 1 {
@@ -762,21 +761,6 @@ fn analyze_expr(
         }
         TirExprKind::Cast { expr, .. } => {
             analyze_expr(expr, current_module, type_table, analysis);
-        }
-        TirExprKind::EffectCall {
-            effect_name,
-            op_name,
-            args,
-            ..
-        } => {
-            // Track effect usage for WASI import DCE
-            analysis
-                .effect_calls
-                .insert((effect_name.clone(), op_name.clone()));
-
-            for arg in args {
-                analyze_expr(arg, current_module, type_table, analysis);
-            }
         }
         TirExprKind::CmRawCall { local_name, args } => {
             // CmRawCall references a lowered WASI import function.
@@ -1455,7 +1439,7 @@ fn collect_types_from_expr(
             collect_types_from_expr(expr, type_table, reachable);
             collect_type_transitive(*target_type, type_table, reachable);
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_types_from_expr(arg, type_table, reachable);
             }

--- a/wado-compiler/src/optimize_inline.rs
+++ b/wado-compiler/src/optimize_inline.rs
@@ -74,9 +74,7 @@ fn count_expr(expr: &TirExpr) -> usize {
         | TirExprKind::Null => 0,
         // Closure and effect-related expressions
         TirExprKind::Capture { .. } | TirExprKind::EnumConstruct { .. } => 0,
-        TirExprKind::CmRawCall { args, .. } => {
-            args.iter().map(count_expr).sum()
-        }
+        TirExprKind::CmRawCall { args, .. } => args.iter().map(count_expr).sum(),
         TirExprKind::IndirectCall { callee, args } => {
             count_expr(callee) + args.iter().map(count_expr).sum::<usize>()
         }

--- a/wado-compiler/src/optimize_inline.rs
+++ b/wado-compiler/src/optimize_inline.rs
@@ -74,7 +74,7 @@ fn count_expr(expr: &TirExpr) -> usize {
         | TirExprKind::Null => 0,
         // Closure and effect-related expressions
         TirExprKind::Capture { .. } | TirExprKind::EnumConstruct { .. } => 0,
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             args.iter().map(count_expr).sum()
         }
         TirExprKind::IndirectCall { callee, args } => {
@@ -385,7 +385,6 @@ fn expr_has_complex_generic_types(expr: &TirExpr, type_table: &TypeTable) -> boo
         TirExprKind::Call { args, .. }
         | TirExprKind::MethodCall { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
         | TirExprKind::CmRawCall { args, .. } => args
             .iter()
             .any(|a| expr_has_complex_generic_types(a, type_table)),
@@ -658,7 +657,7 @@ fn collect_callees_from_expr(expr: &TirExpr, callees: &mut IndexSet<String>) {
         TirExprKind::ClosureToCanonical { functor, .. } => {
             collect_callees_from_expr(functor, callees);
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_callees_from_expr(arg, callees);
             }
@@ -2174,18 +2173,6 @@ fn remap_expr(
                     .collect(),
             }
         }
-        TirExprKind::EffectCall {
-            effect_name,
-            op_name,
-            args,
-        } => TirExprKind::EffectCall {
-            effect_name: effect_name.clone(),
-            op_name: op_name.clone(),
-            args: args
-                .iter()
-                .map(|a| remap_expr(a, param_to_local, local_offset, param_count, source_module))
-                .collect(),
-        },
         TirExprKind::CmRawCall { local_name, args } => TirExprKind::CmRawCall {
             local_name: local_name.clone(),
             args: args
@@ -2914,7 +2901,7 @@ fn inline_calls_in_expr(
                 *expr = inlined_expr;
             }
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 inline_calls_in_expr(
                     arg,

--- a/wado-compiler/src/optimize_licm.rs
+++ b/wado-compiler/src/optimize_licm.rs
@@ -352,7 +352,7 @@ fn collect_modified_vars_in_expr(expr: &TirExpr, modified: &mut IndexSet<u32>) {
                 collect_modified_vars_in_expr(arg, modified);
             }
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_modified_vars_in_expr(arg, modified);
             }
@@ -661,7 +661,7 @@ fn collect_licm_ref_bindings_in_expr(
                 collect_licm_ref_bindings_in_expr(arg, type_table, bindings);
             }
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_licm_ref_bindings_in_expr(arg, type_table, bindings);
             }
@@ -1087,7 +1087,7 @@ fn find_hoist_candidates_in_expr(
                 );
             }
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 find_hoist_candidates_in_expr(
                     arg,
@@ -1500,7 +1500,7 @@ fn replace_hoisted_in_expr(
                 replace_hoisted_in_expr(arg, candidates, ref_bindings);
             }
         }
-        TirExprKind::EffectCall { args, .. } | TirExprKind::CmRawCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 replace_hoisted_in_expr(arg, candidates, ref_bindings);
             }

--- a/wado-compiler/src/optimize_ref_elim.rs
+++ b/wado-compiler/src/optimize_ref_elim.rs
@@ -115,7 +115,7 @@ fn track_local_uses_in_expr(expr: &TirExpr, local_index: u32) -> (bool, u32) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             let mut total = 0;
             let mut all_ok = true;
@@ -349,7 +349,7 @@ fn replace_ref_field_access_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 replace_ref_field_access_in_expr(arg, ref_local, target_local, target_name);
@@ -686,7 +686,7 @@ fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) 
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_ref_bindings_in_expr(arg, bindings);
@@ -892,7 +892,7 @@ fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 remove_dead_ref_bindings_in_expr(arg, dead_locals);

--- a/wado-compiler/src/optimize_ref_elim.rs
+++ b/wado-compiler/src/optimize_ref_elim.rs
@@ -349,7 +349,6 @@ fn replace_ref_field_access_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 replace_ref_field_access_in_expr(arg, ref_local, target_local, target_name);
@@ -686,7 +685,6 @@ fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) 
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_ref_bindings_in_expr(arg, bindings);
@@ -892,7 +890,6 @@ fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 remove_dead_ref_bindings_in_expr(arg, dead_locals);

--- a/wado-compiler/src/optimize_rewrite.rs
+++ b/wado-compiler/src/optimize_rewrite.rs
@@ -151,7 +151,6 @@ fn simplify_labeled_blocks_in_expr(expr: &mut TirExpr) -> bool {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 changed |= simplify_labeled_blocks_in_expr(arg);
@@ -518,7 +517,6 @@ fn insert_moves_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             // Wrap arguments in Move if they are fresh values (argument passing is assignment)
             for arg in args.iter_mut() {
@@ -788,7 +786,6 @@ fn collect_value_copy_types_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_value_copy_types_in_expr(arg, type_table, copy_types);

--- a/wado-compiler/src/optimize_rewrite.rs
+++ b/wado-compiler/src/optimize_rewrite.rs
@@ -151,7 +151,7 @@ fn simplify_labeled_blocks_in_expr(expr: &mut TirExpr) -> bool {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 changed |= simplify_labeled_blocks_in_expr(arg);
@@ -375,7 +375,6 @@ fn is_fresh_value(expr: &TirExpr) -> bool {
         TirExprKind::Call { .. }
         | TirExprKind::StaticCall { .. }
         | TirExprKind::MethodCall { .. }
-        | TirExprKind::EffectCall { .. }
         | TirExprKind::CmRawCall { .. }
         | TirExprKind::IndirectCall { .. } => true,
 
@@ -519,7 +518,7 @@ fn insert_moves_in_expr(expr: &mut TirExpr, type_table: &TypeTable) {
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             // Wrap arguments in Move if they are fresh values (argument passing is assignment)
             for arg in args.iter_mut() {
@@ -789,7 +788,7 @@ fn collect_value_copy_types_in_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 collect_value_copy_types_in_expr(arg, type_table, copy_types);

--- a/wado-compiler/src/optimize_sroa.rs
+++ b/wado-compiler/src/optimize_sroa.rs
@@ -435,7 +435,6 @@ fn check_escape_in_expr(expr: &TirExpr, candidates: &IndexSet<u32>, escaped: &mu
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 check_escape_in_expr(arg, candidates, escaped);
@@ -784,7 +783,6 @@ fn rewrite_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 rewrite_expr(arg, safe_set, field_map, info_map, candidate_mut);

--- a/wado-compiler/src/optimize_sroa.rs
+++ b/wado-compiler/src/optimize_sroa.rs
@@ -435,7 +435,7 @@ fn check_escape_in_expr(expr: &TirExpr, candidates: &IndexSet<u32>, escaped: &mu
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 check_escape_in_expr(arg, candidates, escaped);
@@ -784,7 +784,7 @@ fn rewrite_expr(
         }
         TirExprKind::Call { args, .. }
         | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::EffectCall { args, .. }
+
         | TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
                 rewrite_expr(arg, safe_set, field_map, info_map, candidate_mut);

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1187,11 +1187,6 @@ pub enum TirExprKind {
         type_args: Vec<TypeId>,
         args: Vec<TirExpr>,
     },
-    EffectCall {
-        effect_name: String,
-        op_name: String,
-        args: Vec<TirExpr>,
-    },
     /// Raw Component Model call to a lowered WASI import.
     ///
     /// Used inside synthesized CM adapter functions to call the flat-ABI WASI function

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -2732,24 +2732,6 @@ impl<'a> TirUnparser<'a> {
                 }
                 self.output.push(')');
             }
-            TirExprKind::EffectCall {
-                effect_name,
-                op_name,
-                args,
-                ..
-            } => {
-                self.output.push_str(effect_name);
-                self.output.push_str("::");
-                self.output.push_str(op_name);
-                self.output.push('(');
-                for (i, arg) in args.iter().enumerate() {
-                    if i > 0 {
-                        self.output.push_str(", ");
-                    }
-                    self.unparse_expr(arg);
-                }
-                self.output.push(')');
-            }
             TirExprKind::CmRawCall { local_name, args } => {
                 self.output.push_str("cm_raw_call ");
                 self.output.push_str(local_name);


### PR DESCRIPTION
## Summary

Remove the `TirExprKind::EffectCall` variant from the TIR, which was dead code. The resolver creates `Call` nodes for all WASI operations (both sync and async), and `cm_adapter_gen` identifies effect calls via `ModuleSource::is_effect_like()`. The `EffectCall` variant was never constructed in the current codebase.

## Key Changes

- **Removed `EffectCall` variant** from `TirExprKind` enum in `tir.rs`
- **Removed all match arms** for `EffectCall` across 15 files:
  - Core compiler: `cm_adapter_gen.rs`, `codegen.rs`, `effect_check.rs`, `unparse.rs`
  - Lowering: `lower.rs`, `monomorphize.rs`
  - Optimizers: `optimize_inline.rs`, `optimize_dce.rs`, `optimize_licm.rs`, `optimize_copy_prop.rs`, `optimize_ref_elim.rs`, `optimize_rewrite.rs`, `optimize_sroa.rs`, `optimize_const_fold.rs`
- **Simplified pattern matching** in multiple files by removing `EffectCall` from grouped match arms (e.g., `Call { args, .. } | EffectCall { args, .. }` → `Call { args, .. }`)
- **Updated documentation** in `wep-2026-02-15-cm-adapter-synthesis.md` to reflect completion of Phase 3 cleanup and clarify that `EffectCall` was never constructed

## Implementation Details

- The removal is straightforward since `EffectCall` was never instantiated—no code paths needed to be redirected
- All effect calls are now represented as ordinary `Call` nodes to synthesized adapter functions
- The `cm_adapter_gen` module identifies effect-like calls via `ModuleSource::is_effect_like()` and rewrites them to adapter calls
- All existing tests (3425 E2E, 8 HTTP, 229 unit) continue to pass

https://claude.ai/code/session_01E5Sq1LJyFA4j7JagJWHNeV