### PR TITLE
Extend CM adapter synthesis to resource static methods

### DIFF
--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -74,7 +74,7 @@ Codegen resolves `local_name` to the imported function index. This node is also 
 
 ### Import Adapters — Complete
 
-All WASI interfaces (cli, clocks, random, http, sockets) use adapter synthesis. The old codegen CM paths (`generate_cm_effect_call`, `generate_cm_resource_method_call`) and per-type converters (`cm_list_string_to_array`, `cm_option_string_to_option`, etc.) have been deleted.
+All WASI interfaces (cli, clocks, random, http, sockets) use adapter synthesis. Both instance method calls (MethodCall, e.g., `fields.append(name, value)`) and resource static method calls (StaticCall, e.g., `Response::new(headers, null, trailers)`) are rewritten to adapter calls. The old codegen CM paths (`generate_cm_effect_call`, `generate_cm_resource_method_call`) and per-type converters (`cm_list_string_to_array`, `cm_option_string_to_option`, etc.) have been deleted.
 
 ### Export Adapters — Async Only
 
@@ -238,6 +238,23 @@ For `Array<T>` where T is not u8, `synthesize_lift_from_flat_params` writes flat
 - Requires `builtin::realloc` to be linked (always true for programs with linear memory)
 - Allocates and immediately frees 8 bytes (wasteful but correct)
 - Could be optimized with a direct `synthesize_lift_list_from_flat` that takes ptr/len as locals
+
+#### Call-Site Flattening for Multi-Flat Parameters
+
+Import adapters use two strategies depending on the parameter type:
+
+- **Adapter-internal lowering** (String, Array\<u8\>): The adapter accepts a single Wado-level parameter and lowers it internally to multiple flat CM args (ptr + len). This works because String and Array have well-defined Wado TypeIds that codegen can convert to Wasm types.
+- **Call-site flattening** (Option\<T\>, other multi-flat types): The adapter accepts pre-flattened i32 params, and the call-site rewrite transforms Wado-level args into flat values before passing them.
+
+The call-site flattening approach was chosen for Option\<T\> because adapter-internal lowering faces a fundamental type mismatch: Wado's `null` literal generates `ref.null` (a GC nullable reference) at the Wasm level, but the adapter would need to accept it as a parameter and extract an i32 discriminant + payload. Converting between GC references and i32 scalars requires non-trivial unwrapping logic (pattern matching, unboxing) that the TIR synthesizer cannot easily generate for all Option\<T\> instantiations.
+
+By flattening at the call site:
+- `null` → `[i32(0), i32(0), ...]` (discriminant=0, zero payload)
+- `OptionSome(value)` → `[i32(1), value, ...]` (discriminant=1, inner value)
+
+The adapter body becomes a simple pass-through for these parameters. This avoids the GC-to-scalar type mismatch entirely.
+
+Current limitation: only literal `null` and `OptionSome` expressions are supported at call sites. Arbitrary `Option<T>` variables would require runtime null-check logic at the rewrite site, which is not yet implemented.
 
 #### No Type-Level Validation
 

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -249,6 +249,7 @@ Import adapters use two strategies depending on the parameter type:
 The call-site flattening approach was chosen for Option\<T\> because adapter-internal lowering faces a fundamental type mismatch: Wado's `null` literal generates `ref.null` (a GC nullable reference) at the Wasm level, but the adapter would need to accept it as a parameter and extract an i32 discriminant + payload. Converting between GC references and i32 scalars requires non-trivial unwrapping logic (pattern matching, unboxing) that the TIR synthesizer cannot easily generate for all Option\<T\> instantiations.
 
 By flattening at the call site:
+
 - `null` → `[i32(0), i32(0), ...]` (discriminant=0, zero payload)
 - `OptionSome(value)` → `[i32(1), value, ...]` (discriminant=1, inner value)
 

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -1269,6 +1269,10 @@ pub fn synthesize_lower(
 }
 
 // ============================================================================
+// Option<T> parameter lowering for adapter synthesis
+// ============================================================================
+
+// ============================================================================
 // Flat ABI parameter/result computation
 // ============================================================================
 
@@ -1572,43 +1576,83 @@ fn synthesize_adapter(
 
     // ---- Pass 1: Allocate all parameter locals (contiguous) ----
     // Wasm requires params at indices [0..n-1], so allocate them first.
+    //
+    // For types that the adapter lowers internally (String, Array<u8>), we create
+    // a single placeholder param. The adapter body will lower them to flat CM args.
+    //
+    // For other types (handles, Option<T>, etc.), we create flat params matching
+    // the CM ABI directly. The call site must flatten args before passing them.
+    //
+    // Track (start_param_idx, param_count) per WASI param for Pass 2 indexing.
+    let mut param_mapping: Vec<(usize, usize)> = Vec::new();
     for (param_name, param_type) in &func_info.params {
         let flat_tys = flatten_param_type(param_type);
         if flat_tys.is_empty() {
             continue; // unit param, skip
         }
-        let param_type_id = match param_type {
-            Type::Named(n) if n.name == "String" => TypeTable::I32, // placeholder for String
+        let start = params.len();
+        match param_type {
+            // String: single placeholder param (adapter body lowers to ptr+len)
+            Type::Named(n) if n.name == "String" => {
+                params.push(TirParam {
+                    name: param_name.clone(),
+                    type_id: TypeTable::I32,
+                    local_index: next_local,
+                    span: synth_span(),
+                });
+                local_types.push(TypeTable::I32);
+                next_local += 1;
+                param_mapping.push((start, 1));
+            }
+            // Array<u8>: single placeholder param (adapter body lowers to ptr+len)
             Type::Generic(g)
                 if g.name == "Array"
                     && g.args.len() == 1
                     && matches!(&g.args[0], Type::Named(n) if n.name == "u8") =>
             {
-                TypeTable::I32 // placeholder for Array<u8>
+                params.push(TirParam {
+                    name: param_name.clone(),
+                    type_id: TypeTable::I32,
+                    local_index: next_local,
+                    span: synth_span(),
+                });
+                local_types.push(TypeTable::I32);
+                next_local += 1;
+                param_mapping.push((start, 1));
             }
-            _ => flat_tys[0],
-        };
-        let param_local = next_local;
-        params.push(TirParam {
-            name: param_name.clone(),
-            type_id: param_type_id,
-            local_index: param_local,
-            span: synth_span(),
-        });
-        local_types.push(param_type_id);
-        next_local += 1;
+            // All other types: create flat params matching CM ABI
+            _ => {
+                for (j, flat_ty) in flat_tys.iter().enumerate() {
+                    let name = if flat_tys.len() == 1 {
+                        param_name.clone()
+                    } else {
+                        format!("{param_name}_flat{j}")
+                    };
+                    params.push(TirParam {
+                        name,
+                        type_id: *flat_ty,
+                        local_index: next_local,
+                        span: synth_span(),
+                    });
+                    local_types.push(*flat_ty);
+                    next_local += 1;
+                }
+                param_mapping.push((start, flat_tys.len()));
+            }
+        }
     }
 
     // ---- Pass 2: Generate parameter lowering code ----
     // Intermediate locals (packed i64, etc.) are allocated after all params.
-    let mut param_idx = 0usize;
+    let mut mapping_idx = 0usize;
     for (param_name, param_type) in &func_info.params {
         let flat_tys = flatten_param_type(param_type);
         if flat_tys.is_empty() {
             continue; // unit param, skip
         }
-        let param_local = params[param_idx].local_index;
-        param_idx += 1;
+        let (start_idx, count) = param_mapping[mapping_idx];
+        mapping_idx += 1;
+        let param_local = params[start_idx].local_index;
 
         match param_type {
             // String param: accept Wado String, lower to (ptr, len) pair
@@ -1700,10 +1744,12 @@ fn synthesize_adapter(
                 ));
             }
 
-            // Simple types: pass directly as flat args
+            // All other types (including Option<T>): flat params passed through directly
             _ => {
-                let param_type_id = flat_tys[0];
-                flat_args.push(local_ref(param_local, param_name, param_type_id));
+                for j in 0..count {
+                    let p = &params[start_idx + j];
+                    flat_args.push(local_ref(p.local_index, &p.name, p.type_id));
+                }
             }
         }
     }
@@ -3686,7 +3732,7 @@ pub fn generate_adapters(mut project: Project) -> Result<Project, String> {
             for func_rc in &module.functions {
                 let mut func = func_rc.borrow_mut();
                 if let Some(body) = &mut func.body {
-                    rewrite_calls_in_block(body, &adapter_map, &entry_source);
+                    rewrite_calls_in_block(body, &adapter_map, &entry_source, project.wasi_registry);
                 }
             }
         }
@@ -3996,6 +4042,55 @@ fn fixup_expr_type(expr: &mut TirExpr, type_id: TypeId) {
     }
 }
 
+/// Flatten a Wado-level arg into flat CM ABI args at the call site.
+///
+/// For multi-flat types like `Option<T>`, the Wado-level arg (e.g., `null`)
+/// is expanded into multiple i32 args (discriminant + payload).
+fn flatten_arg_for_call_site(
+    arg: &TirExpr,
+    flat_tys: &[TypeId],
+    flat_args: &mut Vec<TirExpr>,
+) {
+    match &arg.kind {
+        // null literal → discriminant=0, payload=0 for each flat type
+        TirExprKind::Null => {
+            for _ in flat_tys {
+                flat_args.push(i32_const(0));
+            }
+        }
+        // OptionSome(value) → discriminant=1, then flatten inner value
+        TirExprKind::OptionSome { value } => {
+            // First flat type is always the discriminant
+            flat_args.push(i32_const(1));
+            // Remaining flat types are the inner value
+            if flat_tys.len() == 2 {
+                // Single inner flat value (e.g., resource handle)
+                flat_args.push((**value).clone());
+            } else {
+                // Multi-value inner: would need further flattening
+                // For now, handle the common single-value case
+                for j in 1..flat_tys.len() {
+                    if j == 1 {
+                        flat_args.push((**value).clone());
+                    } else {
+                        flat_args.push(i32_const(0));
+                    }
+                }
+            }
+        }
+        // For any other expression, this is an arbitrary Option<T> value.
+        // Currently not supported — would need runtime null-check logic.
+        _ => {
+            panic!(
+                "StaticCall adapter: cannot flatten arg of kind {:?} into {} flat types at call site; \
+                 only null and OptionSome literals are supported",
+                arg.kind,
+                flat_tys.len()
+            );
+        }
+    }
+}
+
 // ============================================================================
 // Call site rewriting
 // ============================================================================
@@ -4004,9 +4099,10 @@ fn rewrite_calls_in_block(
     block: &mut TirBlock,
     adapters: &IndexMap<String, Rc<RefCell<TirFunction>>>,
     entry_source: &ModuleSource,
+    wasi_registry: &WasiRegistry,
 ) {
     for stmt in &mut block.stmts {
-        rewrite_calls_in_stmt(stmt, adapters, entry_source);
+        rewrite_calls_in_stmt(stmt, adapters, entry_source, wasi_registry);
     }
 }
 
@@ -4014,14 +4110,15 @@ fn rewrite_calls_in_stmt(
     stmt: &mut TirStmt,
     adapters: &IndexMap<String, Rc<RefCell<TirFunction>>>,
     entry_source: &ModuleSource,
+    wasi_registry: &WasiRegistry,
 ) {
     match &mut stmt.kind {
         TirStmtKind::Let { value, .. } | TirStmtKind::Expr(value) => {
-            rewrite_calls_in_expr(value, adapters, entry_source);
+            rewrite_calls_in_expr(value, adapters, entry_source, wasi_registry);
         }
         TirStmtKind::Return { value } => {
             if let Some(v) = value {
-                rewrite_calls_in_expr(v, adapters, entry_source);
+                rewrite_calls_in_expr(v, adapters, entry_source, wasi_registry);
             }
         }
         TirStmtKind::If {
@@ -4029,14 +4126,14 @@ fn rewrite_calls_in_stmt(
             then_block,
             else_block,
         } => {
-            rewrite_calls_in_expr(condition, adapters, entry_source);
-            rewrite_calls_in_block(then_block, adapters, entry_source);
+            rewrite_calls_in_expr(condition, adapters, entry_source, wasi_registry);
+            rewrite_calls_in_block(then_block, adapters, entry_source, wasi_registry);
             if let Some(blk) = else_block {
-                rewrite_calls_in_block(blk, adapters, entry_source);
+                rewrite_calls_in_block(blk, adapters, entry_source, wasi_registry);
             }
         }
         TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
-            rewrite_calls_in_block(body, adapters, entry_source);
+            rewrite_calls_in_block(body, adapters, entry_source, wasi_registry);
         }
         TirStmtKind::IfPattern {
             scrutinee,
@@ -4044,18 +4141,21 @@ fn rewrite_calls_in_stmt(
             else_block,
             ..
         } => {
-            rewrite_calls_in_expr(scrutinee, adapters, entry_source);
-            rewrite_calls_in_block(then_block, adapters, entry_source);
+            rewrite_calls_in_expr(scrutinee, adapters, entry_source, wasi_registry);
+            rewrite_calls_in_block(then_block, adapters, entry_source, wasi_registry);
             if let Some(blk) = else_block {
-                rewrite_calls_in_block(blk, adapters, entry_source);
+                rewrite_calls_in_block(blk, adapters, entry_source, wasi_registry);
             }
         }
         TirStmtKind::Break { value, .. } => {
             if let Some(v) = value {
-                rewrite_calls_in_expr(v, adapters, entry_source);
+                rewrite_calls_in_expr(v, adapters, entry_source, wasi_registry);
             }
         }
-        TirStmtKind::Continue | TirStmtKind::LetPattern { .. } => {}
+        TirStmtKind::LetPattern { value, .. } => {
+            rewrite_calls_in_expr(value, adapters, entry_source, wasi_registry);
+        }
+        TirStmtKind::Continue => {}
     }
 }
 
@@ -4063,6 +4163,7 @@ fn rewrite_calls_in_expr(
     expr: &mut TirExpr,
     adapters: &IndexMap<String, Rc<RefCell<TirFunction>>>,
     entry_source: &ModuleSource,
+    wasi_registry: &WasiRegistry,
 ) {
     // Check if this is an effect-like Call that should be rewritten
     let is_effect_call = matches!(&expr.kind, TirExprKind::Call { func, .. }
@@ -4106,7 +4207,7 @@ fn rewrite_calls_in_expr(
 
             // Recurse into args
             for arg in args {
-                rewrite_calls_in_expr(arg, adapters, entry_source);
+                rewrite_calls_in_expr(arg, adapters, entry_source, wasi_registry);
             }
             return;
         }
@@ -4184,7 +4285,95 @@ fn rewrite_calls_in_expr(
             // Recurse into args of the new Call
             if let TirExprKind::Call { args, .. } = &mut expr.kind {
                 for arg in args {
-                    rewrite_calls_in_expr(arg, adapters, entry_source);
+                    rewrite_calls_in_expr(arg, adapters, entry_source, wasi_registry);
+                }
+            }
+            return;
+        }
+    }
+
+    // Check if this is a resource StaticCall that should be rewritten to target an adapter
+    if let TirExprKind::StaticCall { func, .. } = &expr.kind {
+        let func_name = func.name();
+        if let Some(adapter_rc) = adapters.get(&func_name) {
+            // Look up WASI function info to flatten args at the call site
+            let wasi_func_info = wasi_registry.get_function(&func_name).cloned();
+
+            // Extract args before replacing
+            let taken_args =
+                if let TirExprKind::StaticCall { args, .. } = &mut expr.kind {
+                    std::mem::take(args)
+                } else {
+                    unreachable!()
+                };
+
+            // Fix up adapter return type from the call site
+            {
+                let mut adapter = adapter_rc.borrow_mut();
+                if adapter.return_type != expr.type_id {
+                    adapter.return_type = expr.type_id;
+                    fixup_return_type_in_body(&mut adapter, expr.type_id);
+                }
+            }
+
+            // Flatten call site args to match the adapter's flat CM params.
+            // Types that the adapter lowers internally (String, Array<u8>) are
+            // passed through. Option<T> and other multi-flat types are flattened
+            // here into individual i32 args.
+            let flat_call_args = if let Some(func_info) = &wasi_func_info {
+                let mut flat = Vec::new();
+                for (i, (_param_name, param_type)) in func_info.params.iter().enumerate() {
+                    let flat_tys = flatten_param_type(param_type);
+                    if flat_tys.is_empty() || i >= taken_args.len() {
+                        continue;
+                    }
+                    match param_type {
+                        // String/Array<u8>: pass through (adapter body lowers)
+                        Type::Named(n) if n.name == "String" => {
+                            flat.push(taken_args[i].clone());
+                        }
+                        Type::Generic(g)
+                            if g.name == "Array"
+                                && g.args.len() == 1
+                                && matches!(&g.args[0], Type::Named(n) if n.name == "u8") =>
+                        {
+                            flat.push(taken_args[i].clone());
+                        }
+                        _ => {
+                            if flat_tys.len() == 1 {
+                                // Single flat type: pass through
+                                flat.push(taken_args[i].clone());
+                            } else {
+                                // Multi-flat type: flatten at call site
+                                flatten_arg_for_call_site(
+                                    &taken_args[i],
+                                    &flat_tys,
+                                    &mut flat,
+                                );
+                            }
+                        }
+                    }
+                }
+                flat
+            } else {
+                // No WASI function info: pass args as-is (fallback)
+                taken_args
+            };
+
+            // Replace StaticCall with Call targeting the adapter
+            expr.kind = TirExprKind::Call {
+                func: FunctionRef::Resolved {
+                    func: adapter_rc.clone(),
+                    module_source: entry_source.clone(),
+                },
+                args: flat_call_args,
+                type_args: vec![],
+            };
+
+            // Recurse into args of the new Call
+            if let TirExprKind::Call { args, .. } = &mut expr.kind {
+                for arg in args {
+                    rewrite_calls_in_expr(arg, adapters, entry_source, wasi_registry);
                 }
             }
             return;
@@ -4197,44 +4386,44 @@ fn rewrite_calls_in_expr(
         | TirExprKind::CmRawCall { args, .. }
         | TirExprKind::StaticCall { args, .. } => {
             for arg in args {
-                rewrite_calls_in_expr(arg, adapters, entry_source);
+                rewrite_calls_in_expr(arg, adapters, entry_source, wasi_registry);
             }
         }
         TirExprKind::MethodCall { receiver, args, .. } => {
-            rewrite_calls_in_expr(receiver, adapters, entry_source);
+            rewrite_calls_in_expr(receiver, adapters, entry_source, wasi_registry);
             for arg in args {
-                rewrite_calls_in_expr(arg, adapters, entry_source);
+                rewrite_calls_in_expr(arg, adapters, entry_source, wasi_registry);
             }
         }
         TirExprKind::IndirectCall { callee, args } => {
-            rewrite_calls_in_expr(callee, adapters, entry_source);
+            rewrite_calls_in_expr(callee, adapters, entry_source, wasi_registry);
             for arg in args {
-                rewrite_calls_in_expr(arg, adapters, entry_source);
+                rewrite_calls_in_expr(arg, adapters, entry_source, wasi_registry);
             }
         }
         TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
-            rewrite_calls_in_block(block, adapters, entry_source);
+            rewrite_calls_in_block(block, adapters, entry_source, wasi_registry);
         }
         TirExprKind::Binary { left, right, .. } => {
-            rewrite_calls_in_expr(left, adapters, entry_source);
-            rewrite_calls_in_expr(right, adapters, entry_source);
+            rewrite_calls_in_expr(left, adapters, entry_source, wasi_registry);
+            rewrite_calls_in_expr(right, adapters, entry_source, wasi_registry);
         }
         TirExprKind::Unary { expr: inner, .. }
         | TirExprKind::Cast { expr: inner, .. }
         | TirExprKind::FieldAccess { expr: inner, .. }
         | TirExprKind::OptionSome { value: inner }
         | TirExprKind::Move { expr: inner } => {
-            rewrite_calls_in_expr(inner, adapters, entry_source);
+            rewrite_calls_in_expr(inner, adapters, entry_source, wasi_registry);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            rewrite_calls_in_expr(condition, adapters, entry_source);
-            rewrite_calls_in_block(then_branch, adapters, entry_source);
+            rewrite_calls_in_expr(condition, adapters, entry_source, wasi_registry);
+            rewrite_calls_in_block(then_branch, adapters, entry_source, wasi_registry);
             if let Some(blk) = else_branch {
-                rewrite_calls_in_block(blk, adapters, entry_source);
+                rewrite_calls_in_block(blk, adapters, entry_source, wasi_registry);
             }
         }
         TirExprKind::Index { expr: e, index }
@@ -4242,8 +4431,8 @@ fn rewrite_calls_in_expr(
             target: e,
             value: index,
         } => {
-            rewrite_calls_in_expr(e, adapters, entry_source);
-            rewrite_calls_in_expr(index, adapters, entry_source);
+            rewrite_calls_in_expr(e, adapters, entry_source, wasi_registry);
+            rewrite_calls_in_expr(index, adapters, entry_source, wasi_registry);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -4251,37 +4440,37 @@ fn rewrite_calls_in_expr(
             default,
             ..
         } => {
-            rewrite_calls_in_expr(scrutinee, adapters, entry_source);
+            rewrite_calls_in_expr(scrutinee, adapters, entry_source, wasi_registry);
             for arm in arms {
-                rewrite_calls_in_block(arm, adapters, entry_source);
+                rewrite_calls_in_block(arm, adapters, entry_source, wasi_registry);
             }
-            rewrite_calls_in_block(default, adapters, entry_source);
+            rewrite_calls_in_block(default, adapters, entry_source, wasi_registry);
         }
         TirExprKind::Match {
             expr: scrutinee,
             arms,
         } => {
-            rewrite_calls_in_expr(scrutinee, adapters, entry_source);
+            rewrite_calls_in_expr(scrutinee, adapters, entry_source, wasi_registry);
             for arm in arms {
                 if let Some(guard) = &mut arm.guard {
-                    rewrite_calls_in_expr(guard, adapters, entry_source);
+                    rewrite_calls_in_expr(guard, adapters, entry_source, wasi_registry);
                 }
-                rewrite_calls_in_expr(&mut arm.body, adapters, entry_source);
+                rewrite_calls_in_expr(&mut arm.body, adapters, entry_source, wasi_registry);
             }
         }
         TirExprKind::Closure { body, .. } => {
-            rewrite_calls_in_expr(body, adapters, entry_source);
+            rewrite_calls_in_expr(body, adapters, entry_source, wasi_registry);
         }
         TirExprKind::ClosureToCanonical { functor, .. } => {
-            rewrite_calls_in_expr(functor, adapters, entry_source);
+            rewrite_calls_in_expr(functor, adapters, entry_source, wasi_registry);
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for field in &mut fields.iter_mut() {
-                rewrite_calls_in_expr(&mut field.value, adapters, entry_source);
+                rewrite_calls_in_expr(&mut field.value, adapters, entry_source, wasi_registry);
             }
         }
         TirExprKind::GlobalVarSet { value, .. } => {
-            rewrite_calls_in_expr(value, adapters, entry_source);
+            rewrite_calls_in_expr(value, adapters, entry_source, wasi_registry);
         }
         _ => {} // Leaf nodes: no sub-expressions
     }
@@ -4346,7 +4535,10 @@ fn collect_effect_calls_in_stmt(
                 collect_effect_calls_in_expr(v, effects, wasi_registry);
             }
         }
-        TirStmtKind::Continue | TirStmtKind::LetPattern { .. } => {}
+        TirStmtKind::LetPattern { value, .. } => {
+            collect_effect_calls_in_expr(value, effects, wasi_registry);
+        }
+        TirStmtKind::Continue => {}
     }
 }
 
@@ -4371,7 +4563,17 @@ fn collect_effect_calls_in_expr(
                 collect_effect_calls_in_expr(arg, effects, wasi_registry);
             }
         }
-        TirExprKind::CmRawCall { args, .. } | TirExprKind::StaticCall { args, .. } => {
+        TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                collect_effect_calls_in_expr(arg, effects, wasi_registry);
+            }
+        }
+        TirExprKind::StaticCall { func, args, .. } => {
+            // Check if this is a WASI resource static method call (e.g., Response::new)
+            let func_name = func.name();
+            if wasi_registry.get_function(&func_name).is_some() {
+                effects.insert(func_name);
+            }
             for arg in args {
                 collect_effect_calls_in_expr(arg, effects, wasi_registry);
             }

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -3732,7 +3732,12 @@ pub fn generate_adapters(mut project: Project) -> Result<Project, String> {
             for func_rc in &module.functions {
                 let mut func = func_rc.borrow_mut();
                 if let Some(body) = &mut func.body {
-                    rewrite_calls_in_block(body, &adapter_map, &entry_source, project.wasi_registry);
+                    rewrite_calls_in_block(
+                        body,
+                        &adapter_map,
+                        &entry_source,
+                        project.wasi_registry,
+                    );
                 }
             }
         }
@@ -4046,11 +4051,7 @@ fn fixup_expr_type(expr: &mut TirExpr, type_id: TypeId) {
 ///
 /// For multi-flat types like `Option<T>`, the Wado-level arg (e.g., `null`)
 /// is expanded into multiple i32 args (discriminant + payload).
-fn flatten_arg_for_call_site(
-    arg: &TirExpr,
-    flat_tys: &[TypeId],
-    flat_args: &mut Vec<TirExpr>,
-) {
+fn flatten_arg_for_call_site(arg: &TirExpr, flat_tys: &[TypeId], flat_args: &mut Vec<TirExpr>) {
     match &arg.kind {
         // null literal → discriminant=0, payload=0 for each flat type
         TirExprKind::Null => {
@@ -4300,12 +4301,11 @@ fn rewrite_calls_in_expr(
             let wasi_func_info = wasi_registry.get_function(&func_name).cloned();
 
             // Extract args before replacing
-            let taken_args =
-                if let TirExprKind::StaticCall { args, .. } = &mut expr.kind {
-                    std::mem::take(args)
-                } else {
-                    unreachable!()
-                };
+            let taken_args = if let TirExprKind::StaticCall { args, .. } = &mut expr.kind {
+                std::mem::take(args)
+            } else {
+                unreachable!()
+            };
 
             // Fix up adapter return type from the call site
             {
@@ -4345,11 +4345,7 @@ fn rewrite_calls_in_expr(
                                 flat.push(taken_args[i].clone());
                             } else {
                                 // Multi-flat type: flatten at call site
-                                flatten_arg_for_call_site(
-                                    &taken_args[i],
-                                    &flat_tys,
-                                    &mut flat,
-                                );
+                                flatten_arg_for_call_site(&taken_args[i], &flat_tys, &mut flat);
                             }
                         }
                     }

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -9,7 +9,7 @@ use crate::ast::Type;
 use crate::builtin_registry::BuiltinFunctionInfo;
 use crate::bundled::{is_fts_function, wado_bundled_fts_wasm, wado_bundled_libm_wasm};
 use crate::component_model::{
-    CmInstanceTypeGen, CmPrimitiveType, WasiFunctionInfo, WasiInterfaceInfo,
+    CmInstanceTypeGen, WasiFunctionInfo, WasiInterfaceInfo,
     build_local_alias_name, flatten_wasi_param_type, return_type_requires_outptr,
     type_id_to_valtype, wasi_type_to_valtype,
 };
@@ -1160,14 +1160,18 @@ impl Codegen<'_> {
         for tir_func_rc in &entry_tir.functions {
             let tir_func = tir_func_rc.borrow();
             // Skip functions that contain type parameters (from generic structs like Box<T>)
-            // These functions need to be inlined at call sites with concrete types
-            let has_type_params = type_table.contains_type_param(tir_func.return_type)
-                || tir_func
-                    .params
-                    .iter()
-                    .any(|p| type_table.contains_type_param(p.type_id));
-            if has_type_params {
-                continue;
+            // These functions need to be inlined at call sites with concrete types.
+            // CM adapter functions are exempt: they use concrete Wasm-level types
+            // even if their return type references generic type IDs (e.g., Future<T>).
+            if !tir_func.is_cm_adapter {
+                let has_type_params = type_table.contains_type_param(tir_func.return_type)
+                    || tir_func
+                        .params
+                        .iter()
+                        .any(|p| type_table.contains_type_param(p.type_id));
+                if has_type_params {
+                    continue;
+                }
             }
             let param_types: Vec<ValType> = tir_func
                 .params
@@ -1386,13 +1390,16 @@ impl Codegen<'_> {
                 continue;
             }
             // Skip functions that contain type parameters (from generic structs like Box<T>)
-            let has_type_params = type_table.contains_type_param(tir_func.return_type)
-                || tir_func
-                    .params
-                    .iter()
-                    .any(|p| type_table.contains_type_param(p.type_id));
-            if has_type_params {
-                continue;
+            // CM adapter functions are exempt (see type registration loop above).
+            if !tir_func.is_cm_adapter {
+                let has_type_params = type_table.contains_type_param(tir_func.return_type)
+                    || tir_func
+                        .params
+                        .iter()
+                        .any(|p| type_table.contains_type_param(p.type_id));
+                if has_type_params {
+                    continue;
+                }
             }
             // Methods have method_info metadata for building mangled names
             if let Some(ref info) = tir_func.method_info {
@@ -1624,13 +1631,16 @@ impl Codegen<'_> {
                 continue; // Skip world exports - they are handled separately as entry points
             }
             // Skip functions that contain type parameters (from generic structs like Box<T>)
-            let has_type_params = type_table.contains_type_param(tir_func.return_type)
-                || tir_func
-                    .params
-                    .iter()
-                    .any(|p| type_table.contains_type_param(p.type_id));
-            if has_type_params {
-                continue;
+            // CM adapter functions are exempt (see type registration loop above).
+            if !tir_func.is_cm_adapter {
+                let has_type_params = type_table.contains_type_param(tir_func.return_type)
+                    || tir_func
+                        .params
+                        .iter()
+                        .any(|p| type_table.contains_type_param(p.type_id));
+                if has_type_params {
+                    continue;
+                }
             }
             let (wasm_func, hints) =
                 self.generate_function(&tir_func, type_table, &builder, entry_module_source);
@@ -7733,49 +7743,10 @@ impl Codegen<'_> {
             } => {
                 let func_name = static_func.name();
 
-                // Check if this is a WASI static function to use CM ABI arg lowering.
-                // WASI functions need special argument handling (e.g., Option<T> is lowered
-                // to a (discriminant, payload) pair of i32 values instead of a GC nullref).
-                if let Some(func_info) = self.project.wasi_registry.get_function(&func_name) {
-                    for (i, arg) in args.iter().enumerate() {
-                        let param_type = &func_info.params[i].1;
-                        let resolved_type = self.project.wasi_registry.resolve_type(param_type);
-                        match &resolved_type {
-                            Type::Generic(g) if g.name == "Option" => {
-                                // Option<T> param: lower to (discriminant i32, payload i32)
-                                if matches!(arg.kind, TirExprKind::Null) {
-                                    // None: discriminant=0, payload=0
-                                    func.instruction(&Instruction::I32Const(0));
-                                    func.instruction(&Instruction::I32Const(0));
-                                } else {
-                                    // Some(value): discriminant=1, then the inner value
-                                    func.instruction(&Instruction::I32Const(1));
-                                    self.generate_expr(func, arg, type_table, ctx, builder);
-                                }
-                            }
-                            Type::Named(named) if named.name == "String" => {
-                                // String argument: lower to (ptr, len) pair
-                                self.generate_expr(func, arg, type_table, ctx, builder);
-                                let lower_idx = builder.func_idx("core/internal/cm_lower_string");
-                                func.instruction(&Instruction::Call(lower_idx));
-                                let temp = ctx.alloc_local("__cm_i64_temp", ValType::I64);
-                                func.instruction(&Instruction::LocalTee(temp));
-                                func.instruction(&Instruction::I32WrapI64);
-                                func.instruction(&Instruction::LocalGet(temp));
-                                func.instruction(&Instruction::I64Const(32));
-                                func.instruction(&Instruction::I64ShrU);
-                                func.instruction(&Instruction::I32WrapI64);
-                            }
-                            _ => {
-                                // Primitives, resource handles, Future<T>, Stream<T>, etc.
-                                self.generate_expr(func, arg, type_table, ctx, builder);
-                            }
-                        }
-                    }
-                } else {
-                    // Normal path: generate GC-level arguments
-                    self.generate_args(func, args, type_table, ctx, builder);
-                }
+                // WASI resource static methods (e.g., Response::new) are rewritten
+                // to adapter function calls by cm_adapter_gen. No CM-specific
+                // parameter handling needed here.
+                self.generate_args(func, args, type_table, ctx, builder);
 
                 // Check if this is a monomorphized function using metadata
                 let base_struct_name = static_func.base_struct_name();
@@ -7962,302 +7933,9 @@ impl Codegen<'_> {
                         }
                     }
 
-                    // Try WASI function resolution for resource static methods
-                    // Resource methods like Response::new are registered
-                    // in wasi_registry under "Response::new"
-                    if let Some(func_info) = self.project.wasi_registry.get_function(&func_name) {
-                        let local_name = func_info.local_alias_name();
-
-                        // Compute ABI properties from return type
-                        let outptr_alloc = func_info.return_type.as_ref().and_then(|rt| {
-                            let flat = crate::cm_abi::cm_flat_types(rt);
-                            if flat.len() > 1 {
-                                Some((crate::cm_abi::cm_size(rt), crate::cm_abi::cm_align(rt)))
-                            } else {
-                                None
-                            }
-                        });
-                        let tuple_return = func_info
-                            .return_type
-                            .as_ref()
-                            .and_then(crate::cm_abi::cm_tuple_primitive_types);
-                        let result_return = func_info
-                            .return_type
-                            .as_ref()
-                            .and_then(crate::cm_abi::cm_result_return_info);
-
-                        // Handle outptr allocation for Result returns
-                        if let Some((size, align)) = outptr_alloc {
-                            // Allocate outptr using realloc
-                            func.instruction(&Instruction::I32Const(0)); // old_ptr
-                            func.instruction(&Instruction::I32Const(0)); // old_size
-                            func.instruction(&Instruction::I32Const(align as i32)); // align
-                            func.instruction(&Instruction::I32Const(size as i32)); // new_size
-                            let realloc_idx = builder.func_idx("realloc");
-                            func.instruction(&Instruction::Call(realloc_idx));
-
-                            // Store outptr for later use
-                            let outptr_local = ctx.get_local("__cm_outptr").expect(
-                                "__cm_outptr should be pre-allocated for functions with CM complex returns",
-                            );
-                            func.instruction(&Instruction::LocalTee(outptr_local));
-                        }
-
-                        // Call the WASI function
-                        let func_idx = builder.func_idx(&local_name);
-                        func.instruction(&Instruction::Call(func_idx));
-
-                        // Handle tuple return conversion (e.g., Response::new -> [Response, Future])
-                        if let Some(ref elements) = tuple_return {
-                            let outptr_local = ctx.get_local("__cm_outptr").expect(
-                                "__cm_outptr should be pre-allocated for functions with tuple returns",
-                            );
-
-                            // Load all values from outptr onto the stack
-                            let mut offset: u32 = 0;
-                            for prim in elements {
-                                let align = prim.align();
-                                if !offset.is_multiple_of(align) {
-                                    offset += align - (offset % align);
-                                }
-
-                                func.instruction(&Instruction::LocalGet(outptr_local));
-                                match prim {
-                                    CmPrimitiveType::I32 | CmPrimitiveType::U32 => {
-                                        func.instruction(&Instruction::I32Load(
-                                            wasm_encoder::MemArg {
-                                                offset: u64::from(offset),
-                                                align: 2,
-                                                memory_index: 0,
-                                            },
-                                        ));
-                                    }
-                                    CmPrimitiveType::I64 | CmPrimitiveType::U64 => {
-                                        func.instruction(&Instruction::I64Load(
-                                            wasm_encoder::MemArg {
-                                                offset: u64::from(offset),
-                                                align: 3,
-                                                memory_index: 0,
-                                            },
-                                        ));
-                                    }
-                                    CmPrimitiveType::F32 => {
-                                        func.instruction(&Instruction::F32Load(
-                                            wasm_encoder::MemArg {
-                                                offset: u64::from(offset),
-                                                align: 2,
-                                                memory_index: 0,
-                                            },
-                                        ));
-                                    }
-                                    CmPrimitiveType::F64 => {
-                                        func.instruction(&Instruction::F64Load(
-                                            wasm_encoder::MemArg {
-                                                offset: u64::from(offset),
-                                                align: 3,
-                                                memory_index: 0,
-                                            },
-                                        ));
-                                    }
-                                }
-                                offset += prim.size();
-                            }
-
-                            // Create tuple struct from the loaded values
-                            let type_idx =
-                                self.get_struct_or_tuple_type_idx(expr.type_id, type_table);
-                            func.instruction(&Instruction::StructNew(type_idx));
-
-                            // Free the outptr linear memory
-                            if let Some((alloc_size, alloc_align)) = outptr_alloc {
-                                let temp = ctx
-                                    .get_local("__cm_result_temp")
-                                    .expect("__cm_result_temp should be pre-allocated");
-                                func.instruction(&Instruction::LocalSet(temp));
-                                func.instruction(&Instruction::LocalGet(outptr_local));
-                                func.instruction(&Instruction::I32Const(alloc_size as i32));
-                                func.instruction(&Instruction::I32Const(alloc_align as i32));
-                                func.instruction(&Instruction::I32Const(0));
-                                let realloc_idx = builder.func_idx("realloc");
-                                func.instruction(&Instruction::Call(realloc_idx));
-                                func.instruction(&Instruction::Drop);
-                                func.instruction(&Instruction::LocalGet(temp));
-                                func.instruction(&Instruction::RefCastNullable(
-                                    HeapType::Concrete(type_idx),
-                                ));
-                            }
-                        } else if let Some((ok_is_resource, _err_is_enum)) = result_return {
-                            let outptr_local = ctx
-                                .get_local("__cm_outptr")
-                                .expect("__cm_outptr should be pre-allocated for Result returns");
-
-                            // Get Result type info for Ok and Err subtypes
-                            let result_type_id = expr.type_id;
-                            let mangled_name = type_table.mangle_type_name(result_type_id);
-                            let result_module_source = match type_table.get(result_type_id) {
-                                ResolvedType::GenericInstance { module_source, .. } => {
-                                    module_source.clone()
-                                }
-                                other => {
-                                    panic!("Expected GenericInstance (Result), got: {other:?}")
-                                }
-                            };
-                            let qualified_mangled_name =
-                                result_module_source.qualify_name(&mangled_name);
-                            let variant_types = &self.variant_types;
-                            let result_info = variant_types
-                                .get(&qualified_mangled_name)
-                                .unwrap_or_else(|| {
-                                    panic!("Result type not registered: {qualified_mangled_name}")
-                                });
-                            // Result has cases [Ok (0), Err (1)]
-                            let ok_type_idx = result_info.cases[0].type_idx;
-                            let err_type_idx = result_info.cases[1].type_idx;
-                            let base_type_idx = result_info.base_type_idx;
-
-                            // Result type for block result
-                            let result_ref_type = ValType::Ref(RefType {
-                                nullable: true,
-                                heap_type: HeapType::Concrete(base_type_idx),
-                            });
-
-                            // Read discriminant from outptr
-                            func.instruction(&Instruction::LocalGet(outptr_local));
-                            func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
-                                offset: 0,
-                                align: 2,
-                                memory_index: 0,
-                            }));
-
-                            // Branch based on discriminant: 0 = Ok, non-zero = Err
-                            func.instruction(&Instruction::If(wasm_encoder::BlockType::Result(
-                                result_ref_type,
-                            )));
-
-                            // Err case (discriminant != 0)
-                            func.instruction(&Instruction::I32Const(1)); // Err discriminant
-                            // When error type is a variant/enum, the CM value is a discriminant
-                            // that needs to be wrapped in the error variant's GC struct.
-                            // Must create the specific subtype for ref.cast in pattern matching.
-                            // When error type is a variant with GC subtypes, dispatch via br_table
-                            // to create the correct subtype. Otherwise just load the i32 from outptr.
-                            let mut emitted_err_dispatch = false;
-                            if _err_is_enum
-                                && let Some(ValType::Ref(ref_type)) =
-                                    &result_info.cases[1].payload_type
-                                && let HeapType::Concrete(error_base_idx) = ref_type.heap_type
-                            {
-                                let error_variant_info = self
-                                    .variant_types
-                                    .values()
-                                    .find(|v| v.base_type_idx == error_base_idx);
-
-                                if let Some(variant_info) = error_variant_info {
-                                    // Save CM error discriminant to local (blocks partition the stack)
-                                    func.instruction(&Instruction::LocalGet(outptr_local));
-                                    func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
-                                        offset: 4,
-                                        align: 2,
-                                        memory_index: 0,
-                                    }));
-                                    let err_disc_local =
-                                        ctx.alloc_local("__cm_err_disc", ValType::I32);
-                                    func.instruction(&Instruction::LocalSet(err_disc_local));
-
-                                    let error_ref_type = ValType::Ref(RefType {
-                                        nullable: true,
-                                        heap_type: HeapType::Concrete(error_base_idx),
-                                    });
-                                    let num_cases = variant_info.cases.len();
-
-                                    func.instruction(&Instruction::Block(
-                                        wasm_encoder::BlockType::Result(error_ref_type),
-                                    ));
-                                    for _ in 0..num_cases {
-                                        func.instruction(&Instruction::Block(
-                                            wasm_encoder::BlockType::Empty,
-                                        ));
-                                    }
-                                    func.instruction(&Instruction::LocalGet(err_disc_local));
-                                    let labels: Vec<u32> = (0..num_cases as u32).collect();
-                                    func.instruction(&Instruction::BrTable(labels.into(), 0));
-                                    for i in 0..num_cases {
-                                        func.instruction(&Instruction::End);
-                                        func.instruction(&Instruction::I32Const(i as i32));
-                                        func.instruction(&Instruction::StructNew(
-                                            variant_info.cases[i].type_idx,
-                                        ));
-                                        if i < num_cases - 1 {
-                                            func.instruction(&Instruction::Br(
-                                                (num_cases - 1 - i) as u32,
-                                            ));
-                                        }
-                                    }
-                                    func.instruction(&Instruction::End);
-                                    emitted_err_dispatch = true;
-                                }
-                            }
-                            if !emitted_err_dispatch {
-                                // Simple error: load the error value from outptr
-                                func.instruction(&Instruction::LocalGet(outptr_local));
-                                func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
-                                    offset: 4,
-                                    align: 2,
-                                    memory_index: 0,
-                                }));
-                            }
-                            func.instruction(&Instruction::StructNew(err_type_idx));
-
-                            func.instruction(&Instruction::Else);
-
-                            // Ok case (discriminant == 0)
-                            let ok_has_payload = result_info.cases[0].payload_type.is_some();
-                            func.instruction(&Instruction::I32Const(0)); // Ok discriminant
-                            if ok_has_payload {
-                                func.instruction(&Instruction::LocalGet(outptr_local));
-                                if ok_is_resource {
-                                    // Resource handle is i32
-                                    func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
-                                        offset: 4,
-                                        align: 2,
-                                        memory_index: 0,
-                                    }));
-                                } else {
-                                    // Primitive type - for now assume i32
-                                    func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
-                                        offset: 4,
-                                        align: 2,
-                                        memory_index: 0,
-                                    }));
-                                }
-                            }
-                            func.instruction(&Instruction::StructNew(ok_type_idx));
-
-                            func.instruction(&Instruction::End);
-
-                            // Free the outptr linear memory
-                            if let Some((alloc_size, alloc_align)) = outptr_alloc {
-                                let temp = ctx
-                                    .get_local("__cm_result_temp")
-                                    .expect("__cm_result_temp should be pre-allocated");
-                                func.instruction(&Instruction::LocalSet(temp));
-                                func.instruction(&Instruction::LocalGet(outptr_local));
-                                func.instruction(&Instruction::I32Const(alloc_size as i32));
-                                func.instruction(&Instruction::I32Const(alloc_align as i32));
-                                func.instruction(&Instruction::I32Const(0));
-                                let realloc_idx = builder.func_idx("realloc");
-                                func.instruction(&Instruction::Call(realloc_idx));
-                                func.instruction(&Instruction::Drop);
-                                func.instruction(&Instruction::LocalGet(temp));
-                                func.instruction(&Instruction::RefCastNullable(
-                                    HeapType::Concrete(base_type_idx),
-                                ));
-                            }
-                        }
-
-                        return;
-                    }
-
+                    // WASI resource static methods (e.g., Response::new) are now
+                    // rewritten to adapter function calls by cm_adapter_gen.
+                    // If we reach here, the function was not found.
                     panic!("unknown static method: {func_name}");
                 }
             }

--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -9,9 +9,8 @@ use crate::ast::Type;
 use crate::builtin_registry::BuiltinFunctionInfo;
 use crate::bundled::{is_fts_function, wado_bundled_fts_wasm, wado_bundled_libm_wasm};
 use crate::component_model::{
-    CmInstanceTypeGen, WasiFunctionInfo, WasiInterfaceInfo,
-    build_local_alias_name, flatten_wasi_param_type, return_type_requires_outptr,
-    type_id_to_valtype, wasi_type_to_valtype,
+    CmInstanceTypeGen, WasiFunctionInfo, WasiInterfaceInfo, build_local_alias_name,
+    flatten_wasi_param_type, return_type_requires_outptr, type_id_to_valtype, wasi_type_to_valtype,
 };
 use crate::copy_context::{ArrayCopyLocals, CopyContext};
 use crate::name::{

--- a/wado-compiler/tests/fixtures.golden/resource-method-instance.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/resource-method-instance.lowered.wado
@@ -11,7 +11,7 @@
 
 export fn run() with Stdout {
     let family: IpAddressFamily = IpAddressFamily::Ipv4;
-    let result: Result<TcpSocket, ErrorCode> = move TcpSocket::create(family);
+    let result: Result<TcpSocket, ErrorCode> = move __cm_adapter__TcpSocket_create(family);
     if __variant_test(result, case=0, name=Ok) {
         let socket: TcpSocket = __variant_payload(result, case=0);
         core::cli::println(move "Resource extracted from Result");
@@ -22,6 +22,20 @@ export fn run() with Stdout {
 
 fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
+}
+
+fn __cm_adapter__TcpSocket_create(address_family: i32) -> Result<TcpSocket, ErrorCode> {
+    let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
+    cm_raw_call wasi:sockets/TcpSocket::create(address_family, __outptr);
+    let __disc: i32 = core::builtin::i32_load(__outptr);
+    let mut __result_val: Result<TcpSocket, ErrorCode> = move null;
+    if (__disc == 0) {
+        __result_val = move Result<TcpSocket, ErrorCode>::Ok(core::builtin::i32_load((__outptr + 4)));
+    } else {
+        __result_val = move Result<TcpSocket, ErrorCode>::Err(core::builtin::i32_load((__outptr + 4)));
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result_val;
 }
 
 export fn __cm_export__run() {

--- a/wado-compiler/tests/fixtures.golden/resource-method-static.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/resource-method-static.lowered.wado
@@ -11,12 +11,26 @@
 
 export fn run() with Stdout {
     let family: IpAddressFamily = IpAddressFamily::Ipv4;
-    let result: Result<TcpSocket, ErrorCode> = move TcpSocket::create(family);
+    let result: Result<TcpSocket, ErrorCode> = move __cm_adapter__TcpSocket_create(family);
     core::cli::println(move "Resource static method called");
 }
 
 fn __cm_adapter__Stdout_write_via_stream(data: i32) {
     cm_raw_call wasi:cli/Stdout::write_via_stream(data, 2048);
+}
+
+fn __cm_adapter__TcpSocket_create(address_family: i32) -> Result<TcpSocket, ErrorCode> {
+    let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
+    cm_raw_call wasi:sockets/TcpSocket::create(address_family, __outptr);
+    let __disc: i32 = core::builtin::i32_load(__outptr);
+    let mut __result_val: Result<TcpSocket, ErrorCode> = move null;
+    if (__disc == 0) {
+        __result_val = move Result<TcpSocket, ErrorCode>::Ok(core::builtin::i32_load((__outptr + 4)));
+    } else {
+        __result_val = move Result<TcpSocket, ErrorCode>::Err(core::builtin::i32_load((__outptr + 4)));
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result_val;
 }
 
 export fn __cm_export__run() {


### PR DESCRIPTION
## Summary

This PR extends the Component Model (CM) adapter synthesis system to handle resource static method calls (e.g., `TcpSocket::create()`), in addition to the previously supported instance method calls. Resource static methods are now rewritten to call synthesized adapter functions that handle CM ABI parameter flattening and result lifting, eliminating the need for inline CM-specific code generation.

## Key Changes

- **Removed inline CM code generation**: Deleted ~300 lines of inline CM parameter lowering and result lifting code from `codegen.rs` that was previously used for resource static method calls. This logic is now handled by adapter functions.

- **Extended adapter synthesis**: Modified `cm_adapter_gen.rs` to synthesize adapters for resource static methods (e.g., `TcpSocket::create`), not just instance methods. Adapters handle:
  - String parameter lowering (Wado String → ptr+len pair)
  - Array<u8> parameter lowering (Wado Array → ptr+len pair)
  - Option<T> parameter flattening (discriminant + payload)
  - Result<T, E> return lifting with proper discriminant and payload handling

- **Call-site argument flattening**: Implemented `flatten_arg_for_call_site()` to flatten multi-flat arguments (e.g., Option<T>) at the call site before passing to adapters. Supports null and OptionSome literals.

- **Adapter parameter mapping**: Refactored adapter parameter allocation to distinguish between:
  - Types lowered internally by the adapter (String, Array<u8>) → single placeholder param
  - Types with flat CM ABI representation (handles, Option<T>) → multiple flat params matching CM ABI

- **Call rewriting for StaticCall**: Extended `rewrite_calls_in_expr()` to detect and rewrite resource static method calls to adapter function calls, with proper argument flattening based on WASI function metadata.

- **CM adapter exemption**: Updated type registration and function code generation loops to exempt CM adapter functions from generic type parameter checks, since adapters use concrete Wasm-level types even when referencing generic type IDs.

- **Removed unused imports**: Cleaned up unused imports (`CmPrimitiveType`) from codegen.rs.

## Implementation Details

- Adapter functions are synthesized with the naming convention `__cm_adapter__<StructName>_<MethodName>`
- Parameter flattening respects the CM ABI specification: multi-value types like Option<T> are expanded into individual i32 arguments
- Result lifting allocates temporary linear memory via `realloc`, loads discriminant and payload values, constructs the appropriate Result variant, and frees the temporary allocation
- The `is_cm_adapter` flag on TirFunction prevents generic type parameter checks from skipping adapter function code generation

https://claude.ai/code/session_017mVd6FhLPS7otmRNdjxfHm