### PR TITLE
Fix unsafe char conversions and update benchmark labels

### DIFF
--- a/rsc-fpfmt/rsc_fpfmt.wado
+++ b/rsc-fpfmt/rsc_fpfmt.wado
@@ -272,11 +272,11 @@ pub fn digits(d: u64) -> i32 {
 }
 
 fn i2a_first(n: i32) -> char {
-    return (('0' as i32) + n / 10) as char;
+    return char::from_u32_unchecked(('0' as u32) + (n / 10) as u32);
 }
 
 fn i2a_second(n: i32) -> char {
-    return (('0' as i32) + n % 10) as char;
+    return char::from_u32_unchecked(('0' as u32) + (n % 10) as u32);
 }
 
 // Format result to decimal string (no exponent)
@@ -308,12 +308,12 @@ pub fn format_decimal(d: u64, p: i32, nd: i32) -> String {
             buf.append_char('0');
         }
         for let mut i = 0; i < nd; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
     } else if decimal_pos >= nd {
         // Integer with trailing zeros: digits000...
         for let mut i = 0; i < nd; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
         for let mut i = 0; i < decimal_pos - nd; i += 1 {
             buf.append_char('0');
@@ -321,11 +321,11 @@ pub fn format_decimal(d: u64, p: i32, nd: i32) -> String {
     } else {
         // Decimal point in the middle: dig.its
         for let mut i = 0; i < decimal_pos; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
         buf.append_char('.');
         for let mut i = decimal_pos; i < nd; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
     }
 
@@ -351,13 +351,13 @@ pub fn format_exp(d: u64, p: i32, nd: i32, upper: bool) -> String {
     }
 
     // First digit
-    buf.append_char(digit_chars[0] as char);
+    buf.append_char(char::from_u32_unchecked(digit_chars[0] as u32));
 
     // Decimal point and remaining digits
     if nd > 1 {
         buf.append_char('.');
         for let mut i = 1; i < nd; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
     }
 
@@ -373,12 +373,12 @@ pub fn format_exp(d: u64, p: i32, nd: i32, upper: bool) -> String {
     let abs_exp = if exp < 0 { -exp } else { exp };
     if abs_exp < 10 {
         buf.append_char('0');
-        buf.append_char((('0' as i32) + abs_exp) as char);
+        buf.append_char(char::from_u32_unchecked(('0' as u32) + abs_exp as u32));
     } else if abs_exp < 100 {
         buf.append_char(i2a_first(abs_exp));
         buf.append_char(i2a_second(abs_exp));
     } else {
-        buf.append_char((('0' as i32) + abs_exp / 100) as char);
+        buf.append_char(char::from_u32_unchecked(('0' as u32) + (abs_exp / 100) as u32));
         buf.append_char(i2a_first(abs_exp % 100));
         buf.append_char(i2a_second(abs_exp % 100));
     }
@@ -550,7 +550,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
             let remaining_prec = precision - leading_zeros;
             let digits_to_output = if remaining_prec < nd { remaining_prec } else { nd };
             for let mut i = 0; i < digits_to_output; i += 1 {
-                buf.append_char(digit_chars[i] as char);
+                buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
             }
             // Trailing zeros if needed
             let trailing = precision - leading_zeros - digits_to_output;
@@ -561,7 +561,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
     } else if decimal_pos >= nd {
         // Integer part only: digits000...
         for let mut i = 0; i < nd; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
         for let mut i = 0; i < decimal_pos - nd; i += 1 {
             buf.append_char('0');
@@ -575,7 +575,7 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
     } else {
         // Decimal point in the middle: dig.its
         for let mut i = 0; i < decimal_pos; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
         buf.append_char('.');
         // How many digits after decimal
@@ -583,12 +583,12 @@ pub fn format_decimal_prec(d: i64, p: i32, nd: i32, precision: i32) -> String {
         if precision <= after_decimal {
             // Only output precision digits
             for let mut i = decimal_pos; i < decimal_pos + precision; i += 1 {
-                buf.append_char(digit_chars[i] as char);
+                buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
             }
         } else {
             // Output all digits then trailing zeros
             for let mut i = decimal_pos; i < nd; i += 1 {
-                buf.append_char(digit_chars[i] as char);
+                buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
             }
             let trailing = precision - after_decimal;
             for let mut i = 0; i < trailing; i += 1 {
@@ -625,7 +625,7 @@ pub fn format_exp_prec(d: i64, p: i32, nd: i32, precision: i32, upper: bool) -> 
     }
 
     // First digit
-    buf.append_char(digit_chars[0] as char);
+    buf.append_char(char::from_u32_unchecked(digit_chars[0] as u32));
 
     // Decimal point and remaining digits based on precision
     if precision > 0 {
@@ -634,7 +634,7 @@ pub fn format_exp_prec(d: i64, p: i32, nd: i32, precision: i32, upper: bool) -> 
         let available = nd - 1;
         let to_output = if precision < available { precision } else { available };
         for let mut i = 1; i <= to_output; i += 1 {
-            buf.append_char(digit_chars[i] as char);
+            buf.append_char(char::from_u32_unchecked(digit_chars[i] as u32));
         }
         // Trailing zeros if needed
         let trailing = precision - to_output;
@@ -655,12 +655,12 @@ pub fn format_exp_prec(d: i64, p: i32, nd: i32, precision: i32, upper: bool) -> 
     let abs_exp = if exp < 0 { -exp } else { exp };
     if abs_exp < 10 {
         buf.append_char('0');
-        buf.append_char((('0' as i32) + abs_exp) as char);
+        buf.append_char(char::from_u32_unchecked(('0' as u32) + abs_exp as u32));
     } else if abs_exp < 100 {
         buf.append_char(i2a_first(abs_exp));
         buf.append_char(i2a_second(abs_exp));
     } else {
-        buf.append_char((('0' as i32) + abs_exp / 100) as char);
+        buf.append_char(char::from_u32_unchecked(('0' as u32) + (abs_exp / 100) as u32));
         buf.append_char(i2a_first(abs_exp % 100));
         buf.append_char(i2a_second(abs_exp % 100));
     }
@@ -690,7 +690,7 @@ pub fn apply_padding(s: String, spec: FormatSpec, is_neg: bool) -> String {
         // Add sign prefix if present in original string
         let mut start_idx = 0;
         if s.len() > 0 && (s.get_byte(0) == '-' as i32 || s.get_byte(0) == '+' as i32) {
-            result.append_char(s.get_byte(0) as char);
+            result.append_char(char::from_u32_unchecked(s.get_byte(0) as u32));
             start_idx = 1;
         }
 
@@ -701,7 +701,7 @@ pub fn apply_padding(s: String, spec: FormatSpec, is_neg: bool) -> String {
 
         // Add rest of string
         for let mut i = start_idx; i < s.len(); i += 1 {
-            result.append_char(s.get_byte(i) as char);
+            result.append_char(char::from_u32_unchecked(s.get_byte(i) as u32));
         }
 
         return result;

--- a/rsc-fpfmt/rsc_fpfmt_test.wado
+++ b/rsc-fpfmt/rsc_fpfmt_test.wado
@@ -1457,7 +1457,7 @@ fn truncate_str(s: String, max_len: i32) -> String {
     }
     let mut result = String::with_capacity(max_len + 3);
     for let mut i = 0; i < max_len - 3; i += 1 {
-        result.append((s.get_byte(i) as char).to_string());
+        result.append(char::from_u32_unchecked(s.get_byte(i) as u32).to_string());
     }
     result.append("...");
     return result;
@@ -1487,7 +1487,7 @@ fn i32_to_str(n: i32) -> String {
     if is_neg { result.append("-"); }
     let mut i = digits.len() - 1;
     while i >= 0 {
-        result.append(((('0' as i32) + digits[i]) as char).to_string());
+        result.append(char::from_u32_unchecked(('0' as u32) + digits[i] as u32).to_string());
         i = i - 1;
     }
     return result;
@@ -1506,7 +1506,7 @@ fn u64_to_str(n: u64) -> String {
 
     let mut i = digits.len() - 1;
     while i >= 0 {
-        result.append(((('0' as i32) + digits[i]) as char).to_string());
+        result.append(char::from_u32_unchecked(('0' as u32) + digits[i] as u32).to_string());
         i = i - 1;
     }
     return result;
@@ -1515,15 +1515,16 @@ fn u64_to_str(n: u64) -> String {
 // Entry point for running benchmark
 export fn run() with Stdout, MonotonicClock {
     println("======================================================================");
-    println("Float-to-String Benchmark: fpfmt vs ryu (f64.to_string)");
+    println("Float-to-String Benchmark: Wado fpfmt vs bundled fpfmt");
     println("======================================================================");
     println("");
-    println("fpfmt: Russ Cox's unrounded scaling algorithm (rsc_fpfmt.wado)");
-    println("ryu:   Bundled ryu-based f64_to_buffer (f64.to_string)");
+    println("wado:    Wado port of Russ Cox's fpfmt (rsc_fpfmt.wado)");
+    println("bundled: Rust fpfmt crate compiled to Wasm (f64.to_string)");
     println("");
 
     // Number of iterations per test
-    let iterations = 10000;
+    // Note: using 1000 to avoid linear memory exhaustion in the benchmark loop.
+    let iterations = 1000;
 
     // Test categories
     benchmark_category("Integers", iterations, [1.0, 10.0, 100.0, 1000.0, 10000.0]);
@@ -1542,7 +1543,7 @@ export fn run() with Stdout, MonotonicClock {
 
 fn benchmark_category(name: String, iterations: i32, values: Array<f64>) with Stdout, MonotonicClock {
     println(`\n--- {name} ---`);
-    println("Value                      fpfmt(ns)    ryu(ns)       ratio");
+    println("Value                      wado(ns)     bundled(ns)   ratio");
     println("-----------------------------------------------------------------");
 
     for let val of values {
@@ -1551,25 +1552,25 @@ fn benchmark_category(name: String, iterations: i32, values: Array<f64>) with St
 }
 
 fn benchmark_value(val: f64, iterations: i32) with Stdout, MonotonicClock {
-    // Benchmark fpfmt (this implementation)
-    let start_fpfmt = now();
+    // Benchmark Wado fpfmt (this implementation)
+    let start_wado = now();
     for let mut i = 0; i < iterations; i += 1 {
         let _ = f64_to_string_exp(val, false);
     }
-    let end_fpfmt = now();
-    let fpfmt_time = ((end_fpfmt - start_fpfmt) as u64) / (iterations as u64);
+    let end_wado = now();
+    let wado_time = ((end_wado - start_wado) as u64) / (iterations as u64);
 
-    // Benchmark ryu (f64.to_string)
-    let start_ryu = now();
+    // Benchmark bundled fpfmt (f64.to_string)
+    let start_bundled = now();
     for let mut i = 0; i < iterations; i += 1 {
         let _ = val.to_string();
     }
-    let end_ryu = now();
-    let ryu_time = ((end_ryu - start_ryu) as u64) / (iterations as u64);
+    let end_bundled = now();
+    let bundled_time = ((end_bundled - start_bundled) as u64) / (iterations as u64);
 
-    // Calculate ratio (fpfmt / ryu)
-    let ratio = if ryu_time > 0 {
-        (fpfmt_time as f64) / (ryu_time as f64)
+    // Calculate ratio (wado / bundled)
+    let ratio = if bundled_time > 0 {
+        (wado_time as f64) / (bundled_time as f64)
     } else {
         0.0
     };
@@ -1580,16 +1581,16 @@ fn benchmark_value(val: f64, iterations: i32) with Stdout, MonotonicClock {
     let padded_val = pad_right(display_val, 25);
 
     // Build output line
-    let fpfmt_str = format_ns(fpfmt_time);
-    let ryu_str = format_ns(ryu_time);
+    let wado_str = format_ns(wado_time);
+    let bundled_str = format_ns(bundled_time);
     let ratio_str = format_ratio(ratio);
 
     let mut line = String::with_capacity(80);
     line.append(padded_val);
     line.append(" ");
-    line.append(fpfmt_str);
+    line.append(wado_str);
     line.append("    ");
-    line.append(ryu_str);
+    line.append(bundled_str);
     line.append("     ");
     line.append(ratio_str);
     println(line);


### PR DESCRIPTION
## Summary
This PR fixes unsafe character conversions throughout the codebase by replacing direct casts with `char::from_u32_unchecked()`, and updates benchmark output labels to reflect the actual implementations being compared.

## Key Changes

- **Character Conversion Safety**: Replaced all unsafe `as char` casts with `char::from_u32_unchecked()` to properly convert numeric values to characters. This affects:
  - `i2a_first()` and `i2a_second()` helper functions
  - `format_decimal()` and `format_decimal_prec()` digit formatting
  - `format_exp()` and `format_exp_prec()` exponent formatting
  - `apply_padding()` string manipulation
  - Test utility functions (`truncate_str()`, `i32_to_str()`, `u64_to_str()`)

- **Benchmark Label Updates**: Updated benchmark output to accurately describe the implementations:
  - Changed "fpfmt vs ryu" to "Wado fpfmt vs bundled fpfmt"
  - Renamed variable names from `fpfmt`/`ryu` to `wado`/`bundled` for clarity
  - Updated descriptive text to indicate "Wado port" vs "Rust fpfmt crate compiled to Wasm"

- **Benchmark Configuration**: Reduced iteration count from 10,000 to 1,000 with a note explaining this prevents linear memory exhaustion in the benchmark loop

## Implementation Details
The character conversion changes ensure proper Unicode code point handling by explicitly converting u32 values to char using the unchecked variant, which is appropriate since the values being converted (ASCII digit codes) are always valid Unicode code points.

https://claude.ai/code/session_016gomFvAjgo8jWq9WyaJzzk