### PR TITLE
Add WIR (Wasm IR) intermediate representation layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Available phases (in compilation order):
 6. `--tir` - Typed IR (supports `--unparse`)
 7. `--lower` - Lowered TIR (supports `--unparse`)
 8. `--optimize` - Optimized TIR (supports `--unparse`)
+9. `--wir` - Wasm IR (supports `--unparse`)
 
 Optimization levels for `--optimize` phase: `-O0` (none), `-O1` (development), `-O2` (production, default), `-O3` (aggressive), `-Os` (`-O2` + strip names).
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -66,6 +66,8 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 | WorldRegistry    | `world_registry.rs`     | World definitions registry for export signatures      |
 | WasmBuilder      | `wasm_builder.rs`       | Tracks Wasm indices, builds wasm-encoder sections     |
 | Codegen          | `codegen.rs`            | Generates Component Model Wasm from TIR               |
+| WIR              | `wir.rs`                | Wasm IR data structures (WEP: wir-layer)              |
+| WIR Unparse      | `wir_unparse.rs`        | WIR → pseudo-Wado source code for debugging           |
 | Bundled          | `bundled.rs`            | Loads pre-compiled Wasm builtins (wado-bundled)       |
 | Postproc         | `wasm_postprocess.rs`   | Wasm binary transformations                           |
 

--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -871,9 +871,9 @@ The strangler fig approach eliminates these risks:
 
 Set up the WIR data structures, unparse output, and dump integration. No code generation yet.
 
-- [ ] **Step 1a**: Create `wir.rs` with the WIR data structure definitions (types, instructions, module structure). No code uses it yet.
-- [ ] **Step 1b**: Create `wir_unparse.rs` for WIR → pseudo-Wado output.
-- [ ] **Step 1c**: Add `--wir` flag to the dump command (`wado dump --wir --unparse`). Initially outputs an empty `WirModule`.
+- [x] **Step 1a**: Create `wir.rs` with the WIR data structure definitions (types, instructions, module structure). No code uses it yet.
+- [x] **Step 1b**: Create `wir_unparse.rs` for WIR → pseudo-Wado output.
+- [x] **Step 1c**: Add `--wir` flag to the dump command (`wado dump --wir --unparse`). Initially outputs an empty `WirModule`.
 
 After this phase: `wado dump --wir --unparse` works but shows an empty module.
 

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -20,6 +20,7 @@ pub struct DumpOptions {
     pub show_monomorphize: bool,
     pub show_lower: bool,
     pub show_optimize: bool,
+    pub show_wir: bool,
     pub unparse: bool,
     pub opt_level: OptLevel,
     /// Output template for bulk generation, e.g., "path/to/{name}.lowered.wado"
@@ -43,6 +44,7 @@ pub fn print_usage() {
     eprintln!("  --monomorphize (Phase 7: Monomorphize) Show monomorphized TIR");
     eprintln!("  --lower        (Phase 8: Lower) Show lowered TIR");
     eprintln!("  --optimize     (Phase 9: Optimize) Show optimization hints");
+    eprintln!("  --wir          (Phase 10: WIR) Show Wasm IR");
     eprintln!("  --all        Show all phases (default if no phase specified)");
     eprintln!();
     eprintln!("Display Options:");
@@ -65,6 +67,7 @@ pub fn print_usage() {
     eprintln!("  --help       Show this help message");
 }
 
+#[allow(clippy::similar_names)] // show_tir and show_wir are intentional phase names
 pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     let mut inputs: Vec<String> = Vec::new();
     let mut show_tokens = false;
@@ -76,6 +79,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     let mut show_monomorphize = false;
     let mut show_lower = false;
     let mut show_optimize = false;
+    let mut show_wir = false;
     let mut unparse = false;
     let mut opt_level = OptLevel::O2;
     let mut output_template: Option<String> = None;
@@ -95,6 +99,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
             Long("monomorphize") => show_monomorphize = true,
             Long("lower") => show_lower = true,
             Long("optimize") => show_optimize = true,
+            Long("wir") => show_wir = true,
             Long("unparse") => unparse = true,
             Long("all") => {
                 show_tokens = true;
@@ -106,6 +111,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
                 show_monomorphize = true;
                 show_lower = true;
                 show_optimize = true;
+                show_wir = true;
             }
             Short('O') => {
                 let level = parser.value().unwrap_or_else(|_| {
@@ -152,6 +158,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
         && !show_monomorphize
         && !show_lower
         && !show_optimize
+        && !show_wir
     {
         show_tokens = true;
         show_ast = true;
@@ -162,6 +169,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
         show_monomorphize = true;
         show_lower = true;
         show_optimize = true;
+        show_wir = true;
     }
 
     DumpOptions {
@@ -175,6 +183,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
         show_monomorphize,
         show_lower,
         show_optimize,
+        show_wir,
         unparse,
         opt_level,
         output_template,
@@ -708,6 +717,29 @@ async fn run_single(opts: &DumpOptions, input: &str) {
         } else {
             println!("=== Optimized Project (Optimize) ===");
             println!("(Optimization failed or not available)");
+            println!();
+        }
+    }
+
+    // WIR section (Wasm IR phase)
+    if opts.show_wir {
+        if let Some(ref wir_module) = result.wir_module {
+            if opts.unparse {
+                println!("=== WIR (Wasm IR, unparsed) ===");
+                let unparsed = wado_compiler::wir_unparse::unparse_wir(wir_module);
+                if unparsed.is_empty() {
+                    println!("(empty module)");
+                } else {
+                    print!("{unparsed}");
+                }
+            } else {
+                println!("=== WIR (Wasm IR) ===");
+                println!("{wir_module:#?}");
+            }
+            println!();
+        } else {
+            println!("=== WIR (Wasm IR) ===");
+            println!("(WIR generation failed or not available)");
             println!();
         }
     }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -109,6 +109,8 @@ pub mod unparse;
 pub mod wasm_builder;
 pub mod wasm_plan;
 pub mod wasm_postprocess;
+pub mod wir;
+pub mod wir_unparse;
 pub mod world_registry;
 
 pub use analyze::Analyzer;
@@ -172,6 +174,8 @@ pub struct DumpResult {
     pub lowered_tir_modules: Option<IndexMap<ModuleSource, tir::TirModule>>,
     /// Optimized project (contains usage analysis results)
     pub optimized_project: Option<Project>,
+    /// WIR module (after `tir_to_wir` translation)
+    pub wir_module: Option<wir::WirModule>,
     /// Comments for unparsing
     pub comments: comment::CommentMap,
 }
@@ -481,67 +485,74 @@ pub async fn dump_with_host<H: CompilerHost>(
     // === Phase 7b+8+9+10: Build Project and run remaining phases ===
     // Create Project early so CM adapter synthesis runs before monomorphize,
     // matching the compile_with_options pipeline.
-    let (monomorphized_tir_modules_by_source, lowered_tir_modules_by_source, optimized_project) =
-        if let Some(resolved_modules) = tir_modules_by_source.clone() {
-            let module_name = filename.clone().unwrap_or_else(|| "module".to_string());
+    let (
+        monomorphized_tir_modules_by_source,
+        lowered_tir_modules_by_source,
+        optimized_project,
+        wir_module,
+    ) = if let Some(resolved_modules) = tir_modules_by_source.clone() {
+        let module_name = filename.clone().unwrap_or_else(|| "module".to_string());
 
-            let (wasi_registry, world_registry) =
-                component_model::WasiRegistry::build_from_stdlib();
+        let (wasi_registry, world_registry) = component_model::WasiRegistry::build_from_stdlib();
 
-            let temp_type_table = std::cell::RefCell::new(tir::TypeTable::new());
-            let builtin_registry =
-                builtin_registry::BuiltinRegistry::build_from_stdlib(&temp_type_table);
+        let temp_type_table = std::cell::RefCell::new(tir::TypeTable::new());
+        let builtin_registry =
+            builtin_registry::BuiltinRegistry::build_from_stdlib(&temp_type_table);
 
-            let project = Project::new(
-                load_result.entry_module_source.clone(),
-                resolved_modules,
-                symbols.clone(),
-                load_result.implicit_modules.clone(),
-                module_name,
-                wasi_registry,
-                world_registry,
-                builtin_registry,
-            );
+        let project = Project::new(
+            load_result.entry_module_source.clone(),
+            resolved_modules,
+            symbols.clone(),
+            load_result.implicit_modules.clone(),
+            module_name,
+            wasi_registry,
+            world_registry,
+            builtin_registry,
+        );
 
-            // CM Adapter Synthesis (must run before monomorphize)
-            let project = {
-                let _span = logger.span("cm-adapter-gen");
-                cm_adapter_gen::generate_adapters(project).map_err(|message| {
-                    let _ = logger.error(compiler_host::Diagnostic {
-                        severity: compiler_host::Severity::Error,
-                        code: compiler_host::Code::UnsupportedFeature,
-                        message,
-                        span: None,
-                    });
-                    Bail
-                })?
-            };
-
-            // Monomorphize
-            let project = {
-                let _span = logger.span("monomorphize");
-                monomorphize_project(project)
-            };
-            let mono_snapshot = Some(project.tir_modules.clone());
-
-            // Lower
-            let project = {
-                let _span = logger.span("lower");
-                lower_project(project)
-            };
-            let lower_snapshot = Some(project.tir_modules.clone());
-
-            // Optimize
-            let project = {
-                let _span = logger.span("optimize");
-                optimize(project, opt_level)
-            };
-            let optimized = wasm_plan(project).ok();
-
-            (mono_snapshot, lower_snapshot, optimized)
-        } else {
-            (None, None, None)
+        // CM Adapter Synthesis (must run before monomorphize)
+        let project = {
+            let _span = logger.span("cm-adapter-gen");
+            cm_adapter_gen::generate_adapters(project).map_err(|message| {
+                let _ = logger.error(compiler_host::Diagnostic {
+                    severity: compiler_host::Severity::Error,
+                    code: compiler_host::Code::UnsupportedFeature,
+                    message,
+                    span: None,
+                });
+                Bail
+            })?
         };
+
+        // Monomorphize
+        let project = {
+            let _span = logger.span("monomorphize");
+            monomorphize_project(project)
+        };
+        let mono_snapshot = Some(project.tir_modules.clone());
+
+        // Lower
+        let project = {
+            let _span = logger.span("lower");
+            lower_project(project)
+        };
+        let lower_snapshot = Some(project.tir_modules.clone());
+
+        // Optimize
+        let project = {
+            let _span = logger.span("optimize");
+            optimize(project, opt_level)
+        };
+        let optimized = wasm_plan(project).ok();
+
+        // WIR: Generate an empty WirModule for now (Phase 1 scaffolding).
+        // In the future, tir_to_wir will translate the optimized Project here.
+        let wir_module = optimized.as_ref().map(|_| wir::WirModule::empty());
+
+        (mono_snapshot, lower_snapshot, optimized, wir_module)
+    } else {
+        (None, None, None, None)
+    };
 
     Ok(DumpResult {
         source: source.to_string(),
@@ -556,6 +567,7 @@ pub async fn dump_with_host<H: CompilerHost>(
         monomorphized_tir_modules: monomorphized_tir_modules_by_source,
         lowered_tir_modules: lowered_tir_modules_by_source,
         optimized_project,
+        wir_module,
         comments: comment_map,
     })
 }

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1,0 +1,1176 @@
+//! WIR (Wasm IR) — tree-structured intermediate representation between TIR and Wasm binary.
+//!
+//! WIR is close to Wasm semantics but retains enough high-level information to be
+//! readable and debuggable. It maps almost 1:1 to Wasm instructions with these
+//! ergonomic improvements:
+//!
+//! - Named locals (not pre-allocated indices)
+//! - Named types (Wado-level struct/variant/enum/flags, not Wasm type section entries)
+//! - Wado-level value types (Bool, Char, I8, U8, etc. instead of Wasm's i32-for-everything)
+//! - Structured control flow (tree nodes, not flat instruction sequences)
+//! - Explicit value copy operations
+//! - TIR metadata preserved for debugging and unparse
+//!
+//! See `docs/wep-2026-02-14-wir-layer.md` for the full design rationale.
+
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::rc::Rc;
+
+use crate::name::ModuleSource;
+use crate::token::Span;
+
+// =============================================================================
+// Module Level
+// =============================================================================
+
+/// A complete Wasm module in WIR form.
+/// Contains all information needed to emit a valid Wasm binary.
+#[derive(Debug)]
+pub struct WirModule {
+    /// Type definitions: Wado-level types (struct, variant, enum, flags, array, func).
+    /// Not a 1:1 mapping to the Wasm type section — the emit phase expands these.
+    pub types: Vec<WirTypeDef>,
+    /// Rec groups: which types form recursive groups.
+    pub rec_groups: Vec<WirRecGroup>,
+    /// Import section.
+    pub imports: Vec<WirImport>,
+    /// Function declarations with bodies.
+    pub functions: Vec<WirFunction>,
+    /// Global variables.
+    pub globals: Vec<WirGlobal>,
+    /// Export section.
+    pub exports: Vec<WirExport>,
+    /// Element section (for funcref tables).
+    pub elements: Vec<WirElement>,
+    /// Data section (string literals, etc.).
+    pub data: Vec<WirData>,
+    /// Branch hints (from likely/unlikely).
+    pub branch_hints: Vec<WirBranchHint>,
+    /// Name section entries.
+    pub names: WirNames,
+    /// Component Model wrapper info.
+    pub component: WirComponent,
+}
+
+impl WirModule {
+    /// Create an empty `WirModule` with no types, functions, or other content.
+    pub fn empty() -> Self {
+        Self {
+            types: Vec::new(),
+            rec_groups: Vec::new(),
+            imports: Vec::new(),
+            functions: Vec::new(),
+            globals: Vec::new(),
+            exports: Vec::new(),
+            elements: Vec::new(),
+            data: Vec::new(),
+            branch_hints: Vec::new(),
+            names: WirNames::default(),
+            component: WirComponent::default(),
+        }
+    }
+}
+
+// =============================================================================
+// Names
+// =============================================================================
+
+/// A globally-scoped name in WIR.
+///
+/// Carries both forms needed by different consumers:
+/// - `display`: short name for unparse and error messages
+/// - `fq`: module-qualified name for unique identity
+///
+/// The `tir_to_wir` phase constructs `WirName`s from `name.rs` objects
+/// (`StructName`, `FunctionId`, etc.). WIR itself does not import `name.rs` types.
+#[derive(Debug, Clone)]
+pub struct WirName {
+    /// Short display name (e.g., "Point", "Array<i32>", "`Point::sum`").
+    /// Used by unparse and error messages.
+    pub display: String,
+    /// Fully-qualified name (e.g., "core:prelude//Point", "./`geometry.wado/Point::sum`").
+    /// Used as the unique identity key for name→index resolution during emission.
+    pub fq: String,
+}
+
+impl fmt::Display for WirName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display)
+    }
+}
+
+// =============================================================================
+// Type and Function IDs
+// =============================================================================
+
+/// Lightweight reference to a type definition in `WirModule.types`.
+///
+/// - `index`: indexes into `WirModule.types` (not the Wasm type section)
+/// - `fq`: fully-qualified name shared via `Rc<str>` for Debug output
+///
+/// `Eq` and `Hash` use `index` only (O(1) integer operations).
+/// `Debug` prints the fq name (e.g., "core:prelude//Array<i32>").
+/// `Clone` is O(1) — Rc refcount increment (non-atomic, near zero cost).
+#[derive(Clone)]
+pub struct WirTypeId {
+    index: u32,
+    fq: Rc<str>,
+}
+
+impl WirTypeId {
+    /// Create a new `WirTypeId` with the given index and fully-qualified name.
+    pub fn new(index: u32, fq: Rc<str>) -> Self {
+        Self { index, fq }
+    }
+
+    /// Get the index into `WirModule.types`.
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+
+    /// Get the fully-qualified name.
+    pub fn fq(&self) -> &str {
+        &self.fq
+    }
+}
+
+impl PartialEq for WirTypeId {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl Eq for WirTypeId {}
+
+impl Hash for WirTypeId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+impl fmt::Debug for WirTypeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.fq)
+    }
+}
+
+impl fmt::Display for WirTypeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.fq)
+    }
+}
+
+/// Lightweight reference to a function.
+/// Same design as `WirTypeId`.
+#[derive(Clone)]
+pub struct WirFuncId {
+    index: u32,
+    fq: Rc<str>,
+}
+
+impl WirFuncId {
+    /// Create a new `WirFuncId` with the given index and fully-qualified name.
+    pub fn new(index: u32, fq: Rc<str>) -> Self {
+        Self { index, fq }
+    }
+
+    /// Get the index into `WirModule.functions`.
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+
+    /// Get the fully-qualified name.
+    pub fn fq(&self) -> &str {
+        &self.fq
+    }
+}
+
+impl PartialEq for WirFuncId {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl Eq for WirFuncId {}
+
+impl Hash for WirFuncId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+impl fmt::Debug for WirFuncId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.fq)
+    }
+}
+
+impl fmt::Display for WirFuncId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.fq)
+    }
+}
+
+// =============================================================================
+// Metadata
+// =============================================================================
+
+/// Source location and origin metadata, carried through from TIR.
+#[derive(Debug, Clone, Default)]
+pub struct WirMeta {
+    /// Which module this entity was defined in.
+    pub module_source: Option<ModuleSource>,
+    /// Source span in the original Wado source.
+    pub span: Option<Span>,
+    /// Attributes (e.g., `#[hidden]`).
+    pub attributes: Vec<WirAttribute>,
+}
+
+/// An attribute on a WIR entity.
+#[derive(Debug, Clone)]
+pub enum WirAttribute {
+    /// `#[hidden]` — field not shown in debug stringify.
+    Hidden,
+}
+
+/// Generic instantiation origin (e.g., `Array<i32>` from `Array<T>`).
+#[derive(Debug, Clone)]
+pub struct WirGenericOrigin {
+    /// Base generic name (e.g., "Array", "Box").
+    pub base_name: String,
+    /// Type arguments used for instantiation (e.g., ["i32"]).
+    pub type_args: Vec<String>,
+}
+
+/// Newtype origin — when a type was originally a newtype alias.
+#[derive(Debug, Clone)]
+pub struct WirNewtypeOrigin {
+    /// Newtype name (e.g., "Meters").
+    pub name: String,
+    /// Module where the newtype was defined.
+    pub module_source: ModuleSource,
+}
+
+// =============================================================================
+// Type Definitions
+// =============================================================================
+
+/// A Wado-level type definition.
+/// The emit phase expands these into Wasm type section entries:
+///   Struct → 1 Wasm struct type
+///   Variant → N+1 Wasm struct types (base with discriminant field + case subtypes)
+///   Enum → none (represented as i32)
+///   Flags → none (represented as i32 bitfield)
+///   Array → 1 Wasm array type
+///   Func → 1 Wasm func type
+#[derive(Debug)]
+pub enum WirTypeDef {
+    /// Struct type with named fields.
+    Struct(WirStructType),
+    /// Variant type (sum type with payloads).
+    Variant(WirVariantType),
+    /// Enum type (discriminated values without payloads).
+    Enum(WirEnumType),
+    /// Flags type (bitfield).
+    Flags(WirFlagsType),
+    /// Array type.
+    Array(WirArrayType),
+    /// Function type.
+    Func(WirFuncType),
+}
+
+// =============================================================================
+// Struct
+// =============================================================================
+
+/// A struct type with named fields.
+#[derive(Debug)]
+pub struct WirStructType {
+    /// Name (display: "Point", fq: "core:prelude//Point").
+    pub name: WirName,
+    /// Fields with names and types.
+    pub fields: Vec<WirField>,
+    /// Metadata (module source, span, attributes).
+    pub meta: WirMeta,
+    /// Generic instantiation origin (None for non-generic types).
+    pub generic_origin: Option<WirGenericOrigin>,
+    /// If this type was a newtype in the source (resolved by WIR phase).
+    pub newtype_origin: Option<WirNewtypeOrigin>,
+}
+
+/// A field in a struct type.
+#[derive(Debug)]
+pub struct WirField {
+    /// Source-level field name (e.g., "x", "repr", "discriminant").
+    pub name: String,
+    /// WIR type (uses Wado-level primitives, not Wasm `ValType`).
+    pub ty: WirType,
+    /// Whether this field is mutable.
+    pub mutable: bool,
+}
+
+// =============================================================================
+// Variant
+// =============================================================================
+
+/// A variant type (sum type with payloads).
+/// At the Wasm level, expands to a subtype hierarchy: a base struct with a
+/// `discriminant` field, and per-case subtypes that add payload fields.
+#[derive(Debug)]
+pub struct WirVariantType {
+    /// Name (display: "Shape", fq: "./shapes.wado//Shape").
+    pub name: WirName,
+    /// Cases with names and optional payload types.
+    pub cases: Vec<WirVariantCase>,
+    /// Metadata (module source, span, attributes).
+    pub meta: WirMeta,
+    /// Generic instantiation origin (None for non-generic types).
+    pub generic_origin: Option<WirGenericOrigin>,
+    /// If this type was a newtype in the source (resolved by WIR phase).
+    pub newtype_origin: Option<WirNewtypeOrigin>,
+}
+
+/// A case in a variant type.
+#[derive(Debug)]
+pub struct WirVariantCase {
+    /// Case name (e.g., "Circle", "Ok").
+    pub name: String,
+    /// Case index (discriminant value).
+    pub index: u32,
+    /// Payload field types (empty for unit cases like "Point" or "None").
+    pub payload: Vec<WirType>,
+}
+
+// =============================================================================
+// Enum
+// =============================================================================
+
+/// An enum type (discriminated values without payloads).
+/// No Wasm type section entry — values are i32 discriminants.
+#[derive(Debug)]
+pub struct WirEnumType {
+    /// Name (display: "Color", fq: "./colors.wado//Color").
+    pub name: WirName,
+    /// Cases with names and discriminant values.
+    pub cases: Vec<WirEnumCase>,
+    /// Metadata (module source, span, attributes).
+    pub meta: WirMeta,
+}
+
+/// A case in an enum type.
+#[derive(Debug)]
+pub struct WirEnumCase {
+    /// Case name (e.g., "Red", "Less").
+    pub name: String,
+    /// Discriminant value.
+    pub discriminant: i32,
+}
+
+// =============================================================================
+// Flags
+// =============================================================================
+
+/// A flags type (bitfield).
+/// No Wasm type section entry — values are i32 bitfields.
+#[derive(Debug)]
+pub struct WirFlagsType {
+    /// Name (display: "Permissions", fq: "./perms.wado//Permissions").
+    pub name: WirName,
+    /// Flag bits with names and positions.
+    pub bits: Vec<WirFlagBit>,
+    /// Metadata (module source, span, attributes).
+    pub meta: WirMeta,
+}
+
+/// A flag bit in a flags type.
+#[derive(Debug)]
+pub struct WirFlagBit {
+    /// Flag name.
+    pub name: String,
+    /// Bit position (0-indexed).
+    pub position: u32,
+}
+
+// =============================================================================
+// Array and Func Types
+// =============================================================================
+
+/// An array type (maps to 1 Wasm array type).
+#[derive(Debug)]
+pub struct WirArrayType {
+    /// Name.
+    pub name: WirName,
+    /// Element type.
+    pub element_type: WirType,
+    /// Whether elements are mutable.
+    pub mutable: bool,
+    /// Metadata.
+    pub meta: WirMeta,
+    /// Generic instantiation origin.
+    pub generic_origin: Option<WirGenericOrigin>,
+}
+
+/// A function type (maps to 1 Wasm func type).
+#[derive(Debug)]
+pub struct WirFuncType {
+    /// Name.
+    pub name: WirName,
+    /// Parameter types.
+    pub params: Vec<WirType>,
+    /// Result types.
+    pub results: Vec<WirType>,
+}
+
+// =============================================================================
+// WIR Type System
+// =============================================================================
+
+/// WIR type — Wado-level primitives + GC references.
+///
+/// Unlike Wasm's `ValType` (i32/i64/f32/f64 only), WIR preserves the full
+/// Wado type distinctions. The emit phase lowers these:
+///   - I8/I16/U8/U16/Bool/Char → i32 (locals) or i8/i16 (packed struct fields)
+///   - I32/U32 → i32
+///   - I64/U64 → i64
+///   - F32 → f32
+///   - F64 → f64
+///   - Enum/Flags → i32
+#[derive(Debug, Clone)]
+pub enum WirType {
+    // Signed integers
+    I8,
+    I16,
+    I32,
+    I64,
+    // Unsigned integers
+    U8,
+    U16,
+    U32,
+    U64,
+    // Floats
+    F32,
+    F64,
+    // Other primitives
+    Bool,
+    Char,
+    // Unit (no Wasm representation; zero-size)
+    Unit,
+    /// Named enum type (i32 at Wasm level).
+    Enum {
+        type_id: WirTypeId,
+    },
+    /// Named flags type (i32 at Wasm level).
+    Flags {
+        type_id: WirTypeId,
+    },
+    /// Reference to a named GC type.
+    Ref {
+        type_id: WirTypeId,
+        nullable: bool,
+    },
+    /// Abstract reference type (anyref, funcref, etc.).
+    AbstractRef {
+        heap_type: WirAbstractHeapType,
+        nullable: bool,
+    },
+}
+
+/// Abstract heap types for Wasm GC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WirAbstractHeapType {
+    Any,
+    Eq,
+    Struct,
+    Array,
+    Func,
+    None,
+    NoFunc,
+    Extern,
+}
+
+// =============================================================================
+// Functions
+// =============================================================================
+
+/// A function declaration with optional body.
+#[derive(Debug)]
+pub struct WirFunction {
+    /// Function name (display: "`Point::sum`", fq: "./`geometry.wado/Point::sum`").
+    pub name: WirName,
+    /// Function type ID (references a `WirTypeDef::Func` in `WirModule.types`).
+    pub type_id: WirTypeId,
+    /// Parameter names (types come from the referenced `WirFuncType`).
+    pub param_names: Vec<String>,
+    /// Body (None for imported functions).
+    pub body: Option<Vec<WirInstr>>,
+    /// Metadata (module source, span, attributes).
+    pub meta: WirMeta,
+    /// Generic instantiation origin.
+    pub generic_origin: Option<WirGenericOrigin>,
+    /// Effect requirements (for unparse display).
+    pub effects: Vec<String>,
+}
+
+// =============================================================================
+// Instructions
+// =============================================================================
+
+/// WIR instructions are tree-structured where operands are child nodes,
+/// not stack values. This makes the structure inspectable and allows inline
+/// local declaration.
+#[derive(Debug)]
+pub enum WirInstr {
+    // === Locals ===
+    /// Declare a new local variable inline (not in Wasm; lowered to pre-allocated local).
+    DeclareLocal {
+        name: String,
+        ty: WirType,
+    },
+    /// `local.get` by name.
+    LocalGet {
+        name: String,
+    },
+    /// `local.set` by name.
+    LocalSet {
+        name: String,
+        value: Box<WirInstr>,
+    },
+    /// `local.tee` by name.
+    LocalTee {
+        name: String,
+        value: Box<WirInstr>,
+    },
+
+    // === Globals ===
+    /// `global.get` by name.
+    GlobalGet {
+        name: WirName,
+    },
+    /// `global.set` by name.
+    GlobalSet {
+        name: WirName,
+        value: Box<WirInstr>,
+    },
+
+    // === Constants ===
+    I32Const(i32),
+    I64Const(i64),
+    F32Const(f32),
+    F64Const(f64),
+
+    // === Arithmetic (i32) ===
+    I32Add(Box<WirInstr>, Box<WirInstr>),
+    I32Sub(Box<WirInstr>, Box<WirInstr>),
+    I32Mul(Box<WirInstr>, Box<WirInstr>),
+    I32DivS(Box<WirInstr>, Box<WirInstr>),
+    I32DivU(Box<WirInstr>, Box<WirInstr>),
+    I32RemS(Box<WirInstr>, Box<WirInstr>),
+    I32RemU(Box<WirInstr>, Box<WirInstr>),
+    I32And(Box<WirInstr>, Box<WirInstr>),
+    I32Or(Box<WirInstr>, Box<WirInstr>),
+    I32Xor(Box<WirInstr>, Box<WirInstr>),
+    I32Shl(Box<WirInstr>, Box<WirInstr>),
+    I32ShrS(Box<WirInstr>, Box<WirInstr>),
+    I32ShrU(Box<WirInstr>, Box<WirInstr>),
+    I32Eqz(Box<WirInstr>),
+    I32Eq(Box<WirInstr>, Box<WirInstr>),
+    I32Ne(Box<WirInstr>, Box<WirInstr>),
+    I32LtS(Box<WirInstr>, Box<WirInstr>),
+    I32LtU(Box<WirInstr>, Box<WirInstr>),
+    I32GtS(Box<WirInstr>, Box<WirInstr>),
+    I32GtU(Box<WirInstr>, Box<WirInstr>),
+    I32LeS(Box<WirInstr>, Box<WirInstr>),
+    I32LeU(Box<WirInstr>, Box<WirInstr>),
+    I32GeS(Box<WirInstr>, Box<WirInstr>),
+    I32GeU(Box<WirInstr>, Box<WirInstr>),
+    I32WrapI64(Box<WirInstr>),
+    I32Clz(Box<WirInstr>),
+    I32Ctz(Box<WirInstr>),
+    I32Popcnt(Box<WirInstr>),
+    I32TruncF64S(Box<WirInstr>),
+    I32TruncF64U(Box<WirInstr>),
+    I32TruncF32S(Box<WirInstr>),
+    I32TruncF32U(Box<WirInstr>),
+    I32ReinterpretF32(Box<WirInstr>),
+    I32Extend8S(Box<WirInstr>),
+    I32Extend16S(Box<WirInstr>),
+
+    // === Arithmetic (i64) ===
+    I64Add(Box<WirInstr>, Box<WirInstr>),
+    I64Sub(Box<WirInstr>, Box<WirInstr>),
+    I64Mul(Box<WirInstr>, Box<WirInstr>),
+    I64DivS(Box<WirInstr>, Box<WirInstr>),
+    I64DivU(Box<WirInstr>, Box<WirInstr>),
+    I64RemS(Box<WirInstr>, Box<WirInstr>),
+    I64RemU(Box<WirInstr>, Box<WirInstr>),
+    I64And(Box<WirInstr>, Box<WirInstr>),
+    I64Or(Box<WirInstr>, Box<WirInstr>),
+    I64Xor(Box<WirInstr>, Box<WirInstr>),
+    I64Shl(Box<WirInstr>, Box<WirInstr>),
+    I64ShrS(Box<WirInstr>, Box<WirInstr>),
+    I64ShrU(Box<WirInstr>, Box<WirInstr>),
+    I64Eqz(Box<WirInstr>),
+    I64Eq(Box<WirInstr>, Box<WirInstr>),
+    I64Ne(Box<WirInstr>, Box<WirInstr>),
+    I64LtS(Box<WirInstr>, Box<WirInstr>),
+    I64LtU(Box<WirInstr>, Box<WirInstr>),
+    I64GtS(Box<WirInstr>, Box<WirInstr>),
+    I64GtU(Box<WirInstr>, Box<WirInstr>),
+    I64LeS(Box<WirInstr>, Box<WirInstr>),
+    I64LeU(Box<WirInstr>, Box<WirInstr>),
+    I64GeS(Box<WirInstr>, Box<WirInstr>),
+    I64GeU(Box<WirInstr>, Box<WirInstr>),
+    I64ExtendI32S(Box<WirInstr>),
+    I64ExtendI32U(Box<WirInstr>),
+    I64Clz(Box<WirInstr>),
+    I64Ctz(Box<WirInstr>),
+    I64Popcnt(Box<WirInstr>),
+    I64TruncF64S(Box<WirInstr>),
+    I64TruncF64U(Box<WirInstr>),
+    I64TruncF32S(Box<WirInstr>),
+    I64TruncF32U(Box<WirInstr>),
+    I64ReinterpretF64(Box<WirInstr>),
+
+    // === Arithmetic (i128 via i64 pairs, Wasm 3.0) ===
+    I64Add128(Box<WirInstr>, Box<WirInstr>, Box<WirInstr>, Box<WirInstr>),
+    I64Sub128(Box<WirInstr>, Box<WirInstr>, Box<WirInstr>, Box<WirInstr>),
+    I64MulWideU(Box<WirInstr>, Box<WirInstr>),
+    I64MulWideS(Box<WirInstr>, Box<WirInstr>),
+
+    // === Arithmetic (f32) ===
+    F32Add(Box<WirInstr>, Box<WirInstr>),
+    F32Sub(Box<WirInstr>, Box<WirInstr>),
+    F32Mul(Box<WirInstr>, Box<WirInstr>),
+    F32Div(Box<WirInstr>, Box<WirInstr>),
+    F32Neg(Box<WirInstr>),
+    F32Abs(Box<WirInstr>),
+    F32Ceil(Box<WirInstr>),
+    F32Floor(Box<WirInstr>),
+    F32Trunc(Box<WirInstr>),
+    F32Nearest(Box<WirInstr>),
+    F32Sqrt(Box<WirInstr>),
+    F32Min(Box<WirInstr>, Box<WirInstr>),
+    F32Max(Box<WirInstr>, Box<WirInstr>),
+    F32Copysign(Box<WirInstr>, Box<WirInstr>),
+    F32Eq(Box<WirInstr>, Box<WirInstr>),
+    F32Ne(Box<WirInstr>, Box<WirInstr>),
+    F32Lt(Box<WirInstr>, Box<WirInstr>),
+    F32Gt(Box<WirInstr>, Box<WirInstr>),
+    F32Le(Box<WirInstr>, Box<WirInstr>),
+    F32Ge(Box<WirInstr>, Box<WirInstr>),
+    F32ConvertI32S(Box<WirInstr>),
+    F32ConvertI32U(Box<WirInstr>),
+    F32ConvertI64S(Box<WirInstr>),
+    F32ConvertI64U(Box<WirInstr>),
+    F32DemoteF64(Box<WirInstr>),
+    F32ReinterpretI32(Box<WirInstr>),
+
+    // === Arithmetic (f64) ===
+    F64Add(Box<WirInstr>, Box<WirInstr>),
+    F64Sub(Box<WirInstr>, Box<WirInstr>),
+    F64Mul(Box<WirInstr>, Box<WirInstr>),
+    F64Div(Box<WirInstr>, Box<WirInstr>),
+    F64Neg(Box<WirInstr>),
+    F64Abs(Box<WirInstr>),
+    F64Ceil(Box<WirInstr>),
+    F64Floor(Box<WirInstr>),
+    F64Trunc(Box<WirInstr>),
+    F64Nearest(Box<WirInstr>),
+    F64Sqrt(Box<WirInstr>),
+    F64Min(Box<WirInstr>, Box<WirInstr>),
+    F64Max(Box<WirInstr>, Box<WirInstr>),
+    F64Copysign(Box<WirInstr>, Box<WirInstr>),
+    F64Eq(Box<WirInstr>, Box<WirInstr>),
+    F64Ne(Box<WirInstr>, Box<WirInstr>),
+    F64Lt(Box<WirInstr>, Box<WirInstr>),
+    F64Gt(Box<WirInstr>, Box<WirInstr>),
+    F64Le(Box<WirInstr>, Box<WirInstr>),
+    F64Ge(Box<WirInstr>, Box<WirInstr>),
+    F64ConvertI32S(Box<WirInstr>),
+    F64ConvertI32U(Box<WirInstr>),
+    F64ConvertI64S(Box<WirInstr>),
+    F64ConvertI64U(Box<WirInstr>),
+    F64PromoteF32(Box<WirInstr>),
+    F64ReinterpretI64(Box<WirInstr>),
+
+    // === GC: Struct ===
+    /// `struct.new` with type ID.
+    StructNew {
+        type_id: WirTypeId,
+        fields: Vec<WirInstr>,
+    },
+    /// `struct.get` with type ID and field name (field index resolved by emitter).
+    StructGet {
+        type_id: WirTypeId,
+        field_name: String,
+        expr: Box<WirInstr>,
+    },
+    /// `struct.set` with type ID and field name (field index resolved by emitter).
+    StructSet {
+        type_id: WirTypeId,
+        field_name: String,
+        expr: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+
+    // === GC: Array ===
+    ArrayNew {
+        type_id: WirTypeId,
+        init: Box<WirInstr>,
+        len: Box<WirInstr>,
+    },
+    ArrayNewDefault {
+        type_id: WirTypeId,
+        len: Box<WirInstr>,
+    },
+    ArrayNewData {
+        type_id: WirTypeId,
+        data_index: u32,
+        offset: Box<WirInstr>,
+        len: Box<WirInstr>,
+    },
+    ArrayNewFixed {
+        type_id: WirTypeId,
+        elements: Vec<WirInstr>,
+    },
+    ArrayGet {
+        type_id: WirTypeId,
+        array: Box<WirInstr>,
+        index: Box<WirInstr>,
+    },
+    ArrayGetS {
+        type_id: WirTypeId,
+        array: Box<WirInstr>,
+        index: Box<WirInstr>,
+    },
+    ArrayGetU {
+        type_id: WirTypeId,
+        array: Box<WirInstr>,
+        index: Box<WirInstr>,
+    },
+    ArraySet {
+        type_id: WirTypeId,
+        array: Box<WirInstr>,
+        index: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+    ArrayLen(Box<WirInstr>),
+    ArrayCopy {
+        dest_type_id: WirTypeId,
+        src_type_id: WirTypeId,
+        dest: Box<WirInstr>,
+        dest_offset: Box<WirInstr>,
+        src: Box<WirInstr>,
+        src_offset: Box<WirInstr>,
+        len: Box<WirInstr>,
+    },
+    ArrayFill {
+        type_id: WirTypeId,
+        array: Box<WirInstr>,
+        offset: Box<WirInstr>,
+        value: Box<WirInstr>,
+        len: Box<WirInstr>,
+    },
+
+    // === GC: Reference ===
+    RefNull {
+        heap_type: WirAbstractHeapType,
+    },
+    RefIsNull(Box<WirInstr>),
+    RefAsNonNull(Box<WirInstr>),
+    RefCast {
+        type_id: WirTypeId,
+        nullable: bool,
+        expr: Box<WirInstr>,
+    },
+    RefTest {
+        type_id: WirTypeId,
+        nullable: bool,
+        expr: Box<WirInstr>,
+    },
+    RefEq(Box<WirInstr>, Box<WirInstr>),
+    RefI31(Box<WirInstr>),
+    I31GetS(Box<WirInstr>),
+    I31GetU(Box<WirInstr>),
+    ExternInternalize(Box<WirInstr>),
+    ExternExternalize(Box<WirInstr>),
+
+    // === Control Flow ===
+    /// Block with optional label and result type.
+    Block {
+        label: Option<String>,
+        result: Option<WirType>,
+        body: Vec<WirInstr>,
+    },
+    /// Loop with optional label.
+    Loop {
+        label: Option<String>,
+        body: Vec<WirInstr>,
+    },
+    /// If/else with optional result type.
+    If {
+        condition: Box<WirInstr>,
+        result: Option<WirType>,
+        then_body: Vec<WirInstr>,
+        else_body: Option<Vec<WirInstr>>,
+    },
+    /// Branch to label.
+    Br {
+        depth: u32,
+    },
+    /// Conditional branch.
+    BrIf {
+        depth: u32,
+        condition: Box<WirInstr>,
+    },
+    /// Branch table (switch).
+    BrTable {
+        index: Box<WirInstr>,
+        targets: Vec<u32>,
+        default: u32,
+    },
+    /// Return from function.
+    Return {
+        value: Option<Box<WirInstr>>,
+    },
+    /// Unreachable trap.
+    Unreachable,
+    /// No operation (for structure).
+    Nop,
+    /// Drop a value.
+    Drop(Box<WirInstr>),
+    /// Select between two values.
+    Select {
+        condition: Box<WirInstr>,
+        if_true: Box<WirInstr>,
+        if_false: Box<WirInstr>,
+        ty: Option<WirType>,
+    },
+
+    // === Calls ===
+    Call {
+        func_id: WirFuncId,
+        args: Vec<WirInstr>,
+    },
+    CallIndirect {
+        type_id: WirTypeId,
+        table: u32,
+        index: Box<WirInstr>,
+        args: Vec<WirInstr>,
+    },
+    CallRef {
+        type_id: WirTypeId,
+        func_ref: Box<WirInstr>,
+        args: Vec<WirInstr>,
+    },
+    RefFunc {
+        func_id: WirFuncId,
+    },
+
+    // === Memory ===
+    MemorySize,
+    MemoryGrow(Box<WirInstr>),
+    I32Load {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+    },
+    I32Load8U {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+    },
+    I32Load8S {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+    },
+    I32Load16U {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+    },
+    I32Load16S {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+    },
+    I32Store {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+    I32Store8 {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+    I32Store16 {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+    I64Load {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+    },
+    I64Store {
+        offset: u64,
+        align: u32,
+        addr: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+
+    // === Table ===
+    TableGet {
+        table: u32,
+        index: Box<WirInstr>,
+    },
+    TableSet {
+        table: u32,
+        index: Box<WirInstr>,
+        value: Box<WirInstr>,
+    },
+
+    // === High-level compound instructions (lowered to sequences during emission) ===
+    /// Deep copy of a value type (struct, array, variant, option, tuple).
+    /// Lowered to field-by-field copy, array loop, etc. during emission.
+    ValueCopy {
+        type_id: WirTypeId,
+        source_type: WirCopyType,
+        expr: Box<WirInstr>,
+    },
+
+    /// Sequence of instructions (for statement blocks).
+    Seq(Vec<WirInstr>),
+}
+
+// =============================================================================
+// Copy Types
+// =============================================================================
+
+/// What kind of value copy to perform.
+#[derive(Debug)]
+pub enum WirCopyType {
+    Struct {
+        fields: Vec<WirCopyField>,
+    },
+    Array {
+        element_copy: Option<Box<WirCopyType>>,
+    },
+    Variant {
+        cases: Vec<WirCopyCase>,
+    },
+    Option {
+        inner_copy: Box<WirCopyType>,
+    },
+    Tuple {
+        field_copies: Vec<Option<WirCopyType>>,
+    },
+}
+
+/// A field in a struct copy.
+#[derive(Debug)]
+pub struct WirCopyField {
+    pub index: u32,
+    pub needs_copy: bool,
+    pub copy_type: Option<WirCopyType>,
+}
+
+/// A case in a variant copy.
+#[derive(Debug)]
+pub struct WirCopyCase {
+    pub index: u32,
+    pub name: String,
+    pub payload_copy: Option<WirCopyType>,
+}
+
+// =============================================================================
+// Module-level Sections
+// =============================================================================
+
+/// Rec group: a set of mutually-recursive type definitions.
+#[derive(Debug)]
+pub struct WirRecGroup {
+    /// Indices into `WirModule.types`.
+    pub type_indices: Vec<u32>,
+}
+
+/// An import entry.
+#[derive(Debug)]
+pub struct WirImport {
+    /// Import module name.
+    pub module: String,
+    /// Import field name.
+    pub field: String,
+    /// What is being imported.
+    pub desc: WirImportDesc,
+}
+
+/// Import descriptor.
+#[derive(Debug)]
+pub enum WirImportDesc {
+    Func {
+        type_id: WirTypeId,
+        name: WirName,
+    },
+    Global {
+        ty: WirType,
+        mutable: bool,
+    },
+    Memory {
+        min: u32,
+        max: Option<u32>,
+    },
+    Table {
+        ty: WirType,
+        min: u32,
+        max: Option<u32>,
+    },
+}
+
+/// A global variable.
+#[derive(Debug)]
+pub struct WirGlobal {
+    /// Global name.
+    pub name: WirName,
+    /// Value type.
+    pub ty: WirType,
+    /// Whether the global is mutable.
+    pub mutable: bool,
+    /// Initial value expression.
+    pub init: WirInstr,
+    /// Metadata.
+    pub meta: WirMeta,
+}
+
+/// An export entry.
+#[derive(Debug)]
+pub struct WirExport {
+    /// Export name (as seen by the host).
+    pub name: String,
+    /// What is being exported.
+    pub desc: WirExportDesc,
+}
+
+/// Export descriptor.
+#[derive(Debug)]
+pub enum WirExportDesc {
+    Func { func_id: WirFuncId },
+    Global { name: WirName },
+    Memory,
+    Table { index: u32 },
+}
+
+/// An element segment (for funcref tables).
+#[derive(Debug)]
+pub struct WirElement {
+    /// Table index (usually 0).
+    pub table: u32,
+    /// Offset expression.
+    pub offset: WirInstr,
+    /// Function references.
+    pub func_ids: Vec<WirFuncId>,
+}
+
+/// A data segment.
+#[derive(Debug)]
+pub struct WirData {
+    /// Segment data bytes.
+    pub bytes: Vec<u8>,
+    /// Optional memory offset (active segment). None for passive segments.
+    pub offset: Option<WirInstr>,
+}
+
+/// A branch hint annotation.
+#[derive(Debug)]
+pub struct WirBranchHint {
+    /// Function index.
+    pub func_index: u32,
+    /// Instruction offset within the function.
+    pub instr_offset: u32,
+    /// Hint: true = likely, false = unlikely.
+    pub likely: bool,
+}
+
+/// Name section entries for debugging.
+#[derive(Debug, Default)]
+pub struct WirNames {
+    /// Module name.
+    pub module_name: Option<String>,
+    /// Function names: index → name.
+    pub function_names: Vec<(u32, String)>,
+    /// Local names: `function_index` → vec of (`local_index`, name).
+    pub local_names: Vec<(u32, Vec<(u32, String)>)>,
+    /// Type names: index → name.
+    pub type_names: Vec<(u32, String)>,
+    /// Global names: index → name.
+    pub global_names: Vec<(u32, String)>,
+}
+
+// =============================================================================
+// Component Model
+// =============================================================================
+
+/// Component Model wrapper information.
+#[derive(Debug, Default)]
+pub struct WirComponent {
+    /// WASI interfaces to import.
+    pub wasi_imports: Vec<WirWasiImport>,
+    /// Bundled modules (fts, libm).
+    pub bundled_modules: Vec<WirBundledModule>,
+    /// World exports.
+    pub world_exports: Vec<WirWorldExport>,
+    /// Memory module configuration.
+    pub memory: WirMemoryConfig,
+}
+
+/// A WASI interface import.
+#[derive(Debug)]
+pub struct WirWasiImport {
+    /// Interface name (e.g., "wasi:cli/stdout@0.2.0").
+    pub interface: String,
+    /// Functions imported from this interface.
+    pub functions: Vec<WirWasiFunc>,
+}
+
+/// A function from a WASI interface.
+#[derive(Debug)]
+pub struct WirWasiFunc {
+    /// WIT-level function name (e.g., "write-via-stream").
+    pub wit_name: String,
+    /// Internal function name in the core module.
+    pub core_name: String,
+}
+
+/// A bundled module (e.g., fts, libm).
+#[derive(Debug)]
+pub struct WirBundledModule {
+    /// Module name (e.g., "fts", "libm").
+    pub name: String,
+    /// Whether this module is needed.
+    pub needed: bool,
+}
+
+/// A world export.
+#[derive(Debug)]
+pub struct WirWorldExport {
+    /// Export name in the component model.
+    pub name: String,
+    /// Core function to export.
+    pub core_func: String,
+}
+
+/// Memory module configuration.
+#[derive(Debug, Default)]
+pub struct WirMemoryConfig {
+    /// Whether to include a linear memory.
+    pub has_memory: bool,
+    /// Minimum memory pages.
+    pub min_pages: u32,
+}

--- a/wado-compiler/src/wir_unparse.rs
+++ b/wado-compiler/src/wir_unparse.rs
@@ -1,0 +1,1138 @@
+//! WIR → pseudo-Wado unparser for `wado dump --wir --unparse`.
+//!
+//! Renders a `WirModule` as readable pseudo-Wado source code for debugging.
+//! The output uses Wado syntax for type definitions (struct, variant, enum)
+//! and WAT-style mnemonics for arithmetic instructions (i32.add, f64.mul, etc.).
+
+use crate::wir::{
+    WirAbstractHeapType, WirArrayType, WirEnumType, WirExport, WirExportDesc, WirField,
+    WirFlagsType, WirFuncType, WirFunction, WirGlobal, WirImport, WirImportDesc, WirInstr,
+    WirModule, WirStructType, WirType, WirTypeDef, WirVariantType,
+};
+
+/// Unparse a `WirModule` into pseudo-Wado source code.
+pub fn unparse_wir(module: &WirModule) -> String {
+    let mut unparser = WirUnparser::new();
+    unparser.unparse(module);
+    unparser.output
+}
+
+struct WirUnparser {
+    output: String,
+    indent: usize,
+}
+
+impl WirUnparser {
+    fn new() -> Self {
+        Self {
+            output: String::new(),
+            indent: 0,
+        }
+    }
+
+    fn unparse(&mut self, module: &WirModule) {
+        // Type definitions
+        for type_def in &module.types {
+            self.unparse_type_def(type_def);
+            self.newline();
+        }
+
+        // Imports
+        if !module.imports.is_empty() {
+            for import in &module.imports {
+                self.unparse_import(import);
+            }
+            self.newline();
+        }
+
+        // Globals
+        for global in &module.globals {
+            self.unparse_global(global);
+        }
+        if !module.globals.is_empty() {
+            self.newline();
+        }
+
+        // Functions
+        for func in &module.functions {
+            self.unparse_function(func);
+            self.newline();
+        }
+
+        // Exports
+        if !module.exports.is_empty() {
+            for export in &module.exports {
+                self.unparse_export(export);
+            }
+        }
+    }
+
+    // === Type Definitions ===
+
+    fn unparse_type_def(&mut self, type_def: &WirTypeDef) {
+        match type_def {
+            WirTypeDef::Struct(s) => self.unparse_struct_type(s),
+            WirTypeDef::Variant(v) => self.unparse_variant_type(v),
+            WirTypeDef::Enum(e) => self.unparse_enum_type(e),
+            WirTypeDef::Flags(f) => self.unparse_flags_type(f),
+            WirTypeDef::Array(a) => self.unparse_array_type(a),
+            WirTypeDef::Func(f) => self.unparse_func_type(f),
+        }
+    }
+
+    fn unparse_struct_type(&mut self, s: &WirStructType) {
+        self.write_indent();
+        self.write("struct ");
+        self.write(&s.name.display);
+
+        if let Some(ref origin) = s.generic_origin {
+            self.write("<");
+            self.write(&origin.type_args.join(", "));
+            self.write(">");
+        }
+
+        self.write(" {");
+
+        if s.fields.is_empty() {
+            self.write(" }");
+        } else {
+            self.write(" ");
+            for (i, field) in s.fields.iter().enumerate() {
+                if i > 0 {
+                    self.write(", ");
+                }
+                self.unparse_field(field);
+            }
+            self.write(" }");
+        }
+
+        self.unparse_source_comment(&s.meta);
+
+        if let Some(ref origin) = s.generic_origin {
+            self.write(&format!(
+                "  // {}<T> with T={}",
+                origin.base_name,
+                origin.type_args.join(", ")
+            ));
+        }
+
+        if let Some(ref newtype) = s.newtype_origin {
+            self.write(&format!(
+                "  // newtype {} from {}",
+                newtype.name, newtype.module_source
+            ));
+        }
+
+        self.newline();
+    }
+
+    fn unparse_field(&mut self, field: &WirField) {
+        if field.mutable {
+            self.write("mut ");
+        }
+        self.write(&field.name);
+        self.write(": ");
+        self.write(&format_type(&field.ty));
+    }
+
+    fn unparse_variant_type(&mut self, v: &WirVariantType) {
+        self.write_indent();
+        self.write("variant ");
+        self.write(&v.name.display);
+        self.write(" {");
+        self.unparse_source_comment(&v.meta);
+        self.newline();
+
+        self.indent += 1;
+        for case in &v.cases {
+            self.write_indent();
+            self.write(&case.name);
+            if !case.payload.is_empty() {
+                self.write("(");
+                for (i, ty) in case.payload.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.write(&format_type(ty));
+                }
+                self.write(")");
+            }
+            self.write(",");
+            self.newline();
+        }
+        self.indent -= 1;
+
+        self.write_indent();
+        self.write("}");
+        self.newline();
+    }
+
+    fn unparse_enum_type(&mut self, e: &WirEnumType) {
+        self.write_indent();
+        self.write("enum ");
+        self.write(&e.name.display);
+        self.write(" { ");
+
+        for (i, case) in e.cases.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.write(&case.name);
+            self.write(" = ");
+            self.write(&case.discriminant.to_string());
+        }
+
+        self.write(" }");
+        self.unparse_source_comment(&e.meta);
+        self.newline();
+    }
+
+    fn unparse_flags_type(&mut self, f: &WirFlagsType) {
+        self.write_indent();
+        self.write("flags ");
+        self.write(&f.name.display);
+        self.write(" { ");
+
+        for (i, bit) in f.bits.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.write(&bit.name);
+            self.write(" = ");
+            self.write(&format!("bit{}", bit.position));
+        }
+
+        self.write(" }");
+        self.unparse_source_comment(&f.meta);
+        self.newline();
+    }
+
+    fn unparse_array_type(&mut self, a: &WirArrayType) {
+        self.write_indent();
+        self.write("array ");
+        self.write(&a.name.display);
+        if a.mutable {
+            self.write(" (mut ");
+        } else {
+            self.write(" (");
+        }
+        self.write(&format_type(&a.element_type));
+        self.write(")");
+        self.unparse_source_comment(&a.meta);
+        self.newline();
+    }
+
+    fn unparse_func_type(&mut self, f: &WirFuncType) {
+        self.write_indent();
+        self.write("type ");
+        self.write(&f.name.display);
+        self.write(" = fn(");
+        for (i, param) in f.params.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.write(&format_type(param));
+        }
+        self.write(")");
+        if !f.results.is_empty() {
+            self.write(" -> ");
+            if f.results.len() == 1 {
+                self.write(&format_type(&f.results[0]));
+            } else {
+                self.write("[");
+                for (i, r) in f.results.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.write(&format_type(r));
+                }
+                self.write("]");
+            }
+        }
+        self.newline();
+    }
+
+    // === Imports ===
+
+    fn unparse_import(&mut self, import: &WirImport) {
+        self.write_indent();
+        self.write("import ");
+        match &import.desc {
+            WirImportDesc::Func { name, .. } => {
+                self.write("fn ");
+                self.write(&name.display);
+            }
+            WirImportDesc::Global { ty, mutable } => {
+                self.write("global ");
+                if *mutable {
+                    self.write("mut ");
+                }
+                self.write(&format_type(ty));
+            }
+            WirImportDesc::Memory { min, max } => {
+                self.write(&format!("memory ({min}"));
+                if let Some(max) = max {
+                    self.write(&format!(", {max}"));
+                }
+                self.write(")");
+            }
+            WirImportDesc::Table { ty, min, max } => {
+                self.write(&format!("table ({min}"));
+                if let Some(max) = max {
+                    self.write(&format!(", {max}"));
+                }
+                self.write(&format!(") {}", format_type(ty)));
+            }
+        }
+        self.write(&format!(" from \"{}/{}\"", import.module, import.field));
+        self.newline();
+    }
+
+    // === Globals ===
+
+    fn unparse_global(&mut self, global: &WirGlobal) {
+        self.write_indent();
+        self.write("global ");
+        if global.mutable {
+            self.write("mut ");
+        }
+        self.write(&global.name.display);
+        self.write(": ");
+        self.write(&format_type(&global.ty));
+        self.write(" = ");
+        self.unparse_instr_inline(&global.init);
+        self.write(";");
+        self.unparse_source_comment(&global.meta);
+        self.newline();
+    }
+
+    // === Functions ===
+
+    fn unparse_function(&mut self, func: &WirFunction) {
+        self.write_indent();
+        self.write("fn \"");
+        self.write(&func.name.display);
+        self.write("\"(");
+
+        // We need the function type to get parameter types
+        // For now, just output parameter names
+        for (i, name) in func.param_names.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.write(name);
+        }
+        self.write(")");
+
+        if !func.effects.is_empty() {
+            self.write(" with ");
+            self.write(&func.effects.join(", "));
+        }
+
+        self.write(" {");
+        self.unparse_source_comment(&func.meta);
+        self.newline();
+
+        if let Some(ref body) = func.body {
+            self.indent += 1;
+            for instr in body {
+                self.unparse_instr(instr);
+            }
+            self.indent -= 1;
+        }
+
+        self.write_indent();
+        self.write("}");
+        self.newline();
+    }
+
+    // === Instructions ===
+
+    fn unparse_instr(&mut self, instr: &WirInstr) {
+        self.write_indent();
+        self.unparse_instr_inline(instr);
+        self.write(";");
+        self.newline();
+    }
+
+    fn unparse_instr_inline(&mut self, instr: &WirInstr) {
+        match instr {
+            // Locals
+            WirInstr::DeclareLocal { name, ty } => {
+                self.write(&format!("let {name}: {}", format_type(ty)));
+            }
+            WirInstr::LocalGet { name } => {
+                self.write(name);
+            }
+            WirInstr::LocalSet { name, value } => {
+                self.write(name);
+                self.write(" = ");
+                self.unparse_instr_inline(value);
+            }
+            WirInstr::LocalTee { name, value } => {
+                self.write(&format!("local.tee {name}("));
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+
+            // Globals
+            WirInstr::GlobalGet { name } => {
+                self.write(&name.display);
+            }
+            WirInstr::GlobalSet { name, value } => {
+                self.write(&name.display);
+                self.write(" = ");
+                self.unparse_instr_inline(value);
+            }
+
+            // Constants
+            WirInstr::I32Const(v) => self.write(&v.to_string()),
+            WirInstr::I64Const(v) => self.write(&format!("{v}_i64")),
+            WirInstr::F32Const(v) => self.write(&format!("{v}_f32")),
+            WirInstr::F64Const(v) => self.write(&v.to_string()),
+
+            // i32 binary ops
+            WirInstr::I32Add(a, b) => self.write_binop("i32.add", a, b),
+            WirInstr::I32Sub(a, b) => self.write_binop("i32.sub", a, b),
+            WirInstr::I32Mul(a, b) => self.write_binop("i32.mul", a, b),
+            WirInstr::I32DivS(a, b) => self.write_binop("i32.div_s", a, b),
+            WirInstr::I32DivU(a, b) => self.write_binop("i32.div_u", a, b),
+            WirInstr::I32RemS(a, b) => self.write_binop("i32.rem_s", a, b),
+            WirInstr::I32RemU(a, b) => self.write_binop("i32.rem_u", a, b),
+            WirInstr::I32And(a, b) => self.write_binop("i32.and", a, b),
+            WirInstr::I32Or(a, b) => self.write_binop("i32.or", a, b),
+            WirInstr::I32Xor(a, b) => self.write_binop("i32.xor", a, b),
+            WirInstr::I32Shl(a, b) => self.write_binop("i32.shl", a, b),
+            WirInstr::I32ShrS(a, b) => self.write_binop("i32.shr_s", a, b),
+            WirInstr::I32ShrU(a, b) => self.write_binop("i32.shr_u", a, b),
+            WirInstr::I32Eq(a, b) => self.write_binop("i32.eq", a, b),
+            WirInstr::I32Ne(a, b) => self.write_binop("i32.ne", a, b),
+            WirInstr::I32LtS(a, b) => self.write_binop("i32.lt_s", a, b),
+            WirInstr::I32LtU(a, b) => self.write_binop("i32.lt_u", a, b),
+            WirInstr::I32GtS(a, b) => self.write_binop("i32.gt_s", a, b),
+            WirInstr::I32GtU(a, b) => self.write_binop("i32.gt_u", a, b),
+            WirInstr::I32LeS(a, b) => self.write_binop("i32.le_s", a, b),
+            WirInstr::I32LeU(a, b) => self.write_binop("i32.le_u", a, b),
+            WirInstr::I32GeS(a, b) => self.write_binop("i32.ge_s", a, b),
+            WirInstr::I32GeU(a, b) => self.write_binop("i32.ge_u", a, b),
+
+            // i32 unary ops
+            WirInstr::I32Eqz(a) => self.write_unop("i32.eqz", a),
+            WirInstr::I32WrapI64(a) => self.write_unop("i32.wrap_i64", a),
+            WirInstr::I32Clz(a) => self.write_unop("i32.clz", a),
+            WirInstr::I32Ctz(a) => self.write_unop("i32.ctz", a),
+            WirInstr::I32Popcnt(a) => self.write_unop("i32.popcnt", a),
+            WirInstr::I32TruncF64S(a) => self.write_unop("i32.trunc_f64_s", a),
+            WirInstr::I32TruncF64U(a) => self.write_unop("i32.trunc_f64_u", a),
+            WirInstr::I32TruncF32S(a) => self.write_unop("i32.trunc_f32_s", a),
+            WirInstr::I32TruncF32U(a) => self.write_unop("i32.trunc_f32_u", a),
+            WirInstr::I32ReinterpretF32(a) => self.write_unop("i32.reinterpret_f32", a),
+            WirInstr::I32Extend8S(a) => self.write_unop("i32.extend8_s", a),
+            WirInstr::I32Extend16S(a) => self.write_unop("i32.extend16_s", a),
+
+            // i64 binary ops
+            WirInstr::I64Add(a, b) => self.write_binop("i64.add", a, b),
+            WirInstr::I64Sub(a, b) => self.write_binop("i64.sub", a, b),
+            WirInstr::I64Mul(a, b) => self.write_binop("i64.mul", a, b),
+            WirInstr::I64DivS(a, b) => self.write_binop("i64.div_s", a, b),
+            WirInstr::I64DivU(a, b) => self.write_binop("i64.div_u", a, b),
+            WirInstr::I64RemS(a, b) => self.write_binop("i64.rem_s", a, b),
+            WirInstr::I64RemU(a, b) => self.write_binop("i64.rem_u", a, b),
+            WirInstr::I64And(a, b) => self.write_binop("i64.and", a, b),
+            WirInstr::I64Or(a, b) => self.write_binop("i64.or", a, b),
+            WirInstr::I64Xor(a, b) => self.write_binop("i64.xor", a, b),
+            WirInstr::I64Shl(a, b) => self.write_binop("i64.shl", a, b),
+            WirInstr::I64ShrS(a, b) => self.write_binop("i64.shr_s", a, b),
+            WirInstr::I64ShrU(a, b) => self.write_binop("i64.shr_u", a, b),
+            WirInstr::I64Eq(a, b) => self.write_binop("i64.eq", a, b),
+            WirInstr::I64Ne(a, b) => self.write_binop("i64.ne", a, b),
+            WirInstr::I64LtS(a, b) => self.write_binop("i64.lt_s", a, b),
+            WirInstr::I64LtU(a, b) => self.write_binop("i64.lt_u", a, b),
+            WirInstr::I64GtS(a, b) => self.write_binop("i64.gt_s", a, b),
+            WirInstr::I64GtU(a, b) => self.write_binop("i64.gt_u", a, b),
+            WirInstr::I64LeS(a, b) => self.write_binop("i64.le_s", a, b),
+            WirInstr::I64LeU(a, b) => self.write_binop("i64.le_u", a, b),
+            WirInstr::I64GeS(a, b) => self.write_binop("i64.ge_s", a, b),
+            WirInstr::I64GeU(a, b) => self.write_binop("i64.ge_u", a, b),
+
+            // i64 unary ops
+            WirInstr::I64Eqz(a) => self.write_unop("i64.eqz", a),
+            WirInstr::I64ExtendI32S(a) => self.write_unop("i64.extend_i32_s", a),
+            WirInstr::I64ExtendI32U(a) => self.write_unop("i64.extend_i32_u", a),
+            WirInstr::I64Clz(a) => self.write_unop("i64.clz", a),
+            WirInstr::I64Ctz(a) => self.write_unop("i64.ctz", a),
+            WirInstr::I64Popcnt(a) => self.write_unop("i64.popcnt", a),
+            WirInstr::I64TruncF64S(a) => self.write_unop("i64.trunc_f64_s", a),
+            WirInstr::I64TruncF64U(a) => self.write_unop("i64.trunc_f64_u", a),
+            WirInstr::I64TruncF32S(a) => self.write_unop("i64.trunc_f32_s", a),
+            WirInstr::I64TruncF32U(a) => self.write_unop("i64.trunc_f32_u", a),
+            WirInstr::I64ReinterpretF64(a) => self.write_unop("i64.reinterpret_f64", a),
+
+            // i128 ops
+            WirInstr::I64Add128(a, b, c, d) => {
+                self.write("i64.add128(");
+                self.unparse_instr_inline(a);
+                self.write(", ");
+                self.unparse_instr_inline(b);
+                self.write(", ");
+                self.unparse_instr_inline(c);
+                self.write(", ");
+                self.unparse_instr_inline(d);
+                self.write(")");
+            }
+            WirInstr::I64Sub128(a, b, c, d) => {
+                self.write("i64.sub128(");
+                self.unparse_instr_inline(a);
+                self.write(", ");
+                self.unparse_instr_inline(b);
+                self.write(", ");
+                self.unparse_instr_inline(c);
+                self.write(", ");
+                self.unparse_instr_inline(d);
+                self.write(")");
+            }
+            WirInstr::I64MulWideU(a, b) => self.write_binop("i64.mul_wide_u", a, b),
+            WirInstr::I64MulWideS(a, b) => self.write_binop("i64.mul_wide_s", a, b),
+
+            // f32 binary ops
+            WirInstr::F32Add(a, b) => self.write_binop("f32.add", a, b),
+            WirInstr::F32Sub(a, b) => self.write_binop("f32.sub", a, b),
+            WirInstr::F32Mul(a, b) => self.write_binop("f32.mul", a, b),
+            WirInstr::F32Div(a, b) => self.write_binop("f32.div", a, b),
+            WirInstr::F32Min(a, b) => self.write_binop("f32.min", a, b),
+            WirInstr::F32Max(a, b) => self.write_binop("f32.max", a, b),
+            WirInstr::F32Copysign(a, b) => self.write_binop("f32.copysign", a, b),
+            WirInstr::F32Eq(a, b) => self.write_binop("f32.eq", a, b),
+            WirInstr::F32Ne(a, b) => self.write_binop("f32.ne", a, b),
+            WirInstr::F32Lt(a, b) => self.write_binop("f32.lt", a, b),
+            WirInstr::F32Gt(a, b) => self.write_binop("f32.gt", a, b),
+            WirInstr::F32Le(a, b) => self.write_binop("f32.le", a, b),
+            WirInstr::F32Ge(a, b) => self.write_binop("f32.ge", a, b),
+
+            // f32 unary ops
+            WirInstr::F32Neg(a) => self.write_unop("f32.neg", a),
+            WirInstr::F32Abs(a) => self.write_unop("f32.abs", a),
+            WirInstr::F32Ceil(a) => self.write_unop("f32.ceil", a),
+            WirInstr::F32Floor(a) => self.write_unop("f32.floor", a),
+            WirInstr::F32Trunc(a) => self.write_unop("f32.trunc", a),
+            WirInstr::F32Nearest(a) => self.write_unop("f32.nearest", a),
+            WirInstr::F32Sqrt(a) => self.write_unop("f32.sqrt", a),
+            WirInstr::F32ConvertI32S(a) => self.write_unop("f32.convert_i32_s", a),
+            WirInstr::F32ConvertI32U(a) => self.write_unop("f32.convert_i32_u", a),
+            WirInstr::F32ConvertI64S(a) => self.write_unop("f32.convert_i64_s", a),
+            WirInstr::F32ConvertI64U(a) => self.write_unop("f32.convert_i64_u", a),
+            WirInstr::F32DemoteF64(a) => self.write_unop("f32.demote_f64", a),
+            WirInstr::F32ReinterpretI32(a) => self.write_unop("f32.reinterpret_i32", a),
+
+            // f64 binary ops
+            WirInstr::F64Add(a, b) => self.write_binop("f64.add", a, b),
+            WirInstr::F64Sub(a, b) => self.write_binop("f64.sub", a, b),
+            WirInstr::F64Mul(a, b) => self.write_binop("f64.mul", a, b),
+            WirInstr::F64Div(a, b) => self.write_binop("f64.div", a, b),
+            WirInstr::F64Min(a, b) => self.write_binop("f64.min", a, b),
+            WirInstr::F64Max(a, b) => self.write_binop("f64.max", a, b),
+            WirInstr::F64Copysign(a, b) => self.write_binop("f64.copysign", a, b),
+            WirInstr::F64Eq(a, b) => self.write_binop("f64.eq", a, b),
+            WirInstr::F64Ne(a, b) => self.write_binop("f64.ne", a, b),
+            WirInstr::F64Lt(a, b) => self.write_binop("f64.lt", a, b),
+            WirInstr::F64Gt(a, b) => self.write_binop("f64.gt", a, b),
+            WirInstr::F64Le(a, b) => self.write_binop("f64.le", a, b),
+            WirInstr::F64Ge(a, b) => self.write_binop("f64.ge", a, b),
+
+            // f64 unary ops
+            WirInstr::F64Neg(a) => self.write_unop("f64.neg", a),
+            WirInstr::F64Abs(a) => self.write_unop("f64.abs", a),
+            WirInstr::F64Ceil(a) => self.write_unop("f64.ceil", a),
+            WirInstr::F64Floor(a) => self.write_unop("f64.floor", a),
+            WirInstr::F64Trunc(a) => self.write_unop("f64.trunc", a),
+            WirInstr::F64Nearest(a) => self.write_unop("f64.nearest", a),
+            WirInstr::F64Sqrt(a) => self.write_unop("f64.sqrt", a),
+            WirInstr::F64ConvertI32S(a) => self.write_unop("f64.convert_i32_s", a),
+            WirInstr::F64ConvertI32U(a) => self.write_unop("f64.convert_i32_u", a),
+            WirInstr::F64ConvertI64S(a) => self.write_unop("f64.convert_i64_s", a),
+            WirInstr::F64ConvertI64U(a) => self.write_unop("f64.convert_i64_u", a),
+            WirInstr::F64PromoteF32(a) => self.write_unop("f64.promote_f32", a),
+            WirInstr::F64ReinterpretI64(a) => self.write_unop("f64.reinterpret_i64", a),
+
+            // GC: Struct
+            WirInstr::StructNew { type_id, fields } => {
+                self.write(&format!("struct.new {type_id}("));
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.unparse_instr_inline(f);
+                }
+                self.write(")");
+            }
+            WirInstr::StructGet {
+                field_name, expr, ..
+            } => {
+                self.unparse_instr_inline(expr);
+                self.write(".");
+                self.write(field_name);
+            }
+            WirInstr::StructSet {
+                field_name,
+                expr,
+                value,
+                ..
+            } => {
+                self.unparse_instr_inline(expr);
+                self.write(".");
+                self.write(field_name);
+                self.write(" = ");
+                self.unparse_instr_inline(value);
+            }
+
+            // GC: Array
+            WirInstr::ArrayNew { type_id, init, len } => {
+                self.write(&format!("array.new {type_id}("));
+                self.unparse_instr_inline(init);
+                self.write(", ");
+                self.unparse_instr_inline(len);
+                self.write(")");
+            }
+            WirInstr::ArrayNewDefault { type_id, len } => {
+                self.write(&format!("array.new_default {type_id}("));
+                self.unparse_instr_inline(len);
+                self.write(")");
+            }
+            WirInstr::ArrayNewData {
+                type_id,
+                data_index,
+                offset,
+                len,
+            } => {
+                self.write(&format!("array.new_data {type_id} {data_index}("));
+                self.unparse_instr_inline(offset);
+                self.write(", ");
+                self.unparse_instr_inline(len);
+                self.write(")");
+            }
+            WirInstr::ArrayNewFixed { type_id, elements } => {
+                self.write(&format!("array.new_fixed {type_id}("));
+                for (i, e) in elements.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.unparse_instr_inline(e);
+                }
+                self.write(")");
+            }
+            WirInstr::ArrayGet {
+                type_id,
+                array,
+                index,
+            } => {
+                self.write(&format!("array.get {type_id}("));
+                self.unparse_instr_inline(array);
+                self.write(", ");
+                self.unparse_instr_inline(index);
+                self.write(")");
+            }
+            WirInstr::ArrayGetS {
+                type_id,
+                array,
+                index,
+            } => {
+                self.write(&format!("array.get_s {type_id}("));
+                self.unparse_instr_inline(array);
+                self.write(", ");
+                self.unparse_instr_inline(index);
+                self.write(")");
+            }
+            WirInstr::ArrayGetU {
+                type_id,
+                array,
+                index,
+            } => {
+                self.write(&format!("array.get_u {type_id}("));
+                self.unparse_instr_inline(array);
+                self.write(", ");
+                self.unparse_instr_inline(index);
+                self.write(")");
+            }
+            WirInstr::ArraySet {
+                type_id,
+                array,
+                index,
+                value,
+            } => {
+                self.write(&format!("array.set {type_id}("));
+                self.unparse_instr_inline(array);
+                self.write(", ");
+                self.unparse_instr_inline(index);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+            WirInstr::ArrayLen(a) => self.write_unop("array.len", a),
+            WirInstr::ArrayCopy {
+                dest_type_id,
+                src_type_id,
+                dest,
+                dest_offset,
+                src,
+                src_offset,
+                len,
+            } => {
+                self.write(&format!("array.copy {dest_type_id} {src_type_id}("));
+                self.unparse_instr_inline(dest);
+                self.write(", ");
+                self.unparse_instr_inline(dest_offset);
+                self.write(", ");
+                self.unparse_instr_inline(src);
+                self.write(", ");
+                self.unparse_instr_inline(src_offset);
+                self.write(", ");
+                self.unparse_instr_inline(len);
+                self.write(")");
+            }
+            WirInstr::ArrayFill {
+                type_id,
+                array,
+                offset,
+                value,
+                len,
+            } => {
+                self.write(&format!("array.fill {type_id}("));
+                self.unparse_instr_inline(array);
+                self.write(", ");
+                self.unparse_instr_inline(offset);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(", ");
+                self.unparse_instr_inline(len);
+                self.write(")");
+            }
+
+            // GC: Reference
+            WirInstr::RefNull { heap_type } => {
+                self.write(&format!(
+                    "ref.null {}",
+                    format_abstract_heap_type(heap_type)
+                ));
+            }
+            WirInstr::RefIsNull(a) => self.write_unop("ref.is_null", a),
+            WirInstr::RefAsNonNull(a) => self.write_unop("ref.as_non_null", a),
+            WirInstr::RefCast {
+                type_id,
+                nullable,
+                expr,
+            } => {
+                let null_str = if *nullable { " null" } else { "" };
+                self.write(&format!("ref.cast{null_str} {type_id}("));
+                self.unparse_instr_inline(expr);
+                self.write(")");
+            }
+            WirInstr::RefTest {
+                type_id,
+                nullable,
+                expr,
+            } => {
+                let null_str = if *nullable { " null" } else { "" };
+                self.write(&format!("ref.test{null_str} {type_id}("));
+                self.unparse_instr_inline(expr);
+                self.write(")");
+            }
+            WirInstr::RefEq(a, b) => self.write_binop("ref.eq", a, b),
+            WirInstr::RefI31(a) => self.write_unop("ref.i31", a),
+            WirInstr::I31GetS(a) => self.write_unop("i31.get_s", a),
+            WirInstr::I31GetU(a) => self.write_unop("i31.get_u", a),
+            WirInstr::ExternInternalize(a) => self.write_unop("extern.internalize", a),
+            WirInstr::ExternExternalize(a) => self.write_unop("extern.externalize", a),
+
+            // Control Flow
+            WirInstr::Block {
+                label,
+                result,
+                body,
+            } => {
+                if let Some(label) = label {
+                    self.write(&format!("{label}: "));
+                }
+                self.write("block");
+                if let Some(ty) = result {
+                    self.write(&format!(" -> {}", format_type(ty)));
+                }
+                self.write(" {");
+                self.newline();
+                self.indent += 1;
+                for instr in body {
+                    self.unparse_instr(instr);
+                }
+                self.indent -= 1;
+                self.write_indent();
+                self.write("}");
+            }
+            WirInstr::Loop { label, body } => {
+                if let Some(label) = label {
+                    self.write(&format!("{label}: "));
+                }
+                self.write("loop {");
+                self.newline();
+                self.indent += 1;
+                for instr in body {
+                    self.unparse_instr(instr);
+                }
+                self.indent -= 1;
+                self.write_indent();
+                self.write("}");
+            }
+            WirInstr::If {
+                condition,
+                result,
+                then_body,
+                else_body,
+            } => {
+                self.write("if ");
+                self.unparse_instr_inline(condition);
+                if let Some(ty) = result {
+                    self.write(&format!(" -> {}", format_type(ty)));
+                }
+                self.write(" {");
+                self.newline();
+                self.indent += 1;
+                for instr in then_body {
+                    self.unparse_instr(instr);
+                }
+                self.indent -= 1;
+                if let Some(else_body) = else_body {
+                    self.write_indent();
+                    self.write("} else {");
+                    self.newline();
+                    self.indent += 1;
+                    for instr in else_body {
+                        self.unparse_instr(instr);
+                    }
+                    self.indent -= 1;
+                }
+                self.write_indent();
+                self.write("}");
+            }
+            WirInstr::Br { depth } => {
+                self.write(&format!("br {depth}"));
+            }
+            WirInstr::BrIf { depth, condition } => {
+                self.write(&format!("br_if {depth} "));
+                self.unparse_instr_inline(condition);
+            }
+            WirInstr::BrTable {
+                index,
+                targets,
+                default,
+            } => {
+                self.write("br_table ");
+                self.unparse_instr_inline(index);
+                self.write(" [");
+                for (i, t) in targets.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.write(&t.to_string());
+                }
+                self.write(&format!("] default={default}"));
+            }
+            WirInstr::Return { value } => {
+                self.write("return");
+                if let Some(v) = value {
+                    self.write(" ");
+                    self.unparse_instr_inline(v);
+                }
+            }
+            WirInstr::Unreachable => self.write("unreachable"),
+            WirInstr::Nop => self.write("nop"),
+            WirInstr::Drop(a) => self.write_unop("drop", a),
+            WirInstr::Select {
+                condition,
+                if_true,
+                if_false,
+                ty,
+            } => {
+                self.write("select");
+                if let Some(ty) = ty {
+                    self.write(&format!(" {}", format_type(ty)));
+                }
+                self.write("(");
+                self.unparse_instr_inline(condition);
+                self.write(", ");
+                self.unparse_instr_inline(if_true);
+                self.write(", ");
+                self.unparse_instr_inline(if_false);
+                self.write(")");
+            }
+
+            // Calls
+            WirInstr::Call { func_id, args } => {
+                self.write(&format!("call {func_id}("));
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.unparse_instr_inline(a);
+                }
+                self.write(")");
+            }
+            WirInstr::CallIndirect {
+                type_id,
+                table,
+                index,
+                args,
+            } => {
+                self.write(&format!("call_indirect {type_id} table={table}("));
+                self.unparse_instr_inline(index);
+                for a in args {
+                    self.write(", ");
+                    self.unparse_instr_inline(a);
+                }
+                self.write(")");
+            }
+            WirInstr::CallRef {
+                type_id,
+                func_ref,
+                args,
+            } => {
+                self.write(&format!("call_ref {type_id}("));
+                self.unparse_instr_inline(func_ref);
+                for a in args {
+                    self.write(", ");
+                    self.unparse_instr_inline(a);
+                }
+                self.write(")");
+            }
+            WirInstr::RefFunc { func_id } => {
+                self.write(&format!("ref.func {func_id}"));
+            }
+
+            // Memory
+            WirInstr::MemorySize => self.write("memory.size"),
+            WirInstr::MemoryGrow(a) => self.write_unop("memory.grow", a),
+            WirInstr::I32Load { offset, addr, .. } => {
+                self.write(&format!("i32.load offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(")");
+            }
+            WirInstr::I32Load8U { offset, addr, .. } => {
+                self.write(&format!("i32.load8_u offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(")");
+            }
+            WirInstr::I32Load8S { offset, addr, .. } => {
+                self.write(&format!("i32.load8_s offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(")");
+            }
+            WirInstr::I32Load16U { offset, addr, .. } => {
+                self.write(&format!("i32.load16_u offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(")");
+            }
+            WirInstr::I32Load16S { offset, addr, .. } => {
+                self.write(&format!("i32.load16_s offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(")");
+            }
+            WirInstr::I32Store {
+                offset,
+                addr,
+                value,
+                ..
+            } => {
+                self.write(&format!("i32.store offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+            WirInstr::I32Store8 {
+                offset,
+                addr,
+                value,
+                ..
+            } => {
+                self.write(&format!("i32.store8 offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+            WirInstr::I32Store16 {
+                offset,
+                addr,
+                value,
+                ..
+            } => {
+                self.write(&format!("i32.store16 offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+            WirInstr::I64Load { offset, addr, .. } => {
+                self.write(&format!("i64.load offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(")");
+            }
+            WirInstr::I64Store {
+                offset,
+                addr,
+                value,
+                ..
+            } => {
+                self.write(&format!("i64.store offset={offset}("));
+                self.unparse_instr_inline(addr);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+
+            // Table
+            WirInstr::TableGet { table, index } => {
+                self.write(&format!("table.get {table}("));
+                self.unparse_instr_inline(index);
+                self.write(")");
+            }
+            WirInstr::TableSet {
+                table,
+                index,
+                value,
+            } => {
+                self.write(&format!("table.set {table}("));
+                self.unparse_instr_inline(index);
+                self.write(", ");
+                self.unparse_instr_inline(value);
+                self.write(")");
+            }
+
+            // Compound
+            WirInstr::ValueCopy { type_id, expr, .. } => {
+                self.write(&format!("value_copy {type_id}("));
+                self.unparse_instr_inline(expr);
+                self.write(")");
+            }
+
+            WirInstr::Seq(instrs) => {
+                for (i, instr) in instrs.iter().enumerate() {
+                    if i > 0 {
+                        self.write("; ");
+                    }
+                    self.unparse_instr_inline(instr);
+                }
+            }
+        }
+    }
+
+    // === Exports ===
+
+    fn unparse_export(&mut self, export: &WirExport) {
+        self.write_indent();
+        self.write("export ");
+        match &export.desc {
+            WirExportDesc::Func { func_id } => {
+                self.write(&format!("fn {func_id}"));
+            }
+            WirExportDesc::Global { name } => {
+                self.write(&format!("global {}", name.display));
+            }
+            WirExportDesc::Memory => {
+                self.write("memory");
+            }
+            WirExportDesc::Table { index } => {
+                self.write(&format!("table {index}"));
+            }
+        }
+        self.write(&format!(" as \"{}\"", export.name));
+        self.newline();
+    }
+
+    // === Helpers ===
+
+    fn write_binop(&mut self, name: &str, a: &WirInstr, b: &WirInstr) {
+        self.write(name);
+        self.write("(");
+        self.unparse_instr_inline(a);
+        self.write(", ");
+        self.unparse_instr_inline(b);
+        self.write(")");
+    }
+
+    fn write_unop(&mut self, name: &str, a: &WirInstr) {
+        self.write(name);
+        self.write("(");
+        self.unparse_instr_inline(a);
+        self.write(")");
+    }
+
+    fn unparse_source_comment(&mut self, meta: &crate::wir::WirMeta) {
+        if let Some(ref source) = meta.module_source {
+            self.write(&format!("  // from {source}"));
+        }
+    }
+
+    fn write(&mut self, s: &str) {
+        self.output.push_str(s);
+    }
+
+    fn write_indent(&mut self) {
+        for _ in 0..self.indent {
+            self.output.push_str("    ");
+        }
+    }
+
+    fn newline(&mut self) {
+        self.output.push('\n');
+    }
+}
+
+/// Format a `WirType` as a string for display.
+pub fn format_type(ty: &WirType) -> String {
+    match ty {
+        WirType::I8 => "i8".to_string(),
+        WirType::I16 => "i16".to_string(),
+        WirType::I32 => "i32".to_string(),
+        WirType::I64 => "i64".to_string(),
+        WirType::U8 => "u8".to_string(),
+        WirType::U16 => "u16".to_string(),
+        WirType::U32 => "u32".to_string(),
+        WirType::U64 => "u64".to_string(),
+        WirType::F32 => "f32".to_string(),
+        WirType::F64 => "f64".to_string(),
+        WirType::Bool => "bool".to_string(),
+        WirType::Char => "char".to_string(),
+        WirType::Unit => "()".to_string(),
+        WirType::Enum { type_id } => type_id.to_string(),
+        WirType::Flags { type_id } => type_id.to_string(),
+        WirType::Ref { type_id, nullable } => {
+            if *nullable {
+                format!("ref null {type_id}")
+            } else {
+                format!("ref {type_id}")
+            }
+        }
+        WirType::AbstractRef {
+            heap_type,
+            nullable,
+        } => {
+            let ht = format_abstract_heap_type(heap_type);
+            if *nullable {
+                format!("ref null {ht}")
+            } else {
+                format!("ref {ht}")
+            }
+        }
+    }
+}
+
+fn format_abstract_heap_type(ht: &WirAbstractHeapType) -> &'static str {
+    match ht {
+        WirAbstractHeapType::Any => "any",
+        WirAbstractHeapType::Eq => "eq",
+        WirAbstractHeapType::Struct => "struct",
+        WirAbstractHeapType::Array => "array",
+        WirAbstractHeapType::Func => "func",
+        WirAbstractHeapType::None => "none",
+        WirAbstractHeapType::NoFunc => "nofunc",
+        WirAbstractHeapType::Extern => "extern",
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces WIR (Wasm IR), a new tree-structured intermediate representation between TIR and Wasm binary. WIR bridges the gap between high-level Wado semantics and low-level Wasm instructions while remaining readable and debuggable.

## Key Changes

- **New `wir.rs` module (1176 lines)**: Defines the complete WIR data structure including:
  - `WirModule`: Top-level container with types, functions, imports, exports, globals, etc.
  - Type definitions: `WirStructType`, `WirVariantType`, `WirEnumType`, `WirFlagsType`, `WirArrayType`, `WirFuncType`
  - `WirType`: Wado-level type system (I8, U8, Bool, Char, etc.) instead of Wasm's i32-for-everything
  - `WirInstr`: Tree-structured instructions with named locals and explicit operand nesting
  - Lightweight reference types: `WirTypeId` and `WirFuncId` using `Rc<str>` for efficient cloning
  - Metadata preservation: `WirMeta`, `WirAttribute`, `WirGenericOrigin`, `WirNewtypeOrigin`

- **New `wir_unparse.rs` module (1138 lines)**: Unparser for debugging that renders `WirModule` as pseudo-Wado source code with:
  - Type definition unparsing (struct, variant, enum, flags, array, func types)
  - Import/export/global unparsing
  - Function body unparsing with WAT-style mnemonics (i32.add, f64.mul, etc.)
  - Inline instruction rendering for readability

- **Updated `lib.rs`**: 
  - Added `pub mod wir` and `pub mod wir_unparse` exports
  - Extended `DumpResult` struct with `wir_module: Option<wir::WirModule>` field

- **Updated `dump.rs`**: Added `--wir` flag to CLI for dumping WIR representation

- **Updated documentation**: Added WIR to compiler phases in `docs/compiler.md` and `AGENTS.md`

## Notable Implementation Details

- **Efficient ID types**: `WirTypeId` and `WirFuncId` use integer indices for O(1) equality/hashing while storing `Rc<str>` for readable debug output
- **Named locals**: Unlike Wasm's pre-allocated local indices, WIR uses string names that are resolved during emission
- **Tree-structured instructions**: Operands are nested as child nodes rather than stack values, making the IR inspectable and debuggable
- **Wado-level types preserved**: Distinguishes between I8/I16/U8/U16/Bool/Char (lowered to i32 at Wasm level) rather than collapsing to Wasm primitives
- **Metadata carried through**: Source locations, module origins, and attributes preserved from TIR for debugging
- **Generic and newtype tracking**: Captures instantiation origins for better error messages and debugging

https://claude.ai/code/session_01Qj6X5vATqK4ZXmL5mLojCM