### PR TITLE
Add WIR pipeline stub and E2E test infrastructure

### DIFF
--- a/docs/wep-2026-02-14-wir-layer.md
+++ b/docs/wep-2026-02-14-wir-layer.md
@@ -881,11 +881,11 @@ After this phase: `wado dump --wir --unparse` works but shows an empty module.
 
 Set up the mechanism to run the same E2E test fixtures through the WIR pipeline.
 
-- [ ] **Step 2a**: Create `compile_with_wir(&Project) -> Vec<u8>` in a new module. This is the WIR pipeline entry point: calls `tir_to_wir` → `wir_emit` and returns Wasm bytes. Initially returns a minimal valid Wasm component (stub).
-- [ ] **Step 2b**: Create `tests/wir_e2e.rs` — a parallel E2E test harness that uses `compile_with_wir` instead of `Codegen::generate_wasm`. Same fixtures, same `__DATA__` specs. Gated by `WADO_WIR_TEST=1` so normal `make test` is unaffected.
-- [ ] **Step 2c**: Add a progress tracking mechanism — e.g., a test that counts how many fixtures pass vs. fail through the WIR pipeline, printed as a summary.
+- [x] **Step 2a**: Create `compile_with_wir(&Project) -> Vec<u8>` in `tir_to_wir/mod.rs`. Uses `CompilerOptions.use_wir_backend` flag to switch codegen path. Stub returns a minimal valid Wasm component (synchronous `run` → `result<_, _>`).
+- [x] **Step 2b**: Create `tests/wir_e2e.rs` — a parallel E2E test harness that uses `compile_with_wir` instead of `Codegen::generate_wasm`. Same fixtures, same `__DATA__` specs. Gated by `WADO_WIR_TEST=1` so normal `make test` is unaffected.
+- [x] **Step 2c**: Create `tests/wir_progress.rs` — progress tracker that runs all fixtures through the WIR pipeline and reports pass/fail counts. Initial result: 94/670 (14.0%) pass at O2 (tests expecting no output or compile errors before codegen).
 
-After this phase: `WADO_WIR_TEST=1 cargo test --test wir_e2e` runs but all tests fail. The scaffolding for incremental progress is in place.
+After this phase: `WADO_WIR_TEST=1 cargo test --test wir_e2e` runs. 94/670 fixtures pass through the stub (those expecting no output). The scaffolding for incremental progress is in place.
 
 ### Phase 3: Core Translation
 

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -231,6 +231,7 @@ pub async fn compile_with_full_opts(
     let options = wado_compiler::CompilerOptions {
         opt_level: to_compiler_opt_level(opt_level),
         target_world,
+        use_wir_backend: false,
     };
 
     // Compile using async API

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -104,6 +104,7 @@ pub mod stdlib;
 pub mod symbol;
 pub mod syntax;
 pub mod tir;
+pub mod tir_to_wir;
 pub mod token;
 pub mod unparse;
 pub mod wasm_builder;
@@ -188,6 +189,9 @@ pub struct CompilerOptions {
     /// Target world name (e.g., "Command", "Service")
     /// Defaults to "Command" if not specified
     pub target_world: Option<String>,
+    /// Use the WIR backend instead of the legacy codegen.
+    /// When true, the compiler uses `tir_to_wir` → `wir_emit` instead of `Codegen::generate_wasm`.
+    pub use_wir_backend: bool,
 }
 
 /// Compile Wado source code with a `CompilerHost` for I/O operations.
@@ -215,6 +219,7 @@ pub async fn compile_with_host<H: CompilerHost>(
     let options = CompilerOptions {
         opt_level,
         target_world: None,
+        use_wir_backend: false,
     };
     compile_with_options(source, host, filename, options).await
 }
@@ -374,7 +379,10 @@ pub async fn compile_with_options<H: CompilerHost>(
     };
 
     // === Phase 12: Codegen ===
-    let wasm = {
+    let wasm = if options.use_wir_backend {
+        let _span = logger.span("tir_to_wir");
+        tir_to_wir::compile_with_wir(&project)
+    } else {
         let _span = logger.span("codegen");
         Codegen::generate_wasm(&project)
     };

--- a/wado-compiler/src/tir_to_wir/emit.rs
+++ b/wado-compiler/src/tir_to_wir/emit.rs
@@ -1,0 +1,125 @@
+//! WIR emission — converts a `WirModule` into Wasm binary bytes.
+//!
+//! Currently contains only the stub component builder for Phase 2.
+//! Phase 3 will implement the full `WirModule` → Wasm translation.
+
+use wasm_encoder::{
+    CodeSection, ComponentBuilder, ComponentExportKind, ComponentValType, ExportKind,
+    ExportSection, Function, FunctionSection, Instruction, Module, TypeSection, ValType,
+};
+
+/// Build a minimal valid Wasm component for the Phase 2 stub.
+///
+/// The component exports a synchronous "run" function that returns `result<_, _>`
+/// (Ok with unit payload). It has no WASI imports, no stdout, no side effects.
+///
+/// This produces a component that wasmtime can load and execute, allowing
+/// the E2E test infrastructure to run the full pipeline. All tests will fail
+/// because the stub produces no output, but they fail at the assertion level
+/// (output mismatch) rather than the infrastructure level (invalid Wasm).
+pub fn build_stub_component() -> Vec<u8> {
+    let mut component = ComponentBuilder::default();
+
+    // 1. Build a minimal core module that exports "run" returning i32
+    let core_module = build_stub_core_module();
+    component.core_module_raw(Some("m"), &core_module);
+
+    // 2. Instantiate the core module (no imports needed)
+    component.core_instantiate(
+        Some("i"),
+        0, // core module index
+        Vec::<(&str, wasm_encoder::ModuleArg)>::new(),
+    );
+
+    // 3. Alias the core "run" function out of the instance
+    component.core_alias_export(
+        Some("run-core"),
+        0, // core instance index
+        "run",
+        ExportKind::Func,
+    );
+
+    // 4. Define the result type: result<_, _> (both payloads are unit)
+    let (result_type_idx, enc) = component.ty(Some("result-ty"));
+    enc.defined_type().result(None, None);
+
+    // 5. Define the function type: () -> result<_, _>
+    let (_func_type_idx, enc) = component.ty(Some("run-ty"));
+    enc.function()
+        .params::<[(&str, ComponentValType); 0], ComponentValType>([])
+        .result(Some(ComponentValType::Type(result_type_idx)));
+
+    // 6. Canon lift: wrap core function as component function
+    //    Synchronous lifting: core function returns i32 (0=Ok, 1=Err for result)
+    //    call_async works fine with synchronously-lifted functions.
+    component.lift_func(
+        Some("run"),
+        0, // core func index (from alias)
+        1, // component type index (run-ty)
+        [],
+    );
+
+    // 7. Export the component function as "run"
+    component.export(
+        "run",
+        ComponentExportKind::Func,
+        0, // component func index
+        None,
+    );
+
+    component.finish()
+}
+
+/// Build a minimal core Wasm module with a single "run" function.
+///
+/// The function signature is `() -> i32`:
+/// - Returns 0 for Ok(()) in the result discriminant
+fn build_stub_core_module() -> Vec<u8> {
+    let mut module = Module::new();
+
+    // Type section: () -> i32
+    let mut types = TypeSection::new();
+    types.ty().function([], [ValType::I32]);
+    module.section(&types);
+
+    // Function section: 1 function of type 0
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+
+    // Export section: export "run"
+    let mut exports = ExportSection::new();
+    exports.export("run", ExportKind::Func, 0);
+    module.section(&exports);
+
+    // Code section: return 0 (Ok)
+    let mut code = CodeSection::new();
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::I32Const(0)); // result: Ok(())
+    f.instruction(&Instruction::End);
+    code.function(&f);
+    module.section(&code);
+
+    module.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_component_is_valid_wasm() {
+        let wasm = build_stub_component();
+        // Verify it's a valid Wasm component by checking the magic bytes
+        assert!(wasm.len() > 8, "component should have content");
+        // Wasm component magic: \0asm followed by layer 0x0a (component)
+        assert_eq!(&wasm[0..4], b"\0asm", "should start with Wasm magic");
+
+        // Validate with wasmparser
+        let mut validator =
+            wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all());
+        validator
+            .validate_all(&wasm)
+            .expect("stub component should be valid Wasm");
+    }
+}

--- a/wado-compiler/src/tir_to_wir/mod.rs
+++ b/wado-compiler/src/tir_to_wir/mod.rs
@@ -1,0 +1,26 @@
+//! TIR-to-WIR translation — converts optimized TIR (Project) into a WIR module.
+//!
+//! This module is the entry point for the WIR pipeline:
+//!   `compile_with_wir(&Project) -> Vec<u8>`
+//!
+//! Currently a stub that returns a minimal valid Wasm component.
+//! Phase 3 will incrementally implement the actual translation.
+
+use crate::project::Project;
+
+mod emit;
+
+/// Compile a Project to Wasm bytes using the WIR pipeline.
+///
+/// This is the WIR pipeline entry point, parallel to `Codegen::generate_wasm`.
+/// Pipeline: Project → `tir_to_wir` (`WirModule`) → `wir_emit` (Wasm bytes)
+///
+/// Currently returns a minimal stub component. Phase 3 will implement
+/// the actual translation.
+pub fn compile_with_wir(_project: &Project) -> Vec<u8> {
+    // Phase 2 stub: return a minimal valid Wasm component.
+    // The component exports a "run" function that returns Ok(()) with no output.
+    // This allows the test infrastructure to exercise the full pipeline
+    // (compile → instantiate → run → verify) rather than failing at Wasm loading.
+    emit::build_stub_component()
+}

--- a/wado-compiler/tests/common/mod.rs
+++ b/wado-compiler/tests/common/mod.rs
@@ -337,6 +337,26 @@ pub fn compile_source_with_opts(
         .map_err(|_: Bail| bail_to_compile_error(&host.diagnostics(), Some(&filename)))
 }
 
+/// Compile source code with full compiler options (including WIR backend flag)
+pub fn compile_source_with_compiler_options(
+    path: &std::path::Path,
+    source: &str,
+    options: wado_compiler::CompilerOptions,
+) -> Result<wado_compiler::CompileResult, CompileError> {
+    let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+    let host = FilesystemHost::new(base_path);
+    let filename = path.to_string_lossy();
+
+    runtime()
+        .block_on(wado_compiler::compile_with_options(
+            source,
+            &host,
+            Some(&filename),
+            options,
+        ))
+        .map_err(|_: Bail| bail_to_compile_error(&host.diagnostics(), Some(&filename)))
+}
+
 /// Compile a file asynchronously (for use within async context)
 pub async fn compile_file_async(
     path: &std::path::Path,

--- a/wado-compiler/tests/http.rs
+++ b/wado-compiler/tests/http.rs
@@ -69,6 +69,7 @@ async fn compile_http_service(path: &Path) -> Result<Vec<u8>, CompileError> {
     let options = CompilerOptions {
         opt_level: OptLevel::O2,
         target_world: Some("wasi:http/service".to_string()),
+        use_wir_backend: false,
     };
 
     wado_compiler::compile_with_options(&source, &host, Some(&filename), options)

--- a/wado-compiler/tests/wir_e2e.rs
+++ b/wado-compiler/tests/wir_e2e.rs
@@ -1,0 +1,210 @@
+//! WIR pipeline E2E tests — parallel test harness for the WIR backend.
+//!
+//! These tests run the same fixtures as `e2e.rs` but use the WIR pipeline
+//! (`tir_to_wir` → `wir_emit`) instead of `Codegen::generate_wasm`.
+//!
+//! Gated by `WADO_WIR_TEST=1` — not included in normal `make test`.
+//!
+//! Usage:
+//!   WADO_WIR_TEST=1 cargo test -p wado-compiler --test wir_e2e
+
+mod common;
+
+use serde::Deserialize;
+use std::path::Path;
+use wado_compiler::{CompilerOptions, OptLevel};
+
+// ============================================================================
+// Gate: skip all tests unless WADO_WIR_TEST=1
+// ============================================================================
+
+fn wir_tests_enabled() -> bool {
+    std::env::var("WADO_WIR_TEST").is_ok()
+}
+
+// ============================================================================
+// Test Spec (same as e2e.rs)
+// ============================================================================
+
+#[derive(Debug, Deserialize, Default)]
+struct TestSpec {
+    #[serde(default)]
+    stdout: Option<String>,
+    #[serde(default)]
+    stderr: Option<String>,
+    #[serde(default)]
+    stdout_contains: Vec<String>,
+    #[serde(default)]
+    stderr_contains: Vec<String>,
+    #[serde(default)]
+    trapped: bool,
+    #[serde(default)]
+    compile_error: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "TODO")]
+    todo: bool,
+}
+
+// ============================================================================
+// Test Verification (same as e2e.rs)
+// ============================================================================
+
+fn verify_result(result: &common::WasmRunResult, spec: &TestSpec, fixture_name: &str) {
+    assert_eq!(
+        result.trapped, spec.trapped,
+        "[{fixture_name}] trapped mismatch: expected {}, got {}",
+        spec.trapped, result.trapped
+    );
+
+    if let Some(expected_stdout) = &spec.stdout {
+        assert_eq!(
+            &result.stdout, expected_stdout,
+            "[{fixture_name}] stdout mismatch"
+        );
+    }
+
+    if let Some(expected_stderr) = &spec.stderr {
+        assert_eq!(
+            &result.stderr, expected_stderr,
+            "[{fixture_name}] stderr mismatch"
+        );
+    }
+
+    for expected in &spec.stdout_contains {
+        assert!(
+            result.stdout.contains(expected),
+            "[{fixture_name}] stdout should contain '{expected}', but got:\n{}",
+            result.stdout
+        );
+    }
+
+    for expected in &spec.stderr_contains {
+        assert!(
+            result.stderr.contains(expected),
+            "[{fixture_name}] stderr should contain '{expected}', but got:\n{}",
+            result.stderr
+        );
+    }
+}
+
+// ============================================================================
+// WIR Compilation Helper
+// ============================================================================
+
+fn compile_with_wir_backend(
+    path: &Path,
+    source: &str,
+    opt_level: OptLevel,
+) -> Result<wado_compiler::CompileResult, wado_compiler::CompileError> {
+    let options = CompilerOptions {
+        opt_level,
+        use_wir_backend: true,
+        ..CompilerOptions::default()
+    };
+    common::compile_source_with_compiler_options(path, source, options)
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLevel) {
+    let fixture_name = fixture_path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let opt_name = common::opt_level_name(opt_level);
+    let test_id = format!("{fixture_name} [WIR] ({opt_name})");
+
+    let data_section = common::extract_data_section(source).unwrap_or_else(|| {
+        panic!("[{test_id}] missing __DATA__ section");
+    });
+
+    let spec: TestSpec = common::parse_data_section(data_section, &test_id);
+
+    // Handle TODO tests
+    if spec.todo {
+        let test_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_normal_test(fixture_path, source, opt_level, &spec, &test_id);
+        }));
+
+        match test_result {
+            Ok(()) => {
+                panic!(
+                    "[{test_id}] TODO test PASSED! This means the feature is now implemented.\n\
+                     Please remove 'TODO: true' from the __DATA__ section."
+                );
+            }
+            Err(_) => {
+                return;
+            }
+        }
+    }
+
+    run_normal_test(fixture_path, source, opt_level, &spec, &test_id);
+}
+
+fn run_normal_test(
+    fixture_path: &Path,
+    source: &str,
+    opt_level: OptLevel,
+    spec: &TestSpec,
+    test_id: &str,
+) {
+    let compile_result = compile_with_wir_backend(fixture_path, source, opt_level);
+
+    // Handle expected compile errors
+    if let Some(expected_error) = &spec.compile_error {
+        match compile_result {
+            Err(e) => {
+                let error_msg = e.to_string();
+                assert!(
+                    error_msg.contains(expected_error),
+                    "[{test_id}] compile error mismatch:\n  expected to contain: {expected_error}\n  actual error: {error_msg}"
+                );
+                return;
+            }
+            Ok(_) => {
+                panic!(
+                    "[{test_id}] expected compile error containing '{expected_error}', but compilation succeeded"
+                );
+            }
+        }
+    }
+
+    let compile_result = compile_result.unwrap_or_else(|e| {
+        panic!("[{test_id}] compilation failed: {e}");
+    });
+
+    let result = common::run_wasm(compile_result.wasm).unwrap_or_else(|e| {
+        panic!("[{test_id}] runtime error: {e}");
+    });
+
+    verify_result(&result, spec, test_id);
+}
+
+// ============================================================================
+// Test Entry Points (O0 and O2 only for WIR — keep iteration fast)
+// ============================================================================
+
+fn fixture_test_wir_o0(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if !wir_tests_enabled() {
+        return Ok(());
+    }
+    run_fixture_test_with_opt(path, content, OptLevel::O0);
+    Ok(())
+}
+
+fn fixture_test_wir_o2(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if !wir_tests_enabled() {
+        return Ok(());
+    }
+    run_fixture_test_with_opt(path, content, OptLevel::O2);
+    Ok(())
+}
+
+datatest_mini::harness! {
+    { test = fixture_test_wir_o0, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
+    { test = fixture_test_wir_o2, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
+}

--- a/wado-compiler/tests/wir_progress.rs
+++ b/wado-compiler/tests/wir_progress.rs
@@ -45,8 +45,8 @@ struct ProgressStats {
 fn try_run_fixture(path: &Path, source: &str, opt_level: OptLevel) -> Result<(), String> {
     let data_section =
         common::extract_data_section(source).ok_or_else(|| "missing __DATA__".to_string())?;
-    let spec: TestSpec = serde_json::from_str(data_section)
-        .map_err(|e| format!("invalid __DATA__ JSON: {e}"))?;
+    let spec: TestSpec =
+        serde_json::from_str(data_section).map_err(|e| format!("invalid __DATA__ JSON: {e}"))?;
 
     let options = CompilerOptions {
         opt_level,
@@ -77,7 +77,8 @@ fn try_run_fixture(path: &Path, source: &str, opt_level: OptLevel) -> Result<(),
 
     let compile_result = compile_result.map_err(|e| format!("compile error: {e}"))?;
 
-    let result = common::run_wasm(compile_result.wasm).map_err(|e| format!("runtime error: {e}"))?;
+    let result =
+        common::run_wasm(compile_result.wasm).map_err(|e| format!("runtime error: {e}"))?;
 
     // Check trapped
     if result.trapped != spec.trapped {
@@ -223,7 +224,10 @@ fn wir_pipeline_progress() {
     eprintln!("═══════════════════════════════════════════════════════");
     eprintln!("  WIR Pipeline Progress (O2)");
     eprintln!("═══════════════════════════════════════════════════════");
-    eprintln!("  Passed:  {:>4} / {:<4} ({pct:.1}%)", stats.passed, non_todo_total);
+    eprintln!(
+        "  Passed:  {:>4} / {:<4} ({pct:.1}%)",
+        stats.passed, non_todo_total
+    );
     eprintln!("  Failed:  {:>4}", failed);
     if stats.failed_compile > 0 {
         eprintln!("    compile: {:>4}", stats.failed_compile);

--- a/wado-compiler/tests/wir_progress.rs
+++ b/wado-compiler/tests/wir_progress.rs
@@ -1,0 +1,261 @@
+//! WIR pipeline progress tracker.
+//!
+//! Runs all E2E fixtures through the WIR pipeline and reports pass/fail counts.
+//! This test always succeeds — it's informational only.
+//!
+//! Usage:
+//!   WADO_WIR_TEST=1 cargo test -p wado-compiler --test wir_progress -- --nocapture
+
+mod common;
+
+use serde::Deserialize;
+use std::path::Path;
+use wado_compiler::{CompilerOptions, OptLevel};
+
+#[derive(Debug, Deserialize, Default)]
+struct TestSpec {
+    #[serde(default)]
+    stdout: Option<String>,
+    #[serde(default)]
+    stderr: Option<String>,
+    #[serde(default)]
+    stdout_contains: Vec<String>,
+    #[serde(default)]
+    stderr_contains: Vec<String>,
+    #[serde(default)]
+    trapped: bool,
+    #[serde(default)]
+    compile_error: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "TODO")]
+    todo: bool,
+}
+
+#[derive(Debug, Default)]
+struct ProgressStats {
+    total: usize,
+    passed: usize,
+    failed_compile: usize,
+    failed_runtime: usize,
+    failed_output: usize,
+    failed_todo: usize,
+    skipped_todo: usize,
+}
+
+fn try_run_fixture(path: &Path, source: &str, opt_level: OptLevel) -> Result<(), String> {
+    let data_section =
+        common::extract_data_section(source).ok_or_else(|| "missing __DATA__".to_string())?;
+    let spec: TestSpec = serde_json::from_str(data_section)
+        .map_err(|e| format!("invalid __DATA__ JSON: {e}"))?;
+
+    let options = CompilerOptions {
+        opt_level,
+        use_wir_backend: true,
+        ..CompilerOptions::default()
+    };
+
+    let compile_result = common::compile_source_with_compiler_options(path, source, options);
+
+    // Handle expected compile errors
+    if let Some(expected_error) = &spec.compile_error {
+        return match compile_result {
+            Err(e) => {
+                let error_msg = e.to_string();
+                if error_msg.contains(expected_error) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "compile error mismatch: expected '{expected_error}', got '{error_msg}'"
+                    ))
+                }
+            }
+            Ok(_) => Err(format!(
+                "expected compile error '{expected_error}', but succeeded"
+            )),
+        };
+    }
+
+    let compile_result = compile_result.map_err(|e| format!("compile error: {e}"))?;
+
+    let result = common::run_wasm(compile_result.wasm).map_err(|e| format!("runtime error: {e}"))?;
+
+    // Check trapped
+    if result.trapped != spec.trapped {
+        return Err(format!(
+            "trapped mismatch: expected {}, got {}",
+            spec.trapped, result.trapped
+        ));
+    }
+
+    // Check stdout
+    if let Some(expected_stdout) = &spec.stdout {
+        if &result.stdout != expected_stdout {
+            return Err(format!(
+                "stdout mismatch: expected {:?}, got {:?}",
+                expected_stdout, result.stdout
+            ));
+        }
+    }
+
+    // Check stderr
+    if let Some(expected_stderr) = &spec.stderr {
+        if &result.stderr != expected_stderr {
+            return Err(format!(
+                "stderr mismatch: expected {:?}, got {:?}",
+                expected_stderr, result.stderr
+            ));
+        }
+    }
+
+    // Check stdout_contains
+    for expected in &spec.stdout_contains {
+        if !result.stdout.contains(expected) {
+            return Err(format!("stdout missing '{expected}'"));
+        }
+    }
+
+    // Check stderr_contains
+    for expected in &spec.stderr_contains {
+        if !result.stderr.contains(expected) {
+            return Err(format!("stderr missing '{expected}'"));
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn wir_pipeline_progress() {
+    if std::env::var("WADO_WIR_TEST").is_err() {
+        eprintln!("WIR progress: skipped (set WADO_WIR_TEST=1 to run)");
+        return;
+    }
+
+    let fixtures_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let mut entries: Vec<_> = std::fs::read_dir(&fixtures_dir)
+        .expect("fixtures directory should exist")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.ends_with(".wado") && !name.contains('/')
+        })
+        .collect();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let opt_level = OptLevel::O2;
+    let mut stats = ProgressStats::default();
+    let mut failures: Vec<(String, String)> = Vec::new();
+
+    for entry in &entries {
+        let path = entry.path();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let source = std::fs::read_to_string(&path).unwrap();
+
+        // Check if TODO test
+        let data_section = common::extract_data_section(&source);
+        let is_todo = data_section
+            .and_then(|d| serde_json::from_str::<TestSpec>(d).ok())
+            .is_some_and(|s| s.todo);
+
+        stats.total += 1;
+
+        if is_todo {
+            // For TODO tests, we expect failure — run it and check
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                try_run_fixture(&path, &source, opt_level)
+            }));
+
+            match result {
+                Ok(Ok(())) => {
+                    // TODO test passed — this means the feature works now
+                    stats.failed_todo += 1;
+                    failures.push((name, "TODO test unexpectedly passed".to_string()));
+                }
+                Ok(Err(_)) | Err(_) => {
+                    // TODO test failed as expected
+                    stats.skipped_todo += 1;
+                }
+            }
+            continue;
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            try_run_fixture(&path, &source, opt_level)
+        }));
+
+        match result {
+            Ok(Ok(())) => {
+                stats.passed += 1;
+            }
+            Ok(Err(msg)) => {
+                if msg.starts_with("compile error:") {
+                    stats.failed_compile += 1;
+                } else if msg.starts_with("runtime error:") {
+                    stats.failed_runtime += 1;
+                } else {
+                    stats.failed_output += 1;
+                }
+                failures.push((name, msg));
+            }
+            Err(panic_info) => {
+                let msg = panic_info
+                    .downcast_ref::<String>()
+                    .map(|s| s.as_str())
+                    .or_else(|| panic_info.downcast_ref::<&str>().copied())
+                    .unwrap_or("(panic)")
+                    .to_string();
+                stats.failed_runtime += 1;
+                failures.push((name, msg));
+            }
+        }
+    }
+
+    // Print summary
+    let non_todo_total = stats.total - stats.skipped_todo - stats.failed_todo;
+    let failed = non_todo_total - stats.passed;
+    let pct = if non_todo_total == 0 {
+        0.0
+    } else {
+        (stats.passed as f64 / non_todo_total as f64) * 100.0
+    };
+
+    eprintln!();
+    eprintln!("═══════════════════════════════════════════════════════");
+    eprintln!("  WIR Pipeline Progress (O2)");
+    eprintln!("═══════════════════════════════════════════════════════");
+    eprintln!("  Passed:  {:>4} / {:<4} ({pct:.1}%)", stats.passed, non_todo_total);
+    eprintln!("  Failed:  {:>4}", failed);
+    if stats.failed_compile > 0 {
+        eprintln!("    compile: {:>4}", stats.failed_compile);
+    }
+    if stats.failed_runtime > 0 {
+        eprintln!("    runtime: {:>4}", stats.failed_runtime);
+    }
+    if stats.failed_output > 0 {
+        eprintln!("    output:  {:>4}", stats.failed_output);
+    }
+    if stats.skipped_todo > 0 {
+        eprintln!("  TODO (skipped): {:>4}", stats.skipped_todo);
+    }
+    if stats.failed_todo > 0 {
+        eprintln!("  TODO (unexpectedly passed): {:>4}", stats.failed_todo);
+    }
+    eprintln!("═══════════════════════════════════════════════════════");
+
+    // Print first few failures for quick diagnosis
+    if !failures.is_empty() {
+        let show = failures.len().min(10);
+        eprintln!();
+        eprintln!("  First {show} failures:");
+        for (name, msg) in failures.iter().take(show) {
+            let short_msg = if msg.len() > 80 { &msg[..80] } else { msg };
+            eprintln!("    {name}: {short_msg}");
+        }
+        if failures.len() > show {
+            eprintln!("    ... and {} more", failures.len() - show);
+        }
+    }
+    eprintln!();
+
+    // This test always passes — it's informational only
+}


### PR DESCRIPTION
## Summary

Implement Phase 2 of the WIR (Wasm IR) backend by adding the pipeline entry point and test infrastructure. This allows the same E2E fixtures to run through the WIR pipeline (`tir_to_wir` → `wir_emit`) instead of the legacy codegen, with a minimal valid Wasm component stub that enables full infrastructure testing.

## Key Changes

- **New module `tir_to_wir`**: Entry point for the WIR pipeline
  - `tir_to_wir/mod.rs`: Public `compile_with_wir(&Project) -> Vec<u8>` function
  - `tir_to_wir/emit.rs`: Stub component builder that generates a minimal valid Wasm component exporting a synchronous "run" function returning `result<_, _>`

- **Compiler infrastructure**:
  - Added `use_wir_backend: bool` flag to `CompilerOptions` to switch between legacy codegen and WIR pipeline
  - Updated `compile_with_host` to route to `compile_with_wir` when flag is set
  - Added `compile_source_with_compiler_options` helper in test common module to support full option control

- **E2E test harness**:
  - `tests/wir_e2e.rs`: Parallel test runner using `datatest_mini` harness, gated by `WADO_WIR_TEST=1` environment variable
    - Runs same fixtures as `e2e.rs` with WIR backend at O0 and O2 optimization levels
    - Handles TODO tests (expects failure, reports if unexpectedly passing)
    - Verifies output, trapped state, and compile errors
  
  - `tests/wir_progress.rs`: Informational progress tracker (always passes)
    - Runs all fixtures and reports pass/fail counts by category
    - Distinguishes compile errors, runtime errors, and output mismatches
    - Tracks TODO tests separately
    - Prints formatted summary with first 10 failures for quick diagnosis

- **Stub component details**:
  - Generates valid Wasm component with core module exporting `run: () -> i32`
  - Component function lifts core function with result type `result<_, _>`
  - Returns 0 (Ok discriminant) with no output
  - Allows test infrastructure to exercise full pipeline without failing at Wasm loading

## Implementation Notes

- Stub component produces no output, so all tests fail at assertion level (output mismatch) rather than infrastructure level
- WIR tests are opt-in via `WADO_WIR_TEST=1` to avoid slowing down normal test runs
- Progress tracker is informational only and always passes, providing visibility into implementation status
- Phase 3 will incrementally replace stub with actual `WirModule` → Wasm translation

https://claude.ai/code/session_013ak7yLYtTkAWgGGaNjbb1Z