### PR TITLE
Document async HTTP handlers and task return statement

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1209,16 +1209,7 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode> {
 }
 ```
 
-**Key differences from `return`:**
-
-| | `return` | `task return` |
-| --- | --- | --- |
-| Ends the Wasm function | Yes | No |
-| Delivers the CM result | Yes (sync) | Yes (async) |
-| Valid in `async fn` | No | Yes |
-| Valid in non-async fn | Yes | No |
-
-The expression is type-checked against the declared return type of the enclosing `export async fn`.
+The expression is type-checked against the declared return type of the enclosing `export async fn`. Regular `return` is forbidden in `async fn` bodies.
 
 ## Standard Library
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1177,6 +1177,49 @@ export fn run() with Stdout {
 }
 ```
 
+`handle(request)` is the entry point for the wasi:http/service world. It must be declared `async` because HTTP handlers use the Component Model async calling convention, which allows the function to remain alive after delivering the response headers (e.g. to fulfill trailers futures).
+
+```wado
+use { Request, Response, ErrorCode, Fields, Trailers } from "wasi:http";
+
+export async fn handle(request: Request) -> Result<Response, ErrorCode> {
+    let [trailers_future, trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, null, trailers_future);
+
+    // task return delivers the result to the CM runtime without ending the function.
+    // The function continues executing after this point to fulfill trailers.
+    task return Result::<Response, ErrorCode>::Ok(response);
+    trailers_tx.write(Result::<Option<Trailers>, ErrorCode>::Ok(null));
+}
+```
+
+### `task return` Statement
+
+`task return expr;` is a statement valid only inside `export async fn` bodies. It delivers the function's result to the Component Model runtime without terminating the Wasm function, allowing cleanup and future fulfillment to continue afterward.
+
+```wado
+export async fn handle(request: Request) -> Result<Response, ErrorCode> {
+    // ... build response ...
+
+    task return Result::<Response, ErrorCode>::Ok(response);  // deliver result
+
+    // Function is still alive here — fulfill outstanding futures
+    trailers_tx.write(Result::<Option<Trailers>, ErrorCode>::Ok(null));
+}
+```
+
+**Key differences from `return`:**
+
+| | `return` | `task return` |
+| --- | --- | --- |
+| Ends the Wasm function | Yes | No |
+| Delivers the CM result | Yes (sync) | Yes (async) |
+| Valid in `async fn` | No | Yes |
+| Valid in non-async fn | Yes | No |
+
+The expression is type-checked against the declared return type of the enclosing `export async fn`.
+
 ## Standard Library
 
 ```wado

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3457,10 +3457,10 @@ Entry points are integrated in World system.
 
 Each hosted world defines its entry point. Currently supported:
 
-| Hosted World        | Entry Point                                                                     | CLI Command  |
-| ------------------- | ------------------------------------------------------------------------------- | ------------ |
-| `wasi:cli/command`  | `export fn run()`                                                               | `wado run`   |
-| `wasi:http/service` | `export async fn handle(request: Request) -> Result<Response, ErrorCode>`       | `wado serve` |
+| Hosted World        | Entry Point                                                               | CLI Command  |
+| ------------------- | ------------------------------------------------------------------------- | ------------ |
+| `wasi:cli/command`  | `export fn run()`                                                         | `wado run`   |
+| `wasi:http/service` | `export async fn handle(request: Request) -> Result<Response, ErrorCode>` | `wado serve` |
 
 When no explicit `contract` declaration is present, the runtime determines the expected world (e.g., `wado run` expects `wasi:cli/command`).
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3457,12 +3457,38 @@ Entry points are integrated in World system.
 
 Each hosted world defines its entry point. Currently supported:
 
-| Hosted World        | Entry Point                                                         | CLI Command  |
-| ------------------- | ------------------------------------------------------------------- | ------------ |
-| `wasi:cli/command`  | `export fn run()`                                                   | `wado run`   |
-| `wasi:http/service` | `export fn handle(request: Request) -> Result<Response, ErrorCode>` | `wado serve` |
+| Hosted World        | Entry Point                                                                     | CLI Command  |
+| ------------------- | ------------------------------------------------------------------------------- | ------------ |
+| `wasi:cli/command`  | `export fn run()`                                                               | `wado run`   |
+| `wasi:http/service` | `export async fn handle(request: Request) -> Result<Response, ErrorCode>`       | `wado serve` |
 
 When no explicit `contract` declaration is present, the runtime determines the expected world (e.g., `wado run` expects `wasi:cli/command`).
+
+### `task return` Statement
+
+`task return expr;` is a statement valid only inside `export async fn` bodies. It calls the Component Model `task.return` instruction, delivering the function's result to the CM runtime **without terminating the Wasm function**. Execution continues after `task return`, allowing the function to fulfill outstanding futures (e.g. trailers) or perform cleanup.
+
+#### Motivation
+
+HTTP handlers return a `Response` that contains a `Future`-based trailers channel. With a regular `return`, the Wasm function exits immediately, making it impossible to write to that channel. `task return` separates result delivery from function termination:
+
+```wado
+export async fn handle(request: Request) -> Result<Response, ErrorCode> {
+    let [trailers_future, trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, null, trailers_future);
+
+    task return Result::<Response, ErrorCode>::Ok(response); // deliver result; function continues
+    trailers_tx.write(Result::<Option<Trailers>, ErrorCode>::Ok(null)); // fulfill trailers
+}
+```
+
+#### Rules
+
+- `task return` is only valid inside `export async fn` bodies.
+- Regular `return` is forbidden in `async fn` bodies — it would exit the Wasm function without notifying the CM runtime.
+- The `task return` expression is type-checked against the declared return type of the enclosing `export async fn`.
+- The `async` keyword on a function declaration has no effect on callers; Wado is fully colorless. `async` only appears in `export async fn` declarations to signal CM async calling convention at the component boundary.
 
 ### Attribute Syntax for WASI Linking
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for Wado's async HTTP handler support and the `task return` statement, which enables HTTP handlers to deliver responses while continuing execution to fulfill trailers futures.

## Changes
- **Cheatsheet**: Added practical examples of `handle(request)` entry point for `wasi:http/service` world, including a complete example showing how to use `task return` to deliver a response while fulfilling trailers
- **Spec**: Updated HTTP service entry point signature from `export fn` to `export async fn` in the entry points table
- **Spec**: Added new "task return Statement" section documenting:
  - Purpose and motivation (separating result delivery from function termination)
  - Complete example showing trailers fulfillment pattern
  - Detailed rules and constraints for `task return` usage
  - Clarification that `async` is colorless to callers and only signals Component Model async calling convention at component boundaries

## Key Details
The documentation explains that `task return` is necessary because HTTP handlers return a `Response` containing a `Future`-based trailers channel. A regular `return` would exit the Wasm function immediately, making it impossible to write to that channel. `task return` allows the function to remain alive after delivering the response to the CM runtime, enabling cleanup and future fulfillment.

https://claude.ai/code/session_017D4vJd4cBrenMAEGviDV86