### PR TITLE
Enforce strict numeric range for all integer literal bases

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1157,22 +1157,21 @@ fn foo(n: i64) { ... }
 foo(100);  // literal coerced to i64
 ```
 
-**Compile-time range checking**: The compiler rejects literal coercions whose value falls outside the target type's range. The rules differ by literal base:
+**Compile-time range checking**: The compiler rejects literal coercions whose value falls outside the target type's range. All literal bases (decimal, hex `0x`, octal `0o`, binary `0b`) use strict numeric range: the value must lie within `[MIN, MAX]` for signed types or `[0, MAX]` for unsigned types.
 
-- **Decimal literals** use strict numeric range: the value must lie within `[MIN, MAX]` for signed types or `[0, MAX]` for unsigned types.
-- **Non-decimal literals** (hex `0x`, octal `0o`, binary `0b`) use bit-width range for **signed** types: any value that fits in the corresponding unsigned bit width is accepted and reinterpreted as a bit pattern. Unsigned types always use the strict unsigned range regardless of base.
+To reinterpret a bit pattern as a signed integer, use an explicit `as` cast.
 
 ```wado
-// Decimal: strict numeric range
 let a: i8 = 127;                  // OK: max i8
 let b: i8 = 128;                  // compile error: literal out of range for `i8`: 128
 let c: i8 = -128;                 // OK: min i8
 let d: u32 = -1;                  // compile error: literal out of range for `u32`: -1
 
-// Non-decimal: bit-width range for signed types
-let e: i8 = 0xFF;                 // OK: bit pattern of -1 (255 fits in 8-bit)
-let f: i64 = 0xfa8fd5a0081c0289;  // OK: fits in 64-bit
-let g: u32 = 0x1_0000_0000;       // compile error: 33-bit value does not fit in u32
+let e: i8 = 0xFF;                 // compile error: literal out of range for `i8`: 0xFF
+let f: i8 = 0xFF as i8;           // OK: explicit bit-pattern reinterpretation (value: -1)
+let g: i32 = 0xFFFF_FFFF;         // compile error: literal out of range for `i32`: 0xFFFF_FFFF
+let h: i32 = 0xFFFF_FFFF as i32;  // OK: explicit bit-pattern reinterpretation (value: -1)
+let i: u32 = 0x1_0000_0000;       // compile error: 33-bit value does not fit in u32
 ```
 
 **Type conversion** (via `as`):

--- a/wado-compiler/src/resolver/util.rs
+++ b/wado-compiler/src/resolver/util.rs
@@ -2,21 +2,12 @@
 
 use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
 
-/// Returns `true` if the literal repr is hex, octal, or binary (non-decimal).
-/// Non-decimal literals use bit-pattern semantics for signed integer types.
-pub(super) fn is_non_decimal_literal(repr: &str) -> bool {
-    let s = repr.trim_start_matches('-');
-    let lower = s.to_ascii_lowercase();
-    lower.starts_with("0x") || lower.starts_with("0b") || lower.starts_with("0o")
-}
-
 /// Check if a positive integer literal value fits in the target integer type.
 /// Returns `Some(error_message)` if out of range, `None` if OK.
 /// Only checks primitive integer types (not i128/u128, which are handled separately).
 ///
-/// Decimal literals use strict numeric range.
-/// Hex/octal/binary literals use bit-width range for signed types
-/// (e.g. `0xFF` is valid for `i8`, interpreted as the bit pattern -1).
+/// All literal formats (decimal, hex, octal, binary) use strict numeric range.
+/// To reinterpret a bit pattern, use an explicit cast: `0xFF as i8`.
 pub(super) fn check_int_range_positive(
     value: u64,
     target_type: TypeId,
@@ -24,39 +15,12 @@ pub(super) fn check_int_range_positive(
     repr: &str,
 ) -> Option<String> {
     let base_id = type_table.get_ultimate_base_type(target_type);
-    let non_decimal = is_non_decimal_literal(repr);
     let in_range = match type_table.get(base_id) {
         ResolvedType::Primitive(prim) => match prim {
-            // Signed types: non-decimal uses bit-width (bit-pattern), decimal uses MAX_SIGNED
-            PrimitiveType::I8 => {
-                if non_decimal {
-                    u8::try_from(value).is_ok()
-                } else {
-                    i8::try_from(value).is_ok()
-                }
-            }
-            PrimitiveType::I16 => {
-                if non_decimal {
-                    u16::try_from(value).is_ok()
-                } else {
-                    i16::try_from(value).is_ok()
-                }
-            }
-            PrimitiveType::I32 => {
-                if non_decimal {
-                    u32::try_from(value).is_ok()
-                } else {
-                    i32::try_from(value).is_ok()
-                }
-            }
-            PrimitiveType::I64 => {
-                if non_decimal {
-                    true
-                } else {
-                    i64::try_from(value).is_ok()
-                }
-            }
-            // Unsigned types: always check bit width (same for both)
+            PrimitiveType::I8 => i8::try_from(value).is_ok(),
+            PrimitiveType::I16 => i16::try_from(value).is_ok(),
+            PrimitiveType::I32 => i32::try_from(value).is_ok(),
+            PrimitiveType::I64 => i64::try_from(value).is_ok(),
             PrimitiveType::U8 => u8::try_from(value).is_ok(),
             PrimitiveType::U16 => u16::try_from(value).is_ok(),
             PrimitiveType::U32 => u32::try_from(value).is_ok(),

--- a/wado-compiler/tests/fixtures.golden/coerce_struct_field.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_struct_field.lowered.wado
@@ -27,7 +27,7 @@ struct SmallInts {
 }
 
 export fn run() with Stdout {
-    let pm: PmHiLo = move PmHiLo { hi: 0xfa8fd5a0081c0289, lo: 0xe8cd3796329f1bac };
+    let pm: PmHiLo = move PmHiLo { hi: 0x1234_5678_9abc_def0, lo: 0xe8cd3796329f1bac };
     core::cli::println(__tmpl: {
         let mut __r: String = move String { repr: "array_new<u8>"(19), used: 0 };
         __r.String::append(move "hi=");

--- a/wado-compiler/tests/fixtures/coerce_invalid_i16_hex_overflow.wado
+++ b/wado-compiler/tests/fixtures/coerce_invalid_i16_hex_overflow.wado
@@ -1,0 +1,8 @@
+// 0xFFFF = 65535, which is out of range for i16 (-32768..=32767)
+// Bit-pattern reinterpretation requires explicit cast: 0xFFFF as i16
+export fn run() {
+    let i: i16 = 0xFFFF;
+}
+
+__DATA__
+{"compile_error": "literal out of range for `i16`: 0xFFFF"}

--- a/wado-compiler/tests/fixtures/coerce_invalid_i32_hex_bit_pattern.wado
+++ b/wado-compiler/tests/fixtures/coerce_invalid_i32_hex_bit_pattern.wado
@@ -1,0 +1,8 @@
+// 0xFFFF_FFFF = 4294967295, which is out of range for i32 (-2147483648..=2147483647)
+// Bit-pattern reinterpretation requires explicit cast: 0xFFFF_FFFF as i32
+export fn run() {
+    let i: i32 = 0xFFFF_FFFF;
+}
+
+__DATA__
+{"compile_error": "literal out of range for `i32`: 0xFFFF_FFFF"}

--- a/wado-compiler/tests/fixtures/coerce_invalid_i64_hex_bit_pattern.wado
+++ b/wado-compiler/tests/fixtures/coerce_invalid_i64_hex_bit_pattern.wado
@@ -1,0 +1,8 @@
+// 0xFFFF_FFFF_FFFF_FFFF = 18446744073709551615 (u64 max), out of range for i64
+// Bit-pattern reinterpretation requires explicit cast: 0xFFFF_FFFF_FFFF_FFFF as i64
+export fn run() {
+    let i: i64 = 0xFFFF_FFFF_FFFF_FFFF;
+}
+
+__DATA__
+{"compile_error": "literal out of range for `i64`: 0xFFFF_FFFF_FFFF_FFFF"}

--- a/wado-compiler/tests/fixtures/coerce_invalid_i8_binary_overflow.wado
+++ b/wado-compiler/tests/fixtures/coerce_invalid_i8_binary_overflow.wado
@@ -1,0 +1,8 @@
+// 0b1111_1111 = 255, which is out of range for i8 (-128..=127)
+// Bit-pattern reinterpretation requires explicit cast: 0b1111_1111 as i8
+export fn run() {
+    let i: i8 = 0b1111_1111;
+}
+
+__DATA__
+{"compile_error": "literal out of range for `i8`: 0b1111_1111"}

--- a/wado-compiler/tests/fixtures/coerce_invalid_i8_hex_overflow.wado
+++ b/wado-compiler/tests/fixtures/coerce_invalid_i8_hex_overflow.wado
@@ -1,0 +1,8 @@
+// 0xFF = 255, which is out of range for i8 (-128..=127)
+// Bit-pattern reinterpretation requires explicit cast: 0xFF as i8
+export fn run() {
+    let i: i8 = 0xFF;
+}
+
+__DATA__
+{"compile_error": "literal out of range for `i8`: 0xFF"}

--- a/wado-compiler/tests/fixtures/coerce_invalid_i8_octal_overflow.wado
+++ b/wado-compiler/tests/fixtures/coerce_invalid_i8_octal_overflow.wado
@@ -1,0 +1,8 @@
+// 0o200 = 128, which is out of range for i8 (-128..=127)
+// Bit-pattern reinterpretation requires explicit cast: 0o200 as i8
+export fn run() {
+    let i: i8 = 0o200;
+}
+
+__DATA__
+{"compile_error": "literal out of range for `i8`: 0o200"}

--- a/wado-compiler/tests/fixtures/coerce_struct_field.wado
+++ b/wado-compiler/tests/fixtures/coerce_struct_field.wado
@@ -21,7 +21,7 @@ struct SmallInts {
 
 fn get_pm() -> PmHiLo {
     // Hex literals should coerce to i64/u64 based on field type
-    return PmHiLo { hi: 0xfa8fd5a0081c0289, lo: 0xe8cd3796329f1bac };
+    return PmHiLo { hi: 0x1234_5678_9abc_def0, lo: 0xe8cd3796329f1bac };
 }
 
 fn get_point() -> Point64 {
@@ -48,4 +48,4 @@ export fn run() with Stdout {
 }
 
 __DATA__
-{"stdout": "hi=-391859759250406775\nlo=16775125305258875820\nx=-100\ny=200\na=255, b=-128, c=0, d=127\n"}
+{"stdout": "hi=1311768467463790320\nlo=16775125305258875820\nx=-100\ny=200\na=255, b=-128, c=0, d=127\n"}


### PR DESCRIPTION
## Summary
This change unifies integer literal range checking to use strict numeric range for all literal bases (decimal, hex, octal, binary). Previously, non-decimal literals used bit-width semantics for signed types, allowing values like `0xFF` to be assigned to `i8` and reinterpreted as bit patterns. Now, all literals must fit within the target type's numeric range `[MIN, MAX]`, and explicit `as` casts are required for bit-pattern reinterpretation.

## Key Changes

- **Removed bit-pattern semantics for non-decimal literals**: Deleted `is_non_decimal_literal()` function and the conditional logic that treated hex/octal/binary literals differently from decimal literals in `check_int_range_positive()`.

- **Simplified range checking**: All signed integer types (i8, i16, i32, i64) now use the same strict numeric range check regardless of literal base, matching the behavior of unsigned types.

- **Updated documentation**: Modified `docs/spec.md` to clarify that all literal bases use strict numeric range and that bit-pattern reinterpretation requires explicit `as` casts (e.g., `0xFF as i8`).

- **Added comprehensive test cases**: Created new test fixtures to verify that non-decimal literals are properly rejected when out of range:
  - `coerce_invalid_i8_hex_overflow.wado`
  - `coerce_invalid_i8_binary_overflow.wado`
  - `coerce_invalid_i8_octal_overflow.wado`
  - `coerce_invalid_i16_hex_overflow.wado`
  - `coerce_invalid_i32_hex_bit_pattern.wado`
  - `coerce_invalid_i64_hex_bit_pattern.wado`

- **Updated existing test**: Modified `coerce_struct_field.wado` to use a valid hex literal (`0x1234_5678_9abc_def0`) that fits in i64's range, with corresponding output adjustment.

## Implementation Details

The change simplifies the type checking logic by removing the distinction between decimal and non-decimal literals. This makes the language more consistent and predictable: developers must now explicitly use `as` casts to perform bit-pattern reinterpretation, making the intent clearer in the code.

https://claude.ai/code/session_01VqdT6bnfUp98ehHRBMXjmg