### PR TITLE
Add code organization guideline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,7 @@ Wado is designed with the following Wasm features:
 - Use `panic!("not yet implemented")` for things that are not yet implemented.
 - YAGNI. Do the simplest thing that could possibly work.
 - Do not use `HashMap` or `HashSet` from `std::collections`. Use `IndexMap` and `IndexSet` from the `indexmap` crate instead, to ensure deterministic iteration order.
+- Do not use comments to separate sections within a file (e.g., `// --- Section Name ---`). Use Rust's natural structure (modules, impl blocks, trait definitions) to organize code instead.
 
 ### Rules for the Compiler Code Base
 


### PR DESCRIPTION
This change adds a new coding guideline to the AGENTS.md documentation to improve code organization practices in the Wado codebase.

**Summary:**
Added a guideline discouraging the use of comment-based section separators (e.g., `// --- Section Name ---`) in favor of Rust's native structural organization mechanisms.

**Key changes:**
- Added a new rule under the "Design Principles" section stating that developers should use Rust's natural structure (modules, impl blocks, trait definitions) to organize code instead of relying on separator comments

**Rationale:**
This guideline promotes better code organization by leveraging Rust's type system and module structure, which provides clearer semantic boundaries and better IDE support compared to informal comment-based separators. This aligns with the existing principle of writing idiomatic Rust code.

https://claude.ai/code/session_01WDT1X2QdQU25kRQ87Rr3hL