### PR TITLE
Remove unused test utilities and compile function

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -196,11 +196,6 @@ fn to_compiler_opt_level(level: OptLevel) -> wado_compiler::OptLevel {
     }
 }
 
-/// Compile a Wado source file and return the Wasm binary
-pub async fn compile(filename: &str) -> Vec<u8> {
-    compile_with_opts(filename, OptLevel::default(), LogLevel::default()).await
-}
-
 /// Compile a Wado source file with optimization options
 pub async fn compile_with_opts(
     filename: &str,

--- a/wado-compiler/src/wasm_plan.rs
+++ b/wado-compiler/src/wasm_plan.rs
@@ -205,13 +205,6 @@ fn sanitize_kebab_export_name(function_name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{GenericType, NamedType};
-    use crate::token::Span;
-
-    fn make_span() -> Span {
-        Span::new(0, 0, 0, 0)
-    }
-
     #[test]
     fn test_sanitize_kebab_export_name() {
         // Simple case


### PR DESCRIPTION
## Summary
This PR removes unused code from the codebase to improve maintainability and reduce clutter.

## Key Changes
- **wado-compiler/src/wasm_plan.rs**: Removed unused test utilities (`make_span()` function and associated imports for `GenericType`, `NamedType`, and `Span`) from the tests module
- **wado-cli/src/compile.rs**: Removed the `compile()` function which was a simple wrapper around `compile_with_opts()` with default parameters

## Details
The `compile()` function in `compile.rs` was redundant as callers can directly use `compile_with_opts()` with `OptLevel::default()` and `LogLevel::default()`. The test utilities in `wasm_plan.rs` were not being used by any tests in that module.

https://claude.ai/code/session_01VnNPQgVRXDhWEvm8V7nvLg