### PR TITLE
Refactor: Extract utility functions and add ModuleSource helpers

### DIFF
--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -55,10 +55,7 @@ pub fn wasi_type_to_type_id(ty: &Type, type_table: &mut TypeTable) -> TypeId {
             "char" => TypeTable::CHAR,
             // Unit type written as a named type "()"
             "()" => TypeTable::UNIT,
-            "String" => type_table.make_struct(
-                "String".to_string(),
-                ModuleSource::string(),
-            ),
+            "String" => type_table.make_struct("String".to_string(), ModuleSource::string()),
             // Resource/enum/variant types - look up the already-resolved TypeId if available.
             // We try resource, enum, then variant to find the most specific match.
             _ => type_table
@@ -474,10 +471,9 @@ fn synthesize_lift_inner(
                     TypeTable::I32,
                 );
                 let string_type_id = ctx.map_or(TypeTable::I32, |c| {
-                    c.type_table.borrow_mut().make_struct(
-                        "String".to_string(),
-                        ModuleSource::string(),
-                    )
+                    c.type_table
+                        .borrow_mut()
+                        .make_struct("String".to_string(), ModuleSource::string())
                 });
                 internal_call("memory_to_gc_string", vec![ptr, len], string_type_id)
             }

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -57,7 +57,7 @@ pub fn wasi_type_to_type_id(ty: &Type, type_table: &mut TypeTable) -> TypeId {
             "()" => TypeTable::UNIT,
             "String" => type_table.make_struct(
                 "String".to_string(),
-                ModuleSource::core("prelude/string.wado"),
+                ModuleSource::string(),
             ),
             // Resource/enum/variant types - look up the already-resolved TypeId if available.
             // We try resource, enum, then variant to find the most specific match.
@@ -476,7 +476,7 @@ fn synthesize_lift_inner(
                 let string_type_id = ctx.map_or(TypeTable::I32, |c| {
                     c.type_table.borrow_mut().make_struct(
                         "String".to_string(),
-                        ModuleSource::core("prelude/string.wado"),
+                        ModuleSource::string(),
                     )
                 });
                 internal_call("memory_to_gc_string", vec![ptr, len], string_type_id)

--- a/wado-compiler/src/cm_adapter_gen.rs
+++ b/wado-compiler/src/cm_adapter_gen.rs
@@ -81,7 +81,7 @@ pub fn wasi_type_to_type_id(ty: &Type, type_table: &mut TypeTable) -> TypeId {
                 let err_type = wasi_type_to_type_id(&g.args[1], type_table);
                 type_table.make_generic_instance(
                     "Result".to_string(),
-                    ModuleSource::core("prelude/types.wado"),
+                    ModuleSource::types(),
                     vec![ok_type, err_type],
                 )
             }
@@ -111,7 +111,7 @@ pub fn builtin_call(name: &str, args: Vec<TirExpr>, return_type: TypeId) -> TirE
     TirExpr::new(
         TirExprKind::Call {
             func: crate::tir::FunctionRef::External {
-                module_source: ModuleSource::core("builtin"),
+                module_source: ModuleSource::builtin(),
                 name: name.to_string(),
                 monomorph_info: None,
                 method_info: None,
@@ -129,7 +129,7 @@ pub fn internal_call(name: &str, args: Vec<TirExpr>, return_type: TypeId) -> Tir
     TirExpr::new(
         TirExprKind::Call {
             func: crate::tir::FunctionRef::External {
-                module_source: ModuleSource::core("internal"),
+                module_source: ModuleSource::internal(),
                 name: name.to_string(),
                 monomorph_info: None,
                 method_info: None,
@@ -831,7 +831,7 @@ fn synthesize_lift_list(
         generic_static_call(
             "Array",
             "with_capacity",
-            ModuleSource::core("prelude"),
+            ModuleSource::prelude(),
             vec![elem_type_id],
             vec![local_ref(count_local, "__count", TypeTable::I32)],
             array_type_id,
@@ -890,7 +890,7 @@ fn synthesize_lift_list(
         local_ref(result_local, "__result", array_type_id),
         "Array",
         "append",
-        ModuleSource::core("prelude"),
+        ModuleSource::prelude(),
         vec![lifted_elem],
         TypeTable::UNIT,
     )));
@@ -1044,7 +1044,7 @@ fn synthesize_lift_result_inner(
         let err_type_id = wasi_type_to_type_id(err_ty, &mut tt);
         tt.make_generic_instance(
             "Result".to_string(),
-            ModuleSource::core("prelude/types.wado"),
+            ModuleSource::types(),
             vec![ok_type_id, err_type_id],
         )
     } else {

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -410,18 +410,10 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         let cache = cached_core_stdlib();
 
         let implicit_module_sources = [
-            ModuleSource::Core {
-                name: "builtin".to_string(),
-            },
-            ModuleSource::Core {
-                name: "prelude/string.wado".to_string(),
-            },
-            ModuleSource::Core {
-                name: "prelude".to_string(),
-            },
-            ModuleSource::Core {
-                name: "internal".to_string(),
-            },
+            ModuleSource::builtin(),
+            ModuleSource::string(),
+            ModuleSource::prelude(),
+            ModuleSource::internal(),
         ];
 
         for module_source in implicit_module_sources {

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -966,7 +966,7 @@ impl<'a> PatternLowerer<'a> {
         let is_builtin_call = match &inner_value.kind {
             TirExprKind::Call { func: func_ref, .. } => {
                 if let FunctionRef::External { module_source, .. } = func_ref {
-                    matches!(module_source, ModuleSource::Core { name } if name == "builtin")
+                    module_source.is_core_builtin()
                 } else {
                     false
                 }

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -7532,10 +7532,8 @@ fn generate_enum_trait_impls(module: &mut TirModule) {
         // Generate Ord::cmp
         let cmp_key = MethodName::format_local(enum_name, Some("Ord"), "cmp");
         if !existing_trait_methods.contains(&cmp_key) {
-            let ordering_type = type_table.make_enum(
-                "Ordering".to_string(),
-                ModuleSource::traits(),
-            );
+            let ordering_type =
+                type_table.make_enum("Ordering".to_string(), ModuleSource::traits());
             let func = generate_enum_ord_fn(
                 enum_name,
                 enum_type,

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -161,7 +161,7 @@ pub fn lower_modules_indexed(
         // Inject generated Box structs into core:internal module (where they logically live).
         // Falls back to entry module if core:internal doesn't exist (e.g., single-module tests).
         if !box_lowerer.generated_structs.is_empty() {
-            let internal_source = ModuleSource::core("internal");
+            let internal_source = ModuleSource::internal();
             let has_internal = modules.contains_key(&internal_source);
             let target_module = if has_internal {
                 modules.get_mut(&internal_source).unwrap()
@@ -206,7 +206,7 @@ fn create_i128_literal(value: i128, type_id: TypeId, span: Span) -> TirExpr {
     TirExpr::new(
         TirExprKind::StaticCall {
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/int128.wado"),
+                module_source: ModuleSource::int128(),
                 name: "i128::from_i64".to_string(),
                 monomorph_info: None,
                 method_info: Some(method_info),
@@ -235,7 +235,7 @@ fn create_u128_literal(value: u128, type_id: TypeId, span: Span) -> TirExpr {
     TirExpr::new(
         TirExprKind::StaticCall {
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/int128.wado"),
+                module_source: ModuleSource::int128(),
                 name: "u128::from_u64".to_string(),
                 monomorph_info: None,
                 method_info: Some(method_info),
@@ -287,7 +287,7 @@ fn create_i128_eq_call(
         TirExprKind::MethodCall {
             receiver: Box::new(receiver),
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/int128.wado"),
+                module_source: ModuleSource::int128(),
                 name: mangled_method_name,
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
@@ -344,7 +344,7 @@ fn create_u128_eq_call(
         TirExprKind::MethodCall {
             receiver: Box::new(receiver),
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/int128.wado"),
+                module_source: ModuleSource::int128(),
                 name: mangled_method_name,
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
@@ -809,7 +809,7 @@ fn match_to_switch(
                 TirStmtKind::Expr(TirExpr::new(
                     TirExprKind::Call {
                         func: FunctionRef::External {
-                            module_source: ModuleSource::core("internal"),
+                            module_source: ModuleSource::internal(),
                             name: "unreachable".to_string(),
                             monomorph_info: None,
                             method_info: None,
@@ -7534,7 +7534,7 @@ fn generate_enum_trait_impls(module: &mut TirModule) {
         if !existing_trait_methods.contains(&cmp_key) {
             let ordering_type = type_table.make_enum(
                 "Ordering".to_string(),
-                ModuleSource::core("prelude/traits.wado"),
+                ModuleSource::traits(),
             );
             let func = generate_enum_ord_fn(
                 enum_name,

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -3245,7 +3245,7 @@ impl Monomorphizer {
             let method_call = TirExprKind::MethodCall {
                 receiver: Box::new(receiver),
                 func: FunctionRef::External {
-                    module_source: ModuleSource::core("prelude"),
+                    module_source: ModuleSource::prelude(),
                     name: mangled_name,
                     monomorph_info: None,
                     method_info: Some(method_info),
@@ -3296,7 +3296,7 @@ impl Monomorphizer {
             // Get Ordering type for cmp return value
             let ordering_type_id = type_table.intern(ResolvedType::Enum {
                 name: "Ordering".to_string(),
-                module_source: ModuleSource::core("prelude"),
+                module_source: ModuleSource::prelude(),
             });
 
             let method_info =
@@ -3308,7 +3308,7 @@ impl Monomorphizer {
                 TirExprKind::MethodCall {
                     receiver: Box::new(receiver),
                     func: FunctionRef::External {
-                        module_source: ModuleSource::core("prelude"),
+                        module_source: ModuleSource::prelude(),
                         name: mangled_name,
                         monomorph_info: None,
                         method_info: Some(method_info),
@@ -3360,8 +3360,8 @@ impl Monomorphizer {
 /// to set the correct `module_source` so DCE can find the target function.
 fn module_source_for_trait_impl(type_table: &TypeTable, type_id: TypeId) -> Option<ModuleSource> {
     match type_table.get(type_id) {
-        ResolvedType::Primitive(_) => Some(ModuleSource::core("prelude/primitives.wado")),
-        ResolvedType::BuiltinArray(_) => Some(ModuleSource::core("prelude")),
+        ResolvedType::Primitive(_) => Some(ModuleSource::primitives()),
+        ResolvedType::BuiltinArray(_) => Some(ModuleSource::prelude()),
         ResolvedType::Struct { module_source, .. }
         | ResolvedType::GenericInstance { module_source, .. }
         | ResolvedType::Enum { module_source, .. }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -144,10 +144,70 @@ impl ModuleSource {
         Self::Remote { url: url.into() }
     }
 
-    /// Create the module source for the String type (`core:prelude/string.wado`).
+    /// `core:prelude` — the prelude module.
+    #[must_use]
+    pub fn prelude() -> Self {
+        Self::core("prelude")
+    }
+
+    /// `core:prelude/string.wado` — the String type.
     #[must_use]
     pub fn string() -> Self {
         Self::core("prelude/string.wado")
+    }
+
+    /// `core:prelude/array.wado` — the Array type.
+    #[must_use]
+    pub fn array() -> Self {
+        Self::core("prelude/array.wado")
+    }
+
+    /// `core:prelude/format.wado` — format trait helpers.
+    #[must_use]
+    pub fn format() -> Self {
+        Self::core("prelude/format.wado")
+    }
+
+    /// `core:prelude/int128.wado` — 128-bit integer types.
+    #[must_use]
+    pub fn int128() -> Self {
+        Self::core("prelude/int128.wado")
+    }
+
+    /// `core:prelude/primitives.wado` — primitive type methods.
+    #[must_use]
+    pub fn primitives() -> Self {
+        Self::core("prelude/primitives.wado")
+    }
+
+    /// `core:prelude/types.wado` — core type definitions.
+    #[must_use]
+    pub fn types() -> Self {
+        Self::core("prelude/types.wado")
+    }
+
+    /// `core:prelude/traits.wado` — builtin trait definitions.
+    #[must_use]
+    pub fn traits() -> Self {
+        Self::core("prelude/traits.wado")
+    }
+
+    /// `core:internal` — compiler internal functions.
+    #[must_use]
+    pub fn internal() -> Self {
+        Self::core("internal")
+    }
+
+    /// `core:builtin` — builtin wasm instruction mappings.
+    #[must_use]
+    pub fn builtin() -> Self {
+        Self::core("builtin")
+    }
+
+    /// `core:cli` — CLI output functions.
+    #[must_use]
+    pub fn cli() -> Self {
+        Self::core("cli")
     }
 
     /// Create an entry point module source with a filename.
@@ -291,7 +351,7 @@ impl ModuleSource {
     /// for disambiguating same-named types from different modules.
     ///
     /// Examples:
-    /// - `ModuleSource::core("prelude").qualify_name("Option")` → `"core:prelude//Option"`
+    /// - `ModuleSource::prelude().qualify_name("Option")` → `"core:prelude//Option"`
     /// - `ModuleSource::local("./geometry.wado").qualify_name("Point")` → `"./geometry.wado//Point"`
     /// - `ModuleSource::entry_point_with_filename("main.wado").qualify_name("Foo")` → `"main.wado//Foo"`
     #[must_use]
@@ -1285,7 +1345,7 @@ mod tests {
     fn test_build_core_internal_name() {
         let name = build_core_internal_name("log_stdout");
         assert_eq!(name.to_string(), "core/internal/log_stdout");
-        assert_eq!(name.module_source, ModuleSource::core("internal"));
+        assert_eq!(name.module_source, ModuleSource::internal());
         assert_eq!(name.name, "log_stdout");
     }
 
@@ -1471,7 +1531,7 @@ mod tests {
 
     #[test]
     fn test_module_source_to_path() {
-        let source = ModuleSource::core("prelude");
+        let source = ModuleSource::prelude();
         assert_eq!(source.to_path(), vec!["core", "prelude"]);
 
         let source = ModuleSource::wasi("cli");
@@ -1486,7 +1546,8 @@ mod tests {
 
     #[test]
     fn test_module_source_display() {
-        assert_eq!(ModuleSource::core("prelude").to_string(), "core:prelude");
+        assert_eq!(ModuleSource::prelude().to_string(), "core:prelude");
+        assert_eq!(ModuleSource::cli().to_string(), "core:cli");
         assert_eq!(ModuleSource::wasi("cli").to_string(), "wasi:cli");
         assert_eq!(
             ModuleSource::local("./geometry.wado").to_string(),
@@ -1500,16 +1561,16 @@ mod tests {
 
     #[test]
     fn test_module_source_helpers() {
-        let core = ModuleSource::core("internal");
+        let core = ModuleSource::internal();
         assert!(core.is_core());
         assert!(core.is_core_internal());
         assert!(!core.is_wasi());
         assert!(!core.is_local());
 
-        let builtin = ModuleSource::core("builtin");
+        let builtin = ModuleSource::builtin();
         assert!(builtin.is_core_builtin());
 
-        let prelude = ModuleSource::core("prelude");
+        let prelude = ModuleSource::prelude();
         assert!(prelude.is_core_prelude());
 
         let wasi = ModuleSource::wasi("cli");
@@ -1524,7 +1585,7 @@ mod tests {
     #[test]
     fn test_module_source_qualify_name() {
         assert_eq!(
-            ModuleSource::core("prelude").qualify_name("Option"),
+            ModuleSource::prelude().qualify_name("Option"),
             "core:prelude//Option"
         );
         assert_eq!(

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -144,6 +144,12 @@ impl ModuleSource {
         Self::Remote { url: url.into() }
     }
 
+    /// Create the module source for the String type (`core:prelude/string.wado`).
+    #[must_use]
+    pub fn string() -> Self {
+        Self::core("prelude/string.wado")
+    }
+
     /// Create an entry point module source with a filename.
     #[must_use]
     pub fn entry_point_with_filename(filename: impl Into<String>) -> Self {

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -132,7 +132,7 @@ pub fn analyze_project(project: &mut Project) {
     // 3. Any builtin call_indirect_* functions (ambient effect calls)
     let is_builtin_func = |f: &FreeFunctionName| {
         // Check if module_source is core/builtin
-        matches!(&f.module_source, ModuleSource::Core { name } if name == "builtin")
+        f.module_source.is_core_builtin()
             // Legacy format: name starts with "builtin::"
             || f.name.starts_with("builtin::")
     };

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -700,7 +700,7 @@ fn analyze_expr(
                         // (e.g., i32^Ord::cmp, char::is_ascii_space)
                         let prim_name = prim.as_str().to_string();
                         let method_id = FunctionId::Method(MethodName::new(
-                            ModuleSource::core("prelude/primitives.wado"),
+                            ModuleSource::primitives(),
                             prim_name,
                             trait_name.clone(),
                             method_name.clone(),
@@ -1026,7 +1026,7 @@ fn add_to_string_callee(type_id: TypeId, type_table: &TypeTable, analysis: &mut 
             let prim_name = prim.as_str();
             // Method format: module_source/StructName::method_name
             let method_id = FunctionId::Method(MethodName::new(
-                ModuleSource::core("prelude/primitives.wado"),
+                ModuleSource::primitives(),
                 prim_name.to_string(),
                 None,
                 "to_string".to_string(),

--- a/wado-compiler/src/optimize/rewrite.rs
+++ b/wado-compiler/src/optimize/rewrite.rs
@@ -308,7 +308,7 @@ fn try_lower_to_select(
 
     // Construct: builtin::select(condition, true_val, false_val)
     let func_ref = FunctionRef::External {
-        module_source: ModuleSource::core("builtin"),
+        module_source: ModuleSource::builtin(),
         name: "select".to_string(),
         monomorph_info: Some(MonomorphInfo {
             generic_name: "select".to_string(),

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -5169,11 +5169,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
                     // Builtin functions: resolve through core:builtin module
                     if prefix == "builtin" {
-                        (
-                            Some(ModuleSource::builtin()),
-                            suffix.to_string(),
-                            true,
-                        )
+                        (Some(ModuleSource::builtin()), suffix.to_string(), true)
                     }
                     // Check if this is a static method call (Type::method)
                     // Static methods are registered with mangled names "Type::method"
@@ -5289,11 +5285,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 // Check for prelude functions (panic, unreachable)
                 // These are defined in core:internal and re-exported by core:prelude
                 else if matches!(ident.name.as_str(), "panic" | "unreachable") {
-                    (
-                        Some(ModuleSource::internal()),
-                        ident.name.clone(),
-                        true,
-                    )
+                    (Some(ModuleSource::internal()), ident.name.clone(), true)
                 }
                 // Check if this is an imported function (per-module imports)
                 else if self.imported_functions.contains(&ident.name) {
@@ -5615,10 +5607,9 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
     /// Get the String struct type (from core:prelude/string.wado)
     fn get_string_struct_type(&mut self) -> TypeId {
-        self.type_table.borrow_mut().make_struct(
-            "String".to_string(),
-            ModuleSource::string(),
-        )
+        self.type_table
+            .borrow_mut()
+            .make_struct("String".to_string(), ModuleSource::string())
     }
 
     /// Build a `from_pair` call for i128/u128 large literal construction
@@ -10600,10 +10591,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         )];
 
         // Prepare Formatter type and its &mut type
-        let formatter_type = self.type_table.borrow_mut().make_struct(
-            "Formatter".to_string(),
-            ModuleSource::format(),
-        );
+        let formatter_type = self
+            .type_table
+            .borrow_mut()
+            .make_struct("Formatter".to_string(), ModuleSource::format());
         let mut_ref_formatter = self.type_table.borrow_mut().make_mut_ref(formatter_type);
 
         // Track whether we've created the __f local yet
@@ -11096,10 +11087,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
         // Construct Formatter struct literal with custom fields
         let pf = parsed.as_ref().unwrap();
-        let alignment_type = self.type_table.borrow_mut().make_enum(
-            "Alignment".to_string(),
-            ModuleSource::format(),
-        );
+        let alignment_type = self
+            .type_table
+            .borrow_mut()
+            .make_enum("Alignment".to_string(), ModuleSource::format());
         let fill_char = pf.fill.unwrap_or(if pf.zero_pad { '0' } else { ' ' });
         let align_index: u32 = match pf.align {
             Some('<') => 0, // Left

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -6422,34 +6422,21 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 ..
             } => (name.clone(), module_source.clone()),
             // Primitive types have impl blocks in core:prelude/primitives
-            ResolvedType::Primitive(_) => {
-                let prim_module = ModuleSource::Core {
-                    name: "prelude/primitives.wado".to_string(),
-                };
-                (
-                    self.type_table.borrow().mangle_type_name(base_type_id),
-                    prim_module,
-                )
-            }
+            ResolvedType::Primitive(_) => (
+                self.type_table.borrow().mangle_type_name(base_type_id),
+                ModuleSource::primitives(),
+            ),
             // BuiltinArray is Array - impl blocks are in core:prelude/array.wado
-            ResolvedType::BuiltinArray(_) => {
-                let array_module = ModuleSource::Core {
-                    name: "prelude/array.wado".to_string(),
-                };
-                ("Array".to_string(), array_module)
-            }
+            ResolvedType::BuiltinArray(_) => ("Array".to_string(), ModuleSource::array()),
             // Enum types - use enum name and its defining module
             ResolvedType::Enum {
                 name,
                 module_source,
             } => (name.clone(), module_source.clone()),
             // FutureWritable<T> - resource methods declared in core:prelude/types.wado
-            ResolvedType::FutureWritable(_) => (
-                "FutureWritable".to_string(),
-                ModuleSource::Core {
-                    name: "prelude/types.wado".to_string(),
-                },
-            ),
+            ResolvedType::FutureWritable(_) => {
+                ("FutureWritable".to_string(), ModuleSource::types())
+            }
             _ => (
                 self.type_table.borrow().mangle_type_name(base_type_id),
                 self.current_module_source.clone(),
@@ -7689,9 +7676,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 | "bool"
                 | "char"
         ) {
-            return ModuleSource::Core {
-                name: "prelude/primitives.wado".to_string(),
-            };
+            return ModuleSource::primitives();
         }
 
         // Check current module
@@ -7792,9 +7777,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             // FutureWritable<T> - resource methods declared in core:prelude/types.wado
             ResolvedType::FutureWritable(inner) => (
                 "FutureWritable".to_string(),
-                Some(ModuleSource::Core {
-                    name: "prelude/types.wado".to_string(),
-                }),
+                Some(ModuleSource::types()),
                 Some(vec![*inner]),
                 None,
             ),
@@ -11434,10 +11417,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             self.type_table.borrow().get(base_type_id),
             ResolvedType::Primitive(_)
         ) {
-            let prim_module = ModuleSource::Core {
-                name: "prelude/primitives.wado".to_string(),
-            };
-            return Some((type_name, prim_module));
+            return Some((type_name, ModuleSource::primitives()));
         }
 
         None

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -39,11 +39,6 @@ use crate::tir::{
 };
 use crate::token::Span;
 
-/// Helper to get the `ModuleSource` for String type (core:prelude/string.wado)
-fn string_module_source() -> ModuleSource {
-    ModuleSource::core("prelude/string.wado")
-}
-
 /// Parsed format specification from a template string interpolation.
 /// Syntax: `[[fill]align][sign][#][0][width][.precision]type`
 #[allow(dead_code)]
@@ -4710,7 +4705,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
         }
 
-        let op = convert_binary_op(binary.op);
+        let op = util::convert_binary_op(binary.op);
 
         // Type check: both operands of a binary operation must have the same type.
         // This applies to primitives, newtypes, and all non-overloaded binary ops.
@@ -4771,7 +4766,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         }
 
         let expr = self.resolve_expr(&unary.expr, ctx, None);
-        let op = convert_unary_op(unary.op);
+        let op = util::convert_unary_op(unary.op);
 
         // Track address-taken locals for &x and &mut x
         if matches!(unary.op, UnaryOp::Ref | UnaryOp::MutRef)
@@ -5787,7 +5782,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     fn get_string_struct_type(&mut self) -> TypeId {
         self.type_table.borrow_mut().make_struct(
             "String".to_string(),
-            ModuleSource::core("prelude/string.wado"),
+            ModuleSource::string(),
         )
     }
 
@@ -10753,7 +10748,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         let with_capacity_call = TirExpr::new(
             TirExprKind::StaticCall {
                 func: FunctionRef::External {
-                    module_source: string_module_source(),
+                    module_source: ModuleSource::string(),
                     name: "String::with_capacity".to_string(),
                     monomorph_info: None,
                     method_info: Some(LocalMethodName::new(
@@ -10816,7 +10811,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(buf_ref),
                             func: FunctionRef::External {
-                                module_source: string_module_source(),
+                                module_source: ModuleSource::string(),
                                 name: "String::append".to_string(),
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -10854,7 +10849,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             TirExprKind::MethodCall {
                                 receiver: Box::new(buf_ref),
                                 func: FunctionRef::External {
-                                    module_source: string_module_source(),
+                                    module_source: ModuleSource::string(),
                                     name: "String::append".to_string(),
                                     monomorph_info: None,
                                     method_info: Some(LocalMethodName::new(
@@ -12395,42 +12390,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     /// Get the type table (after resolution)
     pub fn into_type_table(self) -> Rc<RefCell<TypeTable>> {
         self.type_table
-    }
-}
-
-/// Convert AST `BinaryOp` to TIR `BinaryOp`
-fn convert_binary_op(op: BinaryOp) -> TirBinaryOp {
-    match op {
-        BinaryOp::Add => TirBinaryOp::Add,
-        BinaryOp::Sub => TirBinaryOp::Sub,
-        BinaryOp::Mul => TirBinaryOp::Mul,
-        BinaryOp::Div => TirBinaryOp::Div,
-        BinaryOp::Mod => TirBinaryOp::Mod,
-        BinaryOp::Eq => TirBinaryOp::Eq,
-        BinaryOp::NotEq => TirBinaryOp::NotEq,
-        BinaryOp::Lt => TirBinaryOp::Lt,
-        BinaryOp::LtEq => TirBinaryOp::LtEq,
-        BinaryOp::Gt => TirBinaryOp::Gt,
-        BinaryOp::GtEq => TirBinaryOp::GtEq,
-        BinaryOp::And => TirBinaryOp::And,
-        BinaryOp::Or => TirBinaryOp::Or,
-        BinaryOp::BitAnd => TirBinaryOp::BitAnd,
-        BinaryOp::BitOr => TirBinaryOp::BitOr,
-        BinaryOp::BitXor => TirBinaryOp::BitXor,
-        BinaryOp::Shl => TirBinaryOp::Shl,
-        BinaryOp::Shr => TirBinaryOp::Shr,
-    }
-}
-
-/// Convert AST `UnaryOp` to TIR `UnaryOp`
-fn convert_unary_op(op: UnaryOp) -> TirUnaryOp {
-    match op {
-        UnaryOp::Neg => TirUnaryOp::Neg,
-        UnaryOp::Not => TirUnaryOp::Not,
-        UnaryOp::BitNot => TirUnaryOp::BitNot,
-        UnaryOp::Ref => TirUnaryOp::Ref,
-        UnaryOp::MutRef => TirUnaryOp::MutRef,
-        UnaryOp::Deref => TirUnaryOp::Deref,
     }
 }
 

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -4276,7 +4276,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         if matches!(ident.name.as_str(), "panic" | "unreachable") {
             return TirExpr::new(
                 TirExprKind::Global {
-                    module_source: ModuleSource::core("internal"),
+                    module_source: ModuleSource::internal(),
                     name: ident.name.clone(),
                 },
                 TypeTable::UNKNOWN,
@@ -4389,7 +4389,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(receiver),
                             func: FunctionRef::External {
-                                module_source: ModuleSource::core("prelude"),
+                                module_source: ModuleSource::prelude(),
                                 name: mangled_method_name,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -4451,7 +4451,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     let ordering_type_id =
                         self.type_table.borrow_mut().intern(ResolvedType::Enum {
                             name: "Ordering".to_string(),
-                            module_source: ModuleSource::core("prelude"),
+                            module_source: ModuleSource::prelude(),
                         });
 
                     let mangled_method_name =
@@ -4461,7 +4461,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(receiver),
                             func: FunctionRef::External {
-                                module_source: ModuleSource::core("prelude"),
+                                module_source: ModuleSource::prelude(),
                                 name: mangled_method_name,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -4590,7 +4590,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(receiver),
                             func: FunctionRef::External {
-                                module_source: ModuleSource::core("prelude"),
+                                module_source: ModuleSource::prelude(),
                                 name: mangled_method_name,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -4654,7 +4654,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(receiver),
                             func: FunctionRef::External {
-                                module_source: ModuleSource::core("prelude"),
+                                module_source: ModuleSource::prelude(),
                                 name: mangled_method_name,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -4842,7 +4842,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(receiver),
                             func: FunctionRef::External {
-                                module_source: ModuleSource::core("prelude"),
+                                module_source: ModuleSource::prelude(),
                                 name: mangled_method_name,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -4892,7 +4892,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         TirExprKind::MethodCall {
                             receiver: Box::new(receiver),
                             func: FunctionRef::External {
-                                module_source: ModuleSource::core("prelude"),
+                                module_source: ModuleSource::prelude(),
                                 name: mangled_method_name,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
@@ -5335,7 +5335,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     // Builtin functions: resolve through core:builtin module
                     if prefix == "builtin" {
                         (
-                            Some(ModuleSource::core("builtin")),
+                            Some(ModuleSource::builtin()),
                             suffix.to_string(),
                             true,
                         )
@@ -5455,7 +5455,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 // These are defined in core:internal and re-exported by core:prelude
                 else if matches!(ident.name.as_str(), "panic" | "unreachable") {
                     (
-                        Some(ModuleSource::core("internal")),
+                        Some(ModuleSource::internal()),
                         ident.name.clone(),
                         true,
                     )
@@ -5823,7 +5823,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         TirExpr::new(
             TirExprKind::StaticCall {
                 func: FunctionRef::External {
-                    module_source: ModuleSource::core("prelude/int128.wado"),
+                    module_source: ModuleSource::int128(),
                     name: mangled_func_name,
                     monomorph_info: None,
                     method_info: Some(method_info),
@@ -6141,7 +6141,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         return Some(TirExpr::new(
                             TirExprKind::StaticCall {
                                 func: FunctionRef::External {
-                                    module_source: ModuleSource::core("prelude/int128.wado"),
+                                    module_source: ModuleSource::int128(),
                                     name: mangled_func_name,
                                     monomorph_info: None,
                                     method_info: Some(method_info),
@@ -6938,7 +6938,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 return TirExpr::new(
                     TirExprKind::Call {
                         func: FunctionRef::External {
-                            module_source: ModuleSource::core("builtin"),
+                            module_source: ModuleSource::builtin(),
                             name: builtin_name.to_string(),
                             monomorph_info: None,
                             method_info: None,
@@ -10784,7 +10784,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Prepare Formatter type and its &mut type
         let formatter_type = self.type_table.borrow_mut().make_struct(
             "Formatter".to_string(),
-            ModuleSource::core("prelude/format.wado"),
+            ModuleSource::format(),
         );
         let mut_ref_formatter = self.type_table.borrow_mut().make_mut_ref(formatter_type);
 
@@ -10985,7 +10985,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         let inspect_call = TirExpr::new(
                             TirExprKind::StaticCall {
                                 func: FunctionRef::External {
-                                    module_source: ModuleSource::core("builtin"),
+                                    module_source: ModuleSource::builtin(),
                                     name: "builtin::inspect".to_string(),
                                     monomorph_info: None,
                                     method_info: None,
@@ -11010,7 +11010,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         let fmt_call = TirExpr::new(
                             TirExprKind::StaticCall {
                                 func: FunctionRef::External {
-                                    module_source: ModuleSource::core("prelude/primitives.wado"),
+                                    module_source: ModuleSource::primitives(),
                                     name: func_name.to_string(),
                                     monomorph_info: None,
                                     method_info: None,
@@ -11086,7 +11086,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             let inspect_call = TirExpr::new(
                                 TirExprKind::StaticCall {
                                     func: FunctionRef::External {
-                                        module_source: ModuleSource::core("builtin"),
+                                        module_source: ModuleSource::builtin(),
                                         name: "builtin::inspect".to_string(),
                                         monomorph_info: None,
                                         method_info: None,
@@ -11260,7 +11260,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             return TirExpr::new(
                 TirExprKind::StaticCall {
                     func: FunctionRef::External {
-                        module_source: ModuleSource::core("prelude/format.wado"),
+                        module_source: ModuleSource::format(),
                         name: "Formatter::new".to_string(),
                         monomorph_info: None,
                         method_info: Some(LocalMethodName::new(
@@ -11280,7 +11280,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         let pf = parsed.as_ref().unwrap();
         let alignment_type = self.type_table.borrow_mut().make_enum(
             "Alignment".to_string(),
-            ModuleSource::core("prelude/format.wado"),
+            ModuleSource::format(),
         );
         let fill_char = pf.fill.unwrap_or(if pf.zero_pad { '0' } else { ' ' });
         let align_index: u32 = match pf.align {
@@ -11531,7 +11531,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         return TirExpr::new(
                             TirExprKind::StaticCall {
                                 func: FunctionRef::External {
-                                    module_source: ModuleSource::core("prelude/int128.wado"),
+                                    module_source: ModuleSource::int128(),
                                     name: mangled_func_name,
                                     monomorph_info: None,
                                     method_info: Some(method_info),
@@ -11626,7 +11626,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 return TirExpr::new(
                     TirExprKind::StaticCall {
                         func: FunctionRef::External {
-                            module_source: ModuleSource::core("prelude/int128.wado"),
+                            module_source: ModuleSource::int128(),
                             name: mangled_func_name,
                             monomorph_info: None,
                             method_info: Some(method_info),
@@ -12274,7 +12274,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     /// Resolve a generic type
     fn resolve_generic_type(&mut self, name: &str, args: &[Type], span: Span) -> TypeId {
         // Prelude module path for looking up Option/Result
-        let prelude_source = ModuleSource::core("prelude");
+        let prelude_source = ModuleSource::prelude();
 
         match name {
             "Option" => {

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -3533,7 +3533,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 let tir_lit = match lit {
                     Literal::Number(n) => {
                         // Float literals cannot be used in match patterns
-                        if Self::is_float_only_literal(&n.repr) {
+                        if util::is_float_only_literal(&n.repr) {
                             let _ = self.logger.error(TypeError::InvalidPattern {
                                 message: "float literals cannot be used in match patterns"
                                     .to_string(),
@@ -3558,12 +3558,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             ResolvedType::Struct { ref name, .. } if name == "u128"
                         );
                         if is_unsigned {
-                            match Self::parse_u128_literal(&n.repr) {
+                            match util::parse_u128_literal(&n.repr) {
                                 Ok(value) => TirLiteralPattern::U128(value),
                                 Err(_) => TirLiteralPattern::U128(0),
                             }
                         } else {
-                            match Self::parse_i128_literal(&n.repr) {
+                            match util::parse_i128_literal(&n.repr) {
                                 Ok(value) => TirLiteralPattern::I128(value),
                                 Err(_) => TirLiteralPattern::I128(0),
                             }
@@ -3799,179 +3799,14 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         TirStmt::new(TirStmtKind::Continue, continue_stmt.span)
     }
 
-    /// Resolve an expression
-    /// Parse an integer literal string into a u64 value
-    /// Supports decimal, hex, binary, octal, and scientific notation (e.g., "1e10")
-    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
-    fn parse_int_literal(repr: &str) -> Result<u64, String> {
-        // Remove underscores for parsing
-        let clean: String = repr.chars().filter(|&c| c != '_').collect();
-
-        // Handle negative numbers by parsing as i64 and reinterpreting bits
-        if clean.starts_with('-') {
-            // Check for scientific notation in negative numbers
-            if clean.to_lowercase().contains('e') {
-                let value: f64 = clean
-                    .parse()
-                    .map_err(|_| format!("invalid integer literal: {repr}"))?;
-                if value.fract() != 0.0 {
-                    return Err(format!("integer literal has fractional part: {repr}"));
-                }
-                if value < i64::MIN as f64 || value > i64::MAX as f64 {
-                    return Err(format!("integer literal out of range: {repr}"));
-                }
-                return Ok((value as i64) as u64);
-            }
-            let value: i64 = clean
-                .parse()
-                .map_err(|_| format!("invalid integer literal: {repr}"))?;
-            // Reinterpret i64 bits as u64 for storage
-            return Ok(value as u64);
-        }
-
-        if clean.starts_with("0x") || clean.starts_with("0X") {
-            u64::from_str_radix(&clean[2..], 16).map_err(|_| format!("invalid hex literal: {repr}"))
-        } else if clean.starts_with("0b") || clean.starts_with("0B") {
-            u64::from_str_radix(&clean[2..], 2)
-                .map_err(|_| format!("invalid binary literal: {repr}"))
-        } else if clean.starts_with("0o") || clean.starts_with("0O") {
-            u64::from_str_radix(&clean[2..], 8)
-                .map_err(|_| format!("invalid octal literal: {repr}"))
-        } else if clean.to_lowercase().contains('e') {
-            // Scientific notation: parse as f64 first, then convert to u64
-            let value: f64 = clean
-                .parse()
-                .map_err(|_| format!("invalid integer literal: {repr}"))?;
-            if value.fract() != 0.0 {
-                return Err(format!("integer literal has fractional part: {repr}"));
-            }
-            if value < 0.0 || value > u64::MAX as f64 {
-                return Err(format!("integer literal out of range: {repr}"));
-            }
-            Ok(value as u64)
-        } else {
-            clean
-                .parse()
-                .map_err(|_| format!("invalid integer literal: {repr}"))
-        }
-    }
-
-    /// Parse a float literal string into an f64 value
-    #[allow(clippy::cast_precision_loss)]
-    fn parse_float_literal(repr: &str) -> Result<f64, String> {
-        // Remove underscores for parsing
-        let clean: String = repr.chars().filter(|&c| c != '_').collect();
-
-        // Handle hex/binary/octal literals as float values (not bit patterns)
-        if clean.starts_with("0x") || clean.starts_with("0X") {
-            let value = u64::from_str_radix(&clean[2..], 16)
-                .map_err(|_| format!("invalid hex literal: {repr}"))?;
-            return Ok(value as f64);
-        } else if clean.starts_with("0b") || clean.starts_with("0B") {
-            let value = u64::from_str_radix(&clean[2..], 2)
-                .map_err(|_| format!("invalid binary literal: {repr}"))?;
-            return Ok(value as f64);
-        } else if clean.starts_with("0o") || clean.starts_with("0O") {
-            let value = u64::from_str_radix(&clean[2..], 8)
-                .map_err(|_| format!("invalid octal literal: {repr}"))?;
-            return Ok(value as f64);
-        }
-
-        clean
-            .parse()
-            .map_err(|_| format!("invalid float literal: {repr}"))
-    }
-
-    /// Check if a number literal can only be a float (has decimal point or negative exponent)
-    fn is_float_only_literal(repr: &str) -> bool {
-        // Has decimal point → float only
-        if repr.contains('.') {
-            return true;
-        }
-
-        // Check for negative exponent (e.g., "1e-5")
-        let lower = repr.to_lowercase();
-        if let Some(e_pos) = lower.find('e') {
-            let after_e = &repr[e_pos + 1..];
-            if after_e.starts_with('-') {
-                return true;
-            }
-        }
-
-        false
-    }
-
-    /// Parse an unsigned integer literal into a u128 value
-    /// Supports decimal, hex, binary, and octal formats
-    fn parse_u128_literal(repr: &str) -> Result<u128, String> {
-        let clean: String = repr.chars().filter(|&c| c != '_').collect();
-
-        if clean.starts_with("0x") || clean.starts_with("0X") {
-            u128::from_str_radix(&clean[2..], 16)
-                .map_err(|_| format!("invalid hex literal: {repr}"))
-        } else if clean.starts_with("0b") || clean.starts_with("0B") {
-            u128::from_str_radix(&clean[2..], 2)
-                .map_err(|_| format!("invalid binary literal: {repr}"))
-        } else if clean.starts_with("0o") || clean.starts_with("0O") {
-            u128::from_str_radix(&clean[2..], 8)
-                .map_err(|_| format!("invalid octal literal: {repr}"))
-        } else {
-            clean
-                .parse()
-                .map_err(|_| format!("invalid integer literal: {repr}"))
-        }
-    }
-
-    /// Parse a signed integer literal into an i128 value
-    /// Supports decimal, hex, binary, and octal formats (negative decimals supported)
-    fn parse_i128_literal(repr: &str) -> Result<i128, String> {
-        let clean: String = repr.chars().filter(|&c| c != '_').collect();
-
-        if clean.starts_with("0x") || clean.starts_with("0X") {
-            // Hex literals are always positive, parse as u128 then convert
-            let unsigned = u128::from_str_radix(&clean[2..], 16)
-                .map_err(|_| format!("invalid hex literal: {repr}"))?;
-            Ok(unsigned as i128)
-        } else if clean.starts_with("0b") || clean.starts_with("0B") {
-            let unsigned = u128::from_str_radix(&clean[2..], 2)
-                .map_err(|_| format!("invalid binary literal: {repr}"))?;
-            Ok(unsigned as i128)
-        } else if clean.starts_with("0o") || clean.starts_with("0O") {
-            let unsigned = u128::from_str_radix(&clean[2..], 8)
-                .map_err(|_| format!("invalid octal literal: {repr}"))?;
-            Ok(unsigned as i128)
-        } else {
-            // Decimal - may be negative
-            clean
-                .parse()
-                .map_err(|_| format!("invalid integer literal: {repr}"))
-        }
-    }
-
-    /// Unpack u128 into (low, high) pair for codegen
-    fn unpack_u128(value: u128) -> (u64, u64) {
-        (value as u64, (value >> 64) as u64)
-    }
-
-    /// Unpack i128 into (low, high) pair for codegen
-    #[allow(clippy::cast_sign_loss)]
-    fn unpack_i128(value: i128) -> (u64, i64) {
-        (value as u64, (value >> 64) as i64)
-    }
-
-    /// Get the clean representation of a literal (without underscores)
-    fn clean_literal_repr(repr: &str) -> String {
-        repr.chars().filter(|&c| c != '_').collect()
-    }
-
     /// Resolve a literal expression
     fn resolve_literal(&mut self, lit: &ast::LiteralExpr, ctx: &FunctionContext) -> TirExpr {
         let (kind, type_id) = match &lit.value {
             Literal::Number(num_lit) => {
                 // Default type: i32 if integer-compatible, f64 if float-only
-                if Self::is_float_only_literal(&num_lit.repr) {
+                if util::is_float_only_literal(&num_lit.repr) {
                     // Must be float (has decimal point or negative exponent)
-                    match Self::parse_float_literal(&num_lit.repr) {
+                    match util::parse_float_literal(&num_lit.repr) {
                         Ok(value) => (
                             TirExprKind::FloatLiteral {
                                 value,
@@ -3995,7 +3830,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     }
                 } else {
                     // Can be integer (default to i32)
-                    match Self::parse_int_literal(&num_lit.repr) {
+                    match util::parse_int_literal(&num_lit.repr) {
                         Ok(value) => (
                             TirExprKind::IntLiteral {
                                 value,
@@ -5914,7 +5749,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             && let Literal::Number(num_lit) = &lit.value
             && self.type_table.borrow().is_integer(target_type)
         {
-            if Self::is_float_only_literal(&num_lit.repr) {
+            if util::is_float_only_literal(&num_lit.repr) {
                 let _ = self.logger.error(TypeError::InvalidLiteral {
                     message: format!(
                         "cannot use float literal '{}' as integer (has decimal point or negative exponent)",
@@ -5931,7 +5766,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     lit.span,
                 ));
             }
-            return Some(match Self::parse_int_literal(&num_lit.repr) {
+            return Some(match util::parse_int_literal(&num_lit.repr) {
                 Ok(value) => {
                     if let Some(err_msg) = util::check_int_range_positive(
                         value,
@@ -5977,7 +5812,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             && let Literal::Number(num_lit) = &lit.value
             && self.type_table.borrow().is_integer(target_type)
         {
-            if Self::is_float_only_literal(&num_lit.repr) {
+            if util::is_float_only_literal(&num_lit.repr) {
                 let _ = self.logger.error(TypeError::InvalidLiteral {
                     message: format!(
                         "cannot use float literal '-{}' as integer (has decimal point or negative exponent)",
@@ -5994,7 +5829,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     unary.span,
                 ));
             }
-            return Some(match Self::parse_int_literal(&num_lit.repr) {
+            return Some(match util::parse_int_literal(&num_lit.repr) {
                 Ok(value) => {
                     if let Some(err_msg) = util::check_int_range_negative(
                         value,
@@ -6039,7 +5874,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             && let Literal::Number(num_lit) = &lit.value
             && self.type_table.borrow().is_float(target_type)
         {
-            return Some(match Self::parse_float_literal(&num_lit.repr) {
+            return Some(match util::parse_float_literal(&num_lit.repr) {
                 Ok(value) => TirExpr::new(
                     TirExprKind::FloatLiteral {
                         value,
@@ -6072,7 +5907,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             && let Literal::Number(num_lit) = &lit.value
             && self.type_table.borrow().is_float(target_type)
         {
-            return Some(match Self::parse_float_literal(&num_lit.repr) {
+            return Some(match util::parse_float_literal(&num_lit.repr) {
                 Ok(value) => TirExpr::new(
                     TirExprKind::FloatLiteral {
                         value: -value,
@@ -6101,7 +5936,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // i128/u128 literal coercion
         if let Expr::Literal(lit) = expr
             && let Literal::Number(num_lit) = &lit.value
-            && !Self::is_float_only_literal(&num_lit.repr)
+            && !util::is_float_only_literal(&num_lit.repr)
         {
             let struct_name = match self.type_table.borrow().get(target_type).clone() {
                 ResolvedType::Struct { name, .. } => Some(name),
@@ -6111,7 +5946,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             if let Some(name) = struct_name
                 && (name == "u128" || name == "i128")
             {
-                if let Ok(value) = Self::parse_int_literal(&num_lit.repr) {
+                if let Ok(value) = util::parse_int_literal(&num_lit.repr) {
                     let use_from_u64_or_i64 = if name == "u128" {
                         true
                     } else {
@@ -6156,8 +5991,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
                 // Value doesn't fit in u64 (or i64 for i128), use from_pair
                 if name == "u128" {
-                    if let Ok(value) = Self::parse_u128_literal(&num_lit.repr) {
-                        let (low, high) = Self::unpack_u128(value);
+                    if let Ok(value) = util::parse_u128_literal(&num_lit.repr) {
+                        let (low, high) = util::unpack_u128(value);
                         return Some(self.build_from_pair_call(
                             &name,
                             low,
@@ -6171,8 +6006,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         span: lit.span,
                     });
                 } else {
-                    if let Ok(value) = Self::parse_i128_literal(&num_lit.repr) {
-                        let (low, high) = Self::unpack_i128(value);
+                    if let Ok(value) = util::parse_i128_literal(&num_lit.repr) {
+                        let (low, high) = util::unpack_i128(value);
                         return Some(self.build_from_pair_call(
                             &name,
                             low,
@@ -6194,7 +6029,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             && unary.op == ast::UnaryOp::Neg
             && let Expr::Literal(lit) = &unary.expr
             && let Literal::Number(num_lit) = &lit.value
-            && !Self::is_float_only_literal(&num_lit.repr)
+            && !util::is_float_only_literal(&num_lit.repr)
         {
             let struct_name = match self.type_table.borrow().get(target_type).clone() {
                 ResolvedType::Struct { name, .. } => Some(name),
@@ -6204,9 +6039,9 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             if let Some(name) = struct_name
                 && name == "i128"
             {
-                let negated_repr = format!("-{}", Self::clean_literal_repr(&num_lit.repr));
-                if let Ok(value) = Self::parse_i128_literal(&negated_repr) {
-                    let (low, high) = Self::unpack_i128(value);
+                let negated_repr = format!("-{}", util::clean_literal_repr(&num_lit.repr));
+                if let Ok(value) = util::parse_i128_literal(&negated_repr) {
+                    let (low, high) = util::unpack_i128(value);
                     return Some(self.build_from_pair_call(
                         &name,
                         low,
@@ -10022,7 +9857,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 value: ast::Literal::Number(num_lit),
                 ..
             }) = &index.index
-                && !Self::is_float_only_literal(&num_lit.repr)
+                && !util::is_float_only_literal(&num_lit.repr)
                 && let Ok(idx) = num_lit.repr.parse::<usize>()
             {
                 if idx < elements.len() {
@@ -11475,10 +11310,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             // Handle number literal cast specially to support values > u64
             if let ast::Expr::Literal(lit) = &cast.expr
                 && let Literal::Number(num_lit) = &lit.value
-                && !Self::is_float_only_literal(&num_lit.repr)
+                && !util::is_float_only_literal(&num_lit.repr)
             {
                 // Try to parse as u64
-                if let Ok(value) = Self::parse_int_literal(&num_lit.repr) {
+                if let Ok(value) = util::parse_int_literal(&num_lit.repr) {
                     // For u128: value fits in u64, use from_u64
                     // For i128: value must also fit in i64 (positive range), otherwise use from_string
                     let use_from_u64_or_i64 = if name == "u128" {
@@ -11526,8 +11361,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
                 // Value doesn't fit in u64 (or i64 for i128), use from_pair
                 if name == "u128" {
-                    if let Ok(value) = Self::parse_u128_literal(&num_lit.repr) {
-                        let (low, high) = Self::unpack_u128(value);
+                    if let Ok(value) = util::parse_u128_literal(&num_lit.repr) {
+                        let (low, high) = util::unpack_u128(value);
                         return self.build_from_pair_call(
                             name,
                             low,
@@ -11542,8 +11377,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     });
                 } else {
                     // i128
-                    if let Ok(value) = Self::parse_i128_literal(&num_lit.repr) {
-                        let (low, high) = Self::unpack_i128(value);
+                    if let Ok(value) = util::parse_i128_literal(&num_lit.repr) {
+                        let (low, high) = util::unpack_i128(value);
                         return self.build_from_pair_call(name, low, high, target_type, cast.span);
                     }
                     let _ = self.logger.error(TypeError::InvalidLiteral {
@@ -11558,13 +11393,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 && unary.op == ast::UnaryOp::Neg
                 && let ast::Expr::Literal(lit) = &unary.expr
                 && let Literal::Number(num_lit) = &lit.value
-                && !Self::is_float_only_literal(&num_lit.repr)
+                && !util::is_float_only_literal(&num_lit.repr)
                 && name == "i128"
             {
                 // Parse the negated value directly using Rust's i128
-                let negated_repr = format!("-{}", Self::clean_literal_repr(&num_lit.repr));
-                if let Ok(value) = Self::parse_i128_literal(&negated_repr) {
-                    let (low, high) = Self::unpack_i128(value);
+                let negated_repr = format!("-{}", util::clean_literal_repr(&num_lit.repr));
+                if let Ok(value) = util::parse_i128_literal(&negated_repr) {
+                    let (low, high) = util::unpack_i128(value);
                     return self.build_from_pair_call(name, low, high, target_type, unary.span);
                 }
                 let _ = self.logger.error(TypeError::InvalidLiteral {

--- a/wado-compiler/src/resolver/util.rs
+++ b/wado-compiler/src/resolver/util.rs
@@ -1,6 +1,43 @@
-//! Utility functions for integer literal range checking during type coercion.
+//! Utility functions for the resolver phase.
 
-use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
+use crate::ast::{BinaryOp, UnaryOp};
+use crate::tir::{PrimitiveType, ResolvedType, TirBinaryOp, TirUnaryOp, TypeId, TypeTable};
+
+/// Convert AST `BinaryOp` to TIR `BinaryOp`.
+pub(super) fn convert_binary_op(op: BinaryOp) -> TirBinaryOp {
+    match op {
+        BinaryOp::Add => TirBinaryOp::Add,
+        BinaryOp::Sub => TirBinaryOp::Sub,
+        BinaryOp::Mul => TirBinaryOp::Mul,
+        BinaryOp::Div => TirBinaryOp::Div,
+        BinaryOp::Mod => TirBinaryOp::Mod,
+        BinaryOp::Eq => TirBinaryOp::Eq,
+        BinaryOp::NotEq => TirBinaryOp::NotEq,
+        BinaryOp::Lt => TirBinaryOp::Lt,
+        BinaryOp::LtEq => TirBinaryOp::LtEq,
+        BinaryOp::Gt => TirBinaryOp::Gt,
+        BinaryOp::GtEq => TirBinaryOp::GtEq,
+        BinaryOp::And => TirBinaryOp::And,
+        BinaryOp::Or => TirBinaryOp::Or,
+        BinaryOp::BitAnd => TirBinaryOp::BitAnd,
+        BinaryOp::BitOr => TirBinaryOp::BitOr,
+        BinaryOp::BitXor => TirBinaryOp::BitXor,
+        BinaryOp::Shl => TirBinaryOp::Shl,
+        BinaryOp::Shr => TirBinaryOp::Shr,
+    }
+}
+
+/// Convert AST `UnaryOp` to TIR `UnaryOp`.
+pub(super) fn convert_unary_op(op: UnaryOp) -> TirUnaryOp {
+    match op {
+        UnaryOp::Neg => TirUnaryOp::Neg,
+        UnaryOp::Not => TirUnaryOp::Not,
+        UnaryOp::BitNot => TirUnaryOp::BitNot,
+        UnaryOp::Ref => TirUnaryOp::Ref,
+        UnaryOp::MutRef => TirUnaryOp::MutRef,
+        UnaryOp::Deref => TirUnaryOp::Deref,
+    }
+}
 
 /// Check if a positive integer literal value fits in the target integer type.
 /// Returns `Some(error_message)` if out of range, `None` if OK.

--- a/wado-compiler/src/resolver/util.rs
+++ b/wado-compiler/src/resolver/util.rs
@@ -146,11 +146,9 @@ pub(super) fn parse_int_literal(repr: &str) -> Result<u64, String> {
     if clean.starts_with("0x") || clean.starts_with("0X") {
         u64::from_str_radix(&clean[2..], 16).map_err(|_| format!("invalid hex literal: {repr}"))
     } else if clean.starts_with("0b") || clean.starts_with("0B") {
-        u64::from_str_radix(&clean[2..], 2)
-            .map_err(|_| format!("invalid binary literal: {repr}"))
+        u64::from_str_radix(&clean[2..], 2).map_err(|_| format!("invalid binary literal: {repr}"))
     } else if clean.starts_with("0o") || clean.starts_with("0O") {
-        u64::from_str_radix(&clean[2..], 8)
-            .map_err(|_| format!("invalid octal literal: {repr}"))
+        u64::from_str_radix(&clean[2..], 8).map_err(|_| format!("invalid octal literal: {repr}"))
     } else if clean.to_lowercase().contains('e') {
         // Scientific notation: parse as f64 first, then convert to u64
         let value: f64 = clean
@@ -221,14 +219,11 @@ pub(super) fn parse_u128_literal(repr: &str) -> Result<u128, String> {
     let clean: String = repr.chars().filter(|&c| c != '_').collect();
 
     if clean.starts_with("0x") || clean.starts_with("0X") {
-        u128::from_str_radix(&clean[2..], 16)
-            .map_err(|_| format!("invalid hex literal: {repr}"))
+        u128::from_str_radix(&clean[2..], 16).map_err(|_| format!("invalid hex literal: {repr}"))
     } else if clean.starts_with("0b") || clean.starts_with("0B") {
-        u128::from_str_radix(&clean[2..], 2)
-            .map_err(|_| format!("invalid binary literal: {repr}"))
+        u128::from_str_radix(&clean[2..], 2).map_err(|_| format!("invalid binary literal: {repr}"))
     } else if clean.starts_with("0o") || clean.starts_with("0O") {
-        u128::from_str_radix(&clean[2..], 8)
-            .map_err(|_| format!("invalid octal literal: {repr}"))
+        u128::from_str_radix(&clean[2..], 8).map_err(|_| format!("invalid octal literal: {repr}"))
     } else {
         clean
             .parse()

--- a/wado-compiler/src/resolver/util.rs
+++ b/wado-compiler/src/resolver/util.rs
@@ -111,3 +111,169 @@ pub(super) fn check_int_range_negative(
         Some(format!("literal out of range for `{type_name}`: -{repr}"))
     }
 }
+
+// Literal parsing functions
+
+/// Parse an integer literal string into a u64 value.
+/// Supports decimal, hex, binary, octal, and scientific notation (e.g., "1e10").
+#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+pub(super) fn parse_int_literal(repr: &str) -> Result<u64, String> {
+    // Remove underscores for parsing
+    let clean: String = repr.chars().filter(|&c| c != '_').collect();
+
+    // Handle negative numbers by parsing as i64 and reinterpreting bits
+    if clean.starts_with('-') {
+        // Check for scientific notation in negative numbers
+        if clean.to_lowercase().contains('e') {
+            let value: f64 = clean
+                .parse()
+                .map_err(|_| format!("invalid integer literal: {repr}"))?;
+            if value.fract() != 0.0 {
+                return Err(format!("integer literal has fractional part: {repr}"));
+            }
+            if value < i64::MIN as f64 || value > i64::MAX as f64 {
+                return Err(format!("integer literal out of range: {repr}"));
+            }
+            return Ok((value as i64) as u64);
+        }
+        let value: i64 = clean
+            .parse()
+            .map_err(|_| format!("invalid integer literal: {repr}"))?;
+        // Reinterpret i64 bits as u64 for storage
+        return Ok(value as u64);
+    }
+
+    if clean.starts_with("0x") || clean.starts_with("0X") {
+        u64::from_str_radix(&clean[2..], 16).map_err(|_| format!("invalid hex literal: {repr}"))
+    } else if clean.starts_with("0b") || clean.starts_with("0B") {
+        u64::from_str_radix(&clean[2..], 2)
+            .map_err(|_| format!("invalid binary literal: {repr}"))
+    } else if clean.starts_with("0o") || clean.starts_with("0O") {
+        u64::from_str_radix(&clean[2..], 8)
+            .map_err(|_| format!("invalid octal literal: {repr}"))
+    } else if clean.to_lowercase().contains('e') {
+        // Scientific notation: parse as f64 first, then convert to u64
+        let value: f64 = clean
+            .parse()
+            .map_err(|_| format!("invalid integer literal: {repr}"))?;
+        if value.fract() != 0.0 {
+            return Err(format!("integer literal has fractional part: {repr}"));
+        }
+        if value < 0.0 || value > u64::MAX as f64 {
+            return Err(format!("integer literal out of range: {repr}"));
+        }
+        Ok(value as u64)
+    } else {
+        clean
+            .parse()
+            .map_err(|_| format!("invalid integer literal: {repr}"))
+    }
+}
+
+/// Parse a float literal string into an f64 value.
+#[allow(clippy::cast_precision_loss)]
+pub(super) fn parse_float_literal(repr: &str) -> Result<f64, String> {
+    // Remove underscores for parsing
+    let clean: String = repr.chars().filter(|&c| c != '_').collect();
+
+    // Handle hex/binary/octal literals as float values (not bit patterns)
+    if clean.starts_with("0x") || clean.starts_with("0X") {
+        let value = u64::from_str_radix(&clean[2..], 16)
+            .map_err(|_| format!("invalid hex literal: {repr}"))?;
+        return Ok(value as f64);
+    } else if clean.starts_with("0b") || clean.starts_with("0B") {
+        let value = u64::from_str_radix(&clean[2..], 2)
+            .map_err(|_| format!("invalid binary literal: {repr}"))?;
+        return Ok(value as f64);
+    } else if clean.starts_with("0o") || clean.starts_with("0O") {
+        let value = u64::from_str_radix(&clean[2..], 8)
+            .map_err(|_| format!("invalid octal literal: {repr}"))?;
+        return Ok(value as f64);
+    }
+
+    clean
+        .parse()
+        .map_err(|_| format!("invalid float literal: {repr}"))
+}
+
+/// Check if a number literal can only be a float (has decimal point or negative exponent).
+pub(super) fn is_float_only_literal(repr: &str) -> bool {
+    // Has decimal point → float only
+    if repr.contains('.') {
+        return true;
+    }
+
+    // Check for negative exponent (e.g., "1e-5")
+    let lower = repr.to_lowercase();
+    if let Some(e_pos) = lower.find('e') {
+        let after_e = &repr[e_pos + 1..];
+        if after_e.starts_with('-') {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Parse an unsigned integer literal into a u128 value.
+/// Supports decimal, hex, binary, and octal formats.
+pub(super) fn parse_u128_literal(repr: &str) -> Result<u128, String> {
+    let clean: String = repr.chars().filter(|&c| c != '_').collect();
+
+    if clean.starts_with("0x") || clean.starts_with("0X") {
+        u128::from_str_radix(&clean[2..], 16)
+            .map_err(|_| format!("invalid hex literal: {repr}"))
+    } else if clean.starts_with("0b") || clean.starts_with("0B") {
+        u128::from_str_radix(&clean[2..], 2)
+            .map_err(|_| format!("invalid binary literal: {repr}"))
+    } else if clean.starts_with("0o") || clean.starts_with("0O") {
+        u128::from_str_radix(&clean[2..], 8)
+            .map_err(|_| format!("invalid octal literal: {repr}"))
+    } else {
+        clean
+            .parse()
+            .map_err(|_| format!("invalid integer literal: {repr}"))
+    }
+}
+
+/// Parse a signed integer literal into an i128 value.
+/// Supports decimal, hex, binary, and octal formats (negative decimals supported).
+pub(super) fn parse_i128_literal(repr: &str) -> Result<i128, String> {
+    let clean: String = repr.chars().filter(|&c| c != '_').collect();
+
+    if clean.starts_with("0x") || clean.starts_with("0X") {
+        // Hex literals are always positive, parse as u128 then convert
+        let unsigned = u128::from_str_radix(&clean[2..], 16)
+            .map_err(|_| format!("invalid hex literal: {repr}"))?;
+        Ok(unsigned as i128)
+    } else if clean.starts_with("0b") || clean.starts_with("0B") {
+        let unsigned = u128::from_str_radix(&clean[2..], 2)
+            .map_err(|_| format!("invalid binary literal: {repr}"))?;
+        Ok(unsigned as i128)
+    } else if clean.starts_with("0o") || clean.starts_with("0O") {
+        let unsigned = u128::from_str_radix(&clean[2..], 8)
+            .map_err(|_| format!("invalid octal literal: {repr}"))?;
+        Ok(unsigned as i128)
+    } else {
+        // Decimal - may be negative
+        clean
+            .parse()
+            .map_err(|_| format!("invalid integer literal: {repr}"))
+    }
+}
+
+/// Unpack u128 into (low, high) pair for codegen.
+pub(super) fn unpack_u128(value: u128) -> (u64, u64) {
+    (value as u64, (value >> 64) as u64)
+}
+
+/// Unpack i128 into (low, high) pair for codegen.
+#[allow(clippy::cast_sign_loss)]
+pub(super) fn unpack_i128(value: i128) -> (u64, i64) {
+    (value as u64, (value >> 64) as i64)
+}
+
+/// Get the clean representation of a literal (without underscores).
+pub(super) fn clean_literal_repr(repr: &str) -> String {
+    repr.chars().filter(|&c| c != '_').collect()
+}

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -510,7 +510,7 @@ mod tests {
     fn test_define_and_lookup() {
         let mut table = SymbolTable::new();
 
-        let core_cli = ModuleSource::core("cli");
+        let core_cli = ModuleSource::cli();
         let id = table.define(
             "println",
             SymbolKind::Function(FunctionSymbol {
@@ -534,7 +534,7 @@ mod tests {
     fn test_import_lookup() {
         let mut table = SymbolTable::new();
 
-        let core_cli = ModuleSource::core("cli");
+        let core_cli = ModuleSource::cli();
         let id = table.define(
             "println",
             SymbolKind::Function(FunctionSymbol {

--- a/wado-compiler/src/synthesize_inspect.rs
+++ b/wado-compiler/src/synthesize_inspect.rs
@@ -46,10 +46,9 @@ pub fn synthesize_inspect(mut project: Project) -> Project {
             let functions: Vec<Rc<RefCell<_>>> = module.functions.clone();
             let all_modules: Vec<&TirModule> = project.tir_modules.values().collect();
 
-            let formatter_struct = tt.borrow_mut().make_struct(
-                "Formatter".to_string(),
-                ModuleSource::format(),
-            );
+            let formatter_struct = tt
+                .borrow_mut()
+                .make_struct("Formatter".to_string(), ModuleSource::format());
             let fmt_type = tt.borrow_mut().make_mut_ref(formatter_struct);
 
             let mut reg = InspectRegistry::new();
@@ -748,10 +747,8 @@ fn synth_body(
 
 /// Resolve string `TypeId`.
 fn str_type(tt: &Rc<RefCell<TypeTable>>) -> TypeId {
-    tt.borrow_mut().make_struct(
-        "String".to_string(),
-        ModuleSource::string(),
-    )
+    tt.borrow_mut()
+        .make_struct("String".to_string(), ModuleSource::string())
 }
 
 /// Build a `f.write_str("text")` statement.
@@ -902,9 +899,7 @@ fn lower_hex_fmt(
 fn display_impl_module(type_id: TypeId, tt: &Rc<RefCell<TypeTable>>) -> ModuleSource {
     match tt.borrow().get(type_id).clone() {
         ResolvedType::Primitive(_) => ModuleSource::primitives(),
-        ResolvedType::Struct { name, .. } if name == "String" => {
-            ModuleSource::format()
-        }
+        ResolvedType::Struct { name, .. } if name == "String" => ModuleSource::format(),
         ResolvedType::Struct { module_source, .. } | ResolvedType::Enum { module_source, .. } => {
             module_source
         }

--- a/wado-compiler/src/synthesize_inspect.rs
+++ b/wado-compiler/src/synthesize_inspect.rs
@@ -48,7 +48,7 @@ pub fn synthesize_inspect(mut project: Project) -> Project {
 
             let formatter_struct = tt.borrow_mut().make_struct(
                 "Formatter".to_string(),
-                ModuleSource::core("prelude/format.wado"),
+                ModuleSource::format(),
             );
             let fmt_type = tt.borrow_mut().make_mut_ref(formatter_struct);
 
@@ -761,7 +761,7 @@ fn ws(text: &str, fmt: TirExpr, tt: &Rc<RefCell<TypeTable>>, span: Span) -> TirS
         TirExprKind::MethodCall {
             receiver: Box::new(fmt),
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/format.wado"),
+                module_source: ModuleSource::format(),
                 name: "Formatter::write_str".to_string(),
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
@@ -789,7 +789,7 @@ fn wc(c: char, fmt: TirExpr, span: Span) -> TirStmt {
         TirExprKind::MethodCall {
             receiver: Box::new(fmt),
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/format.wado"),
+                module_source: ModuleSource::format(),
                 name: "Formatter::write_char".to_string(),
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
@@ -881,7 +881,7 @@ fn lower_hex_fmt(
         TirExprKind::MethodCall {
             receiver: Box::new(receiver),
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/primitives.wado"),
+                module_source: ModuleSource::primitives(),
                 name: mangled,
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
@@ -901,14 +901,14 @@ fn lower_hex_fmt(
 
 fn display_impl_module(type_id: TypeId, tt: &Rc<RefCell<TypeTable>>) -> ModuleSource {
     match tt.borrow().get(type_id).clone() {
-        ResolvedType::Primitive(_) => ModuleSource::core("prelude/primitives.wado"),
+        ResolvedType::Primitive(_) => ModuleSource::primitives(),
         ResolvedType::Struct { name, .. } if name == "String" => {
-            ModuleSource::core("prelude/format.wado")
+            ModuleSource::format()
         }
         ResolvedType::Struct { module_source, .. } | ResolvedType::Enum { module_source, .. } => {
             module_source
         }
-        _ => ModuleSource::core("prelude/primitives.wado"),
+        _ => ModuleSource::primitives(),
     }
 }
 
@@ -925,7 +925,7 @@ fn synth_string(
     let call = TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef::External {
-                module_source: ModuleSource::core("internal"),
+                module_source: ModuleSource::internal(),
                 name: "write_escaped_string".to_string(),
                 monomorph_info: None,
                 method_info: None,
@@ -1243,7 +1243,7 @@ fn synth_array(
         TirExprKind::MethodCall {
             receiver: Box::new(val.clone()),
             func: FunctionRef::External {
-                module_source: ModuleSource::core("prelude/array.wado"),
+                module_source: ModuleSource::array(),
                 name: "Array::len".to_string(),
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new("Array".into(), None, "len".into())),

--- a/wado-compiler/src/synthesize_inspect.rs
+++ b/wado-compiler/src/synthesize_inspect.rs
@@ -623,7 +623,7 @@ fn synth_body(
         } => {
             let n = name.clone();
             let ms = ms.clone();
-            if n == "String" && ms == ModuleSource::core("prelude/string.wado") {
+            if n == "String" && ms == ModuleSource::string() {
                 synth_string(val, fmt, tt, span)
             } else {
                 synth_struct(reg, &n, val, fmt, tt, mods, fmt_type, module_source, span)
@@ -750,7 +750,7 @@ fn synth_body(
 fn str_type(tt: &Rc<RefCell<TypeTable>>) -> TypeId {
     tt.borrow_mut().make_struct(
         "String".to_string(),
-        ModuleSource::core("prelude/string.wado"),
+        ModuleSource::string(),
     )
 }
 

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -659,11 +659,7 @@ impl TypeTable {
 
     /// Create an Array<T> type (`GenericInstance` { name: "Array", ... })
     pub fn make_array(&mut self, element: TypeId) -> TypeId {
-        self.make_generic_instance(
-            "Array".to_string(),
-            ModuleSource::array(),
-            vec![element],
-        )
+        self.make_generic_instance("Array".to_string(), ModuleSource::array(), vec![element])
     }
 
     /// Create a newtype wrapping a base type

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -661,7 +661,7 @@ impl TypeTable {
     pub fn make_array(&mut self, element: TypeId) -> TypeId {
         self.make_generic_instance(
             "Array".to_string(),
-            ModuleSource::core("prelude/array.wado"),
+            ModuleSource::array(),
             vec![element],
         )
     }

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -369,10 +369,7 @@ impl<'a> WirContext<'a> {
                 let struct_name = StructName::new(module_source.clone(), name.clone());
                 // Special case: String struct
                 let lookup_name = if name == "String" {
-                    StructName::new(
-                        ModuleSource::string(),
-                        "String".to_string(),
-                    )
+                    StructName::new(ModuleSource::string(), "String".to_string())
                 } else {
                     struct_name
                 };

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -370,7 +370,7 @@ impl<'a> WirContext<'a> {
                 // Special case: String struct
                 let lookup_name = if name == "String" {
                     StructName::new(
-                        ModuleSource::core("prelude/string.wado"),
+                        ModuleSource::string(),
                         "String".to_string(),
                     )
                 } else {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1479,10 +1479,8 @@ impl FunctionTranslator<'_, '_> {
         let u8_array_type = self.ctx.array_type_by_name.get("u8").cloned();
 
         // Look up String struct type
-        let string_struct_name = crate::name::StructName::new(
-            crate::name::ModuleSource::string(),
-            "String".to_string(),
-        );
+        let string_struct_name =
+            crate::name::StructName::new(crate::name::ModuleSource::string(), "String".to_string());
         let string_type = self.ctx.struct_type_map.get(&string_struct_name).cloned();
 
         let (Some(array_type_id), Some(string_type_id)) = (u8_array_type, string_type) else {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1480,7 +1480,7 @@ impl FunctionTranslator<'_, '_> {
 
         // Look up String struct type
         let string_struct_name = crate::name::StructName::new(
-            crate::name::ModuleSource::core("prelude/string.wado"),
+            crate::name::ModuleSource::string(),
             "String".to_string(),
         );
         let string_type = self.ctx.struct_type_map.get(&string_struct_name).cloned();

--- a/wado-compiler/src/wir_build/types.rs
+++ b/wado-compiler/src/wir_build/types.rs
@@ -452,7 +452,7 @@ fn ensure_box_type(ctx: &mut WirContext<'_>, prim_name: &str, wir_type: crate::w
     if ctx.lookup_struct_by_name(&box_name).is_some() {
         return;
     }
-    let module_source = ModuleSource::core("prelude");
+    let module_source = ModuleSource::prelude();
     let struct_name = StructName::new(module_source.clone(), box_name.clone());
     let fq = format!("{module_source}//{box_name}");
     let type_id = ctx.register_type(
@@ -980,7 +980,7 @@ fn register_array_wrapper_structs(ctx: &mut WirContext<'_>) {
             continue;
         };
 
-        let module_source = ModuleSource::core("prelude");
+        let module_source = ModuleSource::prelude();
         let struct_name = StructName::new(module_source.clone(), mangled.clone());
         if ctx.struct_type_map.contains_key(&struct_name) {
             continue;


### PR DESCRIPTION
## Summary
This PR refactors the resolver module by extracting utility functions into a dedicated `util` module and adds convenient helper methods to `ModuleSource` for commonly-used core modules. This improves code organization, reduces duplication, and makes the codebase more maintainable.

## Key Changes

- **Extracted utility functions to `resolver/util.rs`:**
  - Literal parsing functions: `parse_int_literal`, `parse_float_literal`, `parse_u128_literal`, `parse_i128_literal`
  - Literal validation: `is_float_only_literal`
  - Literal unpacking: `unpack_u128`, `unpack_i128`
  - Operator conversion: `convert_binary_op`, `convert_unary_op`
  - Integer range checking functions (moved from existing util module)

- **Added `ModuleSource` convenience methods in `name.rs`:**
  - `prelude()` → `core:prelude`
  - `string()` → `core:prelude/string.wado`
  - `array()` → `core:prelude/array.wado`
  - `format()` → `core:prelude/format.wado`
  - `int128()` → `core:prelude/int128.wado`
  - `primitives()` → `core:prelude/primitives.wado`
  - `types()` → `core:prelude/types.wado`
  - `traits()` → `core:prelude/traits.wado`
  - `internal()` → `core:internal`
  - `builtin()` → `core:builtin`
  - `cli()` → `core:cli`

- **Updated all call sites** throughout the codebase to use the new helper methods instead of `ModuleSource::core("...")` calls, improving readability and reducing string duplication.

- **Removed unused function:** `string_module_source()` helper from resolver.rs (functionality now provided by `ModuleSource::string()`)

## Implementation Details

- All extracted functions maintain their original behavior and documentation
- The `util` module is private to the resolver (`pub(super)` visibility)
- Helper methods use `#[must_use]` attribute to encourage proper usage
- Updated test cases to use the new helper methods for consistency

https://claude.ai/code/session_01DRnDSBnRQka3yejum1akTP