### PR TITLE
Refactor integer literal parsing to use u128/i128 for better range handling

### DIFF
--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -3830,10 +3830,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     }
                 } else {
                     // Can be integer (default to i32)
-                    match util::parse_int_literal(&num_lit.repr) {
+                    match util::parse_u128_literal(&num_lit.repr) {
                         Ok(value) => (
                             TirExprKind::IntLiteral {
-                                value,
+                                value: value as u64,
                                 repr: num_lit.repr.clone(),
                             },
                             TypeTable::I32,
@@ -5757,7 +5757,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     lit.span,
                 ));
             }
-            return Some(match util::parse_int_literal(&num_lit.repr) {
+            return Some(match util::parse_u128_literal(&num_lit.repr) {
                 Ok(value) => {
                     if let Some(err_msg) = util::check_int_range_positive(
                         value,
@@ -5772,7 +5772,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     }
                     TirExpr::new(
                         TirExprKind::IntLiteral {
-                            value,
+                            value: value as u64,
                             repr: num_lit.repr.clone(),
                         },
                         target_type,
@@ -5820,7 +5820,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     unary.span,
                 ));
             }
-            return Some(match util::parse_int_literal(&num_lit.repr) {
+            return Some(match util::parse_u128_literal(&num_lit.repr) {
                 Ok(value) => {
                     if let Some(err_msg) = util::check_int_range_negative(
                         value,
@@ -5833,7 +5833,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             span: unary.span,
                         });
                     }
-                    let neg_value = (value as i64).wrapping_neg().cast_unsigned();
+                    let neg_value = (value as u64 as i64).wrapping_neg().cast_unsigned();
                     TirExpr::new(
                         TirExprKind::IntLiteral {
                             value: neg_value,
@@ -5937,67 +5937,57 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             if let Some(name) = struct_name
                 && (name == "u128" || name == "i128")
             {
-                if let Ok(value) = util::parse_int_literal(&num_lit.repr) {
-                    let use_from_u64_or_i64 = if name == "u128" {
-                        true
-                    } else {
-                        i64::try_from(value).is_ok()
-                    };
+                let parse_result = if name == "u128" {
+                    util::parse_u128_literal(&num_lit.repr).map(|v| v as i128)
+                } else {
+                    util::parse_i128_literal(&num_lit.repr)
+                };
 
-                    if use_from_u64_or_i64 {
-                        let (inner_type, method_name) = if name == "u128" {
-                            (TypeTable::U64, "from_u64")
+                match parse_result {
+                    Ok(value) => {
+                        // If value fits in u64/i64, use the cheaper from_u64/from_i64
+                        let use_small = if name == "u128" {
+                            u64::try_from(value).is_ok()
                         } else {
-                            (TypeTable::I64, "from_i64")
+                            i64::try_from(value).is_ok()
                         };
 
-                        let inner_literal = TirExpr::new(
-                            TirExprKind::IntLiteral {
-                                value,
-                                repr: num_lit.repr.clone(),
-                            },
-                            inner_type,
-                            lit.span,
-                        );
+                        if use_small {
+                            let (inner_type, method_name, store_value) = if name == "u128" {
+                                (TypeTable::U64, "from_u64", value as u64)
+                            } else {
+                                (TypeTable::I64, "from_i64", value as u64)
+                            };
 
-                        let method_info =
-                            LocalMethodName::new(name.clone(), None, method_name.to_string());
-                        let mangled_func_name = method_info.to_mangled_name();
-
-                        return Some(TirExpr::new(
-                            TirExprKind::StaticCall {
-                                func: FunctionRef::External {
-                                    module_source: ModuleSource::int128(),
-                                    name: mangled_func_name,
-                                    monomorph_info: None,
-                                    method_info: Some(method_info),
+                            let inner_literal = TirExpr::new(
+                                TirExprKind::IntLiteral {
+                                    value: store_value,
+                                    repr: num_lit.repr.clone(),
                                 },
-                                args: vec![inner_literal],
-                            },
-                            target_type,
-                            lit.span,
-                        ));
-                    }
-                }
+                                inner_type,
+                                lit.span,
+                            );
 
-                // Value doesn't fit in u64 (or i64 for i128), use from_pair
-                if name == "u128" {
-                    if let Ok(value) = util::parse_u128_literal(&num_lit.repr) {
-                        let (low, high) = util::unpack_u128(value);
-                        return Some(self.build_from_pair_call(
-                            &name,
-                            low,
-                            high as i64,
-                            target_type,
-                            lit.span,
-                        ));
-                    }
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
-                        message: format!("invalid u128 literal: {}", num_lit.repr),
-                        span: lit.span,
-                    });
-                } else {
-                    if let Ok(value) = util::parse_i128_literal(&num_lit.repr) {
+                            let method_info =
+                                LocalMethodName::new(name.clone(), None, method_name.to_string());
+                            let mangled_func_name = method_info.to_mangled_name();
+
+                            return Some(TirExpr::new(
+                                TirExprKind::StaticCall {
+                                    func: FunctionRef::External {
+                                        module_source: ModuleSource::int128(),
+                                        name: mangled_func_name,
+                                        monomorph_info: None,
+                                        method_info: Some(method_info),
+                                    },
+                                    args: vec![inner_literal],
+                                },
+                                target_type,
+                                lit.span,
+                            ));
+                        }
+
+                        // Value doesn't fit in u64/i64, use from_pair
                         let (low, high) = util::unpack_i128(value);
                         return Some(self.build_from_pair_call(
                             &name,
@@ -6007,10 +5997,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             lit.span,
                         ));
                     }
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
-                        message: format!("invalid i128 literal: {}", num_lit.repr),
-                        span: lit.span,
-                    });
+                    Err(_) => {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                            message: format!("invalid {} literal: {}", name, num_lit.repr),
+                            span: lit.span,
+                        });
+                    }
                 }
             }
         }
@@ -6030,7 +6022,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             if let Some(name) = struct_name
                 && name == "i128"
             {
-                let negated_repr = format!("-{}", util::clean_literal_repr(&num_lit.repr));
+                let negated_repr = format!("-{}", num_lit.repr);
                 if let Ok(value) = util::parse_i128_literal(&negated_repr) {
                     let (low, high) = util::unpack_i128(value);
                     return Some(self.build_from_pair_call(
@@ -11303,79 +11295,66 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 && let Literal::Number(num_lit) = &lit.value
                 && !util::is_float_only_literal(&num_lit.repr)
             {
-                // Try to parse as u64
-                if let Ok(value) = util::parse_int_literal(&num_lit.repr) {
-                    // For u128: value fits in u64, use from_u64
-                    // For i128: value must also fit in i64 (positive range), otherwise use from_string
-                    let use_from_u64_or_i64 = if name == "u128" {
-                        true // u64 always works for u128
-                    } else {
-                        // For i128, check if value fits in i64 positive range
-                        i64::try_from(value).is_ok()
-                    };
+                let parse_result = if name == "u128" {
+                    util::parse_u128_literal(&num_lit.repr).map(|v| v as i128)
+                } else {
+                    util::parse_i128_literal(&num_lit.repr)
+                };
 
-                    if use_from_u64_or_i64 {
-                        let (inner_type, method_name) = if name == "u128" {
-                            (TypeTable::U64, "from_u64")
+                match parse_result {
+                    Ok(value) => {
+                        // If value fits in u64/i64, use the cheaper from_u64/from_i64
+                        let use_small = if name == "u128" {
+                            u64::try_from(value).is_ok()
                         } else {
-                            (TypeTable::I64, "from_i64")
+                            i64::try_from(value).is_ok()
                         };
 
-                        let inner_literal = TirExpr::new(
-                            TirExprKind::IntLiteral {
-                                value,
-                                repr: num_lit.repr.clone(),
-                            },
-                            inner_type,
-                            lit.span,
-                        );
+                        if use_small {
+                            let (inner_type, method_name, store_value) = if name == "u128" {
+                                (TypeTable::U64, "from_u64", value as u64)
+                            } else {
+                                (TypeTable::I64, "from_i64", value as u64)
+                            };
 
-                        let method_info =
-                            LocalMethodName::new(name.clone(), None, method_name.to_string());
-                        let mangled_func_name = method_info.to_mangled_name();
-
-                        return TirExpr::new(
-                            TirExprKind::StaticCall {
-                                func: FunctionRef::External {
-                                    module_source: ModuleSource::int128(),
-                                    name: mangled_func_name,
-                                    monomorph_info: None,
-                                    method_info: Some(method_info),
+                            let inner_literal = TirExpr::new(
+                                TirExprKind::IntLiteral {
+                                    value: store_value,
+                                    repr: num_lit.repr.clone(),
                                 },
-                                args: vec![inner_literal],
-                            },
-                            target_type,
-                            cast.span,
-                        );
-                    }
-                }
+                                inner_type,
+                                lit.span,
+                            );
 
-                // Value doesn't fit in u64 (or i64 for i128), use from_pair
-                if name == "u128" {
-                    if let Ok(value) = util::parse_u128_literal(&num_lit.repr) {
-                        let (low, high) = util::unpack_u128(value);
-                        return self.build_from_pair_call(
-                            name,
-                            low,
-                            high as i64,
-                            target_type,
-                            cast.span,
-                        );
-                    }
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
-                        message: format!("invalid u128 literal: {}", num_lit.repr),
-                        span: lit.span,
-                    });
-                } else {
-                    // i128
-                    if let Ok(value) = util::parse_i128_literal(&num_lit.repr) {
+                            let method_info =
+                                LocalMethodName::new(name.clone(), None, method_name.to_string());
+                            let mangled_func_name = method_info.to_mangled_name();
+
+                            return TirExpr::new(
+                                TirExprKind::StaticCall {
+                                    func: FunctionRef::External {
+                                        module_source: ModuleSource::int128(),
+                                        name: mangled_func_name,
+                                        monomorph_info: None,
+                                        method_info: Some(method_info),
+                                    },
+                                    args: vec![inner_literal],
+                                },
+                                target_type,
+                                cast.span,
+                            );
+                        }
+
+                        // Value doesn't fit in u64/i64, use from_pair
                         let (low, high) = util::unpack_i128(value);
                         return self.build_from_pair_call(name, low, high, target_type, cast.span);
                     }
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
-                        message: format!("invalid i128 literal: {}", num_lit.repr),
-                        span: lit.span,
-                    });
+                    Err(_) => {
+                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                            message: format!("invalid {} literal: {}", name, num_lit.repr),
+                            span: lit.span,
+                        });
+                    }
                 }
             }
 
@@ -11388,7 +11367,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 && name == "i128"
             {
                 // Parse the negated value directly using Rust's i128
-                let negated_repr = format!("-{}", util::clean_literal_repr(&num_lit.repr));
+                let negated_repr = format!("-{}", num_lit.repr);
                 if let Ok(value) = util::parse_i128_literal(&negated_repr) {
                     let (low, high) = util::unpack_i128(value);
                     return self.build_from_pair_call(name, low, high, target_type, unary.span);

--- a/wado-compiler/src/resolver/util.rs
+++ b/wado-compiler/src/resolver/util.rs
@@ -41,12 +41,12 @@ pub(super) fn convert_unary_op(op: UnaryOp) -> TirUnaryOp {
 
 /// Check if a positive integer literal value fits in the target integer type.
 /// Returns `Some(error_message)` if out of range, `None` if OK.
-/// Only checks primitive integer types (not i128/u128, which are handled separately).
+/// Only checks primitive integer types (i128/u128 struct types are handled separately).
 ///
 /// All literal formats (decimal, hex, octal, binary) use strict numeric range.
 /// To reinterpret a bit pattern, use an explicit cast: `0xFF as i8`.
 pub(super) fn check_int_range_positive(
-    value: u64,
+    value: u128,
     target_type: TypeId,
     type_table: &TypeTable,
     repr: &str,
@@ -54,14 +54,14 @@ pub(super) fn check_int_range_positive(
     let base_id = type_table.get_ultimate_base_type(target_type);
     let in_range = match type_table.get(base_id) {
         ResolvedType::Primitive(prim) => match prim {
-            PrimitiveType::I8 => i8::try_from(value).is_ok(),
-            PrimitiveType::I16 => i16::try_from(value).is_ok(),
-            PrimitiveType::I32 => i32::try_from(value).is_ok(),
-            PrimitiveType::I64 => i64::try_from(value).is_ok(),
-            PrimitiveType::U8 => u8::try_from(value).is_ok(),
-            PrimitiveType::U16 => u16::try_from(value).is_ok(),
-            PrimitiveType::U32 => u32::try_from(value).is_ok(),
-            PrimitiveType::U64 => true,
+            PrimitiveType::I8 => value <= i8::MAX as u128,
+            PrimitiveType::I16 => value <= i16::MAX as u128,
+            PrimitiveType::I32 => value <= i32::MAX as u128,
+            PrimitiveType::I64 => value <= i64::MAX as u128,
+            PrimitiveType::U8 => value <= u128::from(u8::MAX),
+            PrimitiveType::U16 => value <= u128::from(u16::MAX),
+            PrimitiveType::U32 => value <= u128::from(u32::MAX),
+            PrimitiveType::U64 => value <= u128::from(u64::MAX),
             _ => return None, // i128/u128/f32/f64/bool/char handled elsewhere
         },
         _ => return None,
@@ -79,9 +79,9 @@ pub(super) fn check_int_range_positive(
 
 /// Check if a negated integer literal `-pos_value` fits in the target integer type.
 /// Returns `Some(error_message)` if out of range, `None` if OK.
-/// Only checks primitive integer types (not i128/u128, which are handled separately).
+/// Only checks primitive integer types (i128/u128 struct types are handled separately).
 pub(super) fn check_int_range_negative(
-    pos_value: u64,
+    pos_value: u128,
     target_type: TypeId,
     type_table: &TypeTable,
     repr: &str,
@@ -89,10 +89,10 @@ pub(super) fn check_int_range_negative(
     let base_id = type_table.get_ultimate_base_type(target_type);
     let in_range = match type_table.get(base_id) {
         ResolvedType::Primitive(prim) => match prim {
-            PrimitiveType::I8 => pos_value <= i64::from(i8::MIN).unsigned_abs(),
-            PrimitiveType::I16 => pos_value <= i64::from(i16::MIN).unsigned_abs(),
-            PrimitiveType::I32 => pos_value <= i64::from(i32::MIN).unsigned_abs(),
-            PrimitiveType::I64 => pos_value <= i64::MIN.unsigned_abs(),
+            PrimitiveType::I8 => pos_value <= u128::from(i8::MIN.unsigned_abs()),
+            PrimitiveType::I16 => pos_value <= u128::from(i16::MIN.unsigned_abs()),
+            PrimitiveType::I32 => pos_value <= u128::from(i32::MIN.unsigned_abs()),
+            PrimitiveType::I64 => pos_value <= u128::from(i64::MIN.unsigned_abs()),
             // Unsigned types cannot hold negative values
             PrimitiveType::U8 | PrimitiveType::U16 | PrimitiveType::U32 | PrimitiveType::U64 => {
                 false
@@ -112,55 +112,39 @@ pub(super) fn check_int_range_negative(
     }
 }
 
-// Literal parsing functions
+/// Normalize a numeric literal representation: remove underscores and lowercase.
+/// This produces a canonical form for parsing (e.g., `"0x_FF"` → `"0xff"`, `"1E10"` → `"1e10"`).
+pub(super) fn normalize_numeric_literal(repr: &str) -> String {
+    repr.chars()
+        .filter(|&c| c != '_')
+        .flat_map(char::to_lowercase)
+        .collect()
+}
 
-/// Parse an integer literal string into a u64 value.
+/// Parse an unsigned integer literal into a u128 value.
 /// Supports decimal, hex, binary, octal, and scientific notation (e.g., "1e10").
 #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
-pub(super) fn parse_int_literal(repr: &str) -> Result<u64, String> {
-    // Remove underscores for parsing
-    let clean: String = repr.chars().filter(|&c| c != '_').collect();
+pub(super) fn parse_u128_literal(repr: &str) -> Result<u128, String> {
+    let clean = normalize_numeric_literal(repr);
 
-    // Handle negative numbers by parsing as i64 and reinterpreting bits
-    if clean.starts_with('-') {
-        // Check for scientific notation in negative numbers
-        if clean.to_lowercase().contains('e') {
-            let value: f64 = clean
-                .parse()
-                .map_err(|_| format!("invalid integer literal: {repr}"))?;
-            if value.fract() != 0.0 {
-                return Err(format!("integer literal has fractional part: {repr}"));
-            }
-            if value < i64::MIN as f64 || value > i64::MAX as f64 {
-                return Err(format!("integer literal out of range: {repr}"));
-            }
-            return Ok((value as i64) as u64);
-        }
-        let value: i64 = clean
-            .parse()
-            .map_err(|_| format!("invalid integer literal: {repr}"))?;
-        // Reinterpret i64 bits as u64 for storage
-        return Ok(value as u64);
-    }
-
-    if clean.starts_with("0x") || clean.starts_with("0X") {
-        u64::from_str_radix(&clean[2..], 16).map_err(|_| format!("invalid hex literal: {repr}"))
-    } else if clean.starts_with("0b") || clean.starts_with("0B") {
-        u64::from_str_radix(&clean[2..], 2).map_err(|_| format!("invalid binary literal: {repr}"))
-    } else if clean.starts_with("0o") || clean.starts_with("0O") {
-        u64::from_str_radix(&clean[2..], 8).map_err(|_| format!("invalid octal literal: {repr}"))
-    } else if clean.to_lowercase().contains('e') {
-        // Scientific notation: parse as f64 first, then convert to u64
+    if let Some(hex) = clean.strip_prefix("0x") {
+        u128::from_str_radix(hex, 16).map_err(|_| format!("invalid hex literal: {repr}"))
+    } else if let Some(bin) = clean.strip_prefix("0b") {
+        u128::from_str_radix(bin, 2).map_err(|_| format!("invalid binary literal: {repr}"))
+    } else if let Some(oct) = clean.strip_prefix("0o") {
+        u128::from_str_radix(oct, 8).map_err(|_| format!("invalid octal literal: {repr}"))
+    } else if clean.contains('e') {
+        // Scientific notation: parse as f64 first, then convert
         let value: f64 = clean
             .parse()
             .map_err(|_| format!("invalid integer literal: {repr}"))?;
         if value.fract() != 0.0 {
             return Err(format!("integer literal has fractional part: {repr}"));
         }
-        if value < 0.0 || value > u64::MAX as f64 {
+        if value < 0.0 || value > u128::MAX as f64 {
             return Err(format!("integer literal out of range: {repr}"));
         }
-        Ok(value as u64)
+        Ok(value as u128)
     } else {
         clean
             .parse()
@@ -168,24 +152,51 @@ pub(super) fn parse_int_literal(repr: &str) -> Result<u64, String> {
     }
 }
 
+/// Parse a signed integer literal into an i128 value.
+/// Supports decimal, hex, binary, octal, and scientific notation.
+/// For non-negative values, delegates to `parse_u128_literal` with an i128 range check.
+#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+pub(super) fn parse_i128_literal(repr: &str) -> Result<i128, String> {
+    let clean = normalize_numeric_literal(repr);
+
+    if clean.starts_with('-') {
+        // Scientific notation in negative numbers
+        if clean.contains('e') {
+            let value: f64 = clean
+                .parse()
+                .map_err(|_| format!("invalid integer literal: {repr}"))?;
+            if value.fract() != 0.0 {
+                return Err(format!("integer literal has fractional part: {repr}"));
+            }
+            return Ok(value as i128);
+        }
+        return clean
+            .parse()
+            .map_err(|_| format!("invalid integer literal: {repr}"));
+    }
+
+    // Non-negative: delegate to unsigned parser, then check i128 range
+    let unsigned = parse_u128_literal(repr)?;
+    i128::try_from(unsigned).map_err(|_| format!("integer literal out of range: {repr}"))
+}
+
 /// Parse a float literal string into an f64 value.
 #[allow(clippy::cast_precision_loss)]
 pub(super) fn parse_float_literal(repr: &str) -> Result<f64, String> {
-    // Remove underscores for parsing
-    let clean: String = repr.chars().filter(|&c| c != '_').collect();
+    let clean = normalize_numeric_literal(repr);
 
     // Handle hex/binary/octal literals as float values (not bit patterns)
-    if clean.starts_with("0x") || clean.starts_with("0X") {
-        let value = u64::from_str_radix(&clean[2..], 16)
-            .map_err(|_| format!("invalid hex literal: {repr}"))?;
+    if let Some(hex) = clean.strip_prefix("0x") {
+        let value =
+            u64::from_str_radix(hex, 16).map_err(|_| format!("invalid hex literal: {repr}"))?;
         return Ok(value as f64);
-    } else if clean.starts_with("0b") || clean.starts_with("0B") {
-        let value = u64::from_str_radix(&clean[2..], 2)
-            .map_err(|_| format!("invalid binary literal: {repr}"))?;
+    } else if let Some(bin) = clean.strip_prefix("0b") {
+        let value =
+            u64::from_str_radix(bin, 2).map_err(|_| format!("invalid binary literal: {repr}"))?;
         return Ok(value as f64);
-    } else if clean.starts_with("0o") || clean.starts_with("0O") {
-        let value = u64::from_str_radix(&clean[2..], 8)
-            .map_err(|_| format!("invalid octal literal: {repr}"))?;
+    } else if let Some(oct) = clean.strip_prefix("0o") {
+        let value =
+            u64::from_str_radix(oct, 8).map_err(|_| format!("invalid octal literal: {repr}"))?;
         return Ok(value as f64);
     }
 
@@ -196,15 +207,14 @@ pub(super) fn parse_float_literal(repr: &str) -> Result<f64, String> {
 
 /// Check if a number literal can only be a float (has decimal point or negative exponent).
 pub(super) fn is_float_only_literal(repr: &str) -> bool {
-    // Has decimal point → float only
     if repr.contains('.') {
         return true;
     }
 
     // Check for negative exponent (e.g., "1e-5")
-    let lower = repr.to_lowercase();
+    let lower = normalize_numeric_literal(repr);
     if let Some(e_pos) = lower.find('e') {
-        let after_e = &repr[e_pos + 1..];
+        let after_e = &lower[e_pos + 1..];
         if after_e.starts_with('-') {
             return true;
         }
@@ -213,62 +223,8 @@ pub(super) fn is_float_only_literal(repr: &str) -> bool {
     false
 }
 
-/// Parse an unsigned integer literal into a u128 value.
-/// Supports decimal, hex, binary, and octal formats.
-pub(super) fn parse_u128_literal(repr: &str) -> Result<u128, String> {
-    let clean: String = repr.chars().filter(|&c| c != '_').collect();
-
-    if clean.starts_with("0x") || clean.starts_with("0X") {
-        u128::from_str_radix(&clean[2..], 16).map_err(|_| format!("invalid hex literal: {repr}"))
-    } else if clean.starts_with("0b") || clean.starts_with("0B") {
-        u128::from_str_radix(&clean[2..], 2).map_err(|_| format!("invalid binary literal: {repr}"))
-    } else if clean.starts_with("0o") || clean.starts_with("0O") {
-        u128::from_str_radix(&clean[2..], 8).map_err(|_| format!("invalid octal literal: {repr}"))
-    } else {
-        clean
-            .parse()
-            .map_err(|_| format!("invalid integer literal: {repr}"))
-    }
-}
-
-/// Parse a signed integer literal into an i128 value.
-/// Supports decimal, hex, binary, and octal formats (negative decimals supported).
-pub(super) fn parse_i128_literal(repr: &str) -> Result<i128, String> {
-    let clean: String = repr.chars().filter(|&c| c != '_').collect();
-
-    if clean.starts_with("0x") || clean.starts_with("0X") {
-        // Hex literals are always positive, parse as u128 then convert
-        let unsigned = u128::from_str_radix(&clean[2..], 16)
-            .map_err(|_| format!("invalid hex literal: {repr}"))?;
-        Ok(unsigned as i128)
-    } else if clean.starts_with("0b") || clean.starts_with("0B") {
-        let unsigned = u128::from_str_radix(&clean[2..], 2)
-            .map_err(|_| format!("invalid binary literal: {repr}"))?;
-        Ok(unsigned as i128)
-    } else if clean.starts_with("0o") || clean.starts_with("0O") {
-        let unsigned = u128::from_str_radix(&clean[2..], 8)
-            .map_err(|_| format!("invalid octal literal: {repr}"))?;
-        Ok(unsigned as i128)
-    } else {
-        // Decimal - may be negative
-        clean
-            .parse()
-            .map_err(|_| format!("invalid integer literal: {repr}"))
-    }
-}
-
-/// Unpack u128 into (low, high) pair for codegen.
-pub(super) fn unpack_u128(value: u128) -> (u64, u64) {
-    (value as u64, (value >> 64) as u64)
-}
-
 /// Unpack i128 into (low, high) pair for codegen.
 #[allow(clippy::cast_sign_loss)]
 pub(super) fn unpack_i128(value: i128) -> (u64, i64) {
     (value as u64, (value >> 64) as i64)
-}
-
-/// Get the clean representation of a literal (without underscores).
-pub(super) fn clean_literal_repr(repr: &str) -> String {
-    repr.chars().filter(|&c| c != '_').collect()
 }


### PR DESCRIPTION
## Summary
This PR refactors the integer literal parsing system to use `u128` and `i128` as the primary parsing types instead of `u64`, enabling proper handling of larger integer values and improving range checking for all primitive integer types.

## Key Changes

- **Unified literal parsing**: Replaced `parse_int_literal()` with `parse_u128_literal()` and `parse_i128_literal()` functions that parse directly into 128-bit types
  - `parse_u128_literal()`: Parses unsigned literals (decimal, hex, binary, octal, scientific notation)
  - `parse_i128_literal()`: Parses signed literals, delegating to unsigned parser for non-negative values
  
- **Improved range checking**: Updated `check_int_range_positive()` and `check_int_range_negative()` to accept `u128` values instead of `u64`, allowing proper validation of the full range of literal values before narrowing to target types

- **Simplified i128/u128 struct literal handling**: Consolidated duplicate logic for handling `i128` and `u128` struct type constructors
  - Unified parsing path that handles both types with a single `parse_result` match
  - Cleaner error handling with a single error case instead of separate branches per type
  - Removed `unpack_u128()` function (now only `unpack_i128()` is needed)

- **Code cleanup**:
  - Introduced `normalize_numeric_literal()` helper to centralize underscore removal and lowercasing
  - Removed `clean_literal_repr()` function in favor of direct literal representation usage
  - Simplified negated literal handling by removing unnecessary normalization calls

## Implementation Details

- All integer literal values are now parsed into their maximum representable type (u128 for unsigned, i128 for signed) before being narrowed to the target type
- This ensures accurate range validation and prevents overflow during intermediate parsing steps
- The refactoring maintains backward compatibility while improving correctness for edge cases involving large literal values

https://claude.ai/code/session_01Uw62DtR87kiRpvGroX3cZS