### PR TITLE
Refactor CLI argument parsing to support in-process testing

### DIFF
--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 description = "CLI for the Wado programming language"
 license = { workspace = true }
 
+[lib]
+name = "wado_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "wado"
 path = "src/main.rs"

--- a/wado-cli/src/args.rs
+++ b/wado-cli/src/args.rs
@@ -36,6 +36,7 @@ impl CliExit {
     }
 
     /// Create a help exit (exit code 0).
+    #[must_use]
     pub fn help(usage: String) -> Self {
         Self {
             message: usage,
@@ -57,12 +58,12 @@ pub fn exit_error(msg: &str) -> ! {
 
 /// Get the next argument, returning an error on failure.
 pub fn next_arg(parser: &mut Parser) -> Result<Option<lexopt::Arg<'_>>, CliExit> {
-    parser.next().map_err(|e| CliExit::error(e))
+    parser.next().map_err(CliExit::error)
 }
 
 /// Get a required value for an option.
 pub fn require_value(parser: &mut Parser) -> Result<OsString, CliExit> {
-    parser.value().map_err(|e| CliExit::error(e))
+    parser.value().map_err(CliExit::error)
 }
 
 /// Get a required string value for an option.
@@ -78,10 +79,7 @@ pub fn require_input(input: Option<String>, usage: &str) -> Result<String, CliEx
 /// Require that at least one input file was specified.
 pub fn require_inputs(inputs: Vec<String>, usage: &str) -> Result<Vec<String>, CliExit> {
     if inputs.is_empty() {
-        Err(CliExit::error_with_usage(
-            "no input file specified",
-            usage,
-        ))
+        Err(CliExit::error_with_usage("no input file specified", usage))
     } else {
         Ok(inputs)
     }
@@ -97,6 +95,7 @@ pub fn reject_multiple_inputs(input: &Option<String>) -> Result<(), CliExit> {
 }
 
 /// Create an error for an unexpected argument.
+#[must_use]
 pub fn unexpected_arg(arg: lexopt::Arg, usage: &str) -> CliExit {
     CliExit::error_with_usage(arg.unexpected(), usage)
 }
@@ -208,6 +207,7 @@ pub fn print_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) {
 }
 
 /// Parse log level from string (consolidated from duplicate implementations).
+#[must_use]
 pub fn parse_log_level(s: &str) -> Option<LogLevel> {
     match s.to_lowercase().as_str() {
         "debug" => Some(LogLevel::Debug),

--- a/wado-cli/src/args.rs
+++ b/wado-cli/src/args.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 use std::process;
 
 use lexopt::Parser;
+use wado_compiler::LogLevel;
 
 /// Exit with an error message
 pub fn exit_error(msg: &str) -> ! {
@@ -64,4 +65,128 @@ pub fn unexpected_arg(arg: lexopt::Arg, print_usage: fn()) -> ! {
     eprintln!("Error: {}", arg.unexpected());
     print_usage();
     process::exit(1);
+}
+
+/// Specification for a single CLI option, used for both matching and help generation.
+///
+/// Define option specs as `const fn spec(&self) -> OptSpec` on per-subcommand enums.
+/// This ensures exhaustive match catches missing definitions at compile time.
+#[derive(Clone, Copy)]
+pub struct OptSpec {
+    /// Long option name (without `--`), e.g., `Some("format")`
+    pub long: Option<&'static str>,
+    /// Short option character, e.g., `Some('o')`
+    pub short: Option<char>,
+    /// Value placeholder for help text, e.g., `Some("<fmt>")`. `None` for flags.
+    pub value: Option<&'static str>,
+    /// Description for help text. Use `\n` for continuation lines.
+    pub desc: &'static str,
+}
+
+/// Shared spec: `--help`
+pub const HELP_SPEC: OptSpec = OptSpec {
+    long: Some("help"),
+    short: None,
+    value: None,
+    desc: "Show this help message",
+};
+
+/// Shared spec: `-O <n>`
+pub const OPT_LEVEL_SPEC: OptSpec = OptSpec {
+    long: None,
+    short: Some('O'),
+    value: Some("<n>"),
+    desc: "Optimization level: -O0, -O1, -O2, -O3, -Os",
+};
+
+/// Shared spec: `--log-level <level>`
+pub const LOG_LEVEL_SPEC: OptSpec = OptSpec {
+    long: Some("log-level"),
+    short: None,
+    value: Some("<level>"),
+    desc: "Log level: debug, info, warn, error, off (default: info)",
+};
+
+/// Match a `lexopt::Arg` against a set of option variants using their specs.
+///
+/// Returns the matching variant if the argument matches a long or short option
+/// defined in the specs. Returns `None` for positional `Value` arguments.
+pub fn match_opt<T: Copy>(
+    arg: &lexopt::Arg<'_>,
+    all: &[T],
+    spec: impl Fn(&T) -> OptSpec,
+) -> Option<T> {
+    match arg {
+        lexopt::Arg::Long(name) => all.iter().find(|t| spec(t).long == Some(*name)).copied(),
+        lexopt::Arg::Short(c) => all.iter().find(|t| spec(t).short == Some(*c)).copied(),
+        lexopt::Arg::Value(_) => None,
+    }
+}
+
+/// Format an option spec as a help label.
+///
+/// - `-o <file>`, `--format <fmt>`, `-f, --filter <pattern>`, `--help`
+fn format_opt_label(spec: &OptSpec) -> String {
+    let mut result = String::new();
+    if let Some(c) = spec.short {
+        result.push('-');
+        result.push(c);
+    }
+    if spec.short.is_some() && spec.long.is_some() {
+        result.push_str(", ");
+    }
+    if let Some(l) = spec.long {
+        result.push_str("--");
+        result.push_str(l);
+    }
+    if let Some(v) = spec.value {
+        result.push(' ');
+        result.push_str(v);
+    }
+    result
+}
+
+/// Print help entries from option variants, auto-aligned.
+///
+/// Each option's label is generated from its spec and descriptions are
+/// aligned to the widest label. Multi-line descriptions (using `\n`) are
+/// printed with continuation lines indented to the description column.
+pub fn print_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) {
+    let labels: Vec<String> = all.iter().map(|t| format_opt_label(&spec(t))).collect();
+    let max_w = labels.iter().map(String::len).max().unwrap_or(0);
+    for (label, t) in labels.iter().zip(all) {
+        let s = spec(t);
+        let mut lines = s.desc.lines();
+        if let Some(first) = lines.next() {
+            eprintln!("  {label:<max_w$}  {first}");
+            for cont in lines {
+                eprintln!("  {:<max_w$}  {cont}", "");
+            }
+        }
+    }
+}
+
+/// Parse log level from string (consolidated from duplicate implementations).
+pub fn parse_log_level(s: &str) -> Option<LogLevel> {
+    match s.to_lowercase().as_str() {
+        "debug" => Some(LogLevel::Debug),
+        "info" => Some(LogLevel::Info),
+        "warn" | "warning" => Some(LogLevel::Warn),
+        "error" => Some(LogLevel::Error),
+        "off" | "none" => Some(LogLevel::Off),
+        _ => None,
+    }
+}
+
+/// Parse `--log-level` argument value from parser, exiting on error.
+pub fn parse_log_level_arg(parser: &mut Parser) -> LogLevel {
+    let level_str = require_string(parser);
+    if let Some(level) = parse_log_level(&level_str) {
+        level
+    } else {
+        eprintln!(
+            "Error: unknown log level '{level_str}'. Use debug, info, warn, error, or off"
+        );
+        process::exit(1);
+    }
 }

--- a/wado-cli/src/args.rs
+++ b/wado-cli/src/args.rs
@@ -1,70 +1,104 @@
 //! Helper functions for lexopt argument parsing
 
 use std::ffi::OsString;
+use std::fmt::Write;
 use std::process;
 
 use lexopt::Parser;
 use wado_compiler::LogLevel;
 
-/// Exit with an error message
+/// Represents a CLI exit (help or error) without calling `process::exit()`.
+///
+/// Returned by `parse_args` functions to enable in-process testing.
+#[derive(Debug)]
+pub struct CliExit {
+    /// The full message to display (to stderr).
+    pub message: String,
+    /// Process exit code (0 for help, 1 for errors).
+    pub exit_code: i32,
+}
+
+impl CliExit {
+    /// Create an error exit with a message.
+    pub fn error(msg: impl std::fmt::Display) -> Self {
+        Self {
+            message: format!("Error: {msg}\n"),
+            exit_code: 1,
+        }
+    }
+
+    /// Create an error exit with a message followed by usage text.
+    pub fn error_with_usage(msg: impl std::fmt::Display, usage: &str) -> Self {
+        Self {
+            message: format!("Error: {msg}\n{usage}"),
+            exit_code: 1,
+        }
+    }
+
+    /// Create a help exit (exit code 0).
+    pub fn help(usage: String) -> Self {
+        Self {
+            message: usage,
+            exit_code: 0,
+        }
+    }
+
+    /// Exit the process with the stored message and code.
+    pub fn exit(&self) -> ! {
+        eprint!("{}", self.message);
+        process::exit(self.exit_code);
+    }
+}
+
+/// Exit with an error message (for use in `run()` functions that still need `-> !`).
 pub fn exit_error(msg: &str) -> ! {
-    eprintln!("Error: {msg}");
-    process::exit(1);
+    CliExit::error(msg).exit()
 }
 
-/// Get the next argument, exiting on error
-pub fn next_arg(parser: &mut Parser) -> Option<lexopt::Arg<'_>> {
-    match parser.next() {
-        Ok(arg) => arg,
-        Err(e) => exit_error(&e.to_string()),
-    }
+/// Get the next argument, returning an error on failure.
+pub fn next_arg(parser: &mut Parser) -> Result<Option<lexopt::Arg<'_>>, CliExit> {
+    parser.next().map_err(|e| CliExit::error(e))
 }
 
-/// Get a required value for an option, exiting on error
-pub fn require_value(parser: &mut Parser) -> OsString {
-    parser
-        .value()
-        .unwrap_or_else(|e| exit_error(&e.to_string()))
+/// Get a required value for an option.
+pub fn require_value(parser: &mut Parser) -> Result<OsString, CliExit> {
+    parser.value().map_err(|e| CliExit::error(e))
 }
 
-/// Get a required string value for an option
-pub fn require_string(parser: &mut Parser) -> String {
-    require_value(parser).to_string_lossy().into_owned()
+/// Get a required string value for an option.
+pub fn require_string(parser: &mut Parser) -> Result<String, CliExit> {
+    Ok(require_value(parser)?.to_string_lossy().into_owned())
 }
 
-/// Require that an input file was specified
-pub fn require_input(input: Option<String>, print_usage: fn()) -> String {
-    if let Some(f) = input {
-        f
-    } else {
-        eprintln!("Error: no input file specified");
-        print_usage();
-        process::exit(1);
-    }
+/// Require that an input file was specified.
+pub fn require_input(input: Option<String>, usage: &str) -> Result<String, CliExit> {
+    input.ok_or_else(|| CliExit::error_with_usage("no input file specified", usage))
 }
 
-/// Require that at least one input file was specified
-pub fn require_inputs(inputs: Vec<String>, print_usage: fn()) -> Vec<String> {
+/// Require that at least one input file was specified.
+pub fn require_inputs(inputs: Vec<String>, usage: &str) -> Result<Vec<String>, CliExit> {
     if inputs.is_empty() {
-        eprintln!("Error: no input file specified");
-        print_usage();
-        process::exit(1);
+        Err(CliExit::error_with_usage(
+            "no input file specified",
+            usage,
+        ))
+    } else {
+        Ok(inputs)
     }
-    inputs
 }
 
-/// Check for multiple input files and error
-pub fn reject_multiple_inputs(input: &Option<String>) {
+/// Check for multiple input files and error.
+pub fn reject_multiple_inputs(input: &Option<String>) -> Result<(), CliExit> {
     if input.is_some() {
-        exit_error("multiple input files not supported");
+        Err(CliExit::error("multiple input files not supported"))
+    } else {
+        Ok(())
     }
 }
 
-/// Handle unexpected argument
-pub fn unexpected_arg(arg: lexopt::Arg, print_usage: fn()) -> ! {
-    eprintln!("Error: {}", arg.unexpected());
-    print_usage();
-    process::exit(1);
+/// Create an error for an unexpected argument.
+pub fn unexpected_arg(arg: lexopt::Arg, usage: &str) -> CliExit {
+    CliExit::error_with_usage(arg.unexpected(), usage)
 }
 
 /// Specification for a single CLI option, used for both matching and help generation.
@@ -146,24 +180,31 @@ fn format_opt_label(spec: &OptSpec) -> String {
     result
 }
 
+/// Format help entries from option variants into a string, auto-aligned.
+pub fn format_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) -> String {
+    let labels: Vec<String> = all.iter().map(|t| format_opt_label(&spec(t))).collect();
+    let max_w = labels.iter().map(String::len).max().unwrap_or(0);
+    let mut buf = String::new();
+    for (label, t) in labels.iter().zip(all) {
+        let s = spec(t);
+        let mut lines = s.desc.lines();
+        if let Some(first) = lines.next() {
+            writeln!(buf, "  {label:<max_w$}  {first}").unwrap();
+            for cont in lines {
+                writeln!(buf, "  {:<max_w$}  {cont}", "").unwrap();
+            }
+        }
+    }
+    buf
+}
+
 /// Print help entries from option variants, auto-aligned.
 ///
 /// Each option's label is generated from its spec and descriptions are
 /// aligned to the widest label. Multi-line descriptions (using `\n`) are
 /// printed with continuation lines indented to the description column.
 pub fn print_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) {
-    let labels: Vec<String> = all.iter().map(|t| format_opt_label(&spec(t))).collect();
-    let max_w = labels.iter().map(String::len).max().unwrap_or(0);
-    for (label, t) in labels.iter().zip(all) {
-        let s = spec(t);
-        let mut lines = s.desc.lines();
-        if let Some(first) = lines.next() {
-            eprintln!("  {label:<max_w$}  {first}");
-            for cont in lines {
-                eprintln!("  {:<max_w$}  {cont}", "");
-            }
-        }
-    }
+    eprint!("{}", format_opts_help(all, &spec));
 }
 
 /// Parse log level from string (consolidated from duplicate implementations).
@@ -178,15 +219,12 @@ pub fn parse_log_level(s: &str) -> Option<LogLevel> {
     }
 }
 
-/// Parse `--log-level` argument value from parser, exiting on error.
-pub fn parse_log_level_arg(parser: &mut Parser) -> LogLevel {
-    let level_str = require_string(parser);
-    if let Some(level) = parse_log_level(&level_str) {
-        level
-    } else {
-        eprintln!(
-            "Error: unknown log level '{level_str}'. Use debug, info, warn, error, or off"
-        );
-        process::exit(1);
-    }
+/// Parse `--log-level` argument value from parser.
+pub fn parse_log_level_arg(parser: &mut Parser) -> Result<LogLevel, CliExit> {
+    let level_str = require_string(parser)?;
+    parse_log_level(&level_str).ok_or_else(|| {
+        CliExit::error(format!(
+            "unknown log level '{level_str}'. Use debug, info, warn, error, or off"
+        ))
+    })
 }

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -2,11 +2,11 @@ use std::fs;
 use std::path::Path;
 use std::process;
 
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 use wado_compiler::LogLevel;
 
 use crate::args::{
-    next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
+    self, next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
 };
 use crate::compiler_host::FilesystemCompilerHost;
 
@@ -67,35 +67,77 @@ pub struct CompileOptions {
     pub skip_validation: bool,
 }
 
+#[derive(Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+enum Opt {
+    Output,
+    Format,
+    WatToStdout,
+    World,
+    OptLevel,
+    LogLevel,
+    NoValidate,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[
+        Self::Output,
+        Self::Format,
+        Self::WatToStdout,
+        Self::World,
+        Self::OptLevel,
+        Self::LogLevel,
+        Self::NoValidate,
+        Self::Help,
+    ];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Output => args::OptSpec {
+                long: None,
+                short: Some('o'),
+                value: Some("<file>"),
+                desc: "Output file path (default: <input>.wasm)",
+            },
+            Self::Format => args::OptSpec {
+                long: Some("format"),
+                short: None,
+                value: Some("<fmt>"),
+                desc: "Output format: wasm, wat (default: guessed from -o extension)",
+            },
+            Self::WatToStdout => args::OptSpec {
+                long: Some("wat-to-stdout"),
+                short: None,
+                value: None,
+                desc: "Output WAT to stdout (shorthand for --format wat -o /dev/stdout)",
+            },
+            Self::World => args::OptSpec {
+                long: Some("world"),
+                short: None,
+                value: Some("<name>"),
+                desc: "Target world (default: wasi:cli/command)\nUse 'test' to export test functions only",
+            },
+            Self::OptLevel => args::OPT_LEVEL_SPEC,
+            Self::LogLevel => args::LOG_LEVEL_SPEC,
+            Self::NoValidate => args::OptSpec {
+                long: Some("no-validate"),
+                short: None,
+                value: None,
+                desc: "Skip Wasm validation (output raw bytes even if invalid)",
+            },
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 pub fn print_usage() {
     eprintln!("Usage: wado compile [options] <file.wado>");
     eprintln!();
     eprintln!("Compile a Wado source file to WebAssembly.");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  -o <file>         Output file path (default: <input>.wasm)");
-    eprintln!("  --format <fmt>    Output format: wasm, wat (default: guessed from -o extension)");
-    eprintln!(
-        "  --wat-to-stdout   Output WAT to stdout (shorthand for --format wat -o /dev/stdout)"
-    );
-    eprintln!("  --world <name>    Target world (default: wasi:cli/command)");
-    eprintln!("                    Use 'test' to export test functions only");
-    eprintln!("  -O<n>             Optimization level: -O0, -O1, -O2, -O3, -Os");
-    eprintln!("  --log-level <l>   Log level: debug, info, warn, error, off (default: info)");
-    eprintln!("  --no-validate     Skip Wasm validation (output raw bytes even if invalid)");
-    eprintln!("  --help            Show this help message");
-}
-
-/// Parse log level from string
-fn parse_log_level(s: &str) -> Option<LogLevel> {
-    match s.to_lowercase().as_str() {
-        "debug" => Some(LogLevel::Debug),
-        "info" => Some(LogLevel::Info),
-        "warn" | "warning" => Some(LogLevel::Warn),
-        "error" => Some(LogLevel::Error),
-        "off" | "none" => Some(LogLevel::Off),
-        _ => None,
-    }
+    args::print_opts_help(Opt::ALL, |o| o.spec());
 }
 
 pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
@@ -108,68 +150,52 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
     let mut target_world: Option<String> = None;
     let mut skip_validation = false;
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
-            }
-            Long("wat-to-stdout") => {
-                wat_to_stdout = true;
-            }
-            Long("no-validate") => {
-                skip_validation = true;
-            }
-            Long("world") => {
-                target_world = Some(require_string(&mut parser));
-            }
-            Short('o') => {
-                output = Some(require_string(&mut parser));
-            }
-            Short('O') => {
-                let val = parser.optional_value();
-                let level_str = val
-                    .as_ref()
-                    .map(|v| v.to_string_lossy())
-                    .unwrap_or_default();
-                opt_level = match level_str.as_ref() {
-                    "" | "0" | "g" => OptLevel::O0,
-                    "1" => OptLevel::O1,
-                    "2" => OptLevel::O2,
-                    "3" => OptLevel::O3,
-                    "s" => OptLevel::Os,
-                    _ => {
-                        eprintln!(
-                            "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
-                        );
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Output => output = Some(require_string(&mut parser)),
+                Opt::Format => {
+                    let fmt_str = require_string(&mut parser);
+                    if let Some(f) = OutputFormat::from_str(&fmt_str) {
+                        format = Some(f);
+                    } else {
+                        eprintln!("Error: unknown format '{fmt_str}'. Use 'wasm' or 'wat'");
                         process::exit(1);
                     }
-                };
-            }
-            Long("format") => {
-                let fmt_str = require_string(&mut parser);
-                if let Some(f) = OutputFormat::from_str(&fmt_str) {
-                    format = Some(f);
-                } else {
-                    eprintln!("Error: unknown format '{fmt_str}'. Use 'wasm' or 'wat'");
-                    process::exit(1);
+                }
+                Opt::WatToStdout => wat_to_stdout = true,
+                Opt::World => target_world = Some(require_string(&mut parser)),
+                Opt::OptLevel => {
+                    let val = parser.optional_value();
+                    let level_str = val
+                        .as_ref()
+                        .map(|v| v.to_string_lossy())
+                        .unwrap_or_default();
+                    opt_level = match level_str.as_ref() {
+                        "" | "0" | "g" => OptLevel::O0,
+                        "1" => OptLevel::O1,
+                        "2" => OptLevel::O2,
+                        "3" => OptLevel::O3,
+                        "s" => OptLevel::Os,
+                        _ => {
+                            eprintln!(
+                                "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
+                            );
+                            process::exit(1);
+                        }
+                    };
+                }
+                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser),
+                Opt::NoValidate => skip_validation = true,
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
                 }
             }
-            Long("log-level") => {
-                let level_str = require_string(&mut parser);
-                if let Some(level) = parse_log_level(&level_str) {
-                    log_level = level;
-                } else {
-                    eprintln!(
-                        "Error: unknown log level '{level_str}'. Use debug, info, warn, error, or off"
-                    );
-                    process::exit(1);
-                }
-            }
-            Value(val) => {
-                reject_multiple_inputs(&input);
-                input = Some(val.to_string_lossy().into_owned());
-            }
-            _ => unexpected_arg(arg, print_usage),
+        } else if let Value(val) = arg {
+            reject_multiple_inputs(&input);
+            input = Some(val.to_string_lossy().into_owned());
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -162,9 +162,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
                 Opt::Format => {
                     let fmt_str = args::require_string(&mut parser)?;
                     format = Some(OutputFormat::from_str(&fmt_str).ok_or_else(|| {
-                        CliExit::error(format!(
-                            "unknown format '{fmt_str}'. Use 'wasm' or 'wat'"
-                        ))
+                        CliExit::error(format!("unknown format '{fmt_str}'. Use 'wasm' or 'wat'"))
                     })?);
                 }
                 Opt::WatToStdout => wat_to_stdout = true,

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::process;
@@ -5,9 +6,7 @@ use std::process;
 use lexopt::Arg::Value;
 use wado_compiler::LogLevel;
 
-use crate::args::{
-    self, next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
-};
+use crate::args::{self, CliExit};
 use crate::compiler_host::FilesystemCompilerHost;
 
 /// Optimization level
@@ -30,7 +29,7 @@ pub enum OptLevel {
     Os,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum OutputFormat {
     Wasm,
     Wat,
@@ -131,16 +130,23 @@ impl Opt {
     }
 }
 
-pub fn print_usage() {
-    eprintln!("Usage: wado compile [options] <file.wado>");
-    eprintln!();
-    eprintln!("Compile a Wado source file to WebAssembly.");
-    eprintln!();
-    eprintln!("Options:");
-    args::print_opts_help(Opt::ALL, |o| o.spec());
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado compile [options] <file.wado>").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Compile a Wado source file to WebAssembly.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
+    buf
 }
 
-pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
+pub fn print_usage() {
+    eprint!("{}", format_usage());
+}
+
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit> {
+    let usage = format_usage();
     let mut output: Option<String> = None;
     let mut format: Option<OutputFormat> = None;
     let mut input: Option<String> = None;
@@ -149,21 +155,20 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
     let mut log_level = LogLevel::default();
     let mut target_world: Option<String> = None;
     let mut skip_validation = false;
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
-                Opt::Output => output = Some(require_string(&mut parser)),
+                Opt::Output => output = Some(args::require_string(&mut parser)?),
                 Opt::Format => {
-                    let fmt_str = require_string(&mut parser);
-                    if let Some(f) = OutputFormat::from_str(&fmt_str) {
-                        format = Some(f);
-                    } else {
-                        eprintln!("Error: unknown format '{fmt_str}'. Use 'wasm' or 'wat'");
-                        process::exit(1);
-                    }
+                    let fmt_str = args::require_string(&mut parser)?;
+                    format = Some(OutputFormat::from_str(&fmt_str).ok_or_else(|| {
+                        CliExit::error(format!(
+                            "unknown format '{fmt_str}'. Use 'wasm' or 'wat'"
+                        ))
+                    })?);
                 }
                 Opt::WatToStdout => wat_to_stdout = true,
-                Opt::World => target_world = Some(require_string(&mut parser)),
+                Opt::World => target_world = Some(args::require_string(&mut parser)?),
                 Opt::OptLevel => {
                     let val = parser.optional_value();
                     let level_str = val
@@ -177,30 +182,26 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
                         "3" => OptLevel::O3,
                         "s" => OptLevel::Os,
                         _ => {
-                            eprintln!(
-                                "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
-                            );
-                            process::exit(1);
+                            return Err(CliExit::error(format!(
+                                "unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
+                            )));
                         }
                     };
                 }
-                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser),
+                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser)?,
                 Opt::NoValidate => skip_validation = true,
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
-            reject_multiple_inputs(&input);
+            args::reject_multiple_inputs(&input)?;
             input = Some(val.to_string_lossy().into_owned());
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
-    CompileOptions {
-        input: require_input(input, print_usage),
+    Ok(CompileOptions {
+        input: args::require_input(input, &usage)?,
         output,
         format,
         opt_level,
@@ -208,7 +209,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> CompileOptions {
         log_level,
         target_world,
         skip_validation,
-    }
+    })
 }
 
 /// Convert CLI `OptLevel` to compiler `OptLevel`

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -3,10 +3,10 @@ use std::io::Write;
 use std::path::Path;
 use std::process;
 
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 use wado_compiler::OptLevel;
 
-use crate::args::{next_arg, require_inputs, unexpected_arg};
+use crate::args::{self, next_arg, require_inputs, unexpected_arg};
 use crate::compiler_host::FilesystemCompilerHost;
 
 pub struct DumpOptions {
@@ -28,6 +28,136 @@ pub struct DumpOptions {
     pub output_template: Option<String>,
 }
 
+#[derive(Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+enum Opt {
+    Tokens,
+    Ast,
+    Desugar,
+    Modules,
+    Symbols,
+    Tir,
+    Monomorphize,
+    Lower,
+    Optimize,
+    Wir,
+    All,
+    Unparse,
+    OptLevel,
+    Output,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[
+        Self::Tokens,
+        Self::Ast,
+        Self::Desugar,
+        Self::Modules,
+        Self::Symbols,
+        Self::Tir,
+        Self::Monomorphize,
+        Self::Lower,
+        Self::Optimize,
+        Self::Wir,
+        Self::All,
+        Self::Unparse,
+        Self::OptLevel,
+        Self::Output,
+        Self::Help,
+    ];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Tokens => args::OptSpec {
+                long: Some("tokens"),
+                short: None,
+                value: None,
+                desc: "(Phase 1: Lexer) Show tokens",
+            },
+            Self::Ast => args::OptSpec {
+                long: Some("ast"),
+                short: None,
+                value: None,
+                desc: "(Phase 2: Parser) Show AST structure",
+            },
+            Self::Desugar => args::OptSpec {
+                long: Some("desugar"),
+                short: None,
+                value: None,
+                desc: "(Phase 3: Desugar) Show desugared AST",
+            },
+            Self::Modules => args::OptSpec {
+                long: Some("modules"),
+                short: None,
+                value: None,
+                desc: "(Phase 4: Load) Show loaded modules",
+            },
+            Self::Symbols => args::OptSpec {
+                long: Some("symbols"),
+                short: None,
+                value: None,
+                desc: "(Phase 5: Analyze) Show symbol table",
+            },
+            Self::Tir => args::OptSpec {
+                long: Some("tir"),
+                short: None,
+                value: None,
+                desc: "(Phase 6: Resolve) Show TIR (Typed IR)",
+            },
+            Self::Monomorphize => args::OptSpec {
+                long: Some("monomorphize"),
+                short: None,
+                value: None,
+                desc: "(Phase 7: Monomorphize) Show monomorphized TIR",
+            },
+            Self::Lower => args::OptSpec {
+                long: Some("lower"),
+                short: None,
+                value: None,
+                desc: "(Phase 8: Lower) Show lowered TIR",
+            },
+            Self::Optimize => args::OptSpec {
+                long: Some("optimize"),
+                short: None,
+                value: None,
+                desc: "(Phase 9: Optimize) Show optimization hints",
+            },
+            Self::Wir => args::OptSpec {
+                long: Some("wir"),
+                short: None,
+                value: None,
+                desc: "(Phase 10: WIR) Show Wasm IR",
+            },
+            Self::All => args::OptSpec {
+                long: Some("all"),
+                short: None,
+                value: None,
+                desc: "Show all phases (default if no phase specified)",
+            },
+            Self::Unparse => args::OptSpec {
+                long: Some("unparse"),
+                short: None,
+                value: None,
+                desc: "Unparse to Wado source code (for ast/desugar/tir/lower/optimize)\nDefault: Debug/tree format",
+            },
+            Self::OptLevel => args::OptSpec {
+                long: None,
+                short: Some('O'),
+                value: Some("<n>"),
+                desc: "Optimization level (for --optimize phase)",
+            },
+            Self::Output => args::OptSpec {
+                long: Some("output"),
+                short: Some('o'),
+                value: Some("<template>"),
+                desc: "Output template for bulk file generation\n{name} is replaced with input filename (without extension)\nExample: -o 'out/{name}.lowered.wado'",
+            },
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 pub fn print_usage() {
     eprintln!("Usage: wado dump [options] <file.wado> [file2.wado ...]");
     eprintln!();
@@ -35,21 +165,16 @@ pub fn print_usage() {
     eprintln!("Supports multiple input files for batch processing.");
     eprintln!();
     eprintln!("Compilation Phases:");
-    eprintln!("  --tokens       (Phase 1: Lexer) Show tokens");
-    eprintln!("  --ast          (Phase 2: Parser) Show AST structure");
-    eprintln!("  --desugar      (Phase 3: Desugar) Show desugared AST");
-    eprintln!("  --modules      (Phase 4: Load) Show loaded modules");
-    eprintln!("  --symbols      (Phase 5: Analyze) Show symbol table");
-    eprintln!("  --tir          (Phase 6: Resolve) Show TIR (Typed IR)");
-    eprintln!("  --monomorphize (Phase 7: Monomorphize) Show monomorphized TIR");
-    eprintln!("  --lower        (Phase 8: Lower) Show lowered TIR");
-    eprintln!("  --optimize     (Phase 9: Optimize) Show optimization hints");
-    eprintln!("  --wir          (Phase 10: WIR) Show Wasm IR");
-    eprintln!("  --all        Show all phases (default if no phase specified)");
+    args::print_opts_help(
+        &[
+            Opt::Tokens, Opt::Ast, Opt::Desugar, Opt::Modules, Opt::Symbols,
+            Opt::Tir, Opt::Monomorphize, Opt::Lower, Opt::Optimize, Opt::Wir, Opt::All,
+        ],
+        |o| o.spec(),
+    );
     eprintln!();
     eprintln!("Display Options:");
-    eprintln!("  --unparse    Unparse to Wado source code (for ast/desugar/tir/lower/optimize)");
-    eprintln!("               Default: Debug/tree format");
+    args::print_opts_help(&[Opt::Unparse], |o| o.spec());
     eprintln!();
     eprintln!("Optimization Level (for --optimize phase):");
     eprintln!("  -O0          No optimizations");
@@ -59,12 +184,10 @@ pub fn print_usage() {
     eprintln!("  -Os          Size optimizations (O2 + strip names)");
     eprintln!();
     eprintln!("Output:");
-    eprintln!("  -o <template>  Output template for bulk file generation");
-    eprintln!("                 {{name}} is replaced with input filename (without extension)");
-    eprintln!("                 Example: -o 'out/{{name}}.lowered.wado'");
+    args::print_opts_help(&[Opt::Output], |o| o.spec());
     eprintln!();
     eprintln!("Other:");
-    eprintln!("  --help       Show this help message");
+    args::print_opts_help(&[Opt::Help], |o| o.spec());
 }
 
 #[allow(clippy::similar_names)] // show_tir and show_wir are intentional phase names
@@ -85,64 +208,66 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     let mut output_template: Option<String> = None;
 
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
-            }
-            Long("tokens") => show_tokens = true,
-            Long("ast") => show_ast = true,
-            Long("desugar") => show_desugar = true,
-            Long("symbols") => show_symbols = true,
-            Long("modules") => show_modules = true,
-            Long("tir") => show_tir = true,
-            Long("monomorphize") => show_monomorphize = true,
-            Long("lower") => show_lower = true,
-            Long("optimize") => show_optimize = true,
-            Long("wir") => show_wir = true,
-            Long("unparse") => unparse = true,
-            Long("all") => {
-                show_tokens = true;
-                show_ast = true;
-                show_desugar = true;
-                show_symbols = true;
-                show_modules = true;
-                show_tir = true;
-                show_monomorphize = true;
-                show_lower = true;
-                show_optimize = true;
-                show_wir = true;
-            }
-            Short('O') => {
-                let level = parser.value().unwrap_or_else(|_| {
-                    eprintln!("Error: -O requires a level (0, 1, 2, 3, or s)");
-                    process::exit(1);
-                });
-                let level_str = level.to_string_lossy();
-                opt_level = match level_str.as_ref() {
-                    "0" => OptLevel::O0,
-                    "1" => OptLevel::O1,
-                    "2" => OptLevel::O2,
-                    "3" => OptLevel::O3,
-                    "s" => OptLevel::Os,
-                    _ => {
-                        eprintln!("Error: Unknown optimization level: -O{level_str}");
-                        eprintln!("Valid levels: -O0, -O1, -O2, -O3, -Os");
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Tokens => show_tokens = true,
+                Opt::Ast => show_ast = true,
+                Opt::Desugar => show_desugar = true,
+                Opt::Symbols => show_symbols = true,
+                Opt::Modules => show_modules = true,
+                Opt::Tir => show_tir = true,
+                Opt::Monomorphize => show_monomorphize = true,
+                Opt::Lower => show_lower = true,
+                Opt::Optimize => show_optimize = true,
+                Opt::Wir => show_wir = true,
+                Opt::All => {
+                    show_tokens = true;
+                    show_ast = true;
+                    show_desugar = true;
+                    show_symbols = true;
+                    show_modules = true;
+                    show_tir = true;
+                    show_monomorphize = true;
+                    show_lower = true;
+                    show_optimize = true;
+                    show_wir = true;
+                }
+                Opt::Unparse => unparse = true,
+                Opt::OptLevel => {
+                    let level = parser.value().unwrap_or_else(|_| {
+                        eprintln!("Error: -O requires a level (0, 1, 2, 3, or s)");
                         process::exit(1);
-                    }
-                };
+                    });
+                    let level_str = level.to_string_lossy();
+                    opt_level = match level_str.as_ref() {
+                        "0" => OptLevel::O0,
+                        "1" => OptLevel::O1,
+                        "2" => OptLevel::O2,
+                        "3" => OptLevel::O3,
+                        "s" => OptLevel::Os,
+                        _ => {
+                            eprintln!("Error: Unknown optimization level: -O{level_str}");
+                            eprintln!("Valid levels: -O0, -O1, -O2, -O3, -Os");
+                            process::exit(1);
+                        }
+                    };
+                }
+                Opt::Output => {
+                    let template = parser.value().unwrap_or_else(|_| {
+                        eprintln!("Error: -o requires an output template");
+                        process::exit(1);
+                    });
+                    output_template = Some(template.to_string_lossy().into_owned());
+                }
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
+                }
             }
-            Short('o') | Long("output") => {
-                let template = parser.value().unwrap_or_else(|_| {
-                    eprintln!("Error: -o requires an output template");
-                    process::exit(1);
-                });
-                output_template = Some(template.to_string_lossy().into_owned());
-            }
-            Value(val) => {
-                inputs.push(val.to_string_lossy().into_owned());
-            }
-            _ => unexpected_arg(arg, print_usage),
+        } else if let Value(val) = arg {
+            inputs.push(val.to_string_lossy().into_owned());
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -161,35 +161,72 @@ impl Opt {
 
 fn format_usage() -> String {
     let mut buf = String::new();
-    writeln!(buf, "Usage: wado dump [options] <file.wado> [file2.wado ...]").unwrap();
+    writeln!(
+        buf,
+        "Usage: wado dump [options] <file.wado> [file2.wado ...]"
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Dump compiler internal state for debugging.").unwrap();
     writeln!(buf, "Supports multiple input files for batch processing.").unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Compilation Phases:").unwrap();
-    write!(buf, "{}", args::format_opts_help(
-        &[
-            Opt::Tokens, Opt::Ast, Opt::Desugar, Opt::Modules, Opt::Symbols,
-            Opt::Tir, Opt::Monomorphize, Opt::Lower, Opt::Optimize, Opt::Wir, Opt::All,
-        ],
-        |o| o.spec(),
-    )).unwrap();
+    write!(
+        buf,
+        "{}",
+        args::format_opts_help(
+            &[
+                Opt::Tokens,
+                Opt::Ast,
+                Opt::Desugar,
+                Opt::Modules,
+                Opt::Symbols,
+                Opt::Tir,
+                Opt::Monomorphize,
+                Opt::Lower,
+                Opt::Optimize,
+                Opt::Wir,
+                Opt::All,
+            ],
+            |o| o.spec(),
+        )
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Display Options:").unwrap();
-    write!(buf, "{}", args::format_opts_help(&[Opt::Unparse], |o| o.spec())).unwrap();
+    write!(
+        buf,
+        "{}",
+        args::format_opts_help(&[Opt::Unparse], |o| o.spec())
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Optimization Level (for --optimize phase):").unwrap();
     writeln!(buf, "  -O0          No optimizations").unwrap();
-    writeln!(buf, "  -O1          Development optimizations (all passes except DCE)").unwrap();
+    writeln!(
+        buf,
+        "  -O1          Development optimizations (all passes except DCE)"
+    )
+    .unwrap();
     writeln!(buf, "  -O2          Production optimizations (default)").unwrap();
     writeln!(buf, "  -O3          Aggressive optimizations").unwrap();
     writeln!(buf, "  -Os          Size optimizations (O2 + strip names)").unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Output:").unwrap();
-    write!(buf, "{}", args::format_opts_help(&[Opt::Output], |o| o.spec())).unwrap();
+    write!(
+        buf,
+        "{}",
+        args::format_opts_help(&[Opt::Output], |o| o.spec())
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Other:").unwrap();
-    write!(buf, "{}", args::format_opts_help(&[Opt::Help], |o| o.spec())).unwrap();
+    write!(
+        buf,
+        "{}",
+        args::format_opts_help(&[Opt::Help], |o| o.spec())
+    )
+    .unwrap();
     buf
 }
 
@@ -242,9 +279,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<DumpOptions, CliExit> {
                 }
                 Opt::Unparse => unparse = true,
                 Opt::OptLevel => {
-                    let level = args::require_value(&mut parser).map_err(|_| {
-                        CliExit::error("-O requires a level (0, 1, 2, 3, or s)")
-                    })?;
+                    let level = args::require_value(&mut parser)
+                        .map_err(|_| CliExit::error("-O requires a level (0, 1, 2, 3, or s)"))?;
                     let level_str = level.to_string_lossy();
                     opt_level = match level_str.as_ref() {
                         "0" => OptLevel::O0,
@@ -260,9 +296,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<DumpOptions, CliExit> {
                     };
                 }
                 Opt::Output => {
-                    let template = args::require_value(&mut parser).map_err(|_| {
-                        CliExit::error("-o requires an output template")
-                    })?;
+                    let template = args::require_value(&mut parser)
+                        .map_err(|_| CliExit::error("-o requires an output template"))?;
                     output_template = Some(template.to_string_lossy().into_owned());
                 }
                 Opt::Help => return Err(CliExit::help(usage)),

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -6,7 +7,7 @@ use std::process;
 use lexopt::Arg::Value;
 use wado_compiler::OptLevel;
 
-use crate::args::{self, next_arg, require_inputs, unexpected_arg};
+use crate::args::{self, CliExit};
 use crate::compiler_host::FilesystemCompilerHost;
 
 pub struct DumpOptions {
@@ -158,40 +159,47 @@ impl Opt {
     }
 }
 
-pub fn print_usage() {
-    eprintln!("Usage: wado dump [options] <file.wado> [file2.wado ...]");
-    eprintln!();
-    eprintln!("Dump compiler internal state for debugging.");
-    eprintln!("Supports multiple input files for batch processing.");
-    eprintln!();
-    eprintln!("Compilation Phases:");
-    args::print_opts_help(
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado dump [options] <file.wado> [file2.wado ...]").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Dump compiler internal state for debugging.").unwrap();
+    writeln!(buf, "Supports multiple input files for batch processing.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Compilation Phases:").unwrap();
+    write!(buf, "{}", args::format_opts_help(
         &[
             Opt::Tokens, Opt::Ast, Opt::Desugar, Opt::Modules, Opt::Symbols,
             Opt::Tir, Opt::Monomorphize, Opt::Lower, Opt::Optimize, Opt::Wir, Opt::All,
         ],
         |o| o.spec(),
-    );
-    eprintln!();
-    eprintln!("Display Options:");
-    args::print_opts_help(&[Opt::Unparse], |o| o.spec());
-    eprintln!();
-    eprintln!("Optimization Level (for --optimize phase):");
-    eprintln!("  -O0          No optimizations");
-    eprintln!("  -O1          Development optimizations (all passes except DCE)");
-    eprintln!("  -O2          Production optimizations (default)");
-    eprintln!("  -O3          Aggressive optimizations");
-    eprintln!("  -Os          Size optimizations (O2 + strip names)");
-    eprintln!();
-    eprintln!("Output:");
-    args::print_opts_help(&[Opt::Output], |o| o.spec());
-    eprintln!();
-    eprintln!("Other:");
-    args::print_opts_help(&[Opt::Help], |o| o.spec());
+    )).unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Display Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(&[Opt::Unparse], |o| o.spec())).unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Optimization Level (for --optimize phase):").unwrap();
+    writeln!(buf, "  -O0          No optimizations").unwrap();
+    writeln!(buf, "  -O1          Development optimizations (all passes except DCE)").unwrap();
+    writeln!(buf, "  -O2          Production optimizations (default)").unwrap();
+    writeln!(buf, "  -O3          Aggressive optimizations").unwrap();
+    writeln!(buf, "  -Os          Size optimizations (O2 + strip names)").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Output:").unwrap();
+    write!(buf, "{}", args::format_opts_help(&[Opt::Output], |o| o.spec())).unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Other:").unwrap();
+    write!(buf, "{}", args::format_opts_help(&[Opt::Help], |o| o.spec())).unwrap();
+    buf
+}
+
+pub fn print_usage() {
+    eprint!("{}", format_usage());
 }
 
 #[allow(clippy::similar_names)] // show_tir and show_wir are intentional phase names
-pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<DumpOptions, CliExit> {
+    let usage = format_usage();
     let mut inputs: Vec<String> = Vec::new();
     let mut show_tokens = false;
     let mut show_ast = false;
@@ -207,7 +215,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
     let mut opt_level = OptLevel::O2;
     let mut output_template: Option<String> = None;
 
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Tokens => show_tokens = true,
@@ -234,10 +242,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
                 }
                 Opt::Unparse => unparse = true,
                 Opt::OptLevel => {
-                    let level = parser.value().unwrap_or_else(|_| {
-                        eprintln!("Error: -O requires a level (0, 1, 2, 3, or s)");
-                        process::exit(1);
-                    });
+                    let level = args::require_value(&mut parser).map_err(|_| {
+                        CliExit::error("-O requires a level (0, 1, 2, 3, or s)")
+                    })?;
                     let level_str = level.to_string_lossy();
                     opt_level = match level_str.as_ref() {
                         "0" => OptLevel::O0,
@@ -246,32 +253,28 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
                         "3" => OptLevel::O3,
                         "s" => OptLevel::Os,
                         _ => {
-                            eprintln!("Error: Unknown optimization level: -O{level_str}");
-                            eprintln!("Valid levels: -O0, -O1, -O2, -O3, -Os");
-                            process::exit(1);
+                            return Err(CliExit::error(format!(
+                                "Unknown optimization level: -O{level_str}\nValid levels: -O0, -O1, -O2, -O3, -Os"
+                            )));
                         }
                     };
                 }
                 Opt::Output => {
-                    let template = parser.value().unwrap_or_else(|_| {
-                        eprintln!("Error: -o requires an output template");
-                        process::exit(1);
-                    });
+                    let template = args::require_value(&mut parser).map_err(|_| {
+                        CliExit::error("-o requires an output template")
+                    })?;
                     output_template = Some(template.to_string_lossy().into_owned());
                 }
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
             inputs.push(val.to_string_lossy().into_owned());
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
-    let inputs = require_inputs(inputs, print_usage);
+    let inputs = args::require_inputs(inputs, &usage)?;
 
     // Default: show all
     if !show_tokens
@@ -297,7 +300,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
         show_wir = true;
     }
 
-    DumpOptions {
+    Ok(DumpOptions {
         inputs,
         show_tokens,
         show_ast,
@@ -312,7 +315,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> DumpOptions {
         unparse,
         opt_level,
         output_template,
-    }
+    })
 }
 
 pub async fn run(opts: DumpOptions) {

--- a/wado-cli/src/format.rs
+++ b/wado-cli/src/format.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::process;
@@ -5,7 +6,7 @@ use std::time::Instant;
 
 use lexopt::Arg::Value;
 
-use crate::args::{self, next_arg, unexpected_arg};
+use crate::args::{self, CliExit};
 
 pub struct FormatOptions {
     pub inputs: Vec<String>,
@@ -42,55 +43,61 @@ impl Opt {
     }
 }
 
-pub fn print_usage() {
-    eprintln!("Usage: wado format [options] <file.wado>...");
-    eprintln!();
-    eprintln!("Options:");
-    args::print_opts_help(Opt::ALL, |o| o.spec());
-    eprintln!();
-    eprintln!("Without -w, outputs formatted code to stdout (single file only).");
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado format [options] <file.wado>...").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Without -w, outputs formatted code to stdout (single file only).").unwrap();
+    buf
 }
 
-pub fn parse_args(mut parser: lexopt::Parser) -> FormatOptions {
+pub fn print_usage() {
+    eprint!("{}", format_usage());
+}
+
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<FormatOptions, CliExit> {
+    let usage = format_usage();
     let mut inputs: Vec<String> = Vec::new();
     let mut write_in_place = false;
     let mut check = false;
 
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Write => write_in_place = true,
                 Opt::Check => check = true,
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
             inputs.push(val.to_string_lossy().into_owned());
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
     if inputs.is_empty() {
-        eprintln!("Error: no input file specified");
-        print_usage();
-        process::exit(1);
+        return Err(CliExit::error_with_usage(
+            "no input file specified",
+            &usage,
+        ));
     }
 
     // Multiple files require -w or --check
     if inputs.len() > 1 && !write_in_place && !check {
-        eprintln!("Error: multiple files require -w or --check");
-        print_usage();
-        process::exit(1);
+        return Err(CliExit::error_with_usage(
+            "multiple files require -w or --check",
+            &usage,
+        ));
     }
 
-    FormatOptions {
+    Ok(FormatOptions {
         inputs,
         write_in_place,
         check,
-    }
+    })
 }
 
 pub fn run(opts: FormatOptions) {

--- a/wado-cli/src/format.rs
+++ b/wado-cli/src/format.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use std::process;
 use std::time::Instant;
 
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 
-use crate::args::{next_arg, unexpected_arg};
+use crate::args::{self, next_arg, unexpected_arg};
 
 pub struct FormatOptions {
     pub inputs: Vec<String>,
@@ -13,13 +13,40 @@ pub struct FormatOptions {
     pub check: bool,
 }
 
+#[derive(Clone, Copy)]
+enum Opt {
+    Write,
+    Check,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[Self::Write, Self::Check, Self::Help];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Write => args::OptSpec {
+                long: Some("write"),
+                short: Some('w'),
+                value: None,
+                desc: "Write formatted output back to file",
+            },
+            Self::Check => args::OptSpec {
+                long: Some("check"),
+                short: None,
+                value: None,
+                desc: "Check if file is formatted (exit 1 if not)",
+            },
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 pub fn print_usage() {
     eprintln!("Usage: wado format [options] <file.wado>...");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  -w, --write    Write formatted output back to file");
-    eprintln!("  --check        Check if file is formatted (exit 1 if not)");
-    eprintln!("  --help         Show this help message");
+    args::print_opts_help(Opt::ALL, |o| o.spec());
     eprintln!();
     eprintln!("Without -w, outputs formatted code to stdout (single file only).");
 }
@@ -30,15 +57,19 @@ pub fn parse_args(mut parser: lexopt::Parser) -> FormatOptions {
     let mut check = false;
 
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Write => write_in_place = true,
+                Opt::Check => check = true,
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
+                }
             }
-            Short('w') | Long("write") => write_in_place = true,
-            Long("check") => check = true,
-            Value(val) => inputs.push(val.to_string_lossy().into_owned()),
-            _ => unexpected_arg(arg, print_usage),
+        } else if let Value(val) = arg {
+            inputs.push(val.to_string_lossy().into_owned());
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/src/format.rs
+++ b/wado-cli/src/format.rs
@@ -50,7 +50,11 @@ fn format_usage() -> String {
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "Without -w, outputs formatted code to stdout (single file only).").unwrap();
+    writeln!(
+        buf,
+        "Without -w, outputs formatted code to stdout (single file only)."
+    )
+    .unwrap();
     buf
 }
 
@@ -79,10 +83,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<FormatOptions, CliExit> 
     }
 
     if inputs.is_empty() {
-        return Err(CliExit::error_with_usage(
-            "no input file specified",
-            &usage,
-        ));
+        return Err(CliExit::error_with_usage("no input file specified", &usage));
     }
 
     // Multiple files require -w or --check

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -1,0 +1,26 @@
+// Allow certain pedantic lints that are common in CLI code:
+// - ref_option: &Option<T> is fine when coming from struct fields
+// - missing_panics_doc: Mutex unwrap panics are obvious
+// - struct_excessive_bools: CLI option structs naturally have many bools
+// - too_many_lines: Large functions are acceptable in CLI code
+// - needless_pass_by_value: Ownership transfer is sometimes intentional
+#![allow(
+    clippy::ref_option,
+    clippy::missing_panics_doc,
+    clippy::struct_excessive_bools,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+
+pub mod args;
+pub mod compile;
+pub mod compiler_host;
+pub mod dump;
+pub mod format;
+pub mod run;
+pub mod runtime;
+pub mod serve;
+pub mod syntax;
+pub mod test;
+
+pub use compiler_host::FilesystemCompilerHost;

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -1,30 +1,3 @@
-// Allow certain pedantic lints that are common in CLI code:
-// - ref_option: &Option<T> is fine when coming from struct fields
-// - missing_panics_doc: Mutex unwrap panics are obvious
-// - struct_excessive_bools: CLI option structs naturally have many bools
-// - too_many_lines: Large functions are acceptable in CLI code
-// - needless_pass_by_value: Ownership transfer is sometimes intentional
-#![allow(
-    clippy::ref_option,
-    clippy::missing_panics_doc,
-    clippy::struct_excessive_bools,
-    clippy::too_many_lines,
-    clippy::needless_pass_by_value
-)]
-
-mod args;
-mod compile;
-mod compiler_host;
-mod dump;
-mod format;
-mod run;
-mod runtime;
-mod serve;
-mod syntax;
-mod test;
-
-pub use compiler_host::FilesystemCompilerHost;
-
 use std::process;
 
 use lexopt::Arg::{Long, Value};
@@ -139,32 +112,39 @@ async fn main() {
             if let Some(cmd) = Cmd::from_name(&cmd_str) {
                 match cmd {
                     Cmd::Compile => {
-                        let opts = compile::parse_args(parser);
-                        compile::run(opts).await;
+                        let opts = wado_cli::compile::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::compile::run(opts).await;
                     }
                     Cmd::Run => {
-                        let opts = run::parse_args(parser);
-                        run::run(opts).await;
+                        let opts = wado_cli::run::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::run::run(opts).await;
                     }
                     Cmd::Serve => {
-                        let opts = serve::parse_args(parser);
-                        serve::run(opts).await;
+                        let opts = wado_cli::serve::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::serve::run(opts).await;
                     }
                     Cmd::Test => {
-                        let opts = test::parse_args(parser);
-                        test::run(opts).await;
+                        let opts = wado_cli::test::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::test::run(opts).await;
                     }
                     Cmd::Format => {
-                        let opts = format::parse_args(parser);
-                        format::run(opts);
+                        let opts = wado_cli::format::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::format::run(opts);
                     }
                     Cmd::Dump => {
-                        let opts = dump::parse_args(parser);
-                        dump::run(opts).await;
+                        let opts = wado_cli::dump::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::dump::run(opts).await;
                     }
                     Cmd::Syntax => {
-                        let opts = syntax::parse_args(parser);
-                        syntax::run(opts);
+                        let opts = wado_cli::syntax::parse_args(parser)
+                            .unwrap_or_else(|e| e.exit());
+                        wado_cli::syntax::run(opts);
                     }
                 }
             } else {

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -112,38 +112,34 @@ async fn main() {
             if let Some(cmd) = Cmd::from_name(&cmd_str) {
                 match cmd {
                     Cmd::Compile => {
-                        let opts = wado_cli::compile::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts =
+                            wado_cli::compile::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::compile::run(opts).await;
                     }
                     Cmd::Run => {
-                        let opts = wado_cli::run::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts = wado_cli::run::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::run::run(opts).await;
                     }
                     Cmd::Serve => {
-                        let opts = wado_cli::serve::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts = wado_cli::serve::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::serve::run(opts).await;
                     }
                     Cmd::Test => {
-                        let opts = wado_cli::test::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts = wado_cli::test::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::test::run(opts).await;
                     }
                     Cmd::Format => {
-                        let opts = wado_cli::format::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts =
+                            wado_cli::format::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::format::run(opts);
                     }
                     Cmd::Dump => {
-                        let opts = wado_cli::dump::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts = wado_cli::dump::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::dump::run(opts).await;
                     }
                     Cmd::Syntax => {
-                        let opts = wado_cli::syntax::parse_args(parser)
-                            .unwrap_or_else(|e| e.exit());
+                        let opts =
+                            wado_cli::syntax::parse_args(parser).unwrap_or_else(|e| e.exit());
                         wado_cli::syntax::run(opts);
                     }
                 }

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -29,47 +29,84 @@ use std::process;
 
 use lexopt::Arg::{Long, Value};
 
+#[derive(Clone, Copy)]
+enum Cmd {
+    Compile,
+    Run,
+    Serve,
+    Test,
+    Format,
+    Dump,
+    Syntax,
+}
+
+impl Cmd {
+    const ALL: &[Self] = &[
+        Self::Compile,
+        Self::Run,
+        Self::Serve,
+        Self::Test,
+        Self::Format,
+        Self::Dump,
+        Self::Syntax,
+    ];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Compile => "compile",
+            Self::Run => "run",
+            Self::Serve => "serve",
+            Self::Test => "test",
+            Self::Format => "format",
+            Self::Dump => "dump",
+            Self::Syntax => "syntax",
+        }
+    }
+
+    const fn args(self) -> &'static str {
+        match self {
+            Self::Compile | Self::Run | Self::Serve => "[options] <file.wado>",
+            Self::Test => "[options] [files...]",
+            Self::Format | Self::Dump => "[options] <file.wado>...",
+            Self::Syntax => "[options]",
+        }
+    }
+
+    const fn desc(self) -> &'static str {
+        match self {
+            Self::Compile => "Compile a Wado source file",
+            Self::Run => "Compile and run a Wado CLI program",
+            Self::Serve => "Compile and serve a Wado HTTP service",
+            Self::Test => "Run tests in Wado source files",
+            Self::Format => "Format a Wado source file",
+            Self::Dump => "Dump compiler internal state",
+            Self::Syntax => "Generate syntax definition files",
+        }
+    }
+
+    fn from_name(s: &str) -> Option<Self> {
+        Self::ALL.iter().find(|c| c.name() == s).copied()
+    }
+}
+
 fn print_usage() {
     eprintln!("Usage: wado <command> [options]");
     eprintln!();
     eprintln!("Commands:");
-    eprintln!("  compile [options] <file.wado>  Compile a Wado source file");
-    eprintln!("  run [options] <file.wado>      Compile and run a Wado CLI program");
-    eprintln!("  serve [options] <file.wado>    Compile and serve a Wado HTTP service");
-    eprintln!("  test [options] <files...>      Run tests in Wado source files");
-    eprintln!("  format [options] <file.wado>   Format a Wado source file");
-    eprintln!("  dump [options] <file.wado>     Dump compiler internal state");
-    eprintln!("  syntax [options]               Generate syntax definition files");
-    eprintln!();
-    eprintln!("Compile options:");
-    eprintln!("  -o <file>        Output file path (default: <input>.wasm)");
-    eprintln!("  --format <fmt>   Output format: wasm, wat (default: guessed from -o extension)");
-    eprintln!();
-    eprintln!("Run options:");
-    eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
-    eprintln!("  --profile <mode> Profiling: guest, jitdump, perfmap");
-    eprintln!();
-    eprintln!("Serve options:");
-    eprintln!("  --addr <addr>    Address to listen on (default: 0.0.0.0:8080)");
-    eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
-    eprintln!();
-    eprintln!("Test options:");
-    eprintln!("  -f, --filter <pattern>  Filter tests by name pattern");
-    eprintln!("  -p, --parallel <N>      Number of parallel workers (default: num CPUs)");
-    eprintln!();
-    eprintln!("Format options:");
-    eprintln!("  -w, --write      Write formatted output back to file");
-    eprintln!("  --check          Check if file is formatted (exit 1 if not)");
-    eprintln!();
-    eprintln!("Dump options:");
-    eprintln!("  --ast        Show the AST");
-    eprintln!("  --symbols    Show the symbol table");
-    eprintln!("  --modules    Show loaded modules");
-    eprintln!("  --all        Show all information (default)");
+    let labels: Vec<String> = Cmd::ALL
+        .iter()
+        .map(|c| format!("{} {}", c.name(), c.args()))
+        .collect();
+    let max_w = labels.iter().map(String::len).max().unwrap_or(0);
+    for (label, cmd) in labels.iter().zip(Cmd::ALL) {
+        eprintln!("  {label:<max_w$}  {}", cmd.desc());
+    }
     eprintln!();
     eprintln!("Global options:");
-    eprintln!("  --help       Show this help message");
-    eprintln!("  --version    Show version information");
+    eprintln!("  --help     Show this help message");
+    eprintln!("  --version  Show version information");
+    eprintln!();
+    eprintln!("Use 'wado <command> --help' for more information on a command.");
 }
 
 fn print_version() {
@@ -97,42 +134,43 @@ async fn main() {
             print_version();
             process::exit(0);
         }
-        Value(cmd) => {
-            let cmd = cmd.to_string_lossy();
-            match cmd.as_ref() {
-                "compile" => {
-                    let opts = compile::parse_args(parser);
-                    compile::run(opts).await;
+        Value(cmd_val) => {
+            let cmd_str = cmd_val.to_string_lossy();
+            if let Some(cmd) = Cmd::from_name(&cmd_str) {
+                match cmd {
+                    Cmd::Compile => {
+                        let opts = compile::parse_args(parser);
+                        compile::run(opts).await;
+                    }
+                    Cmd::Run => {
+                        let opts = run::parse_args(parser);
+                        run::run(opts).await;
+                    }
+                    Cmd::Serve => {
+                        let opts = serve::parse_args(parser);
+                        serve::run(opts).await;
+                    }
+                    Cmd::Test => {
+                        let opts = test::parse_args(parser);
+                        test::run(opts).await;
+                    }
+                    Cmd::Format => {
+                        let opts = format::parse_args(parser);
+                        format::run(opts);
+                    }
+                    Cmd::Dump => {
+                        let opts = dump::parse_args(parser);
+                        dump::run(opts).await;
+                    }
+                    Cmd::Syntax => {
+                        let opts = syntax::parse_args(parser);
+                        syntax::run(opts);
+                    }
                 }
-                "run" => {
-                    let opts = run::parse_args(parser);
-                    run::run(opts).await;
-                }
-                "serve" => {
-                    let opts = serve::parse_args(parser);
-                    serve::run(opts).await;
-                }
-                "dump" => {
-                    let opts = dump::parse_args(parser);
-                    dump::run(opts).await;
-                }
-                "format" => {
-                    let opts = format::parse_args(parser);
-                    format::run(opts);
-                }
-                "syntax" => {
-                    let opts = syntax::parse_args(parser);
-                    syntax::run(opts);
-                }
-                "test" => {
-                    let opts = test::parse_args(parser);
-                    test::run(opts).await;
-                }
-                _ => {
-                    eprintln!("Error: unknown command '{cmd}'");
-                    print_usage();
-                    process::exit(1);
-                }
+            } else {
+                eprintln!("Error: unknown command '{cmd_str}'");
+                print_usage();
+                process::exit(1);
             }
         }
         _ => {

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::io::BufWriter;
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -9,7 +10,7 @@ use lexopt::Arg::Value;
 use wasmtime::component::Component;
 use wasmtime::{GuestProfiler, UpdateDeadline};
 
-use crate::args::{self, next_arg, require_input, require_string, unexpected_arg};
+use crate::args::{self, CliExit};
 use crate::compile::{self, OptLevel};
 use crate::runtime::{self, ProfileMode};
 use wado_compiler::LogLevel;
@@ -74,40 +75,46 @@ impl Opt {
     }
 }
 
-pub fn print_usage() {
-    eprintln!("Usage: wado run [options] <file.wado>");
-    eprintln!();
-    eprintln!("Compile and run a Wado CLI program (wasi:cli/command world).");
-    eprintln!();
-    eprintln!("Options:");
-    args::print_opts_help(Opt::ALL, |o| o.spec());
-    eprintln!();
-    eprintln!("By default, the current directory is preopened as '.' for WASI filesystem access.");
-    eprintln!();
-    eprintln!("Profiling examples:");
-    eprintln!("  wado run --profile guest prog.wado");
-    eprintln!("    => writes profile.json, view at https://profiler.firefox.com/");
-    eprintln!();
-    eprintln!("  wado run --profile guest,output.json,5 prog.wado");
-    eprintln!("    => custom output path and 5ms sampling interval");
-    eprintln!();
-    eprintln!("  perf record -k mono wado run --profile jitdump prog.wado");
-    eprintln!("  perf inject --jit --input perf.data --output perf.jit.data");
-    eprintln!("  perf report --input perf.jit.data");
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado run [options] <file.wado>").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Compile and run a Wado CLI program (wasi:cli/command world).").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "By default, the current directory is preopened as '.' for WASI filesystem access.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Profiling examples:").unwrap();
+    writeln!(buf, "  wado run --profile guest prog.wado").unwrap();
+    writeln!(buf, "    => writes profile.json, view at https://profiler.firefox.com/").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "  wado run --profile guest,output.json,5 prog.wado").unwrap();
+    writeln!(buf, "    => custom output path and 5ms sampling interval").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "  perf record -k mono wado run --profile jitdump prog.wado").unwrap();
+    writeln!(buf, "  perf inject --jit --input perf.data --output perf.jit.data").unwrap();
+    writeln!(buf, "  perf report --input perf.jit.data").unwrap();
+    buf
 }
 
-fn parse_profile(s: &str) -> ProfileMode {
+pub fn print_usage() {
+    eprint!("{}", format_usage());
+}
+
+fn parse_profile(s: &str) -> Result<ProfileMode, CliExit> {
     if s == "jitdump" {
-        return ProfileMode::JitDump;
+        return Ok(ProfileMode::JitDump);
     }
     if s == "perfmap" {
-        return ProfileMode::PerfMap;
+        return Ok(ProfileMode::PerfMap);
     }
     if s == "guest" {
-        return ProfileMode::Guest {
+        return Ok(ProfileMode::Guest {
             path: "profile.json".to_owned(),
             interval_ms: 10,
-        };
+        });
     }
     if let Some(rest) = s.strip_prefix("guest,") {
         let parts: Vec<&str> = rest.splitn(2, ',').collect();
@@ -117,20 +124,21 @@ fn parse_profile(s: &str) -> ProfileMode {
             parts[0].to_owned()
         };
         let interval_ms = if parts.len() > 1 {
-            parts[1].parse::<u64>().unwrap_or_else(|_| {
-                eprintln!("Error: invalid profiling interval '{}'", parts[1]);
-                process::exit(1);
-            })
+            parts[1].parse::<u64>().map_err(|_| {
+                CliExit::error(format!("invalid profiling interval '{}'", parts[1]))
+            })?
         } else {
             10
         };
-        return ProfileMode::Guest { path, interval_ms };
+        return Ok(ProfileMode::Guest { path, interval_ms });
     }
-    eprintln!("Error: unknown profile mode '{s}'. Use guest, jitdump, or perfmap");
-    process::exit(1);
+    Err(CliExit::error(format!(
+        "unknown profile mode '{s}'. Use guest, jitdump, or perfmap"
+    )))
 }
 
-pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<RunOptions, CliExit> {
+    let usage = format_usage();
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
     let mut log_level = LogLevel::default();
@@ -140,11 +148,11 @@ pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
     let mut explicit_dirs = false;
     let mut no_dir = false;
 
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Dir => {
-                    let dir_spec = require_string(&mut parser);
+                    let dir_spec = args::require_string(&mut parser)?;
                     // Support "host::guest" or just "host" (guest defaults to host path).
                     let (host, guest) = if let Some((h, g)) = dir_spec.split_once("::") {
                         (h.to_owned(), g.to_owned())
@@ -168,22 +176,18 @@ pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
                         "3" => OptLevel::O3,
                         "s" => OptLevel::Os,
                         _ => {
-                            eprintln!(
-                                "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
-                            );
-                            process::exit(1);
+                            return Err(CliExit::error(format!(
+                                "unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
+                            )));
                         }
                     };
                 }
-                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser),
+                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser)?,
                 Opt::Profile => {
-                    let spec = require_string(&mut parser);
-                    profile = parse_profile(&spec);
+                    let spec = args::require_string(&mut parser)?;
+                    profile = parse_profile(&spec)?;
                 }
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
             let s = val.to_string_lossy().into_owned();
@@ -194,7 +198,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
                 program_args.push(s);
             }
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
@@ -203,14 +207,14 @@ pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
         preopened_dirs.push((".".to_owned(), ".".to_owned()));
     }
 
-    RunOptions {
-        input: require_input(input, print_usage),
+    Ok(RunOptions {
+        input: args::require_input(input, &usage)?,
         opt_level,
         log_level,
         profile,
         preopened_dirs,
         program_args,
-    }
+    })
 }
 
 async fn run_cli_component(

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -79,22 +79,42 @@ fn format_usage() -> String {
     let mut buf = String::new();
     writeln!(buf, "Usage: wado run [options] <file.wado>").unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "Compile and run a Wado CLI program (wasi:cli/command world).").unwrap();
+    writeln!(
+        buf,
+        "Compile and run a Wado CLI program (wasi:cli/command world)."
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "By default, the current directory is preopened as '.' for WASI filesystem access.").unwrap();
+    writeln!(
+        buf,
+        "By default, the current directory is preopened as '.' for WASI filesystem access."
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Profiling examples:").unwrap();
     writeln!(buf, "  wado run --profile guest prog.wado").unwrap();
-    writeln!(buf, "    => writes profile.json, view at https://profiler.firefox.com/").unwrap();
+    writeln!(
+        buf,
+        "    => writes profile.json, view at https://profiler.firefox.com/"
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "  wado run --profile guest,output.json,5 prog.wado").unwrap();
     writeln!(buf, "    => custom output path and 5ms sampling interval").unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "  perf record -k mono wado run --profile jitdump prog.wado").unwrap();
-    writeln!(buf, "  perf inject --jit --input perf.data --output perf.jit.data").unwrap();
+    writeln!(
+        buf,
+        "  perf record -k mono wado run --profile jitdump prog.wado"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "  perf inject --jit --input perf.data --output perf.jit.data"
+    )
+    .unwrap();
     writeln!(buf, "  perf report --input perf.jit.data").unwrap();
     buf
 }
@@ -124,9 +144,9 @@ fn parse_profile(s: &str) -> Result<ProfileMode, CliExit> {
             parts[0].to_owned()
         };
         let interval_ms = if parts.len() > 1 {
-            parts[1].parse::<u64>().map_err(|_| {
-                CliExit::error(format!("invalid profiling interval '{}'", parts[1]))
-            })?
+            parts[1]
+                .parse::<u64>()
+                .map_err(|_| CliExit::error(format!("invalid profiling interval '{}'", parts[1])))?
         } else {
             10
         };

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -5,11 +5,11 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 use wasmtime::component::Component;
 use wasmtime::{GuestProfiler, UpdateDeadline};
 
-use crate::args::{next_arg, require_input, require_string, unexpected_arg};
+use crate::args::{self, next_arg, require_input, require_string, unexpected_arg};
 use crate::compile::{self, OptLevel};
 use crate::runtime::{self, ProfileMode};
 use wado_compiler::LogLevel;
@@ -26,24 +26,61 @@ pub struct RunOptions {
     pub program_args: Vec<String>,
 }
 
+#[derive(Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+enum Opt {
+    Dir,
+    NoDir,
+    OptLevel,
+    LogLevel,
+    Profile,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[
+        Self::Dir,
+        Self::NoDir,
+        Self::OptLevel,
+        Self::LogLevel,
+        Self::Profile,
+        Self::Help,
+    ];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Dir => args::OptSpec {
+                long: Some("dir"),
+                short: None,
+                value: Some("<path>"),
+                desc: "Preopen directory for WASI filesystem access\nUse --dir host::guest to specify different guest path\nOverrides the default of preopening the current directory",
+            },
+            Self::NoDir => args::OptSpec {
+                long: Some("no-dir"),
+                short: None,
+                value: None,
+                desc: "Do not preopen any directories (disables the default)",
+            },
+            Self::OptLevel => args::OPT_LEVEL_SPEC,
+            Self::LogLevel => args::LOG_LEVEL_SPEC,
+            Self::Profile => args::OptSpec {
+                long: Some("profile"),
+                short: None,
+                value: Some("<mode>"),
+                desc: "Enable profiling:\n  guest[,path[,interval_ms]]  Cross-platform guest profiling\n                               (default: profile.json, 10ms)\n  jitdump   Linux perf jitdump (use with perf record -k mono)\n  perfmap   Linux perf map (use with perf record -k mono)",
+            },
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 pub fn print_usage() {
     eprintln!("Usage: wado run [options] <file.wado>");
     eprintln!();
     eprintln!("Compile and run a Wado CLI program (wasi:cli/command world).");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --dir <path>       Preopen directory for WASI filesystem access.");
-    eprintln!("                     Use --dir host::guest to specify different guest path.");
-    eprintln!("                     Overrides the default of preopening the current directory.");
-    eprintln!("  --no-dir           Do not preopen any directories (disables the default).");
-    eprintln!("  -O<n>              Optimization level: -O0, -O1, -O2, -O3, -Os");
-    eprintln!("  --log-level <l>    Log level: debug, info, warn, error, off (default: info)");
-    eprintln!("  --profile <mode>   Enable profiling:");
-    eprintln!("                       guest[,path[,interval_ms]]  Cross-platform guest profiling");
-    eprintln!("                                                   (default: profile.json, 10ms)");
-    eprintln!("                       jitdump   Linux perf jitdump (use with perf record -k mono)");
-    eprintln!("                       perfmap   Linux perf map (use with perf record -k mono)");
-    eprintln!("  --help             Show this help message");
+    args::print_opts_help(Opt::ALL, |o| o.spec());
     eprintln!();
     eprintln!("By default, the current directory is preopened as '.' for WASI filesystem access.");
     eprintln!();
@@ -57,17 +94,6 @@ pub fn print_usage() {
     eprintln!("  perf record -k mono wado run --profile jitdump prog.wado");
     eprintln!("  perf inject --jit --input perf.data --output perf.jit.data");
     eprintln!("  perf report --input perf.jit.data");
-}
-
-fn parse_log_level(s: &str) -> Option<LogLevel> {
-    match s.to_lowercase().as_str() {
-        "debug" => Some(LogLevel::Debug),
-        "info" => Some(LogLevel::Info),
-        "warn" | "warning" => Some(LogLevel::Warn),
-        "error" => Some(LogLevel::Error),
-        "off" | "none" => Some(LogLevel::Off),
-        _ => None,
-    }
 }
 
 fn parse_profile(s: &str) -> ProfileMode {
@@ -115,70 +141,60 @@ pub fn parse_args(mut parser: lexopt::Parser) -> RunOptions {
     let mut no_dir = false;
 
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
-            }
-            Long("dir") => {
-                let dir_spec = require_string(&mut parser);
-                // Support "host::guest" or just "host" (guest defaults to host path).
-                let (host, guest) = if let Some((h, g)) = dir_spec.split_once("::") {
-                    (h.to_owned(), g.to_owned())
-                } else {
-                    (dir_spec.clone(), dir_spec)
-                };
-                preopened_dirs.push((host, guest));
-                explicit_dirs = true;
-            }
-            Long("no-dir") => {
-                no_dir = true;
-            }
-            Long("profile") => {
-                let spec = require_string(&mut parser);
-                profile = parse_profile(&spec);
-            }
-            Short('O') => {
-                let val = parser.optional_value();
-                let level_str = val
-                    .as_ref()
-                    .map(|v| v.to_string_lossy())
-                    .unwrap_or_default();
-                opt_level = match level_str.as_ref() {
-                    "" | "0" | "g" => OptLevel::O0,
-                    "1" => OptLevel::O1,
-                    "2" => OptLevel::O2,
-                    "3" => OptLevel::O3,
-                    "s" => OptLevel::Os,
-                    _ => {
-                        eprintln!(
-                            "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
-                        );
-                        process::exit(1);
-                    }
-                };
-            }
-            Long("log-level") => {
-                let level_str = require_string(&mut parser);
-                if let Some(level) = parse_log_level(&level_str) {
-                    log_level = level;
-                } else {
-                    eprintln!(
-                        "Error: unknown log level '{level_str}'. Use debug, info, warn, error, or off"
-                    );
-                    process::exit(1);
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Dir => {
+                    let dir_spec = require_string(&mut parser);
+                    // Support "host::guest" or just "host" (guest defaults to host path).
+                    let (host, guest) = if let Some((h, g)) = dir_spec.split_once("::") {
+                        (h.to_owned(), g.to_owned())
+                    } else {
+                        (dir_spec.clone(), dir_spec)
+                    };
+                    preopened_dirs.push((host, guest));
+                    explicit_dirs = true;
+                }
+                Opt::NoDir => no_dir = true,
+                Opt::OptLevel => {
+                    let val = parser.optional_value();
+                    let level_str = val
+                        .as_ref()
+                        .map(|v| v.to_string_lossy())
+                        .unwrap_or_default();
+                    opt_level = match level_str.as_ref() {
+                        "" | "0" | "g" => OptLevel::O0,
+                        "1" => OptLevel::O1,
+                        "2" => OptLevel::O2,
+                        "3" => OptLevel::O3,
+                        "s" => OptLevel::Os,
+                        _ => {
+                            eprintln!(
+                                "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
+                            );
+                            process::exit(1);
+                        }
+                    };
+                }
+                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser),
+                Opt::Profile => {
+                    let spec = require_string(&mut parser);
+                    profile = parse_profile(&spec);
+                }
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
                 }
             }
-            Value(val) => {
-                let s = val.to_string_lossy().into_owned();
-                if input.is_none() {
-                    input = Some(s);
-                } else {
-                    // Arguments after the source file are passed to the program.
-                    program_args.push(s);
-                }
+        } else if let Value(val) = arg {
+            let s = val.to_string_lossy().into_owned();
+            if input.is_none() {
+                input = Some(s);
+            } else {
+                // Arguments after the source file are passed to the program.
+                program_args.push(s);
             }
-            _ => unexpected_arg(arg, print_usage),
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/src/runtime.rs
+++ b/wado-cli/src/runtime.rs
@@ -53,6 +53,7 @@ pub enum ProfileMode {
 }
 
 /// Create a wasmtime Config with all required Wasm features enabled.
+#[must_use]
 pub fn create_config(opt_level: OptLevel, profile: &ProfileMode) -> Config {
     let mut config = Config::new();
     config.async_support(true);

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::process;
 use std::sync::Arc;
@@ -19,9 +20,7 @@ use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::p3::bindings::Service;
 use wasmtime_wasi_http::p3::{Request as WasiRequest, WasiHttpCtx, WasiHttpCtxView, WasiHttpView};
 
-use crate::args::{
-    self, next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
-};
+use crate::args::{self, CliExit};
 use crate::compile::{self, OptLevel};
 use crate::runtime;
 use wado_compiler::LogLevel;
@@ -60,25 +59,32 @@ impl Opt {
     }
 }
 
-pub fn print_usage() {
-    eprintln!("Usage: wado serve [options] <file.wado>");
-    eprintln!();
-    eprintln!("Compile and serve a Wado HTTP service using wasmtime.");
-    eprintln!();
-    eprintln!("Options:");
-    args::print_opts_help(Opt::ALL, |o| o.spec());
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado serve [options] <file.wado>").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Compile and serve a Wado HTTP service using wasmtime.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
+    buf
 }
 
-pub fn parse_args(mut parser: lexopt::Parser) -> ServeOptions {
+pub fn print_usage() {
+    eprint!("{}", format_usage());
+}
+
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
+    let usage = format_usage();
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
     let mut log_level = LogLevel::default();
     let mut addr = "0.0.0.0:8080".to_string();
 
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
-                Opt::Addr => addr = require_string(&mut parser),
+                Opt::Addr => addr = args::require_string(&mut parser)?,
                 Opt::OptLevel => {
                     let val = parser.optional_value();
                     let level_str = val
@@ -92,33 +98,29 @@ pub fn parse_args(mut parser: lexopt::Parser) -> ServeOptions {
                         "3" => OptLevel::O3,
                         "s" => OptLevel::Os,
                         _ => {
-                            eprintln!(
-                                "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
-                            );
-                            process::exit(1);
+                            return Err(CliExit::error(format!(
+                                "unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
+                            )));
                         }
                     };
                 }
-                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser),
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser)?,
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
-            reject_multiple_inputs(&input);
+            args::reject_multiple_inputs(&input)?;
             input = Some(val.to_string_lossy().into_owned());
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
-    ServeOptions {
-        input: require_input(input, print_usage),
+    Ok(ServeOptions {
+        input: args::require_input(input, &usage)?,
         opt_level,
         log_level,
         addr,
-    }
+    })
 }
 
 struct HttpWasiCtx;

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -10,7 +10,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use hyper_util::rt::TokioIo;
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use wasmtime::component::{Component, Linker, ResourceTable};
@@ -20,7 +20,7 @@ use wasmtime_wasi_http::p3::bindings::Service;
 use wasmtime_wasi_http::p3::{Request as WasiRequest, WasiHttpCtx, WasiHttpCtxView, WasiHttpView};
 
 use crate::args::{
-    next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
+    self, next_arg, reject_multiple_inputs, require_input, require_string, unexpected_arg,
 };
 use crate::compile::{self, OptLevel};
 use crate::runtime;
@@ -33,28 +33,40 @@ pub struct ServeOptions {
     pub addr: String,
 }
 
+#[derive(Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+enum Opt {
+    Addr,
+    OptLevel,
+    LogLevel,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[Self::Addr, Self::OptLevel, Self::LogLevel, Self::Help];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Addr => args::OptSpec {
+                long: Some("addr"),
+                short: None,
+                value: Some("<addr>"),
+                desc: "Address to listen on (default: 0.0.0.0:8080)",
+            },
+            Self::OptLevel => args::OPT_LEVEL_SPEC,
+            Self::LogLevel => args::LOG_LEVEL_SPEC,
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 pub fn print_usage() {
     eprintln!("Usage: wado serve [options] <file.wado>");
     eprintln!();
     eprintln!("Compile and serve a Wado HTTP service using wasmtime.");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --addr <addr>    Address to listen on (default: 0.0.0.0:8080)");
-    eprintln!("  -O<n>            Optimization level: -O0, -O1, -O2, -O3, -Os");
-    eprintln!("  --log-level <l>  Log level: debug, info, warn, error, off (default: info)");
-    eprintln!("  --help           Show this help message");
-}
-
-/// Parse log level from string
-fn parse_log_level(s: &str) -> Option<LogLevel> {
-    match s.to_lowercase().as_str() {
-        "debug" => Some(LogLevel::Debug),
-        "info" => Some(LogLevel::Info),
-        "warn" | "warning" => Some(LogLevel::Warn),
-        "error" => Some(LogLevel::Error),
-        "off" | "none" => Some(LogLevel::Off),
-        _ => None,
-    }
+    args::print_opts_help(Opt::ALL, |o| o.spec());
 }
 
 pub fn parse_args(mut parser: lexopt::Parser) -> ServeOptions {
@@ -64,50 +76,40 @@ pub fn parse_args(mut parser: lexopt::Parser) -> ServeOptions {
     let mut addr = "0.0.0.0:8080".to_string();
 
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
-            }
-            Long("addr") => {
-                addr = require_string(&mut parser);
-            }
-            Short('O') => {
-                let val = parser.optional_value();
-                let level_str = val
-                    .as_ref()
-                    .map(|v| v.to_string_lossy())
-                    .unwrap_or_default();
-                opt_level = match level_str.as_ref() {
-                    "" | "0" | "g" => OptLevel::O0,
-                    "1" => OptLevel::O1,
-                    "2" => OptLevel::O2,
-                    "3" => OptLevel::O3,
-                    "s" => OptLevel::Os,
-                    _ => {
-                        eprintln!(
-                            "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
-                        );
-                        process::exit(1);
-                    }
-                };
-            }
-            Long("log-level") => {
-                let level_str = require_string(&mut parser);
-                if let Some(level) = parse_log_level(&level_str) {
-                    log_level = level;
-                } else {
-                    eprintln!(
-                        "Error: unknown log level '{level_str}'. Use debug, info, warn, error, or off"
-                    );
-                    process::exit(1);
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Addr => addr = require_string(&mut parser),
+                Opt::OptLevel => {
+                    let val = parser.optional_value();
+                    let level_str = val
+                        .as_ref()
+                        .map(|v| v.to_string_lossy())
+                        .unwrap_or_default();
+                    opt_level = match level_str.as_ref() {
+                        "" | "0" | "g" => OptLevel::O0,
+                        "1" => OptLevel::O1,
+                        "2" => OptLevel::O2,
+                        "3" => OptLevel::O3,
+                        "s" => OptLevel::Os,
+                        _ => {
+                            eprintln!(
+                                "Error: unknown optimization level '-O{level_str}'. Use -O0, -O1, -O2, -O3, -Os, or -Og"
+                            );
+                            process::exit(1);
+                        }
+                    };
+                }
+                Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser),
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
                 }
             }
-            Value(val) => {
-                reject_multiple_inputs(&input);
-                input = Some(val.to_string_lossy().into_owned());
-            }
-            _ => unexpected_arg(arg, print_usage),
+        } else if let Value(val) = arg {
+            reject_multiple_inputs(&input);
+            input = Some(val.to_string_lossy().into_owned());
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -7,13 +7,13 @@ use std::fs;
 use std::io::{self, Write};
 use std::process;
 
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 use lexopt::Parser;
 use serde_json::json;
 
 use wado_compiler::syntax::SyntaxDefinition;
 
-use crate::args::{exit_error, next_arg, require_string, unexpected_arg};
+use crate::args::{self, exit_error, next_arg, require_string, unexpected_arg};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SyntaxFormat {
@@ -36,17 +36,42 @@ pub struct SyntaxOptions {
     pub output: Option<String>,
 }
 
+#[derive(Clone, Copy)]
+enum Opt {
+    Format,
+    Output,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[Self::Format, Self::Output, Self::Help];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Format => args::OptSpec {
+                long: Some("format"),
+                short: None,
+                value: Some("<fmt>"),
+                desc: "Output format: tmLanguage, language-config (default: tmLanguage)",
+            },
+            Self::Output => args::OptSpec {
+                long: Some("output"),
+                short: Some('o'),
+                value: Some("<file>"),
+                desc: "Output file (default: stdout)",
+            },
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 fn print_usage() {
     eprintln!("Usage: wado syntax [options]");
     eprintln!();
     eprintln!("Generate syntax definition files for editor integrations.");
     eprintln!();
     eprintln!("Options:");
-    eprintln!(
-        "  --format <fmt>   Output format: tmLanguage, language-config (default: tmLanguage)"
-    );
-    eprintln!("  -o <file>        Output file (default: stdout)");
-    eprintln!("  --help           Show this help message");
+    args::print_opts_help(Opt::ALL, |o| o.spec());
     eprintln!();
     eprintln!("Examples:");
     eprintln!("  wado syntax --format tmLanguage -o wado.tmLanguage.json");
@@ -58,25 +83,27 @@ pub fn parse_args(mut parser: Parser) -> SyntaxOptions {
     let mut output = None;
 
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Format => {
+                    let fmt_str = require_string(&mut parser);
+                    format = SyntaxFormat::from_str(&fmt_str).unwrap_or_else(|| {
+                        exit_error(&format!("unknown format: {fmt_str}"));
+                    });
+                }
+                Opt::Output => {
+                    output = Some(require_string(&mut parser));
+                }
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
+                }
             }
-            Long("format") => {
-                let fmt_str = require_string(&mut parser);
-                format = SyntaxFormat::from_str(&fmt_str).unwrap_or_else(|| {
-                    exit_error(&format!("unknown format: {fmt_str}"));
-                });
-            }
-            Short('o') | Long("output") => {
-                output = Some(require_string(&mut parser));
-            }
-            Value(_) => {
-                // No positional arguments expected
-                exit_error("unexpected argument");
-            }
-            _ => unexpected_arg(arg, print_usage),
+        } else if let Value(_) = arg {
+            // No positional arguments expected
+            exit_error("unexpected argument");
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -3,9 +3,9 @@
 //! Transforms canonical syntax definitions from wado-compiler into
 //! editor-specific formats (`TextMate` grammar, VS Code language configuration).
 
+use std::fmt::Write as _;
 use std::fs;
 use std::io::{self, Write};
-use std::process;
 
 use lexopt::Arg::Value;
 use lexopt::Parser;
@@ -13,7 +13,7 @@ use serde_json::json;
 
 use wado_compiler::syntax::SyntaxDefinition;
 
-use crate::args::{self, exit_error, next_arg, require_string, unexpected_arg};
+use crate::args::{self, exit_error, CliExit};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SyntaxFormat {
@@ -65,49 +65,49 @@ impl Opt {
     }
 }
 
-fn print_usage() {
-    eprintln!("Usage: wado syntax [options]");
-    eprintln!();
-    eprintln!("Generate syntax definition files for editor integrations.");
-    eprintln!();
-    eprintln!("Options:");
-    args::print_opts_help(Opt::ALL, |o| o.spec());
-    eprintln!();
-    eprintln!("Examples:");
-    eprintln!("  wado syntax --format tmLanguage -o wado.tmLanguage.json");
-    eprintln!("  wado syntax --format language-config -o language-configuration.json");
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado syntax [options]").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Generate syntax definition files for editor integrations.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Examples:").unwrap();
+    writeln!(buf, "  wado syntax --format tmLanguage -o wado.tmLanguage.json").unwrap();
+    writeln!(buf, "  wado syntax --format language-config -o language-configuration.json").unwrap();
+    buf
 }
 
-pub fn parse_args(mut parser: Parser) -> SyntaxOptions {
+pub fn parse_args(mut parser: Parser) -> Result<SyntaxOptions, CliExit> {
+    let usage = format_usage();
     let mut format = SyntaxFormat::TmLanguage;
     let mut output = None;
 
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Format => {
-                    let fmt_str = require_string(&mut parser);
-                    format = SyntaxFormat::from_str(&fmt_str).unwrap_or_else(|| {
-                        exit_error(&format!("unknown format: {fmt_str}"));
-                    });
+                    let fmt_str = args::require_string(&mut parser)?;
+                    format = SyntaxFormat::from_str(&fmt_str).ok_or_else(|| {
+                        CliExit::error(format!("unknown format: {fmt_str}"))
+                    })?;
                 }
                 Opt::Output => {
-                    output = Some(require_string(&mut parser));
+                    output = Some(args::require_string(&mut parser)?);
                 }
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(_) = arg {
             // No positional arguments expected
-            exit_error("unexpected argument");
+            return Err(CliExit::error("unexpected argument"));
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
-    SyntaxOptions { format, output }
+    Ok(SyntaxOptions { format, output })
 }
 
 pub fn run(opts: SyntaxOptions) {

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 use wado_compiler::syntax::SyntaxDefinition;
 
-use crate::args::{self, exit_error, CliExit};
+use crate::args::{self, CliExit, exit_error};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SyntaxFormat {
@@ -69,14 +69,26 @@ fn format_usage() -> String {
     let mut buf = String::new();
     writeln!(buf, "Usage: wado syntax [options]").unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "Generate syntax definition files for editor integrations.").unwrap();
+    writeln!(
+        buf,
+        "Generate syntax definition files for editor integrations."
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Examples:").unwrap();
-    writeln!(buf, "  wado syntax --format tmLanguage -o wado.tmLanguage.json").unwrap();
-    writeln!(buf, "  wado syntax --format language-config -o language-configuration.json").unwrap();
+    writeln!(
+        buf,
+        "  wado syntax --format tmLanguage -o wado.tmLanguage.json"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "  wado syntax --format language-config -o language-configuration.json"
+    )
+    .unwrap();
     buf
 }
 
@@ -90,9 +102,8 @@ pub fn parse_args(mut parser: Parser) -> Result<SyntaxOptions, CliExit> {
             match opt {
                 Opt::Format => {
                     let fmt_str = args::require_string(&mut parser)?;
-                    format = SyntaxFormat::from_str(&fmt_str).ok_or_else(|| {
-                        CliExit::error(format!("unknown format: {fmt_str}"))
-                    })?;
+                    format = SyntaxFormat::from_str(&fmt_str)
+                        .ok_or_else(|| CliExit::error(format!("unknown format: {fmt_str}")))?;
                 }
                 Opt::Output => {
                     output = Some(args::require_string(&mut parser)?);

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::process;
 use std::sync::Arc;
 
@@ -8,7 +9,7 @@ use tokio::sync::mpsc;
 use wasmtime::Engine;
 use wasmtime::component::Component;
 
-use crate::args::{self, next_arg, unexpected_arg};
+use crate::args::{self, CliExit};
 use crate::compile;
 use crate::runtime;
 
@@ -47,17 +48,23 @@ impl Opt {
     }
 }
 
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado test [options] [files...]").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "If no files are specified, searches for **/*_test.wado recursively.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
+    buf
+}
+
 pub fn print_usage() {
-    eprintln!("Usage: wado test [options] [files...]");
-    eprintln!();
-    eprintln!("If no files are specified, searches for **/*_test.wado recursively.");
-    eprintln!();
-    eprintln!("Options:");
-    args::print_opts_help(Opt::ALL, |o| o.spec());
+    eprint!("{}", format_usage());
 }
 
 /// Find all *_test.wado files recursively in the current directory
-fn find_test_files() -> Vec<String> {
+fn find_test_files() -> Result<Vec<String>, CliExit> {
     let pattern = "**/*_test.wado";
     let mut files: Vec<String> = Vec::new();
 
@@ -68,53 +75,55 @@ fn find_test_files() -> Vec<String> {
             }
         }
         Err(e) => {
-            eprintln!("Error: failed to glob pattern: {e}");
-            process::exit(1);
+            return Err(CliExit::error(format!(
+                "failed to glob pattern: {e}"
+            )));
         }
     }
 
     files.sort();
-    files
+    Ok(files)
 }
 
-pub fn parse_args(mut parser: lexopt::Parser) -> TestOptions {
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
+    let usage = format_usage();
     let mut paths: Vec<String> = Vec::new();
     let mut filter: Option<String> = None;
     let mut jobs: Option<usize> = None;
-    while let Some(arg) = next_arg(&mut parser) {
+    while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Filter => {
-                    filter = Some(parser.value().unwrap().to_string_lossy().into_owned());
+                    filter = Some(args::require_string(&mut parser)?);
                 }
                 Opt::Parallel => {
-                    let val = parser.value().unwrap().to_string_lossy().into_owned();
+                    let val = args::require_string(&mut parser)?;
                     match val.parse::<usize>() {
                         Ok(n) if n > 0 => jobs = Some(n),
                         _ => {
-                            eprintln!("Error: --parallel requires a positive integer");
-                            process::exit(1);
+                            return Err(CliExit::error(
+                                "--parallel requires a positive integer",
+                            ));
                         }
                     }
                 }
-                Opt::Help => {
-                    print_usage();
-                    process::exit(0);
-                }
+                Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
             paths.push(val.to_string_lossy().into_owned());
         } else {
-            unexpected_arg(arg, print_usage);
+            return Err(args::unexpected_arg(arg, &usage));
         }
     }
 
     // If no files specified, search for *_test.wado files
     if paths.is_empty() {
-        paths = find_test_files();
+        paths = find_test_files()?;
         if paths.is_empty() {
-            eprintln!("No test files found (looking for **/*_test.wado)");
-            process::exit(0);
+            return Err(CliExit {
+                message: "No test files found (looking for **/*_test.wado)\n".to_owned(),
+                exit_code: 0,
+            });
         }
     }
 
@@ -125,11 +134,11 @@ pub fn parse_args(mut parser: lexopt::Parser) -> TestOptions {
         (cpus / 2).max(2)
     });
 
-    TestOptions {
+    Ok(TestOptions {
         paths,
         filter,
         jobs,
-    }
+    })
 }
 
 /// A compiled test module ready for parallel execution

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -52,7 +52,11 @@ fn format_usage() -> String {
     let mut buf = String::new();
     writeln!(buf, "Usage: wado test [options] [files...]").unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "If no files are specified, searches for **/*_test.wado recursively.").unwrap();
+    writeln!(
+        buf,
+        "If no files are specified, searches for **/*_test.wado recursively."
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
@@ -75,9 +79,7 @@ fn find_test_files() -> Result<Vec<String>, CliExit> {
             }
         }
         Err(e) => {
-            return Err(CliExit::error(format!(
-                "failed to glob pattern: {e}"
-            )));
+            return Err(CliExit::error(format!("failed to glob pattern: {e}")));
         }
     }
 
@@ -101,9 +103,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
                     match val.parse::<usize>() {
                         Ok(n) if n > 0 => jobs = Some(n),
                         _ => {
-                            return Err(CliExit::error(
-                                "--parallel requires a positive integer",
-                            ));
+                            return Err(CliExit::error("--parallel requires a positive integer"));
                         }
                     }
                 }

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use glob::glob;
-use lexopt::Arg::{Long, Short, Value};
+use lexopt::Arg::Value;
 use tokio::sync::mpsc;
 use wasmtime::Engine;
 use wasmtime::component::Component;
 
-use crate::args::{next_arg, unexpected_arg};
+use crate::args::{self, next_arg, unexpected_arg};
 use crate::compile;
 use crate::runtime;
 
@@ -18,15 +18,42 @@ pub struct TestOptions {
     pub jobs: usize,
 }
 
+#[derive(Clone, Copy)]
+enum Opt {
+    Filter,
+    Parallel,
+    Help,
+}
+
+impl Opt {
+    const ALL: &[Self] = &[Self::Filter, Self::Parallel, Self::Help];
+
+    const fn spec(self) -> args::OptSpec {
+        match self {
+            Self::Filter => args::OptSpec {
+                long: Some("filter"),
+                short: Some('f'),
+                value: Some("<pattern>"),
+                desc: "Filter tests by name pattern",
+            },
+            Self::Parallel => args::OptSpec {
+                long: Some("parallel"),
+                short: Some('p'),
+                value: Some("<N>"),
+                desc: "Number of parallel workers (default: num CPUs)",
+            },
+            Self::Help => args::HELP_SPEC,
+        }
+    }
+}
+
 pub fn print_usage() {
     eprintln!("Usage: wado test [options] [files...]");
     eprintln!();
     eprintln!("If no files are specified, searches for **/*_test.wado recursively.");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  -f, --filter <pattern>  Filter tests by name pattern");
-    eprintln!("  -p, --parallel <N>      Number of parallel workers (default: num CPUs)");
-    eprintln!("  --help                  Show this help message");
+    args::print_opts_help(Opt::ALL, |o| o.spec());
 }
 
 /// Find all *_test.wado files recursively in the current directory
@@ -55,28 +82,30 @@ pub fn parse_args(mut parser: lexopt::Parser) -> TestOptions {
     let mut filter: Option<String> = None;
     let mut jobs: Option<usize> = None;
     while let Some(arg) = next_arg(&mut parser) {
-        match arg {
-            Long("help") => {
-                print_usage();
-                process::exit(0);
-            }
-            Short('f') | Long("filter") => {
-                filter = Some(parser.value().unwrap().to_string_lossy().into_owned());
-            }
-            Short('p') | Long("parallel") => {
-                let val = parser.value().unwrap().to_string_lossy().into_owned();
-                match val.parse::<usize>() {
-                    Ok(n) if n > 0 => jobs = Some(n),
-                    _ => {
-                        eprintln!("Error: --parallel requires a positive integer");
-                        process::exit(1);
+        if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
+            match opt {
+                Opt::Filter => {
+                    filter = Some(parser.value().unwrap().to_string_lossy().into_owned());
+                }
+                Opt::Parallel => {
+                    let val = parser.value().unwrap().to_string_lossy().into_owned();
+                    match val.parse::<usize>() {
+                        Ok(n) if n > 0 => jobs = Some(n),
+                        _ => {
+                            eprintln!("Error: --parallel requires a positive integer");
+                            process::exit(1);
+                        }
                     }
                 }
+                Opt::Help => {
+                    print_usage();
+                    process::exit(0);
+                }
             }
-            Value(val) => {
-                paths.push(val.to_string_lossy().into_owned());
-            }
-            _ => unexpected_arg(arg, print_usage),
+        } else if let Value(val) = arg {
+            paths.push(val.to_string_lossy().into_owned());
+        } else {
+            unexpected_arg(arg, print_usage);
         }
     }
 

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -14,7 +14,11 @@ fn assert_err<T>(result: Result<T, CliExit>, expected: &str) {
     match result {
         Ok(_) => panic!("expected CliExit error, but got Ok"),
         Err(err) => {
-            assert_eq!(err.exit_code, 1, "expected exit_code 1, got {}", err.exit_code);
+            assert_eq!(
+                err.exit_code, 1,
+                "expected exit_code 1, got {}",
+                err.exit_code
+            );
             assert!(
                 err.message.contains(expected),
                 "expected message to contain {expected:?}, got {:?}",
@@ -30,7 +34,11 @@ fn assert_help<T>(result: Result<T, CliExit>, expected: &str) {
     match result {
         Ok(_) => panic!("expected CliExit help, but got Ok"),
         Err(err) => {
-            assert_eq!(err.exit_code, 0, "expected exit_code 0, got {}", err.exit_code);
+            assert_eq!(
+                err.exit_code, 0,
+                "expected exit_code 0, got {}",
+                err.exit_code
+            );
             assert!(
                 err.message.contains(expected),
                 "expected message to contain {expected:?}, got {:?}",
@@ -164,11 +172,15 @@ fn compile_multiple_inputs() {
 #[test]
 fn compile_all_options() {
     let parser = Parser::from_args(&[
-        "-o", "out.wat",
-        "--format", "wat",
+        "-o",
+        "out.wat",
+        "--format",
+        "wat",
         "-O3",
-        "--log-level", "warn",
-        "--world", "wasi:http/service",
+        "--log-level",
+        "warn",
+        "--world",
+        "wasi:http/service",
         "--no-validate",
         "input.wado",
     ]);
@@ -191,7 +203,10 @@ fn run_basic() {
     assert_eq!(opts.input, "input.wado");
     assert_eq!(opts.opt_level, OptLevel::O2);
     // Default: current dir is preopened
-    assert_eq!(opts.preopened_dirs, vec![(".".to_string(), ".".to_string())]);
+    assert_eq!(
+        opts.preopened_dirs,
+        vec![(".".to_string(), ".".to_string())]
+    );
     assert!(opts.program_args.is_empty());
 }
 
@@ -200,7 +215,10 @@ fn run_with_dir() {
     let parser = Parser::from_args(&["--dir", "/tmp::/guest", "input.wado"]);
     let opts = wado_cli::run::parse_args(parser).unwrap();
     // --dir overrides default
-    assert_eq!(opts.preopened_dirs, vec![("/tmp".to_string(), "/guest".to_string())]);
+    assert_eq!(
+        opts.preopened_dirs,
+        vec![("/tmp".to_string(), "/guest".to_string())]
+    );
 }
 
 #[test]
@@ -254,22 +272,12 @@ fn run_log_level() {
 fn run_profile_guest() {
     let parser = Parser::from_args(&["--profile", "guest", "input.wado"]);
     let opts = wado_cli::run::parse_args(parser).unwrap();
-    assert!(matches!(opts.profile, wado_cli::runtime::ProfileMode::Guest { .. }));
+    assert!(matches!(
+        opts.profile,
+        wado_cli::runtime::ProfileMode::Guest { .. }
+    ));
 }
 
-#[test]
-fn run_profile_jitdump() {
-    let parser = Parser::from_args(&["--profile", "jitdump", "input.wado"]);
-    let opts = wado_cli::run::parse_args(parser).unwrap();
-    assert!(matches!(opts.profile, wado_cli::runtime::ProfileMode::JitDump));
-}
-
-#[test]
-fn run_profile_perfmap() {
-    let parser = Parser::from_args(&["--profile", "perfmap", "input.wado"]);
-    let opts = wado_cli::run::parse_args(parser).unwrap();
-    assert!(matches!(opts.profile, wado_cli::runtime::ProfileMode::PerfMap));
-}
 
 #[test]
 fn run_profile_invalid() {
@@ -303,7 +311,10 @@ fn serve_help() {
 #[test]
 fn serve_no_input() {
     let parser = Parser::from_args::<&[&str]>(&[]);
-    assert_err(wado_cli::serve::parse_args(parser), "no input file specified");
+    assert_err(
+        wado_cli::serve::parse_args(parser),
+        "no input file specified",
+    );
 }
 
 #[test]
@@ -347,13 +358,19 @@ fn test_with_parallel() {
 #[test]
 fn test_parallel_invalid() {
     let parser = Parser::from_args(&["-p", "0", "a.wado"]);
-    assert_err(wado_cli::test::parse_args(parser), "--parallel requires a positive integer");
+    assert_err(
+        wado_cli::test::parse_args(parser),
+        "--parallel requires a positive integer",
+    );
 }
 
 #[test]
 fn test_parallel_non_numeric() {
     let parser = Parser::from_args(&["-p", "abc", "a.wado"]);
-    assert_err(wado_cli::test::parse_args(parser), "--parallel requires a positive integer");
+    assert_err(
+        wado_cli::test::parse_args(parser),
+        "--parallel requires a positive integer",
+    );
 }
 
 #[test]
@@ -397,13 +414,19 @@ fn format_multiple_files_with_write() {
 #[test]
 fn format_multiple_files_without_write() {
     let parser = Parser::from_args(&["a.wado", "b.wado"]);
-    assert_err(wado_cli::format::parse_args(parser), "multiple files require -w or --check");
+    assert_err(
+        wado_cli::format::parse_args(parser),
+        "multiple files require -w or --check",
+    );
 }
 
 #[test]
 fn format_no_input() {
     let parser = Parser::from_args::<&[&str]>(&[]);
-    assert_err(wado_cli::format::parse_args(parser), "no input file specified");
+    assert_err(
+        wado_cli::format::parse_args(parser),
+        "no input file specified",
+    );
 }
 
 #[test]
@@ -542,7 +565,10 @@ fn dump_all() {
 #[test]
 fn dump_no_input() {
     let parser = Parser::from_args::<&[&str]>(&[]);
-    assert_err(wado_cli::dump::parse_args(parser), "no input file specified");
+    assert_err(
+        wado_cli::dump::parse_args(parser),
+        "no input file specified",
+    );
 }
 
 #[test]
@@ -591,16 +617,29 @@ fn syntax_unexpected_positional() {
 
 #[test]
 fn match_opt_long() {
-    use wado_cli::args::{match_opt, OptSpec};
+    use wado_cli::args::{OptSpec, match_opt};
 
     #[derive(Clone, Copy, Debug, PartialEq)]
-    enum TestOpt { Help, Verbose }
+    enum TestOpt {
+        Help,
+        Verbose,
+    }
 
     let specs: &[TestOpt] = &[TestOpt::Help, TestOpt::Verbose];
     let spec_fn = |o: &TestOpt| -> OptSpec {
         match o {
-            TestOpt::Help => OptSpec { long: Some("help"), short: None, value: None, desc: "" },
-            TestOpt::Verbose => OptSpec { long: Some("verbose"), short: Some('v'), value: None, desc: "" },
+            TestOpt::Help => OptSpec {
+                long: Some("help"),
+                short: None,
+                value: None,
+                desc: "",
+            },
+            TestOpt::Verbose => OptSpec {
+                long: Some("verbose"),
+                short: Some('v'),
+                value: None,
+                desc: "",
+            },
         }
     };
 
@@ -616,14 +655,21 @@ fn match_opt_long() {
 
 #[test]
 fn match_opt_short() {
-    use wado_cli::args::{match_opt, OptSpec};
+    use wado_cli::args::{OptSpec, match_opt};
 
     #[derive(Clone, Copy, Debug, PartialEq)]
-    enum TestOpt { Output }
+    enum TestOpt {
+        Output,
+    }
 
     let specs: &[TestOpt] = &[TestOpt::Output];
     let spec_fn = |_: &TestOpt| -> OptSpec {
-        OptSpec { long: Some("output"), short: Some('o'), value: Some("<file>"), desc: "" }
+        OptSpec {
+            long: Some("output"),
+            short: Some('o'),
+            value: Some("<file>"),
+            desc: "",
+        }
     };
 
     let arg = lexopt::Arg::Short('o');
@@ -635,32 +681,54 @@ fn match_opt_short() {
 
 #[test]
 fn format_opts_help_output() {
-    use wado_cli::args::{format_opts_help, OptSpec};
+    use wado_cli::args::{OptSpec, format_opts_help};
 
     #[derive(Clone, Copy)]
-    enum TestOpt { Help, Verbose }
+    enum TestOpt {
+        Help,
+        Verbose,
+    }
 
     let specs: &[TestOpt] = &[TestOpt::Help, TestOpt::Verbose];
     let spec_fn = |o: &TestOpt| -> OptSpec {
         match o {
-            TestOpt::Help => OptSpec { long: Some("help"), short: None, value: None, desc: "Show help" },
-            TestOpt::Verbose => OptSpec { long: Some("verbose"), short: Some('v'), value: None, desc: "Be verbose" },
+            TestOpt::Help => OptSpec {
+                long: Some("help"),
+                short: None,
+                value: None,
+                desc: "Show help",
+            },
+            TestOpt::Verbose => OptSpec {
+                long: Some("verbose"),
+                short: Some('v'),
+                value: None,
+                desc: "Be verbose",
+            },
         }
     };
 
     let output = format_opts_help(specs, spec_fn);
     assert!(output.contains("--help"), "should contain --help");
-    assert!(output.contains("-v, --verbose"), "should contain -v, --verbose");
+    assert!(
+        output.contains("-v, --verbose"),
+        "should contain -v, --verbose"
+    );
     assert!(output.contains("Show help"), "should contain description");
 }
 
 #[test]
 fn parse_log_level_valid() {
     use wado_cli::args::parse_log_level;
-    assert_eq!(parse_log_level("debug"), Some(wado_compiler::LogLevel::Debug));
+    assert_eq!(
+        parse_log_level("debug"),
+        Some(wado_compiler::LogLevel::Debug)
+    );
     assert_eq!(parse_log_level("info"), Some(wado_compiler::LogLevel::Info));
     assert_eq!(parse_log_level("warn"), Some(wado_compiler::LogLevel::Warn));
-    assert_eq!(parse_log_level("error"), Some(wado_compiler::LogLevel::Error));
+    assert_eq!(
+        parse_log_level("error"),
+        Some(wado_compiler::LogLevel::Error)
+    );
     assert_eq!(parse_log_level("off"), Some(wado_compiler::LogLevel::Off));
     assert_eq!(parse_log_level("invalid"), None);
 }

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -278,7 +278,6 @@ fn run_profile_guest() {
     ));
 }
 
-
 #[test]
 fn run_profile_invalid() {
     let parser = Parser::from_args(&["--profile", "unknown", "input.wado"]);

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -1,0 +1,666 @@
+//! In-process CLI argument parsing tests.
+//!
+//! Tests `parse_args` functions directly without spawning processes,
+//! using `lexopt::Parser::from_args` to construct parsers from argument slices.
+
+use lexopt::Parser;
+
+use wado_cli::args::CliExit;
+use wado_cli::compile::{self, OptLevel, OutputFormat};
+
+/// Assert that a `Result<T, CliExit>` is an error with exit code 1
+/// and the message contains the given substring.
+fn assert_err<T>(result: Result<T, CliExit>, expected: &str) {
+    match result {
+        Ok(_) => panic!("expected CliExit error, but got Ok"),
+        Err(err) => {
+            assert_eq!(err.exit_code, 1, "expected exit_code 1, got {}", err.exit_code);
+            assert!(
+                err.message.contains(expected),
+                "expected message to contain {expected:?}, got {:?}",
+                err.message
+            );
+        }
+    }
+}
+
+/// Assert that a `Result<T, CliExit>` is a help exit (exit code 0)
+/// and the message contains the given substring.
+fn assert_help<T>(result: Result<T, CliExit>, expected: &str) {
+    match result {
+        Ok(_) => panic!("expected CliExit help, but got Ok"),
+        Err(err) => {
+            assert_eq!(err.exit_code, 0, "expected exit_code 0, got {}", err.exit_code);
+            assert!(
+                err.message.contains(expected),
+                "expected message to contain {expected:?}, got {:?}",
+                err.message
+            );
+        }
+    }
+}
+
+// ---- compile ----
+
+#[test]
+fn compile_basic() {
+    let parser = Parser::from_args(&["input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.input, "input.wado");
+    assert_eq!(opts.output, None);
+    assert_eq!(opts.format, None);
+    assert_eq!(opts.opt_level, OptLevel::O2); // default
+    assert!(!opts.wat_to_stdout);
+    assert!(!opts.skip_validation);
+}
+
+#[test]
+fn compile_with_output() {
+    let parser = Parser::from_args(&["-o", "out.wasm", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.input, "input.wado");
+    assert_eq!(opts.output, Some("out.wasm".to_string()));
+}
+
+#[test]
+fn compile_format_wat() {
+    let parser = Parser::from_args(&["--format", "wat", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.format, Some(OutputFormat::Wat));
+}
+
+#[test]
+fn compile_format_wasm() {
+    let parser = Parser::from_args(&["--format", "wasm", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.format, Some(OutputFormat::Wasm));
+}
+
+#[test]
+fn compile_wat_to_stdout() {
+    let parser = Parser::from_args(&["--wat-to-stdout", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert!(opts.wat_to_stdout);
+}
+
+#[test]
+fn compile_opt_levels() {
+    for (arg, expected) in [
+        ("-O0", OptLevel::O0),
+        ("-O1", OptLevel::O1),
+        ("-O2", OptLevel::O2),
+        ("-O3", OptLevel::O3),
+        ("-Os", OptLevel::Os),
+    ] {
+        let parser = Parser::from_args(&[arg, "input.wado"]);
+        let opts = compile::parse_args(parser).unwrap();
+        assert_eq!(opts.opt_level, expected, "failed for {arg}");
+    }
+}
+
+#[test]
+fn compile_no_validate() {
+    let parser = Parser::from_args(&["--no-validate", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert!(opts.skip_validation);
+}
+
+#[test]
+fn compile_world() {
+    let parser = Parser::from_args(&["--world", "test", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.target_world, Some("test".to_string()));
+}
+
+#[test]
+fn compile_log_level() {
+    let parser = Parser::from_args(&["--log-level", "debug", "input.wado"]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.log_level, wado_compiler::LogLevel::Debug);
+}
+
+#[test]
+fn compile_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(compile::parse_args(parser), "Usage: wado compile");
+}
+
+#[test]
+fn compile_no_input() {
+    let parser = Parser::from_args::<&[&str]>(&[]);
+    assert_err(compile::parse_args(parser), "no input file specified");
+}
+
+#[test]
+fn compile_unknown_option() {
+    let parser = Parser::from_args(&["--unknown", "input.wado"]);
+    assert_err(compile::parse_args(parser), "invalid option");
+}
+
+#[test]
+fn compile_invalid_format() {
+    let parser = Parser::from_args(&["--format", "invalid", "input.wado"]);
+    assert_err(compile::parse_args(parser), "unknown format");
+}
+
+#[test]
+fn compile_invalid_opt_level() {
+    let parser = Parser::from_args(&["-Ox", "input.wado"]);
+    assert_err(compile::parse_args(parser), "unknown optimization level");
+}
+
+#[test]
+fn compile_invalid_log_level() {
+    let parser = Parser::from_args(&["--log-level", "invalid", "input.wado"]);
+    assert_err(compile::parse_args(parser), "unknown log level");
+}
+
+#[test]
+fn compile_multiple_inputs() {
+    let parser = Parser::from_args(&["a.wado", "b.wado"]);
+    assert_err(compile::parse_args(parser), "multiple input files");
+}
+
+#[test]
+fn compile_all_options() {
+    let parser = Parser::from_args(&[
+        "-o", "out.wat",
+        "--format", "wat",
+        "-O3",
+        "--log-level", "warn",
+        "--world", "wasi:http/service",
+        "--no-validate",
+        "input.wado",
+    ]);
+    let opts = compile::parse_args(parser).unwrap();
+    assert_eq!(opts.input, "input.wado");
+    assert_eq!(opts.output, Some("out.wat".to_string()));
+    assert_eq!(opts.format, Some(OutputFormat::Wat));
+    assert_eq!(opts.opt_level, OptLevel::O3);
+    assert_eq!(opts.log_level, wado_compiler::LogLevel::Warn);
+    assert_eq!(opts.target_world, Some("wasi:http/service".to_string()));
+    assert!(opts.skip_validation);
+}
+
+// ---- run ----
+
+#[test]
+fn run_basic() {
+    let parser = Parser::from_args(&["input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert_eq!(opts.input, "input.wado");
+    assert_eq!(opts.opt_level, OptLevel::O2);
+    // Default: current dir is preopened
+    assert_eq!(opts.preopened_dirs, vec![(".".to_string(), ".".to_string())]);
+    assert!(opts.program_args.is_empty());
+}
+
+#[test]
+fn run_with_dir() {
+    let parser = Parser::from_args(&["--dir", "/tmp::/guest", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    // --dir overrides default
+    assert_eq!(opts.preopened_dirs, vec![("/tmp".to_string(), "/guest".to_string())]);
+}
+
+#[test]
+fn run_no_dir() {
+    let parser = Parser::from_args(&["--no-dir", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert!(opts.preopened_dirs.is_empty());
+}
+
+#[test]
+fn run_program_args() {
+    let parser = Parser::from_args(&["input.wado", "arg1", "arg2"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert_eq!(opts.input, "input.wado");
+    assert_eq!(opts.program_args, vec!["arg1", "arg2"]);
+}
+
+#[test]
+fn run_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(wado_cli::run::parse_args(parser), "Usage: wado run");
+}
+
+#[test]
+fn run_no_input() {
+    let parser = Parser::from_args::<&[&str]>(&[]);
+    assert_err(wado_cli::run::parse_args(parser), "no input file specified");
+}
+
+#[test]
+fn run_unknown_option() {
+    let parser = Parser::from_args(&["--unknown", "input.wado"]);
+    assert_err(wado_cli::run::parse_args(parser), "invalid option");
+}
+
+#[test]
+fn run_opt_level() {
+    let parser = Parser::from_args(&["-O3", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert_eq!(opts.opt_level, OptLevel::O3);
+}
+
+#[test]
+fn run_log_level() {
+    let parser = Parser::from_args(&["--log-level", "error", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert_eq!(opts.log_level, wado_compiler::LogLevel::Error);
+}
+
+#[test]
+fn run_profile_guest() {
+    let parser = Parser::from_args(&["--profile", "guest", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert!(matches!(opts.profile, wado_cli::runtime::ProfileMode::Guest { .. }));
+}
+
+#[test]
+fn run_profile_jitdump() {
+    let parser = Parser::from_args(&["--profile", "jitdump", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert!(matches!(opts.profile, wado_cli::runtime::ProfileMode::JitDump));
+}
+
+#[test]
+fn run_profile_perfmap() {
+    let parser = Parser::from_args(&["--profile", "perfmap", "input.wado"]);
+    let opts = wado_cli::run::parse_args(parser).unwrap();
+    assert!(matches!(opts.profile, wado_cli::runtime::ProfileMode::PerfMap));
+}
+
+#[test]
+fn run_profile_invalid() {
+    let parser = Parser::from_args(&["--profile", "unknown", "input.wado"]);
+    assert_err(wado_cli::run::parse_args(parser), "unknown profile mode");
+}
+
+// ---- serve ----
+
+#[test]
+fn serve_basic() {
+    let parser = Parser::from_args(&["input.wado"]);
+    let opts = wado_cli::serve::parse_args(parser).unwrap();
+    assert_eq!(opts.input, "input.wado");
+    assert_eq!(opts.addr, "0.0.0.0:8080");
+}
+
+#[test]
+fn serve_custom_addr() {
+    let parser = Parser::from_args(&["--addr", "127.0.0.1:3000", "input.wado"]);
+    let opts = wado_cli::serve::parse_args(parser).unwrap();
+    assert_eq!(opts.addr, "127.0.0.1:3000");
+}
+
+#[test]
+fn serve_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(wado_cli::serve::parse_args(parser), "Usage: wado serve");
+}
+
+#[test]
+fn serve_no_input() {
+    let parser = Parser::from_args::<&[&str]>(&[]);
+    assert_err(wado_cli::serve::parse_args(parser), "no input file specified");
+}
+
+#[test]
+fn serve_opt_level() {
+    let parser = Parser::from_args(&["-Os", "input.wado"]);
+    let opts = wado_cli::serve::parse_args(parser).unwrap();
+    assert_eq!(opts.opt_level, OptLevel::Os);
+}
+
+#[test]
+fn serve_log_level() {
+    let parser = Parser::from_args(&["--log-level", "warn", "input.wado"]);
+    let opts = wado_cli::serve::parse_args(parser).unwrap();
+    assert_eq!(opts.log_level, wado_compiler::LogLevel::Warn);
+}
+
+// ---- test ----
+
+#[test]
+fn test_with_files() {
+    let parser = Parser::from_args(&["a.wado", "b.wado"]);
+    let opts = wado_cli::test::parse_args(parser).unwrap();
+    assert_eq!(opts.paths, vec!["a.wado", "b.wado"]);
+    assert_eq!(opts.filter, None);
+}
+
+#[test]
+fn test_with_filter() {
+    let parser = Parser::from_args(&["-f", "pattern", "a.wado"]);
+    let opts = wado_cli::test::parse_args(parser).unwrap();
+    assert_eq!(opts.filter, Some("pattern".to_string()));
+}
+
+#[test]
+fn test_with_parallel() {
+    let parser = Parser::from_args(&["-p", "4", "a.wado"]);
+    let opts = wado_cli::test::parse_args(parser).unwrap();
+    assert_eq!(opts.jobs, 4);
+}
+
+#[test]
+fn test_parallel_invalid() {
+    let parser = Parser::from_args(&["-p", "0", "a.wado"]);
+    assert_err(wado_cli::test::parse_args(parser), "--parallel requires a positive integer");
+}
+
+#[test]
+fn test_parallel_non_numeric() {
+    let parser = Parser::from_args(&["-p", "abc", "a.wado"]);
+    assert_err(wado_cli::test::parse_args(parser), "--parallel requires a positive integer");
+}
+
+#[test]
+fn test_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(wado_cli::test::parse_args(parser), "Usage: wado test");
+}
+
+// ---- format ----
+
+#[test]
+fn format_basic() {
+    let parser = Parser::from_args(&["input.wado"]);
+    let opts = wado_cli::format::parse_args(parser).unwrap();
+    assert_eq!(opts.inputs, vec!["input.wado"]);
+    assert!(!opts.write_in_place);
+    assert!(!opts.check);
+}
+
+#[test]
+fn format_write() {
+    let parser = Parser::from_args(&["-w", "input.wado"]);
+    let opts = wado_cli::format::parse_args(parser).unwrap();
+    assert!(opts.write_in_place);
+}
+
+#[test]
+fn format_check() {
+    let parser = Parser::from_args(&["--check", "input.wado"]);
+    let opts = wado_cli::format::parse_args(parser).unwrap();
+    assert!(opts.check);
+}
+
+#[test]
+fn format_multiple_files_with_write() {
+    let parser = Parser::from_args(&["-w", "a.wado", "b.wado"]);
+    let opts = wado_cli::format::parse_args(parser).unwrap();
+    assert_eq!(opts.inputs, vec!["a.wado", "b.wado"]);
+}
+
+#[test]
+fn format_multiple_files_without_write() {
+    let parser = Parser::from_args(&["a.wado", "b.wado"]);
+    assert_err(wado_cli::format::parse_args(parser), "multiple files require -w or --check");
+}
+
+#[test]
+fn format_no_input() {
+    let parser = Parser::from_args::<&[&str]>(&[]);
+    assert_err(wado_cli::format::parse_args(parser), "no input file specified");
+}
+
+#[test]
+fn format_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(wado_cli::format::parse_args(parser), "Usage: wado format");
+}
+
+// ---- dump ----
+
+#[test]
+fn dump_basic() {
+    let parser = Parser::from_args(&["input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert_eq!(opts.inputs, vec!["input.wado"]);
+    // Default: show all phases
+    assert!(opts.show_tokens);
+    assert!(opts.show_ast);
+    assert!(opts.show_tir);
+    assert!(opts.show_wir);
+}
+
+#[test]
+fn dump_single_phase() {
+    let parser = Parser::from_args(&["--ast", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_ast);
+    assert!(!opts.show_tokens);
+    assert!(!opts.show_tir);
+}
+
+#[test]
+fn dump_unparse() {
+    let parser = Parser::from_args(&["--ast", "--unparse", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_ast);
+    assert!(opts.unparse);
+}
+
+#[test]
+fn dump_opt_level() {
+    let parser = Parser::from_args(&["--optimize", "-O3", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_optimize);
+    assert_eq!(opts.opt_level, wado_compiler::OptLevel::O3);
+}
+
+#[test]
+fn dump_output_template() {
+    let parser = Parser::from_args(&["--optimize", "-o", "out/{name}.wado", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert_eq!(opts.output_template, Some("out/{name}.wado".to_string()));
+}
+
+#[test]
+fn dump_tokens() {
+    let parser = Parser::from_args(&["--tokens", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_tokens);
+    assert!(!opts.show_ast);
+    assert!(!opts.show_tir);
+}
+
+#[test]
+fn dump_desugar() {
+    let parser = Parser::from_args(&["--desugar", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_desugar);
+    assert!(!opts.show_ast);
+}
+
+#[test]
+fn dump_modules() {
+    let parser = Parser::from_args(&["--modules", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_modules);
+    assert!(!opts.show_symbols);
+}
+
+#[test]
+fn dump_symbols() {
+    let parser = Parser::from_args(&["--symbols", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_symbols);
+    assert!(!opts.show_modules);
+}
+
+#[test]
+fn dump_tir() {
+    let parser = Parser::from_args(&["--tir", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_tir);
+    assert!(!opts.show_wir);
+}
+
+#[test]
+fn dump_monomorphize() {
+    let parser = Parser::from_args(&["--monomorphize", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_monomorphize);
+    assert!(!opts.show_lower);
+}
+
+#[test]
+fn dump_lower() {
+    let parser = Parser::from_args(&["--lower", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_lower);
+    assert!(!opts.show_monomorphize);
+}
+
+#[test]
+fn dump_wir() {
+    let parser = Parser::from_args(&["--wir", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_wir);
+    assert!(!opts.show_tir);
+}
+
+#[test]
+fn dump_all() {
+    let parser = Parser::from_args(&["--all", "input.wado"]);
+    let opts = wado_cli::dump::parse_args(parser).unwrap();
+    assert!(opts.show_tokens);
+    assert!(opts.show_ast);
+    assert!(opts.show_desugar);
+    assert!(opts.show_modules);
+    assert!(opts.show_symbols);
+    assert!(opts.show_tir);
+    assert!(opts.show_monomorphize);
+    assert!(opts.show_lower);
+    assert!(opts.show_optimize);
+    assert!(opts.show_wir);
+}
+
+#[test]
+fn dump_no_input() {
+    let parser = Parser::from_args::<&[&str]>(&[]);
+    assert_err(wado_cli::dump::parse_args(parser), "no input file specified");
+}
+
+#[test]
+fn dump_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(wado_cli::dump::parse_args(parser), "Usage: wado dump");
+}
+
+// ---- syntax ----
+
+#[test]
+fn syntax_default() {
+    let parser = Parser::from_args::<&[&str]>(&[]);
+    let opts = wado_cli::syntax::parse_args(parser).unwrap();
+    assert_eq!(opts.format, wado_cli::syntax::SyntaxFormat::TmLanguage);
+    assert_eq!(opts.output, None);
+}
+
+#[test]
+fn syntax_with_format() {
+    let parser = Parser::from_args(&["--format", "language-config"]);
+    let opts = wado_cli::syntax::parse_args(parser).unwrap();
+    assert_eq!(opts.format, wado_cli::syntax::SyntaxFormat::LanguageConfig);
+}
+
+#[test]
+fn syntax_with_output() {
+    let parser = Parser::from_args(&["-o", "out.json"]);
+    let opts = wado_cli::syntax::parse_args(parser).unwrap();
+    assert_eq!(opts.output, Some("out.json".to_string()));
+}
+
+#[test]
+fn syntax_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(wado_cli::syntax::parse_args(parser), "Usage: wado syntax");
+}
+
+#[test]
+fn syntax_unexpected_positional() {
+    let parser = Parser::from_args(&["foo"]);
+    assert_err(wado_cli::syntax::parse_args(parser), "unexpected argument");
+}
+
+// ---- args helpers ----
+
+#[test]
+fn match_opt_long() {
+    use wado_cli::args::{match_opt, OptSpec};
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum TestOpt { Help, Verbose }
+
+    let specs: &[TestOpt] = &[TestOpt::Help, TestOpt::Verbose];
+    let spec_fn = |o: &TestOpt| -> OptSpec {
+        match o {
+            TestOpt::Help => OptSpec { long: Some("help"), short: None, value: None, desc: "" },
+            TestOpt::Verbose => OptSpec { long: Some("verbose"), short: Some('v'), value: None, desc: "" },
+        }
+    };
+
+    let arg = lexopt::Arg::Long("help");
+    assert_eq!(match_opt(&arg, specs, spec_fn), Some(TestOpt::Help));
+
+    let arg = lexopt::Arg::Long("verbose");
+    assert_eq!(match_opt(&arg, specs, spec_fn), Some(TestOpt::Verbose));
+
+    let arg = lexopt::Arg::Long("unknown");
+    assert_eq!(match_opt(&arg, specs, spec_fn), None);
+}
+
+#[test]
+fn match_opt_short() {
+    use wado_cli::args::{match_opt, OptSpec};
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum TestOpt { Output }
+
+    let specs: &[TestOpt] = &[TestOpt::Output];
+    let spec_fn = |_: &TestOpt| -> OptSpec {
+        OptSpec { long: Some("output"), short: Some('o'), value: Some("<file>"), desc: "" }
+    };
+
+    let arg = lexopt::Arg::Short('o');
+    assert_eq!(match_opt(&arg, specs, spec_fn), Some(TestOpt::Output));
+
+    let arg = lexopt::Arg::Short('x');
+    assert_eq!(match_opt(&arg, specs, spec_fn), None);
+}
+
+#[test]
+fn format_opts_help_output() {
+    use wado_cli::args::{format_opts_help, OptSpec};
+
+    #[derive(Clone, Copy)]
+    enum TestOpt { Help, Verbose }
+
+    let specs: &[TestOpt] = &[TestOpt::Help, TestOpt::Verbose];
+    let spec_fn = |o: &TestOpt| -> OptSpec {
+        match o {
+            TestOpt::Help => OptSpec { long: Some("help"), short: None, value: None, desc: "Show help" },
+            TestOpt::Verbose => OptSpec { long: Some("verbose"), short: Some('v'), value: None, desc: "Be verbose" },
+        }
+    };
+
+    let output = format_opts_help(specs, spec_fn);
+    assert!(output.contains("--help"), "should contain --help");
+    assert!(output.contains("-v, --verbose"), "should contain -v, --verbose");
+    assert!(output.contains("Show help"), "should contain description");
+}
+
+#[test]
+fn parse_log_level_valid() {
+    use wado_cli::args::parse_log_level;
+    assert_eq!(parse_log_level("debug"), Some(wado_compiler::LogLevel::Debug));
+    assert_eq!(parse_log_level("info"), Some(wado_compiler::LogLevel::Info));
+    assert_eq!(parse_log_level("warn"), Some(wado_compiler::LogLevel::Warn));
+    assert_eq!(parse_log_level("error"), Some(wado_compiler::LogLevel::Error));
+    assert_eq!(parse_log_level("off"), Some(wado_compiler::LogLevel::Off));
+    assert_eq!(parse_log_level("invalid"), None);
+}


### PR DESCRIPTION
## Summary

This PR refactors the CLI argument parsing infrastructure to return `Result<T, CliExit>` instead of calling `process::exit()` directly. This enables comprehensive in-process testing of argument parsing logic without spawning subprocesses, while maintaining backward compatibility with the existing CLI behavior.

## Key Changes

- **New `CliExit` type**: Introduced a `CliExit` struct that encapsulates exit messages and codes (0 for help, 1 for errors) without immediately terminating the process. This allows parse functions to return errors that can be tested.

- **Refactored `args.rs` module**: 
  - Updated helper functions (`next_arg`, `require_value`, `require_string`, `require_input`, `require_inputs`, `reject_multiple_inputs`) to return `Result<T, CliExit>` instead of calling `exit_error()`
  - Added `OptSpec` struct and `format_opts_help()` function to centralize option specification and help text generation
  - Added common option specs (`OPT_LEVEL_SPEC`, `LOG_LEVEL_SPEC`, `HELP_SPEC`) for reuse across subcommands

- **Updated all subcommand modules** (`compile.rs`, `run.rs`, `serve.rs`, `test.rs`, `format.rs`, `dump.rs`, `syntax.rs`):
  - Changed `parse_args()` functions to return `Result<Options, CliExit>` instead of `Options`
  - Replaced manual help text with structured `OptSpec` enums and `format_usage()` functions
  - Updated error handling to use `CliExit::error()` and `CliExit::error_with_usage()`
  - Simplified argument parsing by using the new helper functions

- **Created library structure**: Added `src/lib.rs` to expose modules for testing, and updated `Cargo.toml` to define the library target alongside the binary.

- **Comprehensive test suite**: Added `tests/cli_parse.rs` with 70+ tests covering:
  - Basic argument parsing for all subcommands
  - Option validation and error cases
  - Help message generation
  - Edge cases (missing inputs, unknown options, invalid values)
  - All subcommands: compile, run, serve, test, format, dump

- **Updated `main.rs`**: Modified to handle `CliExit` results from subcommand parsers, calling `.exit()` only when needed.

## Implementation Details

- The refactoring maintains the same CLI behavior—errors still exit with code 1, help exits with code 0, and messages go to stderr.
- All parse functions now use a consistent error handling pattern with `?` operator for cleaner code.
- Help text generation is now data-driven through `OptSpec`, reducing duplication and making it easier to maintain consistency across subcommands.
- The `CliExit::exit()` method is marked `-> !` to maintain type safety in the main entry point.

https://claude.ai/code/session_01HZj8Vo3HfvXchB3z3sSZWA