### PR TITLE
Add git-upstream-sync skill for resolving PR conflicts

### DIFF
--- a/.claude/skills/git-upstream-sync/SKILL.md
+++ b/.claude/skills/git-upstream-sync/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: git-upstream-sync
+description: Sync current branch with origin/main when a GitHub PR has conflicts. Merges with zdiff3, commits conflict markers separately, then resolves conflicts.
+---
+
+# Git Upstream Sync
+
+Resolve GitHub PR conflicts by merging origin/main into the current branch.
+
+## Procedure
+
+### 1. Fetch and merge with zdiff3
+
+```sh
+git fetch origin main
+git merge --conflict=zdiff3 origin/main
+```
+
+### 2. If conflicts exist, commit them as-is
+
+If the merge produces conflicts, **commit the conflict markers without resolving them first**. This records the raw conflict state in a dedicated commit, separate from the resolution.
+
+```sh
+git add -A
+git commit -m "merge origin/main (conflicts unresolved)"
+```
+
+### 3. Resolve conflicts
+
+After committing the unresolved state:
+
+1. Read each conflicted file and understand both sides of the conflict
+2. Resolve the conflicts by editing the files (remove conflict markers, choose correct code)
+3. Stage and commit the resolution as a separate commit:
+
+```sh
+git add -A
+git commit -m "resolve merge conflicts"
+```
+
+## Important
+
+- Always use `--conflict=zdiff3` so the merge base is visible in conflict markers
+- Always commit the unresolved conflicts first, then resolve in a separate commit — this preserves a clear record of what the conflicts looked like vs how they were resolved
+- Do NOT squash the two commits together


### PR DESCRIPTION
## Summary
This PR adds a new skill documentation that provides a structured procedure for resolving GitHub PR conflicts by syncing the current branch with origin/main.

## Changes
- Added `.claude/skills/git-upstream-sync/SKILL.md` with a complete workflow for conflict resolution
  - Documents the three-step process: fetch and merge with zdiff3, commit unresolved conflicts, then resolve in a separate commit
  - Emphasizes using `--conflict=zdiff3` to preserve merge base visibility in conflict markers
  - Recommends keeping conflict commits separate from resolution commits for clear audit trail

## Key Details
The skill promotes a deliberate conflict resolution workflow that:
- Uses zdiff3 merge strategy for better conflict context
- Separates the "raw conflict state" commit from the "resolution" commit
- Prevents squashing these commits together to maintain a clear record of what conflicts existed and how they were resolved

https://claude.ai/code/session_01KmqrHJAh8DEZo2ASwV4agH