### PR TITLE
Fix Moonbit build output paths and update Go version constraint

### DIFF
--- a/wasm-size/README.md
+++ b/wasm-size/README.md
@@ -28,7 +28,9 @@ Compares WebAssembly binary sizes across different languages.
 | c              |        2,275 |
 | zig            |        4,449 |
 | assemblyscript |        6,913 |
+| moonbit        |       21,103 |
 | rust           |       42,587 |
+| tinygo         |      162,341 |
 
 ### pi_approx
 
@@ -38,7 +40,9 @@ Compares WebAssembly binary sizes across different languages.
 | zig            |       10,608 |
 | assemblyscript |       11,372 |
 | c              |       14,275 |
+| moonbit        |       31,133 |
 | rust           |       62,952 |
+| tinygo         |      187,167 |
 
 ### zlib
 

--- a/wasm-size/mise.toml
+++ b/wasm-size/mise.toml
@@ -11,7 +11,7 @@
 [tools]
 node = "latest"
 zig = "latest"
-go = "latest"
+go = "1.25"                              # TinyGo 0.40.x requires go <= 1.25
 wasmtime = "41"                        # matches project's Cargo.toml
 "github:tinygo-org/tinygo" = "latest"  # TinyGo (needs go)
 "github:WebAssembly/wasi-sdk" = "latest" # clang + wasm-ld + wasi-sysroot
@@ -134,12 +134,14 @@ run = """
 set -e
 mkdir -p "$OUT_DIR"
 
+export PATH="$HOME/.moon/bin:$PATH"
+
 if command -v moon >/dev/null 2>&1; then
     echo "Building Moonbit..."
     (cd hello_world && moon build --target wasm --release --strip)
     (cd pi_approx && moon build --target wasm --release --strip)
-    cp hello_world/_build/wasm/release/build/main.wasm "$OUT_DIR/hello_world_moonbit.wasm"
-    cp pi_approx/_build/wasm/release/build/main.wasm "$OUT_DIR/pi_approx_moonbit.wasm"
+    cp hello_world/_build/wasm/release/build/hello_world.wasm "$OUT_DIR/hello_world_moonbit.wasm"
+    cp pi_approx/_build/wasm/release/build/pi_approx.wasm "$OUT_DIR/pi_approx_moonbit.wasm"
 else
     echo "SKIP: Moonbit (curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash)"
 fi


### PR DESCRIPTION
## Summary
This PR fixes the Moonbit WebAssembly build process and updates toolchain version constraints to ensure compatibility with TinyGo 0.40.x.

## Key Changes
- **Go version constraint**: Updated from `latest` to `1.25` to maintain compatibility with TinyGo 0.40.x, which requires Go <= 1.25
- **Moonbit build paths**: Corrected the output file paths in the build script from `main.wasm` to the actual generated filenames (`hello_world.wasm` and `pi_approx.wasm`)
- **PATH configuration**: Added `$HOME/.moon/bin` to the PATH to ensure the Moonbit compiler is properly discovered during builds
- **Documentation**: Updated README.md with benchmark results for Moonbit and TinyGo implementations, showing their relative binary sizes compared to other languages

## Implementation Details
The Moonbit build was failing because the copy commands were looking for `main.wasm` in the build output directory, but the compiler actually generates files named after the project (e.g., `hello_world.wasm`). The PATH update ensures the `moon` command is available even if it's not in the default system PATH.

https://claude.ai/code/session_01CQt6ZHKasetws259dALGfD