### PR TITLE
Add expect_trap attribute to failing test and remove TODO flag

### DIFF
--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -337,7 +337,7 @@ fn test_test_passing() {
 #[test]
 fn test_test_failing() {
     wado()
-        .args(["test", "wado-compiler/tests/fixtures/test_fail.wado"])
+        .args(["test", "wado-cli/tests/fixtures/test_fail.wado"])
         .assert()
         .failure()
         .stdout(predicate::str::contains("1 passed, 1 failed"));

--- a/wado-cli/tests/fixtures/test_fail.wado
+++ b/wado-cli/tests/fixtures/test_fail.wado
@@ -1,0 +1,7 @@
+test "passing" {
+    let x = 1;
+}
+
+test "failing" {
+    assert 1 == 2, "this should fail";
+}

--- a/wado-compiler/tests/fixtures/test_fail.wado
+++ b/wado-compiler/tests/fixtures/test_fail.wado
@@ -1,4 +1,4 @@
-// Test file with a failing test to verify exit code behavior
+// Test file with #[expect_trap] to verify expected-trap tests pass
 
 test "passing" {
     let x = 1;

--- a/wado-compiler/tests/fixtures/test_fail.wado
+++ b/wado-compiler/tests/fixtures/test_fail.wado
@@ -4,9 +4,10 @@ test "passing" {
     let x = 1;
 }
 
+#[expect_trap]
 test "failing" {
     assert 1 == 2, "this should fail";
 }
 
 __DATA__
-{"test": {}, "TODO": true}
+{"test": {}}


### PR DESCRIPTION
This change updates the test fixture to properly handle expected test failures.

Key changes made:
- Added `#[expect_trap]` attribute to the "failing" test to mark it as an expected failure
- Removed the `"TODO": true` flag from the test data configuration, as the expect_trap attribute now properly documents the expected behavior

These changes improve test clarity by using the explicit `expect_trap` attribute instead of a TODO flag to indicate that the assertion failure is intentional and expected.

https://claude.ai/code/session_01UkMc1NJw6gQbENv7H11yC2