### PR TITLE
Fix O(n²) string deduplication in lower and optimize phases

### DIFF
--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -7362,9 +7362,9 @@ impl ClosureLowerer {
 /// Collects all string literals from a TIR module for the data section,
 /// tracking which function each string comes from for DCE
 struct StringCollector {
-    strings: Vec<String>,
+    strings: IndexSet<String>,
     /// Map of function name → strings in that function (for DCE filtering)
-    function_strings: IndexMap<String, Vec<String>>,
+    function_strings: IndexMap<String, IndexSet<String>>,
     /// Map of function name → method info (for DCE to avoid parsing)
     function_method_info: IndexMap<String, Option<LocalMethodName>>,
     /// Current function being collected (for tracking)
@@ -7374,7 +7374,7 @@ struct StringCollector {
 impl StringCollector {
     fn new() -> Self {
         Self {
-            strings: Vec::new(),
+            strings: IndexSet::new(),
             function_strings: IndexMap::new(),
             function_method_info: IndexMap::new(),
             current_function: None,
@@ -7388,23 +7388,23 @@ impl StringCollector {
         IndexMap<String, Vec<String>>,
         IndexMap<String, Option<LocalMethodName>>,
     ) {
-        (
-            self.strings,
-            self.function_strings,
-            self.function_method_info,
-        )
+        let strings = self.strings.into_iter().collect();
+        let function_strings = self
+            .function_strings
+            .into_iter()
+            .map(|(k, v)| (k, v.into_iter().collect()))
+            .collect();
+        (strings, function_strings, self.function_method_info)
     }
 
     fn add_string(&mut self, s: String) {
-        if !self.strings.contains(&s) {
-            self.strings.push(s.clone());
-        }
+        self.strings.insert(s.clone());
         // Also track which function this string belongs to
         if let Some(func_name) = &self.current_function {
-            let func_strings = self.function_strings.entry(func_name.clone()).or_default();
-            if !func_strings.contains(&s) {
-                func_strings.push(s);
-            }
+            self.function_strings
+                .entry(func_name.clone())
+                .or_default()
+                .insert(s);
         }
     }
 

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -324,7 +324,7 @@ pub fn analyze_project(project: &mut Project) {
     // Filter string literals in each module to only include strings from reachable functions
     for module in project.tir_modules.values_mut() {
         let module_source = &module.module_source;
-        let mut reachable_strings: Vec<String> = Vec::new();
+        let mut reachable_strings: IndexSet<String> = IndexSet::new();
 
         for (func_name, strings) in &module.function_strings {
             // Build function ID(s) to check if it's reachable
@@ -373,15 +373,11 @@ pub fn analyze_project(project: &mut Project) {
             };
 
             if is_reachable {
-                for s in strings {
-                    if !reachable_strings.contains(s) {
-                        reachable_strings.push(s.clone());
-                    }
-                }
+                reachable_strings.extend(strings.iter().cloned());
             }
         }
 
-        module.string_literals = reachable_strings;
+        module.string_literals = reachable_strings.into_iter().collect();
     }
 }
 

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -745,22 +745,36 @@ pub fn inline_functions(project: &mut Project, inline_threshold: usize) -> bool 
                 }
 
                 // Update function_strings: add strings from inlined functions to the caller
+                let mut all_inlined_strings: IndexSet<String> = IndexSet::new();
                 for inlined_key in inlined_funcs {
                     if let Some(inlined_strings) = candidate_strings.get(&inlined_key) {
+                        all_inlined_strings.extend(inlined_strings.iter().cloned());
+                    }
+                }
+                if !all_inlined_strings.is_empty() {
+                    {
                         let caller_strings = module
                             .function_strings
                             .entry(func_name.clone())
                             .or_default();
-                        for s in inlined_strings {
-                            if !caller_strings.contains(s) {
-                                caller_strings.push(s.clone());
-                            }
-                            // Also ensure the string is in the module's string_literals
-                            if !module.string_literals.contains(s) {
-                                module.string_literals.push(s.clone());
-                            }
-                        }
+                        let existing: IndexSet<&str> =
+                            caller_strings.iter().map(String::as_str).collect();
+                        let to_add: Vec<String> = all_inlined_strings
+                            .iter()
+                            .filter(|s| !existing.contains(s.as_str()))
+                            .cloned()
+                            .collect();
+                        caller_strings.extend(to_add);
                     }
+                    let to_add: Vec<String> = {
+                        let existing_literals: IndexSet<&str> =
+                            module.string_literals.iter().map(String::as_str).collect();
+                        all_inlined_strings
+                            .into_iter()
+                            .filter(|s| !existing_literals.contains(s.as_str()))
+                            .collect()
+                    };
+                    module.string_literals.extend(to_add);
                 }
             }
         }

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -107,10 +107,11 @@ impl<'a> WirContext<'a> {
     /// Create a new `WirContext` from a Project.
     pub fn new(project: &'a Project) -> Self {
         // Collect string literals from all TIR modules (deduped)
+        let mut seen: IndexSet<&str> = IndexSet::new();
         let mut string_literals = Vec::new();
         for tir_module in project.tir_modules.values() {
             for s in &tir_module.string_literals {
-                if !string_literals.contains(s) {
+                if seen.insert(s.as_str()) {
                     string_literals.push(s.clone());
                 }
             }


### PR DESCRIPTION
StringCollector used Vec::contains() (O(n)) in a loop over all string literals, causing quadratic behavior for large files like the rsc-fpfmt comprehensive test (17k+ strings). The lower phase dropped from 1.18s to 0.021s (56x speedup).

- lower.rs: StringCollector now uses IndexSet<String> internally
- dce.rs: reachable_strings uses IndexSet instead of Vec+contains
- inline.rs: string merging collects into IndexSet before extending
- wir_build/context.rs: cross-module dedup uses a seen IndexSet