### PR TITLE
Replace actions/cache with Swatinem/rust-cache and upgrade Rust to 1.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - uses: jdx/mise-action@v3
         with:
@@ -91,19 +80,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
+      - uses: Swatinem/rust-cache@v2
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked --all -- --skip fixture_test_
@@ -115,19 +92,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
+      - uses: Swatinem/rust-cache@v2
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o0
@@ -139,19 +104,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
+      - uses: Swatinem/rust-cache@v2
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o1
@@ -163,19 +116,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
+      - uses: Swatinem/rust-cache@v2
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o3
@@ -187,19 +128,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
+      - uses: Swatinem/rust-cache@v2
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_os
@@ -211,19 +140,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
+      - uses: Swatinem/rust-cache@v2
       - uses: rui314/setup-mold@v1
 
       - run: make test-wado
@@ -235,6 +152,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+
       - run: cargo check --locked -p wado-compiler --target wasm32-unknown-unknown
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
-
       - run: cargo check --locked -p wado-compiler --target wasm32-unknown-unknown
 
   test:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92"
+channel = "1.93"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary
This PR simplifies the CI workflow by replacing the manual Cargo cache configuration with the specialized `Swatinem/rust-cache` action, and upgrades the Rust toolchain from 1.92 to 1.93.

## Key Changes
- **Cache Management**: Replaced `actions/cache@v5` with `Swatinem/rust-cache@v2` across all CI jobs
  - Removes manual cache path configuration (`.cargo/bin/`, `.cargo/registry/`, `.cargo/git/db/`, `target/`)
  - Eliminates custom cache key and restore-keys logic
  - The specialized action handles Rust-specific caching more efficiently and reliably
  
- **Rust Toolchain**: Updated `rust-toolchain.toml` from channel 1.92 to 1.93
  - Maintains existing components: clippy, rustfmt
  - Maintains existing targets: wasm32-unknown-unknown

## Implementation Details
The `Swatinem/rust-cache` action is purpose-built for Rust projects and automatically:
- Detects and caches appropriate Cargo directories
- Handles cache invalidation based on lock files
- Provides better performance and reliability compared to generic caching

This change reduces CI configuration complexity while improving maintainability and cache effectiveness.

https://claude.ai/code/session_01SgCDyKTZ4qPeE6nPuhLe8Z