### PR TITLE
Add trait bound checking for generic impl blocks

### DIFF
--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -84,7 +84,7 @@ impl IndexAssign<i32> for Array<T> {
     }
 }
 
-impl Eq for Array<T> {
+impl<T: Eq> Eq for Array<T> {
     pub fn eq(&self, other: &Self) -> bool {
         if self.used != other.used {
             return false;
@@ -98,7 +98,7 @@ impl Eq for Array<T> {
     }
 }
 
-impl Ord for Array<T> {
+impl<T: Ord> Ord for Array<T> {
     pub fn cmp(&self, other: &Self) -> Ordering {
         let min_len = i32_min(self.used, other.used);
         for let mut i = 0; i < min_len; i += 1 {

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -1386,6 +1386,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             Type,
             Vec<Function>,
             Vec<crate::ast::AssociatedTypeBinding>,
+            Vec<crate::ast::GenericParam>,
         )> = Vec::new();
 
         if let Some(entries) = self.trait_impl_index.get(struct_name) {
@@ -1399,6 +1400,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         trait_type.clone(),
                         impl_block.methods.clone(),
                         impl_block.associated_types.clone(),
+                        impl_block.type_params.clone(),
                     ));
                 }
             }
@@ -1415,12 +1417,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     trait_type.clone(),
                     impl_block.methods.clone(),
                     impl_block.associated_types.clone(),
+                    impl_block.type_params.clone(),
                 ));
             }
         }
 
         // Process collected impl blocks
-        for (impl_ty, trait_type, methods, associated_types) in impl_blocks_to_check {
+        for (impl_ty, trait_type, methods, associated_types, type_params) in impl_blocks_to_check {
             let impl_struct_name = self.get_type_name(&impl_ty);
             if impl_struct_name != struct_name {
                 continue;
@@ -1430,6 +1433,49 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let found_trait_name = self.get_type_name(&trait_type);
             if found_trait_name != trait_name {
                 continue;
+            }
+
+            // Check trait bounds on type parameters (e.g., impl<T: Eq> Eq for Array<T>)
+            if !type_params.iter().all(|p| p.bounds.is_empty()) && !concrete_type_args.is_empty() {
+                let bounds_map: IndexMap<&str, Vec<String>> = type_params
+                    .iter()
+                    .filter(|p| !p.bounds.is_empty())
+                    .map(|p| {
+                        (
+                            p.name.as_str(),
+                            p.bounds.iter().map(|b| b.name.clone()).collect(),
+                        )
+                    })
+                    .collect();
+
+                let mut bounds_satisfied = true;
+                if let ast::Type::Generic(generic) = &impl_ty {
+                    for (i, arg) in generic.args.iter().enumerate() {
+                        if let ast::Type::Named(named) = arg
+                            && let Some(bounds) = bounds_map.get(named.name.as_str())
+                            && let Some(&type_arg) = concrete_type_args.get(i)
+                        {
+                            if matches!(
+                                self.type_table.borrow().get(type_arg),
+                                ResolvedType::TypeParam { .. }
+                            ) {
+                                continue;
+                            }
+                            for bound in bounds {
+                                if !self.type_implements_trait(type_arg, bound) {
+                                    bounds_satisfied = false;
+                                    break;
+                                }
+                            }
+                        }
+                        if !bounds_satisfied {
+                            break;
+                        }
+                    }
+                }
+                if !bounds_satisfied {
+                    continue;
+                }
             }
 
             // Build type parameter mapping from impl_ty to concrete types

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -106,62 +106,65 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
                     };
                     {
-                    let receiver = self.adjust_receiver_for_self_kind(
-                        left.clone(),
-                        trait_info.self_kind,
-                        binary.span,
-                    );
+                        let receiver = self.adjust_receiver_for_self_kind(
+                            left.clone(),
+                            trait_info.self_kind,
+                            binary.span,
+                        );
 
-                    let arg_ref_type = self
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::Ref(right.type_id));
+                        let arg_ref_type = self
+                            .type_table
+                            .borrow_mut()
+                            .intern(ResolvedType::Ref(right.type_id));
 
-                    let arg_ref = TirExpr::new(
-                        TirExprKind::Unary {
-                            op: TirUnaryOp::Ref,
-                            expr: Box::new(right.clone()),
-                        },
-                        arg_ref_type,
-                        binary.span,
-                    );
-
-                    let mangled_method_name =
-                        MethodName::format_local(&struct_name, Some(&trait_info.trait_name), "eq");
-
-                    let call_expr = TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef::External {
-                                module_source: ModuleSource::prelude(),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(LocalMethodName::new(
-                                    struct_name.clone(),
-                                    Some(trait_info.trait_name.clone()),
-                                    "eq".to_string(),
-                                )),
-                            },
-                            type_args: vec![],
-                            args: vec![arg_ref],
-                        },
-                        TypeTable::BOOL,
-                        binary.span,
-                    );
-
-                    // Apply negation for !=
-                    if binary.op == BinaryOp::NotEq {
-                        return TirExpr::new(
+                        let arg_ref = TirExpr::new(
                             TirExprKind::Unary {
-                                op: TirUnaryOp::Not,
-                                expr: Box::new(call_expr),
+                                op: TirUnaryOp::Ref,
+                                expr: Box::new(right.clone()),
+                            },
+                            arg_ref_type,
+                            binary.span,
+                        );
+
+                        let mangled_method_name = MethodName::format_local(
+                            &struct_name,
+                            Some(&trait_info.trait_name),
+                            "eq",
+                        );
+
+                        let call_expr = TirExpr::new(
+                            TirExprKind::MethodCall {
+                                receiver: Box::new(receiver),
+                                func: FunctionRef::External {
+                                    module_source: ModuleSource::prelude(),
+                                    name: mangled_method_name,
+                                    monomorph_info: None,
+                                    method_info: Some(LocalMethodName::new(
+                                        struct_name.clone(),
+                                        Some(trait_info.trait_name.clone()),
+                                        "eq".to_string(),
+                                    )),
+                                },
+                                type_args: vec![],
+                                args: vec![arg_ref],
                             },
                             TypeTable::BOOL,
                             binary.span,
                         );
-                    }
 
-                    return call_expr;
+                        // Apply negation for !=
+                        if binary.op == BinaryOp::NotEq {
+                            return TirExpr::new(
+                                TirExprKind::Unary {
+                                    op: TirUnaryOp::Not,
+                                    expr: Box::new(call_expr),
+                                },
+                                TypeTable::BOOL,
+                                binary.span,
+                            );
+                        }
+
+                        return call_expr;
                     }
                 }
 
@@ -171,8 +174,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     binary.op,
                     BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq
                 ) {
-                    let Some(trait_info) =
-                        self.find_ord_trait_impl(&struct_name, left.type_id)
+                    let Some(trait_info) = self.find_ord_trait_impl(&struct_name, left.type_id)
                     else {
                         let type_name = self.type_table.borrow().type_name(left.type_id);
                         let op_str = match binary.op {
@@ -191,90 +193,93 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
                     };
                     {
-                    let receiver = self.adjust_receiver_for_self_kind(
-                        left.clone(),
-                        trait_info.self_kind,
-                        binary.span,
-                    );
+                        let receiver = self.adjust_receiver_for_self_kind(
+                            left.clone(),
+                            trait_info.self_kind,
+                            binary.span,
+                        );
 
-                    let arg_ref_type = self
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::Ref(right.type_id));
+                        let arg_ref_type = self
+                            .type_table
+                            .borrow_mut()
+                            .intern(ResolvedType::Ref(right.type_id));
 
-                    let arg_ref = TirExpr::new(
-                        TirExprKind::Unary {
-                            op: TirUnaryOp::Ref,
-                            expr: Box::new(right.clone()),
-                        },
-                        arg_ref_type,
-                        binary.span,
-                    );
-
-                    // Get Ordering type for cmp return value
-                    let ordering_type_id =
-                        self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                            name: "Ordering".to_string(),
-                            module_source: ModuleSource::prelude(),
-                        });
-
-                    let mangled_method_name =
-                        MethodName::format_local(&struct_name, Some(&trait_info.trait_name), "cmp");
-
-                    let cmp_call = TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef::External {
-                                module_source: ModuleSource::prelude(),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(LocalMethodName::new(
-                                    struct_name.clone(),
-                                    Some(trait_info.trait_name.clone()),
-                                    "cmp".to_string(),
-                                )),
+                        let arg_ref = TirExpr::new(
+                            TirExprKind::Unary {
+                                op: TirUnaryOp::Ref,
+                                expr: Box::new(right.clone()),
                             },
-                            type_args: vec![],
-                            args: vec![arg_ref],
-                        },
-                        ordering_type_id,
-                        binary.span,
-                    );
+                            arg_ref_type,
+                            binary.span,
+                        );
 
-                    // Determine comparison operator and Ordering variant:
-                    // < : cmp(a, b) == Ordering::Less
-                    // > : cmp(a, b) == Ordering::Greater
-                    // <= : cmp(a, b) != Ordering::Greater
-                    // >= : cmp(a, b) != Ordering::Less
-                    let (compare_op, case_name, case_index): (TirBinaryOp, &str, u32) =
-                        match binary.op {
-                            BinaryOp::Lt => (TirBinaryOp::Eq, "Less", 0),
-                            BinaryOp::Gt => (TirBinaryOp::Eq, "Greater", 2),
-                            BinaryOp::LtEq => (TirBinaryOp::NotEq, "Greater", 2),
-                            BinaryOp::GtEq => (TirBinaryOp::NotEq, "Less", 0),
-                            _ => unreachable!(),
-                        };
+                        // Get Ordering type for cmp return value
+                        let ordering_type_id =
+                            self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                                name: "Ordering".to_string(),
+                                module_source: ModuleSource::prelude(),
+                            });
 
-                    // Create Ordering enum value for comparison
-                    let ordering_variant = TirExpr::new(
-                        TirExprKind::EnumConstruct {
-                            enum_type: ordering_type_id,
-                            case_name: case_name.to_string(),
-                            case_index,
-                        },
-                        ordering_type_id,
-                        binary.span,
-                    );
+                        let mangled_method_name = MethodName::format_local(
+                            &struct_name,
+                            Some(&trait_info.trait_name),
+                            "cmp",
+                        );
 
-                    return TirExpr::new(
-                        TirExprKind::Binary {
-                            op: compare_op,
-                            left: Box::new(cmp_call),
-                            right: Box::new(ordering_variant),
-                        },
-                        TypeTable::BOOL,
-                        binary.span,
-                    );
+                        let cmp_call = TirExpr::new(
+                            TirExprKind::MethodCall {
+                                receiver: Box::new(receiver),
+                                func: FunctionRef::External {
+                                    module_source: ModuleSource::prelude(),
+                                    name: mangled_method_name,
+                                    monomorph_info: None,
+                                    method_info: Some(LocalMethodName::new(
+                                        struct_name.clone(),
+                                        Some(trait_info.trait_name.clone()),
+                                        "cmp".to_string(),
+                                    )),
+                                },
+                                type_args: vec![],
+                                args: vec![arg_ref],
+                            },
+                            ordering_type_id,
+                            binary.span,
+                        );
+
+                        // Determine comparison operator and Ordering variant:
+                        // < : cmp(a, b) == Ordering::Less
+                        // > : cmp(a, b) == Ordering::Greater
+                        // <= : cmp(a, b) != Ordering::Greater
+                        // >= : cmp(a, b) != Ordering::Less
+                        let (compare_op, case_name, case_index): (TirBinaryOp, &str, u32) =
+                            match binary.op {
+                                BinaryOp::Lt => (TirBinaryOp::Eq, "Less", 0),
+                                BinaryOp::Gt => (TirBinaryOp::Eq, "Greater", 2),
+                                BinaryOp::LtEq => (TirBinaryOp::NotEq, "Greater", 2),
+                                BinaryOp::GtEq => (TirBinaryOp::NotEq, "Less", 0),
+                                _ => unreachable!(),
+                            };
+
+                        // Create Ordering enum value for comparison
+                        let ordering_variant = TirExpr::new(
+                            TirExprKind::EnumConstruct {
+                                enum_type: ordering_type_id,
+                                case_name: case_name.to_string(),
+                                case_index,
+                            },
+                            ordering_type_id,
+                            binary.span,
+                        );
+
+                        return TirExpr::new(
+                            TirExprKind::Binary {
+                                op: compare_op,
+                                left: Box::new(cmp_call),
+                                right: Box::new(ordering_variant),
+                            },
+                            TypeTable::BOOL,
+                            binary.span,
+                        );
                     }
                 }
             }

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -88,9 +88,24 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
             if let Some(struct_name) = struct_name {
                 // Handle Eq trait (== and !=)
-                if matches!(binary.op, BinaryOp::Eq | BinaryOp::NotEq)
-                    && let Some(trait_info) = self.find_eq_trait_impl(&struct_name, left.type_id)
-                {
+                if matches!(binary.op, BinaryOp::Eq | BinaryOp::NotEq) {
+                    let Some(trait_info) = self.find_eq_trait_impl(&struct_name, left.type_id)
+                    else {
+                        let type_name = self.type_table.borrow().type_name(left.type_id);
+                        let op_str = if binary.op == BinaryOp::Eq {
+                            "=="
+                        } else {
+                            "!="
+                        };
+                        let _ = self.logger.error(TypeError::InvalidPattern {
+                            message: format!(
+                                "operator `{op_str}` cannot be applied to type `{type_name}` (does not implement Eq trait)"
+                            ),
+                            span: binary.span,
+                        });
+                        return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
+                    };
+                    {
                     let receiver = self.adjust_receiver_for_self_kind(
                         left.clone(),
                         trait_info.self_kind,
@@ -147,6 +162,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
 
                     return call_expr;
+                    }
                 }
 
                 // Handle Ord trait (<, >, <=, >=)
@@ -154,8 +170,27 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 if matches!(
                     binary.op,
                     BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq
-                ) && let Some(trait_info) = self.find_ord_trait_impl(&struct_name, left.type_id)
-                {
+                ) {
+                    let Some(trait_info) =
+                        self.find_ord_trait_impl(&struct_name, left.type_id)
+                    else {
+                        let type_name = self.type_table.borrow().type_name(left.type_id);
+                        let op_str = match binary.op {
+                            BinaryOp::Lt => "<",
+                            BinaryOp::Gt => ">",
+                            BinaryOp::LtEq => "<=",
+                            BinaryOp::GtEq => ">=",
+                            _ => unreachable!(),
+                        };
+                        let _ = self.logger.error(TypeError::InvalidPattern {
+                            message: format!(
+                                "operator `{op_str}` cannot be applied to type `{type_name}` (does not implement Ord trait)"
+                            ),
+                            span: binary.span,
+                        });
+                        return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
+                    };
+                    {
                     let receiver = self.adjust_receiver_for_self_kind(
                         left.clone(),
                         trait_info.self_kind,
@@ -240,6 +275,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         TypeTable::BOOL,
                         binary.span,
                     );
+                    }
                 }
             }
         }

--- a/wado-compiler/tests/fixtures/trait_bound_array_eq.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_array_eq.wado
@@ -1,0 +1,15 @@
+// Test that Array<T> == Array<T> requires T: Eq
+
+struct Foo {
+    x: i32,
+}
+
+export fn run() {
+    let a: Array<Foo> = [Foo { x: 1 }];
+    let b: Array<Foo> = [Foo { x: 1 }];
+    // Foo does not implement Eq, so == on Array<Foo> should fail
+    assert a == b;
+}
+
+__DATA__
+{"compile_error": "=="}

--- a/wado-compiler/tests/fixtures/trait_bound_array_ord.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_array_ord.wado
@@ -1,0 +1,15 @@
+// Test that Array<T> comparison requires T: Ord
+
+struct Foo {
+    x: i32,
+}
+
+export fn run() {
+    let a: Array<Foo> = [Foo { x: 1 }];
+    let b: Array<Foo> = [Foo { x: 2 }];
+    // Foo does not implement Ord, so < on Array<Foo> should fail
+    assert a < b;
+}
+
+__DATA__
+{"compile_error": "<"}


### PR DESCRIPTION
## Summary
This PR adds proper trait bound validation for generic type parameters in trait implementations. Previously, generic impl blocks like `impl<T: Eq> Eq for Array<T>` would not validate that the concrete type argument satisfies the required trait bounds, leading to incorrect trait resolution.

## Key Changes

- **Operator Resolution Error Handling**: Refactored the Eq and Ord trait operator resolution in `operators.rs` to properly handle cases where trait implementations are not found. Instead of silently failing, the compiler now emits clear error messages indicating which operator cannot be applied and why (e.g., "operator `==` cannot be applied to type `Foo` (does not implement Eq trait)").

- **Trait Bound Validation**: Enhanced `method_lookup.rs` to check trait bounds on type parameters when resolving trait implementations. When an impl block has generic type parameters with trait bounds (e.g., `impl<T: Eq>`), the resolver now validates that concrete type arguments satisfy those bounds before considering the impl block as a valid match.

- **Array Trait Implementations**: Updated `array.wado` to properly declare trait bounds on generic impl blocks:
  - `impl<T: Eq> Eq for Array<T>` - Array equality now requires element type to implement Eq
  - `impl<T: Ord> Ord for Array<T>` - Array comparison now requires element type to implement Ord

- **Test Coverage**: Added two new test fixtures to verify the trait bound checking:
  - `trait_bound_array_eq.wado` - Ensures Array<T> == fails when T doesn't implement Eq
  - `trait_bound_array_ord.wado` - Ensures Array<T> comparison fails when T doesn't implement Ord

## Implementation Details

The trait bound checking logic:
1. Collects all impl blocks that could potentially match the struct type
2. For each impl block with generic type parameters, extracts the trait bounds
3. Maps the bounds to the concrete type arguments provided
4. Validates that each concrete type argument satisfies its corresponding bounds
5. Only considers the impl block valid if all bounds are satisfied

https://claude.ai/code/session_018wd5Rq9TgkM5XNJGNq8eav