### PR TITLE
Expand language spec with shebang, control flow, and stdlib details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ The compiler is implemented in `wado-compiler/`.
 
 Standard libraries (a.k.a. stdlib) are implemented in `wado-compiler/lib`, with `wasi/` for WASI interface and `core/` for the core library.
 
-See `docs/compiler.md` in order to develop the compiler.
+See `docs/compiler.md` in order to develop the compiler. See `docs/optimizer.md` for optimization passes and future plans.
 
 Builtin functions that are directly mapped to wasm instructions or external functions are implemented in `wado-compiler/lib/core/builtin.wado`.
 

--- a/README.md
+++ b/README.md
@@ -10,33 +10,48 @@ Existing solutions bundle their own memory management runtime into every `.wasm`
 
 The timing matters too. With Wasm Component Model and WASI P3 maturing in 2026, Wado is designed from the ground up for this new era — no legacy baggage, no retrofitting.
 
-## Hello World
+## FizzBuzz
 
 ```wado
-#!/usr/bin/env wado run
 use { println, Stdout } from "core:cli";
 
-// run() is the entry point of the wasi:cli/command hosted world
+variant FizzBuzz {
+    Fizz,
+    Buzz,
+    FizzBuzz,
+    Number(i32),
+}
+
+fn classify(n: i32) -> FizzBuzz {
+    if n % 15 == 0 { return FizzBuzz::FizzBuzz; }
+    if n % 3 == 0 { return FizzBuzz::Fizz; }
+    if n % 5 == 0 { return FizzBuzz::Buzz; }
+    return FizzBuzz::Number(n);
+}
+
 export fn run() with Stdout {
-    println("Hello, world!");
+    for let mut i = 1; i <= 20; i += 1 {
+        println(match classify(i) {
+            Fizz => "Fizz",
+            Buzz => "Buzz",
+            FizzBuzz => "FizzBuzz",
+            Number(n) => `{n}`,
+        });
+    }
 }
 ```
 
 Run it:
 
 ```sh
-wado run example/hello.wado
+wado run example/fizzbuzz.wado
 ```
 
 Compile to WebAssembly:
 
 ```sh
-wado compile example/hello.wado # generates example/hello.wasm
-wado compile -o example/hello.wasm example/hello.wado # ditto
-wado compile --format wasm example/hello.wado # ditto
-
-wado compile --format wat example/hello.wado # generates example/hello.wat with WAT format
-wado compile -o example/hello.wat example/hello.wado  # ditto
+wado compile example/fizzbuzz.wado          # generates example/fizzbuzz.wasm
+wado compile --format wat example/fizzbuzz.wado  # generates example/fizzbuzz.wat
 ```
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -10,6 +10,35 @@ Existing solutions bundle their own memory management runtime into every `.wasm`
 
 The timing matters too. With Wasm Component Model and WASI P3 maturing in 2026, Wado is designed from the ground up for this new era — no legacy baggage, no retrofitting.
 
+## Hello World
+
+```wado
+#!/usr/bin/env wado run
+use { println, Stdout } from "core:cli";
+
+// run() is the entry point of the wasi:cli/command hosted world
+export fn run() with Stdout {
+    println("Hello, world!");
+}
+```
+
+Run it:
+
+```sh
+wado run example/hello.wado
+```
+
+Compile to WebAssembly:
+
+```sh
+wado compile example/hello.wado # generates example/hello.wasm
+wado compile -o example/hello.wasm example/hello.wado # ditto
+wado compile --format wasm example/hello.wado # ditto
+
+wado compile --format wat example/hello.wado # generates example/hello.wat with WAT format
+wado compile -o example/hello.wat example/hello.wado  # ditto
+```
+
 ## FizzBuzz
 
 ```wado
@@ -41,17 +70,8 @@ export fn run() with Stdout {
 }
 ```
 
-Run it:
-
 ```sh
 wado run example/fizzbuzz.wado
-```
-
-Compile to WebAssembly:
-
-```sh
-wado compile example/fizzbuzz.wado          # generates example/fizzbuzz.wasm
-wado compile --format wat example/fizzbuzz.wado  # generates example/fizzbuzz.wat
 ```
 
 ## Key Features

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1603,6 +1603,16 @@ struct Foo {
     secret: String, // won't be shown in debug stringify
 }
 
+// Inline hints for optimizer
+#[inline]              // hint: prefer inlining this function
+fn small_helper() -> i32 { return 42; }
+
+#[inline(always)]      // always inline (ignores threshold)
+fn critical_path() -> i32 { return 1; }
+
+#[inline(never)]       // never inline (useful for cold paths, debugging)
+fn error_handler() { panic("error"); }
+
 // Test attributes
 #[expect_trap]
 test "should panic" {

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -453,7 +453,7 @@ Variants are sum types with payloads (unlike enums which have no payloads):
 // Custom variant with unit and payload cases
 variant Shape {
     Circle(f64),           // radius
-    Rectangle(f64, f64),   // width, height
+    Rectangle([f64, f64]), // width, height (explicit tuple payload)
     Point,                 // no payload
 }
 
@@ -465,6 +465,7 @@ variant Maybe<T> {
 
 // Construction
 let c = Shape::Circle(5.0);
+let r = Shape::Rectangle([10.0, 20.0]);
 let p = Shape::Point;
 
 // Option and Result are defined as variants in core:prelude

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2,8 +2,6 @@
 
 Quick reference for Wado syntax.
 
-## Concepts
-
 ## Comments
 
 ```wado
@@ -71,6 +69,8 @@ let z: i64 = 100;       // with type annotation
 
 ## Global Variables
 
+See [WEP: Global Variables](./wep-2026-01-27-global-variables.md).
+
 ```wado
 // Module-level globals
 global PI: f64 = 3.14159;           // immutable
@@ -127,6 +127,8 @@ Result<T, E>            // result type
 
 ## Newtype
 
+See [WEP: Newtype Semantics](./wep-2026-01-29-newtype-semantics.md).
+
 ```wado
 type Meters = f64;
 type Kilometers = f64;
@@ -166,6 +168,8 @@ impl Location {
 ```
 
 ## Tuples and Arrays
+
+See [WEP: Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md).
 
 ```wado
 // Tuples
@@ -447,7 +451,7 @@ pub flags PathFlags {
 
 ## Variants
 
-Variants are sum types with payloads (unlike enums which have no payloads):
+Variants are sum types with payloads (unlike enums which have no payloads). See [WEP: Variant Payload Design](./wep-2026-01-25-variant-payload-design.md).
 
 ```wado
 // Custom variant with unit and payload cases
@@ -776,7 +780,7 @@ Note: `IndexValue` returns elements by value (copy) and panics if the index/key 
 
 ### Trait Bounds
 
-Type parameters can have trait bounds that constrain what types can be used:
+Type parameters can have trait bounds that constrain what types can be used. See [WEP: Trait Bounds Enforcement](./wep-2026-02-07-trait-bounds.md).
 
 ```wado
 // Struct with trait bound - T must implement Ord
@@ -977,7 +981,7 @@ let name = match color {
 let description = match value {
     Some(n) => {
         let doubled = n * 2;
-        return `value is {doubled}`;
+        `value is {doubled}`
     },
     None => "no value",
 };
@@ -1012,6 +1016,8 @@ if let Some(x) = opt {
 ```
 
 ## Operators
+
+See [WEP: Operator Precedence and Associativity](./wep-2026-01-11-operator-precedence.md) and [WEP: Operator Overloading](./wep-2026-01-18-operator-overloading.md).
 
 ```wado
 // Arithmetic
@@ -1077,6 +1083,8 @@ read(&mut y);         // OK: &mut i32 coerced to &i32
 ```
 
 ## Value Semantics
+
+See [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md).
 
 ```wado
 // Value types copy on assignment
@@ -1163,6 +1171,8 @@ pub use { foo as baz } from "./internal.wado"; // re-export with rename
 
 ## Effects
 
+See [WEP: Effect System Design](./wep-2026-01-27-effect-system-design.md).
+
 ```wado
 // Declare effect requirement
 fn write_file(path: String, data: String) with FileSystem {
@@ -1189,10 +1199,12 @@ fn for_each(items: Array<i32>, f: fn(i32) with Stdout) with Stdout {
 
 ## Reference Storage (`stores`)
 
+> Not yet implemented. See [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md).
+
 ```wado
 // Declare that function stores a reference parameter
 fn register(data: &Data) -> Handle with stores[data] {
-    registry.push(data);  // stores the reference
+    registry.append(data);  // stores the reference
     return new_handle();
 }
 
@@ -1203,7 +1215,7 @@ fn store_and_log(data: &Data) with Stdout, stores[data] {
 }
 
 // Functor type that stores its parameter
-fn take_storing(f: Fn(&Data) with stores[0]) { ... }
+fn take_storing(f: fn(&Data) with stores[0]) { ... }
 ```
 
 Note: `stores` is for function parameters. Closures use "capture" terminology (`|| x + 1` captures `x`).
@@ -1362,6 +1374,8 @@ let y = container.transform::<i32, i64>(10, 20 as i64);
 
 ## Closures
 
+See [WEP: Closure Implementation](./wep-2026-01-16-closure-implementation.md).
+
 ```wado
 // Pure closure (no captures) - expression body
 let add_one = |x: i32| x + 1;
@@ -1409,7 +1423,7 @@ println(`{get()}`);  // 2
 
 ## Iterators
 
-Wado provides iterator traits for generic iteration over collections.
+Wado provides iterator traits for generic iteration over collections. See [WEP: Iterator Traits Design](./wep-2026-01-24-iterator-traits.md).
 
 ### Iterator Traits
 
@@ -1620,4 +1634,6 @@ Wado intentionally does not support macros.
 
 ## See Also
 
+- [Language Specification](./spec.md) - Full language specification
+- [Wado Evolution Proposals](../CLAUDE.md#wado-evolution-proposals-wep) - Design decisions and rationale
 - [wado-compiler/tests/fixtures/\*.wado](wado-compiler/tests/fixtures) - E2E test fixtures

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -789,16 +789,16 @@ Eq::eq(&a, &b)
 
 ```wado
 // a < b desugars to:
-Ord::lt(&a, &b)
-
-// a <= b desugars to:
-Ord::lt(&a, &b) || Eq::eq(&a, &b)
+Ord::cmp(&a, &b) == Ordering::Less
 
 // a > b desugars to:
-Ord::lt(&b, &a)
+Ord::cmp(&a, &b) == Ordering::Greater
+
+// a <= b desugars to:
+Ord::cmp(&a, &b) != Ordering::Greater
 
 // a >= b desugars to:
-Ord::lt(&b, &a) || Eq::eq(&a, &b)
+Ord::cmp(&a, &b) != Ordering::Less
 ```
 
 **Resolution:**

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -7,7 +7,7 @@ This document describes the Wado compiler architecture and implementation status
 The compiler follows a multi-phase pipeline:
 
 ```
-Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve → Effect Check → Synthesis → Monomorphize → Lower → Optimize → WIR Build → Codegen
+Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve → Effect Check → Synthesis → Monomorphize → Lower → Optimize → WIR Build → WIR Optimize → Codegen
 ```
 
 ### Compilation Pipeline
@@ -24,59 +24,66 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 | Synthesis    | Project       | Project         | Enum traits, inspect debug output, CM adapter synthesis   |
 | Monomorphize | Project       | Project         | Instantiate generics with concrete types                  |
 | Lower        | Project       | Project         | Closure, i128 match, global init, string literal lowering |
-| Optimize     | Project       | Project         | Inlining, copy-prop, LICM, DCE, post-opt rewrite          |
+| Optimize     | Project       | Project         | Inlining, copy-prop, LICM, DCE, post-opt rewrite         |
 | WIR Build    | Project       | WirModule       | Planning + TIR → WIR (Wasm IR) translation                |
+| WIR Optimize | WirModule     | WirModule       | Multi-value SROA, array data promotion, peephole          |
 | Codegen      | WirModule     | Wasm bytes      | WIR emission to core Wasm + Component Model wrapping      |
 
 **Note:** The Desugar phase is integrated into the Load phase. Each module goes through the same frontend pipeline: `lexer → parser → bind → desugar`.
 
 ### Modules
 
-| Module            | File                      | Description                                               |
-| ----------------- | ------------------------- | --------------------------------------------------------- |
-| Lexer             | `lexer.rs`                | Tokenizes source code, extracts `__DATA__` section        |
-| Parser            | `parser.rs`               | Recursive descent parser, builds AST                      |
-| AST               | `ast.rs`                  | AST node definitions, `Module::data_section()` API        |
-| Token             | `token.rs`                | Token types and spans                                     |
-| Comment           | `comment.rs`              | Comment collection and CommentMap for formatting          |
-| Bind              | `bind.rs`                 | Local name binding, scope analysis, mutability check      |
-| Loader            | `loader.rs`               | Module loading, dependency resolution                     |
-| Desugar           | `desugar.rs`              | AST transformations (compound assign, etc.)               |
-| EffectCheck       | `effect_check.rs`         | Validates effect requirements for function calls          |
-| Unparser          | `unparse.rs`              | Converts AST/TIR back to source code                      |
-| Analyzer          | `analyze.rs`              | Semantic analysis, symbol table construction              |
-| Symbol            | `symbol.rs`               | Symbol table data structures                              |
-| Name              | `name.rs`                 | Name mangling utilities for methods and symbols           |
-| Resolver          | `resolver.rs`             | Type resolution, AST to TIR, produces Project             |
-| TIR               | `tir.rs`                  | Typed Intermediate Representation                         |
-| Synthesis         | `synthesis.rs`            | Unified synthesis phase (`synthesis/`)                    |
-| SynthCommon       | `synthesis/common.rs`     | Shared TIR builders for synthesis phases                  |
-| SynthTraits       | `synthesis/traits.rs`     | Auto-derived Eq/Ord for enum types                        |
-| SynthInspect      | `synthesis/inspect.rs`    | Inspect debug output synthesis (type→TIR)                 |
-| SynthCmAdapter    | `synthesis/cm_adapter.rs` | CM boundary adapter synthesis (TIR functions)             |
-| CmAbi             | `cm_abi.rs`               | Canonical ABI layout computation                          |
-| Monomorphize      | `monomorphize.rs`         | Generic type/function instantiation (Project→Project)     |
-| Lower             | `lower.rs`                | Closure, i128 match, global init, string lowering         |
-| Project           | `project.rs`              | Project: compilation context passed through pipeline      |
-| Optimize          | `optimize.rs`             | Optimization coordinator, dispatches to sub-modules       |
-| OptimizeConstFold | `optimize_const_fold.rs`  | Constant folding for integer arithmetic                   |
-| OptimizeDCE       | `optimize_dce.rs`         | Dead code elimination via reachability analysis           |
-| OptimizeInline    | `optimize_inline.rs`      | Function inlining for small, pure functions               |
-| OptimizeRefElim   | `optimize_ref_elim.rs`    | Reference elimination after inlining                      |
-| OptimizeCopyProp  | `optimize_copy_prop.rs`   | Copy propagation for trivial bindings                     |
-| OptimizeLICM      | `optimize_licm.rs`        | Loop-invariant code motion                                |
-| OptimizeRewrite   | `optimize_rewrite.rs`     | Select lowering, move insertion, copy type collection     |
-| OptimizeSROA      | `optimize_sroa.rs`        | Scalar replacement of aggregates (struct/tuple elim)      |
-| WasmPlan          | `wasm_plan.rs`            | `ComponentPlan` types and `build_component_plan`          |
-| Stdlib            | `stdlib.rs`               | Embedded core library sources                             |
-| ComponentModel    | `component_model.rs`      | WASI import registry and CM ABI type support              |
-| BuiltinRegistry   | `builtin_registry.rs`     | Builtin function registry from `core:builtin`             |
-| WorldRegistry     | `world_registry.rs`       | World definitions registry for export signatures          |
-| WIR               | `wir.rs`                  | Wasm IR data structures                                   |
-| WIR Unparse       | `wir_unparse.rs`          | WIR → pseudo-Wado source code for debugging               |
-| WIR Build         | `wir_build.rs`            | Planning + TIR→WIR translation (`wir_build/`)             |
-| Codegen           | `codegen.rs`              | WIR→Wasm emission + Component Model wrapping (`codegen/`) |
-| Bundled           | `bundled.rs`              | Loads pre-compiled Wasm builtins (wado-bundled)           |
+| Module         | File                      | Description                                               |
+| -------------- | ------------------------- | --------------------------------------------------------- |
+| Lexer          | `lexer.rs`                | Tokenizes source code, extracts `__DATA__` section        |
+| Parser         | `parser.rs`               | Recursive descent parser, builds AST                      |
+| AST            | `ast.rs`                  | AST node definitions, `Module::data_section()` API        |
+| Token          | `token.rs`                | Token types and spans                                     |
+| Syntax         | `syntax.rs`               | Syntax definitions (keywords, operators)                  |
+| Comment        | `comment.rs`              | Comment collection and CommentMap for formatting          |
+| Bind           | `bind.rs`                 | Local name binding, scope analysis, mutability check      |
+| Loader         | `loader.rs`               | Module loading, dependency resolution                     |
+| Desugar        | `desugar.rs`              | AST transformations (compound assign, etc.)               |
+| EffectCheck    | `effect_check.rs`         | Validates effect requirements for function calls          |
+| Unparser       | `unparse.rs`              | Converts AST/TIR back to source code                     |
+| Analyzer       | `analyze.rs`              | Semantic analysis, symbol table construction              |
+| Symbol         | `symbol.rs`               | Symbol table data structures                              |
+| Name           | `name.rs`                 | Name mangling utilities for methods and symbols           |
+| Resolver       | `resolver.rs`             | Type resolution, AST to TIR, produces Project (`resolver/`) |
+| TIR            | `tir.rs`                  | Typed Intermediate Representation                         |
+| Synthesis      | `synthesis.rs`            | Unified synthesis phase (`synthesis/`)                    |
+| SynthCommon    | `synthesis/common.rs`     | Shared TIR builders for synthesis phases                  |
+| SynthTraits    | `synthesis/traits.rs`     | Auto-derived Eq/Ord for enum types                        |
+| SynthInspect   | `synthesis/inspect.rs`    | Inspect debug output synthesis (type→TIR)                 |
+| SynthCmAdapter | `synthesis/cm_adapter.rs` | CM boundary adapter synthesis (TIR functions)             |
+| CmAbi          | `cm_abi.rs`               | Canonical ABI layout computation                          |
+| Monomorphize   | `monomorphize.rs`         | Generic type/function instantiation (Project→Project)     |
+| Lower          | `lower.rs`                | Closure, i128 match, global init, string lowering         |
+| Project        | `project.rs`              | Project: compilation context passed through pipeline      |
+| Optimize       | `optimize.rs`             | Optimization coordinator (`optimize/`)                    |
+| ConstFold      | `optimize/const_fold.rs`  | Constant folding for integer/float arithmetic             |
+| ConstProp      | `optimize/const_prop.rs`  | Constant propagation for immutable globals                |
+| ConstGlobal    | `optimize/const_global_promotion.rs` | Promote runtime globals to compile-time constants |
+| DCE            | `optimize/dce.rs`         | Dead code elimination via reachability analysis           |
+| Inline         | `optimize/inline.rs`      | Function inlining for small, pure functions               |
+| RefElim        | `optimize/ref_elim.rs`    | Reference elimination after inlining                      |
+| CopyProp       | `optimize/copy_prop.rs`   | Copy propagation for trivial bindings                     |
+| SROA           | `optimize/sroa.rs`        | Scalar replacement of aggregates (struct/tuple elim)      |
+| LICM           | `optimize/licm.rs`        | Loop-invariant code motion                                |
+| Rewrite        | `optimize/rewrite.rs`     | Select lowering, move insertion, block simplification     |
+| WasmPlan       | `wasm_plan.rs`            | `ComponentPlan` types and `build_component_plan`          |
+| Stdlib         | `stdlib.rs`               | Embedded core library sources                             |
+| CompilerHost   | `compiler_host.rs`        | I/O abstraction for the compiler                          |
+| Logger         | `logger.rs`               | Diagnostic logging with timestamps                        |
+| ComponentModel | `component_model.rs`      | WASI import registry and CM ABI type support              |
+| BuiltinRegistry | `builtin_registry.rs`    | Builtin function registry from `core:builtin`             |
+| WorldRegistry  | `world_registry.rs`       | World definitions registry for export signatures          |
+| WIR            | `wir.rs`                  | Wasm IR data structures                                   |
+| WIR Unparse    | `wir_unparse.rs`          | WIR → pseudo-Wado source code for debugging               |
+| WIR Build      | `wir_build.rs`            | Planning + TIR→WIR translation (`wir_build/`)             |
+| WIR Optimize   | `wir_optimize.rs`         | WIR-level optimizations (multi-value SROA, etc.)          |
+| Codegen        | `codegen.rs`              | WIR→Wasm emission + Component Model wrapping (`codegen/`) |
+| Bundled        | `bundled.rs`              | Loads pre-compiled Wasm builtins (wado-bundled-libm)      |
 
 ---
 
@@ -130,26 +137,13 @@ fn run() with Stdout {
 }
 ```
 
-### Bundled Builtins (wado-bundled)
+### Bundled Library (wado-bundled-libm)
 
-The `wado-bundled` crate provides pre-compiled Wasm functions for operations that are complex to implement in pure Wasm instructions. These are statically linked into the generated component.
+The `wado-bundled-libm` crate provides pre-compiled Wasm math functions (deterministic libm). These are statically linked into the generated component.
 
-**Location:** `wado-bundled/` (compiles to `wasm32-unknown-unknown`)
+**Location:** `wado-bundled-libm/` (compiles to `wasm32-unknown-unknown`)
 
-**Current Functions:**
-
-| Function        | Signature           | Description                          |
-| --------------- | ------------------- | ------------------------------------ |
-| `f64_to_buffer` | `(f64, i32) -> i32` | Format f64 to buffer, returns length |
-| `f32_to_buffer` | `(f32, i32) -> i32` | Format f32 to buffer, returns length |
-
-**Build Process:**
-
-```bash
-make update-bundled   # Rebuild wado-bundled.wat from Rust source
-```
-
-The bundled module is stored as WAT in `wado-compiler/lib/builtins/wado-bundled.wat` for version control visibility. It's parsed at compile time using the `wat` crate.
+Float-to-string formatting was previously a bundled Wasm module but is now implemented in pure Wado (`core:prelude/fpfmt.wado`).
 
 ### Monomorphization
 
@@ -217,21 +211,26 @@ Embedded `.wado` files in `wado-compiler/lib/`:
 | `core:prelude/array.wado`      | `prelude/array.wado`      | Array type and array iterators                     |
 | `core:prelude/int128.wado`     | `prelude/int128.wado`     | u128/i128 types (re-exported from prelude)         |
 | `core:prelude/primitives.wado` | `prelude/primitives.wado` | Primitive type trait implementations               |
+| `core:prelude/format.wado`     | `prelude/format.wado`     | Format traits (Display, Formatter)                 |
+| `core:prelude/fpfmt.wado`      | `prelude/fpfmt.wado`      | Float-to-string formatting (pure Wado)             |
 | `core:cli`                     | `cli.wado`                | CLI output (println, eprintln, etc.)               |
 | `core:clocks`                  | `clocks.wado`             | MonotonicClock, now()                              |
 | `core:stream`                  | `stream.wado`             | Stream utilities                                   |
 | `core:collections`             | `collections.wado`        | TreeMap and other collections                      |
+| `core:zlib`                    | `zlib.wado`               | Compression (zlib/deflate)                         |
 | `core:internal`                | `internal.wado`           | Compiler-generated code support, panic/unreachable |
 | `core:builtin`                 | `builtin.wado`            | Compiler intrinsics with `#[canonical(...)]` attrs |
 
 **WASI Library (`wasi/`):**
 
-| Module            | File              | Description      |
-| ----------------- | ----------------- | ---------------- |
-| `wasi:io`         | `io.wado`         | I/O interfaces   |
-| `wasi:cli`        | `cli.wado`        | CLI interfaces   |
-| `wasi:clocks`     | `clocks.wado`     | Clock interfaces |
-| `wasi:filesystem` | `filesystem.wado` | FS interfaces    |
+| Module            | File              | Description         |
+| ----------------- | ----------------- | ------------------- |
+| `wasi:cli`        | `cli.wado`        | CLI interfaces      |
+| `wasi:clocks`     | `clocks.wado`     | Clock interfaces    |
+| `wasi:filesystem` | `filesystem.wado` | FS interfaces       |
+| `wasi:http`       | `http.wado`       | HTTP interfaces     |
+| `wasi:random`     | `random.wado`     | Random interfaces   |
+| `wasi:sockets`    | `sockets.wado`    | Socket interfaces   |
 
 ### Standard Library Tests
 
@@ -369,34 +368,40 @@ The `BuiltinRegistry` module (`builtin_registry.rs`) collects function signature
 
 Builtins in `builtin.wado` are divided into two categories:
 
-1. **Canonical builtins** - Functions with `#[canonical("name")]` attribute are imported as Component Model canonical built-ins
+1. **Canonical builtins** - Functions with `#[canonical("namespace", "name")]` attribute are imported as Component Model canonical built-ins
 2. **Instruction builtins** - Functions without the attribute compile directly to Wasm instructions
 
 ```wado
 // Canonical builtin - imported as CM function "stream-new"
-#[canonical("stream-new")]
+#[canonical("wasi", "stream-new")]
 fn stream_new() -> i64;
 
 // Instruction builtin - compiles to Wasm i32.and instruction
 fn i32_and(a: i32, b: i32) -> i32;
 ```
 
-**Canonical Builtins (12 functions):**
+**Canonical Builtins:**
 
-| Wado Name              | Canonical Name         | Category         |
-| ---------------------- | ---------------------- | ---------------- |
-| `stream_new`           | `stream-new`           | Stream           |
-| `stream_write`         | `stream-write`         | Stream           |
-| `stream_drop_writable` | `stream-drop-writable` | Stream           |
-| `stream_drop_readable` | `stream-drop-readable` | Stream           |
-| `task_return`          | `task-return`          | Async task       |
-| `waitable_set_new`     | `waitable-set-new`     | Async task       |
-| `waitable_join`        | `waitable-join`        | Async task       |
-| `waitable_set_wait`    | `waitable-set-wait`    | Async task       |
-| `subtask_drop`         | `subtask-drop`         | Async task       |
-| `realloc`              | `realloc`              | Memory (bundled) |
-| `f64_to_buffer`        | `f64_to_buffer`        | Float (bundled)  |
-| `f32_to_buffer`        | `f32_to_buffer`        | Float (bundled)  |
+Builtins with `#[canonical("namespace", "name")]` are imported as CM canonical built-ins. The namespace determines the import source: `"wasi"` for CM canonical builtins, `"mem"` for memory operations, `"bundled"` for wado-bundled-libm.
+
+| Wado Name              | Namespace  | Canonical Name         | Category       |
+| ---------------------- | ---------- | ---------------------- | -------------- |
+| `stream_new`           | `wasi`     | `stream-new`           | Stream         |
+| `stream_read`          | `wasi`     | `stream-read`          | Stream         |
+| `stream_write`         | `wasi`     | `stream-write`         | Stream         |
+| `stream_drop_writable` | `wasi`     | `stream-drop-writable` | Stream         |
+| `stream_drop_readable` | `wasi`     | `stream-drop-readable` | Stream         |
+| `future_new`           | `wasi`     | `future-new`           | Future         |
+| `future_write`         | `wasi`     | `future-write`         | Future         |
+| `future_drop_writable` | `wasi`     | `future-drop-writable` | Future         |
+| `future_drop_readable` | `wasi`     | `future-drop-readable` | Future         |
+| `task_return`          | `wasi`     | `task-return`          | Async task     |
+| `waitable_set_new`     | `wasi`     | `waitable-set-new`     | Async task     |
+| `waitable_join`        | `wasi`     | `waitable-join`        | Async task     |
+| `waitable_set_wait`    | `wasi`     | `waitable-set-wait`    | Async task     |
+| `subtask_drop`         | `wasi`     | `subtask-drop`         | Async task     |
+| `realloc`              | `mem`      | `realloc`              | Memory         |
+| `libm_sin`, etc.       | `bundled`  | `libm_sin`, etc.       | Math (libm)    |
 
 **Instruction Builtins:**
 
@@ -1581,12 +1586,8 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 
 ### Partial Implementations
 
-- **Template strings**: Syntax and basic interpolation work. Format specifiers (`.2f`, `0.3f`, etc.) are parsed but not implemented in codegen.
 - **Variant pattern matching**: Single-payload and tuple-payload cases work (`if let Circle(r) = shape`, `if let Rect([w, h]) = shape`). Struct payloads not yet supported. See [WEP: Variant Payload Design](./wep-2026-01-25-variant-payload-design.md).
-- **`core:prelude`**: Partial (parser doesn't support generic resources)
-- **Function types**: Parser supports `Fn(T) -> U` syntax, basic closure codegen works, but full function type support is incomplete.
-- **`flags` declarations**: Fully implemented as newtypes over `u32`. Members resolve to bitmask literals (`1 << index`); `none()`/`all()` are special static methods; bitwise operators (`|`, `&`, `^`) work via newtype inheritance; arithmetic operators are rejected at compile time. WASI flags types are emitted as CM `flags` in instance types.
-- **Inner attributes (`#![...]`)**: Parser supports inner attributes like `#![no_prelude]`, used in semantic analysis.
+- **Function types**: Parser supports `fn(T) -> U` syntax, closure codegen works (both pure and capturing), but full function type support is incomplete.
 
 ### Known Limitations
 
@@ -1595,7 +1596,6 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 3. **No type checking**: The analyzer doesn't perform type checking yet
 4. **GC arrays cannot be passed directly to streams**: As of wasmtime v40, `stream<u8>` operations require linear memory. GC arrays must be copied to linear memory before writing to streams. See [component-model#525](https://github.com/WebAssembly/component-model/issues/525)
 5. **Non-pub functions from other modules are skipped**: The codegen currently only includes `pub` functions from imported modules (`core::*`). Internal helper functions must be marked `pub` to be included in compilation. This limitation could be addressed later with proper internal dependency tracking.
-6. **Auto-deref doesn't work on `&Array<T>`**: Method calls like `arr_ref.len()` where `arr_ref: &Array<i32>` fail with "unknown function: Array<i32>::len". This is due to how Array methods are resolved with monomorphized type names after auto-deref. Workaround: dereference explicitly `(*arr_ref).len()`.
 
 ---
 
@@ -1605,11 +1605,6 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 
 - Range expressions
 - `?` operator (error propagation)
-
-### Patterns
-
-- Literal patterns
-- Struct patterns
 
 ### Semantic Analysis
 
@@ -1622,15 +1617,7 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 ### Code Generation
 
 - Custom variant pattern matching (struct payloads, see WEP)
-- Closures - with captures (see WEP)
 - Effect handlers
-- Template string format specifiers (`.2f`, etc.)
 - Value semantics for Result<T, E> (blocked on Result codegen)
-- String UTF-8 validation (reject invalid byte sequences at construction)
-- Reactive signals (source values)
-- Reactive signals (derived values)
-- Reactive effect blocks (syntax TBD)
-- Reactive references (`&reactive T`)
-- Multiple modules/files
-- Other WASI interfaces (filesystem, etc.)
+- Reactive signals (source values, derived values, effect blocks)
 - Generic function/method type inference

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -24,7 +24,7 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 | Synthesis    | Project       | Project         | Enum traits, inspect debug output, CM adapter synthesis   |
 | Monomorphize | Project       | Project         | Instantiate generics with concrete types                  |
 | Lower        | Project       | Project         | Closure, i128 match, global init, string literal lowering |
-| Optimize     | Project       | Project         | Inlining, copy-prop, LICM, DCE, post-opt rewrite         |
+| Optimize     | Project       | Project         | Inlining, copy-prop, LICM, DCE, post-opt rewrite          |
 | WIR Build    | Project       | WirModule       | Planning + TIR → WIR (Wasm IR) translation                |
 | WIR Optimize | WirModule     | WirModule       | Multi-value SROA, array data promotion, peephole          |
 | Codegen      | WirModule     | Wasm bytes      | WIR emission to core Wasm + Component Model wrapping      |
@@ -33,57 +33,57 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 
 ### Modules
 
-| Module         | File                      | Description                                               |
-| -------------- | ------------------------- | --------------------------------------------------------- |
-| Lexer          | `lexer.rs`                | Tokenizes source code, extracts `__DATA__` section        |
-| Parser         | `parser.rs`               | Recursive descent parser, builds AST                      |
-| AST            | `ast.rs`                  | AST node definitions, `Module::data_section()` API        |
-| Token          | `token.rs`                | Token types and spans                                     |
-| Syntax         | `syntax.rs`               | Syntax definitions (keywords, operators)                  |
-| Comment        | `comment.rs`              | Comment collection and CommentMap for formatting          |
-| Bind           | `bind.rs`                 | Local name binding, scope analysis, mutability check      |
-| Loader         | `loader.rs`               | Module loading, dependency resolution                     |
-| Desugar        | `desugar.rs`              | AST transformations (compound assign, etc.)               |
-| EffectCheck    | `effect_check.rs`         | Validates effect requirements for function calls          |
-| Unparser       | `unparse.rs`              | Converts AST/TIR back to source code                     |
-| Analyzer       | `analyze.rs`              | Semantic analysis, symbol table construction              |
-| Symbol         | `symbol.rs`               | Symbol table data structures                              |
-| Name           | `name.rs`                 | Name mangling utilities for methods and symbols           |
-| Resolver       | `resolver.rs`             | Type resolution, AST to TIR, produces Project (`resolver/`) |
-| TIR            | `tir.rs`                  | Typed Intermediate Representation                         |
-| Synthesis      | `synthesis.rs`            | Unified synthesis phase (`synthesis/`)                    |
-| SynthCommon    | `synthesis/common.rs`     | Shared TIR builders for synthesis phases                  |
-| SynthTraits    | `synthesis/traits.rs`     | Auto-derived Eq/Ord for enum types                        |
-| SynthInspect   | `synthesis/inspect.rs`    | Inspect debug output synthesis (type→TIR)                 |
-| SynthCmAdapter | `synthesis/cm_adapter.rs` | CM boundary adapter synthesis (TIR functions)             |
-| CmAbi          | `cm_abi.rs`               | Canonical ABI layout computation                          |
-| Monomorphize   | `monomorphize.rs`         | Generic type/function instantiation (Project→Project)     |
-| Lower          | `lower.rs`                | Closure, i128 match, global init, string lowering         |
-| Project        | `project.rs`              | Project: compilation context passed through pipeline      |
-| Optimize       | `optimize.rs`             | Optimization coordinator (`optimize/`)                    |
-| ConstFold      | `optimize/const_fold.rs`  | Constant folding for integer/float arithmetic             |
-| ConstProp      | `optimize/const_prop.rs`  | Constant propagation for immutable globals                |
-| ConstGlobal    | `optimize/const_global_promotion.rs` | Promote runtime globals to compile-time constants |
-| DCE            | `optimize/dce.rs`         | Dead code elimination via reachability analysis           |
-| Inline         | `optimize/inline.rs`      | Function inlining for small, pure functions               |
-| RefElim        | `optimize/ref_elim.rs`    | Reference elimination after inlining                      |
-| CopyProp       | `optimize/copy_prop.rs`   | Copy propagation for trivial bindings                     |
-| SROA           | `optimize/sroa.rs`        | Scalar replacement of aggregates (struct/tuple elim)      |
-| LICM           | `optimize/licm.rs`        | Loop-invariant code motion                                |
-| Rewrite        | `optimize/rewrite.rs`     | Select lowering, move insertion, block simplification     |
-| WasmPlan       | `wasm_plan.rs`            | `ComponentPlan` types and `build_component_plan`          |
-| Stdlib         | `stdlib.rs`               | Embedded core library sources                             |
-| CompilerHost   | `compiler_host.rs`        | I/O abstraction for the compiler                          |
-| Logger         | `logger.rs`               | Diagnostic logging with timestamps                        |
-| ComponentModel | `component_model.rs`      | WASI import registry and CM ABI type support              |
-| BuiltinRegistry | `builtin_registry.rs`    | Builtin function registry from `core:builtin`             |
-| WorldRegistry  | `world_registry.rs`       | World definitions registry for export signatures          |
-| WIR            | `wir.rs`                  | Wasm IR data structures                                   |
-| WIR Unparse    | `wir_unparse.rs`          | WIR → pseudo-Wado source code for debugging               |
-| WIR Build      | `wir_build.rs`            | Planning + TIR→WIR translation (`wir_build/`)             |
-| WIR Optimize   | `wir_optimize.rs`         | WIR-level optimizations (multi-value SROA, etc.)          |
-| Codegen        | `codegen.rs`              | WIR→Wasm emission + Component Model wrapping (`codegen/`) |
-| Bundled        | `bundled.rs`              | Loads pre-compiled Wasm builtins (wado-bundled-libm)      |
+| Module          | File                                 | Description                                                 |
+| --------------- | ------------------------------------ | ----------------------------------------------------------- |
+| Lexer           | `lexer.rs`                           | Tokenizes source code, extracts `__DATA__` section          |
+| Parser          | `parser.rs`                          | Recursive descent parser, builds AST                        |
+| AST             | `ast.rs`                             | AST node definitions, `Module::data_section()` API          |
+| Token           | `token.rs`                           | Token types and spans                                       |
+| Syntax          | `syntax.rs`                          | Syntax definitions (keywords, operators)                    |
+| Comment         | `comment.rs`                         | Comment collection and CommentMap for formatting            |
+| Bind            | `bind.rs`                            | Local name binding, scope analysis, mutability check        |
+| Loader          | `loader.rs`                          | Module loading, dependency resolution                       |
+| Desugar         | `desugar.rs`                         | AST transformations (compound assign, etc.)                 |
+| EffectCheck     | `effect_check.rs`                    | Validates effect requirements for function calls            |
+| Unparser        | `unparse.rs`                         | Converts AST/TIR back to source code                        |
+| Analyzer        | `analyze.rs`                         | Semantic analysis, symbol table construction                |
+| Symbol          | `symbol.rs`                          | Symbol table data structures                                |
+| Name            | `name.rs`                            | Name mangling utilities for methods and symbols             |
+| Resolver        | `resolver.rs`                        | Type resolution, AST to TIR, produces Project (`resolver/`) |
+| TIR             | `tir.rs`                             | Typed Intermediate Representation                           |
+| Synthesis       | `synthesis.rs`                       | Unified synthesis phase (`synthesis/`)                      |
+| SynthCommon     | `synthesis/common.rs`                | Shared TIR builders for synthesis phases                    |
+| SynthTraits     | `synthesis/traits.rs`                | Auto-derived Eq/Ord for enum types                          |
+| SynthInspect    | `synthesis/inspect.rs`               | Inspect debug output synthesis (type→TIR)                   |
+| SynthCmAdapter  | `synthesis/cm_adapter.rs`            | CM boundary adapter synthesis (TIR functions)               |
+| CmAbi           | `cm_abi.rs`                          | Canonical ABI layout computation                            |
+| Monomorphize    | `monomorphize.rs`                    | Generic type/function instantiation (Project→Project)       |
+| Lower           | `lower.rs`                           | Closure, i128 match, global init, string lowering           |
+| Project         | `project.rs`                         | Project: compilation context passed through pipeline        |
+| Optimize        | `optimize.rs`                        | Optimization coordinator (`optimize/`)                      |
+| ConstFold       | `optimize/const_fold.rs`             | Constant folding for integer/float arithmetic               |
+| ConstProp       | `optimize/const_prop.rs`             | Constant propagation for immutable globals                  |
+| ConstGlobal     | `optimize/const_global_promotion.rs` | Promote runtime globals to compile-time constants           |
+| DCE             | `optimize/dce.rs`                    | Dead code elimination via reachability analysis             |
+| Inline          | `optimize/inline.rs`                 | Function inlining for small, pure functions                 |
+| RefElim         | `optimize/ref_elim.rs`               | Reference elimination after inlining                        |
+| CopyProp        | `optimize/copy_prop.rs`              | Copy propagation for trivial bindings                       |
+| SROA            | `optimize/sroa.rs`                   | Scalar replacement of aggregates (struct/tuple elim)        |
+| LICM            | `optimize/licm.rs`                   | Loop-invariant code motion                                  |
+| Rewrite         | `optimize/rewrite.rs`                | Select lowering, move insertion, block simplification       |
+| WasmPlan        | `wasm_plan.rs`                       | `ComponentPlan` types and `build_component_plan`            |
+| Stdlib          | `stdlib.rs`                          | Embedded core library sources                               |
+| CompilerHost    | `compiler_host.rs`                   | I/O abstraction for the compiler                            |
+| Logger          | `logger.rs`                          | Diagnostic logging with timestamps                          |
+| ComponentModel  | `component_model.rs`                 | WASI import registry and CM ABI type support                |
+| BuiltinRegistry | `builtin_registry.rs`                | Builtin function registry from `core:builtin`               |
+| WorldRegistry   | `world_registry.rs`                  | World definitions registry for export signatures            |
+| WIR             | `wir.rs`                             | Wasm IR data structures                                     |
+| WIR Unparse     | `wir_unparse.rs`                     | WIR → pseudo-Wado source code for debugging                 |
+| WIR Build       | `wir_build.rs`                       | Planning + TIR→WIR translation (`wir_build/`)               |
+| WIR Optimize    | `wir_optimize.rs`                    | WIR-level optimizations (multi-value SROA, etc.)            |
+| Codegen         | `codegen.rs`                         | WIR→Wasm emission + Component Model wrapping (`codegen/`)   |
+| Bundled         | `bundled.rs`                         | Loads pre-compiled Wasm builtins (wado-bundled-libm)        |
 
 ---
 
@@ -223,14 +223,14 @@ Embedded `.wado` files in `wado-compiler/lib/`:
 
 **WASI Library (`wasi/`):**
 
-| Module            | File              | Description         |
-| ----------------- | ----------------- | ------------------- |
-| `wasi:cli`        | `cli.wado`        | CLI interfaces      |
-| `wasi:clocks`     | `clocks.wado`     | Clock interfaces    |
-| `wasi:filesystem` | `filesystem.wado` | FS interfaces       |
-| `wasi:http`       | `http.wado`       | HTTP interfaces     |
-| `wasi:random`     | `random.wado`     | Random interfaces   |
-| `wasi:sockets`    | `sockets.wado`    | Socket interfaces   |
+| Module            | File              | Description       |
+| ----------------- | ----------------- | ----------------- |
+| `wasi:cli`        | `cli.wado`        | CLI interfaces    |
+| `wasi:clocks`     | `clocks.wado`     | Clock interfaces  |
+| `wasi:filesystem` | `filesystem.wado` | FS interfaces     |
+| `wasi:http`       | `http.wado`       | HTTP interfaces   |
+| `wasi:random`     | `random.wado`     | Random interfaces |
+| `wasi:sockets`    | `sockets.wado`    | Socket interfaces |
 
 ### Standard Library Tests
 
@@ -384,24 +384,24 @@ fn i32_and(a: i32, b: i32) -> i32;
 
 Builtins with `#[canonical("namespace", "name")]` are imported as CM canonical built-ins. The namespace determines the import source: `"wasi"` for CM canonical builtins, `"mem"` for memory operations, `"bundled"` for wado-bundled-libm.
 
-| Wado Name              | Namespace  | Canonical Name         | Category       |
-| ---------------------- | ---------- | ---------------------- | -------------- |
-| `stream_new`           | `wasi`     | `stream-new`           | Stream         |
-| `stream_read`          | `wasi`     | `stream-read`          | Stream         |
-| `stream_write`         | `wasi`     | `stream-write`         | Stream         |
-| `stream_drop_writable` | `wasi`     | `stream-drop-writable` | Stream         |
-| `stream_drop_readable` | `wasi`     | `stream-drop-readable` | Stream         |
-| `future_new`           | `wasi`     | `future-new`           | Future         |
-| `future_write`         | `wasi`     | `future-write`         | Future         |
-| `future_drop_writable` | `wasi`     | `future-drop-writable` | Future         |
-| `future_drop_readable` | `wasi`     | `future-drop-readable` | Future         |
-| `task_return`          | `wasi`     | `task-return`          | Async task     |
-| `waitable_set_new`     | `wasi`     | `waitable-set-new`     | Async task     |
-| `waitable_join`        | `wasi`     | `waitable-join`        | Async task     |
-| `waitable_set_wait`    | `wasi`     | `waitable-set-wait`    | Async task     |
-| `subtask_drop`         | `wasi`     | `subtask-drop`         | Async task     |
-| `realloc`              | `mem`      | `realloc`              | Memory         |
-| `libm_sin`, etc.       | `bundled`  | `libm_sin`, etc.       | Math (libm)    |
+| Wado Name              | Namespace | Canonical Name         | Category    |
+| ---------------------- | --------- | ---------------------- | ----------- |
+| `stream_new`           | `wasi`    | `stream-new`           | Stream      |
+| `stream_read`          | `wasi`    | `stream-read`          | Stream      |
+| `stream_write`         | `wasi`    | `stream-write`         | Stream      |
+| `stream_drop_writable` | `wasi`    | `stream-drop-writable` | Stream      |
+| `stream_drop_readable` | `wasi`    | `stream-drop-readable` | Stream      |
+| `future_new`           | `wasi`    | `future-new`           | Future      |
+| `future_write`         | `wasi`    | `future-write`         | Future      |
+| `future_drop_writable` | `wasi`    | `future-drop-writable` | Future      |
+| `future_drop_readable` | `wasi`    | `future-drop-readable` | Future      |
+| `task_return`          | `wasi`    | `task-return`          | Async task  |
+| `waitable_set_new`     | `wasi`    | `waitable-set-new`     | Async task  |
+| `waitable_join`        | `wasi`    | `waitable-join`        | Async task  |
+| `waitable_set_wait`    | `wasi`    | `waitable-set-wait`    | Async task  |
+| `subtask_drop`         | `wasi`    | `subtask-drop`         | Async task  |
+| `realloc`              | `mem`     | `realloc`              | Memory      |
+| `libm_sin`, etc.       | `bundled` | `libm_sin`, etc.       | Math (libm) |
 
 **Instruction Builtins:**
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -870,12 +870,19 @@ builtin::memory_store8(addr: i32, value: i32)  // Store byte to memory
 builtin::memory_load8_u(addr: i32) -> i32      // Load unsigned byte from memory
 builtin::realloc(oldptr: i32, oldsize: i32, align: i32, newsize: i32) -> i32
 
-// Stream intrinsics (Component Model)
+// Stream/Future intrinsics (Component Model)
+// These are low-level i32 handle operations used internally by the resolver.
+// User code accesses Stream<T>/Future<T> resource types from core:prelude/types.wado.
 builtin::stream_new() -> i64              // Create stream, returns rx|tx packed
                                           // Extract: rx = handles as i32, tx = (handles >> 32) as i32
+builtin::stream_read(rx: i32, ptr: i32, len: i32) -> i32
 builtin::stream_write(tx: i32, ptr: i32, len: i32) -> i32
 builtin::stream_drop_writable(tx: i32)
 builtin::stream_drop_readable(rx: i32)
+builtin::future_new() -> i64             // Create future, returns rx|tx packed
+builtin::future_write(tx: i32, ptr: i32) -> i32
+builtin::future_drop_writable(tx: i32)
+builtin::future_drop_readable(rx: i32)
 
 // Async task intrinsics (Component Model)
 builtin::waitable_set_new() -> i32
@@ -1078,7 +1085,7 @@ pub struct FormatSpec {
 - Interpolation expressions are evaluated
 - Template strings produce `ref (array u8)` type
 - Integer interpolation (signed i8/i16/i32/i64 and unsigned u8/u16/u32/u64 converted to decimal string)
-- Float interpolation (f32/f64 via `wado-bundled` functions using the `ryu` algorithm)
+- Float interpolation (f32/f64 via `core:prelude/fpfmt.wado` pure Wado formatter)
 - String concatenation using GC array allocation and `array.copy`
 
 ### Inspect Synthesis (`synthesize_inspect.rs`)
@@ -1534,13 +1541,13 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 
 - Component Model binary output
 - WASI P3 imports (`wasi:cli/stdout`, `wasi:cli/types`)
-- Stream intrinsics (`stream.new`, `stream.write`, `stream.drop-*`)
+- Stream/Future intrinsics (`stream.*`, `future.*`)
 - Async task intrinsics (`task.return`, `waitable-set.*`, `subtask.drop`)
 - Memory module with string data
 - `println` function (core::cli)
 - Multiple function calls
 - Async function lifting/lowering
-- Template strings (literals, integer interpolation, float interpolation via wado-bundled)
+- Template strings (literals, integer interpolation, float interpolation, format specifiers)
 - Variables and locals (`let`, `let mut`)
 - Global variables (`global`, `global mut`) with Wasm global section
 - Control flow (`if` statements, `if let init`, `while`, `for`, `loop`, `for-of`)
@@ -1570,8 +1577,8 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 - Variant construction (`Option::<T>::Some(x)`, `Color::Red`, `Shape::Circle(r)`)
 - Option pattern matching (`if let Some(x) = ...`)
 - Custom variant pattern matching (`if let Circle(r) = shape`, `if let Rect([w, h]) = shape`)
-- Closures - pure (no captures)
-- Template string type conversion (i8/i16/i32/i64/u8/u16/u32/u64/bool/char → string, f32/f64 → string via wado-bundled)
+- Closures (pure and capturing, `&mut ||` for mutable captures)
+- Template string type conversion (i8/i16/i32/i64/u8/u16/u32/u64/bool/char → string, f32/f64 → string)
 - Value semantics for structs (field-by-field copy on assignment)
 - Value semantics for arrays (element-by-element copy on assignment)
 - Value semantics for tuples (field-by-field copy on assignment)

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -873,6 +873,10 @@ builtin::realloc(oldptr: i32, oldsize: i32, align: i32, newsize: i32) -> i32
 // Stream/Future intrinsics (Component Model)
 // These are low-level i32 handle operations used internally by the resolver.
 // User code accesses Stream<T>/Future<T> resource types from core:prelude/types.wado.
+// NOTE: Migration from builtin-based to resource-based is incomplete.
+// Resource declarations exist in types.wado but method resolution (.new(), .read(),
+// .write(), .close(), .drop()) is still hardcoded in the resolver (method_call.rs)
+// rather than being driven by the resource declarations.
 builtin::stream_new() -> i64              // Create stream, returns rx|tx packed
                                           // Extract: rx = handles as i32, tx = (handles >> 32) as i32
 builtin::stream_read(rx: i32, ptr: i32, len: i32) -> i32
@@ -1595,6 +1599,7 @@ Checked during analysis phase. Non-exhaustive patterns are compile errors.
 
 - **Variant pattern matching**: Single-payload and tuple-payload cases work (`if let Circle(r) = shape`, `if let Rect([w, h]) = shape`). Struct payloads not yet supported. See [WEP: Variant Payload Design](./wep-2026-01-25-variant-payload-design.md).
 - **Function types**: Parser supports `fn(T) -> U` syntax, closure codegen works (both pure and capturing), but full function type support is incomplete.
+- **Stream/Future resource migration**: Resource declarations (`resource Stream<T>`, `resource Future<T>`, etc.) exist in `core:prelude/types.wado`, but method resolution (`.new()`, `.read()`, `.write()`, `.close()`, `.drop()`) is still hardcoded in the resolver (`method_call.rs`) rather than being driven by the resource declarations. The low-level canonical builtins in `builtin.wado` (`stream_new`, `stream_read`, `future_write`, etc.) remain the actual backing implementation.
 
 ### Known Limitations
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -76,9 +76,13 @@ Eliminates unnecessary reference bindings introduced during inlining. When `let 
 
 **Module:** `optimize/sroa.rs`
 
-Decomposes struct and tuple allocations into individual scalar locals when the aggregate does not escape. After inlining exposes patterns like `let s = Point { x: expr1, y: expr2 }; let a = s.x;`, SROA replaces the struct with per-field scalar locals (`__sroa_s_x`, `__sroa_s_y`), eliminating the GC heap allocation. Copy propagation then cleans up the trivial copies.
+Decomposes struct and tuple allocations into individual scalar locals, eliminating GC heap allocations. After inlining exposes patterns like `let s = Point { x: expr1, y: expr2 }; let a = s.x;`, SROA replaces the struct with per-field scalar locals (`__sroa_s_x`, `__sroa_s_y`). Copy propagation then cleans up the trivial copies. Mutable field writes (`s.x = value`) are transformed into scalar local assignments.
 
-Escape analysis ensures safety: a candidate is decomposed only if it is never passed to a function, returned, address-taken, captured by a closure, or stored into another aggregate. Field reads, field writes, and reads through `Move` wrappers are allowed.
+Two-tier escape analysis determines eligibility:
+
+- **Safe (non-escaping):** The aggregate is only used for field reads, field writes, and reads through `Move` wrappers. Fully decomposed with no reconstruction overhead.
+- **Soft escape (reconstructible):** The aggregate escapes only to call arguments, return statements, or labeled block breaks. SROA still decomposes the aggregate into scalars for field accesses, and automatically reconstructs a fresh struct/tuple literal at each escape site. This enables SROA even when the aggregate is partially passed around.
+- **Hard escape (excluded):** Address taken (`&s`), captured by a closure, stored into another aggregate, or used as a bare local in a non-reconstructible position. Not decomposed.
 
 This is the single most impactful optimization for WasmGC-targeting compilers, as struct allocations are GC-managed heap objects.
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -168,6 +168,41 @@ Wraps fresh values (literals, call results) in `Move` nodes to avoid unnecessary
 
 ## Not Yet Implemented
 
+### Library Call Optimization
+
+Rewrites calls to known stdlib functions into more efficient instruction sequences when arguments are compile-time constants. Similar to LLVM's `SimplifyLibCalls` pass.
+
+#### `String.append(short_const)` → `append_char` sequence
+
+When `append` is called with a constant string of 4 bytes or fewer, expand into a sequence of `append_char` calls. This eliminates the constant string's GC array allocation and avoids the general-purpose append loop.
+
+```wado
+// Before:
+builder.append("OK");
+
+// After (optimized):
+builder.append_char('O');
+builder.append_char('K');
+```
+
+Each `append_char` is a simple array grow + set, while `append(str)` requires allocating the constant string as a GC array, then looping over its bytes. For short constants (1–4 bytes), the expanded form is strictly cheaper.
+
+#### Template string with single interpolation → direct `to_string`
+
+When a template string contains exactly one interpolation with no prefix or suffix (`` `{expr}` ``), the StringBuilder allocation is unnecessary. Replace with a direct stringification of the expression.
+
+```wado
+// Before (desugared):
+let __sb = String::with_capacity(16);
+__sb.append(expr.to_string());
+// result = __sb
+
+// After (optimized):
+// result = expr.to_string()
+```
+
+Eliminates the StringBuilder GC allocation entirely. For the common pattern of `` `{x}` `` used to convert a value to a string, this is a significant win.
+
 ### Strength Reduction
 
 Transform expensive loop operations into cheaper equivalents. For example, replace `p * p` recomputed each iteration with an accumulator updated by addition.

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -194,6 +194,18 @@ Could be extended to Global Value Numbering (GVN), which is more powerful: it de
 
 The current constant propagation handles immutable globals with scalar initializers. SCCP is a more powerful variant that simultaneously propagates constants through local variables and eliminates dead branches, handling inter-dependent constant conditions that the current separate passes miss.
 
+### Interprocedural Sparse Conditional Constant Propagation (IPSCCP)
+
+Extends SCCP across function boundaries. Propagates constants from call sites into callee parameters, and propagates constant return values back to callers. When a function is always called with a constant argument, the parameter is replaced with the constant inside the function body, enabling further folding and dead branch elimination. When a function always returns the same constant, all call sites are replaced with that constant.
+
+LLVM's IPSCCP is one of its most effective interprocedural passes. In Wado's context, it is particularly valuable because:
+
+- Monomorphized generic functions often receive constant arguments (e.g., capacity values, flag booleans)
+- Stdlib wrapper functions frequently forward constants through several call layers
+- Combined with function specialization, it enables aggressive optimization of hot paths without inlining
+
+Depends on SCCP as the intraprocedural foundation.
+
 ### Copy Propagation (Cross-Block)
 
 The current copy propagation works within simple cases. Extending it to handle cross-block propagation using reaching definitions would catch more redundant copies.

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -54,7 +54,7 @@ The optimizer runs after lowering and before Wasm emission:
    9. Loop-Invariant Code Motion (LICM)
 2. DCE Analysis and removal of unreachable functions/types (all levels)
 3. Post-optimization rewrites (labeled block simplification, select lowering, move insertion; all levels)
-4. WIR-level optimizations (multi-value SROA, large array splitting; see [WIR Optimizations](#wir-optimizations))
+4. WIR-level optimizations (multi-value SROA, constant array data promotion, large array splitting; see [WIR Optimizations](#wir-optimizations))
 
 ## Implemented Optimizations
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -174,34 +174,11 @@ Rewrites calls to known stdlib functions into more efficient instruction sequenc
 
 #### `String.append(short_const)` → `append_char` sequence
 
-When `append` is called with a constant string of 4 bytes or fewer, expand into a sequence of `append_char` calls. This eliminates the constant string's GC array allocation and avoids the general-purpose append loop.
-
-```wado
-// Before:
-builder.append("OK");
-
-// After (optimized):
-builder.append_char('O');
-builder.append_char('K');
-```
-
-Each `append_char` is a simple array grow + set, while `append(str)` requires allocating the constant string as a GC array, then looping over its bytes. For short constants (1–4 bytes), the expanded form is strictly cheaper.
+When `append` is called with a constant string of 4 bytes or fewer, expand into a sequence of `append_char` calls. Each `append_char` is a simple array grow + set, while `append(str)` requires allocating the constant string as a GC array and looping over its bytes.
 
 #### Template string with single interpolation → direct `to_string`
 
-When a template string contains exactly one interpolation with no prefix or suffix (`` `{expr}` ``), the StringBuilder allocation is unnecessary. Replace with a direct stringification of the expression.
-
-```wado
-// Before (desugared):
-let __sb = String::with_capacity(16);
-__sb.append(expr.to_string());
-// result = __sb
-
-// After (optimized):
-// result = expr.to_string()
-```
-
-Eliminates the StringBuilder GC allocation entirely. For the common pattern of `` `{x}` `` used to convert a value to a string, this is a significant win.
+When a template string contains exactly one interpolation with no prefix or suffix (`` `{expr}` ``), replace with `expr.to_string()` directly. Eliminates the StringBuilder GC allocation entirely.
 
 ### Strength Reduction
 
@@ -276,139 +253,7 @@ Apply algebraic laws to simplify expressions. Often implemented as part of peeph
 
 When a function returns a struct or tuple that is immediately destructured at every call site, the return can be scalarized using Wasm multi-value returns. This eliminates the GC struct allocation at the function boundary without requiring inlining.
 
-The compiler already implements this for builtins (e.g., `i64_add128` returns two `i64` values on the Wasm stack via `MultiValueStructNew`/`MultiValueLocalBind` in WIR). Extending this to user-defined functions is a natural next step.
-
-#### Current State: Builtin Multi-Value Pipeline
-
-The existing pipeline for builtins:
-
-1. `lower.rs`: `is_multivalue_builtin_pattern()` detects builtin multi-value calls and **preserves** `LetPattern` (instead of lowering to `Let + FieldAccess`)
-2. `wir_build/translate.rs`: Wraps the Wasm multi-value instruction in `MultiValueStructNew`
-3. `translate_let_pattern()`: Detects `MultiValueStructNew` → replaces with `MultiValueLocalBind` (tuple elision, no struct allocation)
-
-#### Goal: Extend to User-Defined Functions
-
-Example:
-
-```wado
-fn minmax(a: i32, b: i32) -> [i32, i32] {
-    if a < b { return [a, b]; }
-    return [b, a];
-}
-let [lo, hi] = minmax(x, y);  // immediate destructuring
-```
-
-Current codegen:
-
-```wat
-(func $minmax (param i32 i32) (result (ref $tuple_i32_i32))
-  ;; ... compute ...
-  (struct.new $tuple_i32_i32)  ;; heap allocation
-)
-;; caller:
-(call $minmax)
-(local.tee $tmp)
-(struct.get $tuple_i32_i32 0)  ;; field extraction
-(local.set $lo)
-(local.get $tmp)
-(struct.get $tuple_i32_i32 1)
-(local.set $hi)
-```
-
-Optimized codegen with multi-value return:
-
-```wat
-(func $minmax (param i32 i32) (result i32 i32)
-  ;; ... compute ...
-  ;; no struct.new — two i32 values on stack
-)
-;; caller:
-(call $minmax)
-(local.set $hi)  ;; directly from stack (LIFO order)
-(local.set $lo)
-```
-
-#### Implementation Phase: Hybrid TIR Analysis + WIR Generation
-
-Two approaches were considered:
-
-**Option A: Pure WIR optimization pass** — Add an optimization phase after WIR build that rewrites signatures and call sites. WIR already has `MultiValueStructNew`/`MultiValueLocalBind` infrastructure and Wasm-level types. However, WIR currently has no optimization framework, and introducing one is a significant architectural change.
-
-**Option B (preferred): Hybrid TIR analysis + WIR generation** — The TIR optimizer identifies candidate functions via whole-program analysis and marks them. WIR build then uses these marks to generate multi-value signatures and call sites.
-
-Rationale for Option B:
-
-1. **Whole-program analysis is natural at TIR level** — The TIR optimizer already performs cross-function analysis (inlining, DCE). Adding call-site analysis fits this model.
-2. **Leverages existing fixed-point iteration** — SROA decomposes struct locals, copy propagation cleans up, then multi-value candidate detection runs in the same loop. Interplay between passes is valuable.
-3. **No new WIR optimization framework needed** — The "decision" happens at TIR, the "execution" happens during WIR build (which already handles the builtin case).
-4. **Clean separation of concerns** — "What to optimize" is a TIR-level question. "How to emit multi-value Wasm" is a WIR-level question.
-
-Note: A WIR optimization framework may be useful in the future for other purposes (stack scheduling, register allocation, peephole). Option B does not preclude adding one later.
-
-#### Implementation Strategy
-
-1. **TIR analysis pass** (new pass in `optimize/`): Scan all internal functions that return a struct or tuple. For each, check that ALL call sites either:
-   - Immediately destructure via `LetPattern` (tuple or struct destructuring)
-   - Only access fields without escaping the value (SROA will have decomposed these)
-     Mark qualifying functions with a metadata flag (e.g., `multivalue_return: true`).
-
-2. **Callee rewrite at WIR build**: When generating a marked function, emit multiple Wasm result types instead of a single struct ref. Replace `struct.new` at return sites with bare stack values.
-
-3. **Call site rewrite at WIR build**: For calls to marked functions, emit `MultiValueLocalBind` instead of `Call` + `StructGet` sequences. The existing `translate_let_pattern()` mechanism can be extended.
-
-4. **Fallback**: If any call site uses the return value as a whole (passes it to another function, stores it, etc.), the function is NOT marked. No cloning — keep it simple.
-
-#### Applicable Syntax Patterns
-
-**Pattern 1: Direct destructuring (primary target)**
-
-```wado
-let [lo, hi] = minmax(x, y);
-```
-
-Directly maps to `MultiValueLocalBind`. Simplest case.
-
-**Pattern 2: Struct destructuring**
-
-```wado
-struct Point { x: i32, y: i32 }
-fn origin() -> Point { return Point { x: 0, y: 0 }; }
-let { x, y } = origin();
-```
-
-Same as tuple but field order follows struct definition order.
-
-**Pattern 3: Field access only (SROA-assisted)**
-
-```wado
-let result = minmax(x, y);
-use(result.0);
-use(result.1);
-```
-
-After SROA decomposes `result` into `__sroa_result_0` and `__sroa_result_1`, the pattern becomes equivalent to destructuring. The multi-value analysis can recognize SROA-decomposed call results.
-
-**Pattern 4: Partial use with wildcard**
-
-```wado
-let [lo, _] = minmax(x, y);
-```
-
-The unused return value is emitted as `drop` in Wasm. Already supported by `MultiValueLocalBind`.
-
-**Not applicable:**
-
-- Mixed call sites (some destructure, some use whole value) — would require function cloning
-- CM export boundaries — always need single-value returns per Component Model ABI
-- Deeply nested tuples (`[i32, [String, bool]]`) — recursive flattening adds complexity, defer to future work
-- Functions with reference-type return fields — `struct.get` on GC refs has different semantics than stack values
-- Best limited to small returns (2-4 fields) to avoid Wasm stack depth issues
-
-#### Interaction with Existing Passes
-
-- **SROA**: Decomposes local struct variables. Multi-value return scalarization complements SROA by eliminating the struct at the function boundary. SROA handles the "local" case, multi-value handles the "cross-function" case.
-- **Function inlining**: Inlining eliminates the function boundary entirely, making multi-value optimization unnecessary. Multi-value is most valuable for functions too large to inline.
-- **Copy propagation**: After multi-value rewrite, trivial copies (`let x = __multivalue_0`) are cleaned up by copy propagation.
+The compiler already implements this for builtins (e.g., `i64_add128` returns two `i64` values on the Wasm stack via `MultiValueStructNew`/`MultiValueLocalBind` in WIR). Extending this to user-defined functions is a natural next step. Complements SROA: SROA handles the local case, multi-value handles the cross-function case. Most valuable for functions too large to inline.
 
 ### Function Specialization
 
@@ -416,17 +261,33 @@ Create specialized versions of functions for known constant arguments. When cons
 
 LLVM implements this as `FunctionSpecialization`. It is particularly effective when combined with interprocedural constant propagation.
 
+### Argument Promotion
+
+When a function takes a reference parameter (`&T`) but only accesses specific fields, promote those fields to direct scalar parameters (LLVM: `-argpromotion`). Eliminates the GC ref parameter, which in turn enables caller-side SROA on the struct that was only constructed to pass as a reference. Particularly impactful for `&self` methods that only read a few fields.
+
+### Dead Argument Elimination
+
+Remove function parameters that are unused at all call sites (LLVM: `-deadargelim`). Common after monomorphization where generic parameters or feature-specific arguments become dead. Reduces call overhead and enables further interprocedural optimizations.
+
+### Store-to-Load Forwarding
+
+When a `struct.set` is followed by a `struct.get` on the same object and field with no intervening aliasing writes, forward the stored value directly without the load (part of LLVM's GVN). Common pattern after function inlining exposes field write + field read sequences.
+
+### Jump Threading
+
+When a branch condition is already determined along a specific incoming edge, thread the jump directly to the target block, bypassing redundant comparisons (LLVM: `-jump-threading`). Effective for `match` expression chains and sequential `if-else if` patterns.
+
+### Reassociation
+
+Reorder associative and commutative operations to group constants together, enabling more constant folding (LLVM: `-reassociate`). For example, `(x + 1) + 2` → `x + (1 + 2)` → `x + 3`.
+
+### SimplifyCFG
+
+General control flow graph simplification: merge redundant blocks, eliminate empty blocks, simplify trivial branches (LLVM: `-simplifycfg`). The current Constant Branch Pruning is a subset of this. Extending it to handle block merging and unreachable block elimination would clean up more patterns exposed by other passes.
+
 ### Tail Call Optimization via `return_call`
 
-Emit WebAssembly's `return_call` instruction for tail-recursive function calls instead of a regular `call` + `return`. Part of Wasm 3.0 standard.
-
-Detection pattern: `return func(...)` where the call is the direct child of `return`.
-
-Benefits:
-
-- Eliminates stack overflow for deep recursion
-- Reduces function call overhead
-- Simple implementation — just emit a different Wasm instruction
+Emit WebAssembly's `return_call` instruction for tail-recursive function calls instead of a regular `call` + `return`. Part of Wasm 3.0 standard. Eliminates stack overflow for deep recursion.
 
 ## Leveraging Bit Manipulation Intrinsics
 
@@ -445,78 +306,7 @@ The compiler exposes `i32_clz` and `i64_clz` in `core/builtin.wado`, mapped dire
 
 ### Pattern Recognition Opportunities
 
-The optimizer could detect these idioms in user code and rewrite them to use single Wasm instructions:
-
-#### Log2 (integer)
-
-```wado
-// User writes:
-fn ilog2(x: i32) -> i32 {
-    let mut n = 0;
-    let mut v = x;
-    while v > 1 { v = v / 2; n += 1; }
-    return n;
-}
-
-// Optimizer rewrites to:
-fn ilog2(x: i32) -> i32 {
-    return 31 - builtin::i32_clz(x);
-}
-```
-
-#### Power-of-2 Check
-
-```wado
-// User writes:
-fn is_power_of_2(x: i32) -> bool {
-    return x > 0 && (x & (x - 1)) == 0;
-}
-
-// With popcnt, this becomes:
-fn is_power_of_2(x: i32) -> bool {
-    return builtin::i32_popcnt(x) == 1;  // single instruction
-}
-```
-
-#### Find Lowest Set Bit
-
-```wado
-// User writes a loop scanning bits from LSB:
-let mut pos = 0;
-let mut v = mask;
-while v & 1 == 0 { v = v >> 1; pos += 1; }
-
-// Optimizer rewrites to:
-let pos = builtin::i32_ctz(mask);  // single instruction
-```
-
-#### Bit Count / Hamming Weight
-
-```wado
-// User writes:
-fn popcount(x: i32) -> i32 {
-    let mut count = 0;
-    let mut v = x;
-    while v != 0 { count += v & 1; v = v >> 1; }
-    return count;
-}
-
-// Optimizer rewrites to:
-fn popcount(x: i32) -> i32 {
-    return builtin::i32_popcnt(x);  // single instruction
-}
-```
-
-#### Integer Width / Bit Length
-
-```wado
-// Number of bits needed to represent a value:
-fn bit_length(x: i32) -> i32 {
-    return 32 - builtin::i32_clz(x);
-}
-```
-
-These patterns appear frequently in bitmap data structures, hash tables, memory allocators, and compression algorithms. Recognizing them turns O(n) loops into O(1) instructions.
+The optimizer could detect common bit manipulation idioms (log2 via division loop, popcount via shift loop, find-lowest-bit via LSB scan) and rewrite them to use single Wasm instructions (`clz`, `ctz`, `popcnt`). These patterns appear frequently in bitmap data structures, hash tables, and compression algorithms. Recognizing them turns O(n) loops into O(1) instructions.
 
 ## WebAssembly-Specific Optimizations
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -66,6 +66,12 @@ Eliminates function call overhead by replacing small pure function calls with th
 
 Eligibility: pure (no effects), non-recursive, no reference parameters/returns, no generics, not from core library, expression count below threshold.
 
+Inline hints via `#[inline]` attributes override the default heuristics:
+
+- `#[inline]` — prefer inlining (treated as eligible even if slightly above threshold)
+- `#[inline(always)]` — always inline regardless of size or threshold
+- `#[inline(never)]` — never inline (useful for cold error paths or debugging)
+
 ### Reference Elimination
 
 **Module:** `optimize/ref_elim.rs`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -53,6 +53,15 @@ Block comments do not nest.
 
 TODO: the parser keeps comments in the AST.
 
+### Shebang
+
+```wado
+#!/usr/bin/env wado
+export fn run() { ... }
+```
+
+`#!` at position 0 is a shebang and is ignored. `#![` is an inner attribute, not a shebang.
+
 ### Data Section
 
 The `__DATA__` marker separates source code from embedded data. Everything after `__DATA__` on its own line is captured as raw text and is not parsed as Wado code.
@@ -315,6 +324,38 @@ if x < 0 {
     println("zero");
 } else {
     println("positive");
+}
+```
+
+**If Expression:**
+
+```wado
+let abs = if x < 0 { -x } else { x };
+
+let grade = if score >= 90 { "A" } else if score >= 80 { "B" } else { "C" };
+```
+
+Trailing semicolons are optional in expression blocks (like trailing commas).
+
+**If with Init (Go-style):**
+
+```wado
+if let x = get_value(); x > 0 {
+    println(`positive: {x}`);
+} else {
+    println(`non-positive: {x}`);
+}
+// x is not in scope here
+```
+
+**If Let Pattern Matching:**
+
+```wado
+let opt: Option<i32> = Option::<i32>::Some(42);
+if let Some(x) = opt {
+    println(`Got: {x}`);
+} else {
+    println("None");
 }
 ```
 
@@ -927,7 +968,32 @@ s.len() -> usize           // Length in bytes
 s.is_empty() -> bool       // Check if empty
 ```
 
-**Note**: `bytes()` and `chars()` currently return `Array<T>` (copy). Future versions will support slices and iterators for zero-copy access.
+**Note**: `bytes()` and `chars()` return iterator objects (`StrUtf8ByteIter` and `StrCharIter`) that implement both `Iterator` and `IntoIterator`, so they work with `for-of` directly:
+
+```wado
+for let c of "hello".chars() {
+    println(`{c}`);  // h, e, l, l, o
+}
+
+for let b of "hello".bytes() {
+    println(`{b}`);  // 104, 101, 108, 108, 111
+}
+```
+
+**String Building:**
+
+The `append` method provides efficient O(1) amortized string building:
+
+```wado
+let mut builder = String::with_capacity(20);
+builder.append("Hello");
+builder.append(", ");
+builder.append("World!");
+// builder is now "Hello, World!"
+
+// Static method for two-string concatenation
+let combined = String::concat("Hello, ", "World!");  // "Hello, World!"
+```
 
 #### Concatenation
 
@@ -1408,6 +1474,15 @@ See `docs/wep-2026-01-15-tuple-and-array-literals.md` for detailed rationale.
 
 Arrays support index-based access and assignment:
 
+**Array Constructors:**
+
+```wado
+let arr = Array::<i32>::with_capacity(10);     // empty array with pre-allocated capacity
+let bools = Array::<bool>::filled(100, true);  // array of 100 elements, all true
+```
+
+**Array Operations:**
+
 ```wado
 let mut arr: Array<i32> = [1, 2, 3];
 
@@ -1428,6 +1503,23 @@ let len = arr.len(); // Get length
 - Requires the array variable to be declared with `let mut`
 - Index must be within bounds (runtime check, traps if out of bounds)
 - Works with arrays of any element type
+
+**Sorting** (stable, O(n log n) worst case):
+
+| Method      | Mutates? | Comparator        |
+| ----------- | -------- | ----------------- |
+| `sort()`    | Yes      | `<` (requires `T: Ord`) |
+| `sort_by()` | Yes      | Custom `fn(&T, &T) -> Ordering` |
+| `sorted()`  | No       | `<` (requires `T: Ord`) |
+| `sorted_by()` | No    | Custom `fn(&T, &T) -> Ordering` |
+
+```wado
+let mut nums: Array<i32> = [5, 3, 8, 1];
+nums.sort();                             // in-place ascending
+
+let orig: Array<i32> = [5, 3, 8, 1];
+let asc = orig.sorted();                // returns new sorted array
+```
 
 #### Collection Literal Coercion
 
@@ -1544,7 +1636,27 @@ let capture = |x: i32| x + outer;  // Captures `outer` by value
 capture(5);  // Returns 15
 ```
 
-Closures capture variables by value (copy semantics). For capturing by reference, see the `stores[...]` syntax in the Effect System section.
+Closures capture variables by value (copy semantics) by default. For capturing by reference, see the `stores[...]` syntax in the Effect System section.
+
+**Mutable Closures (`&mut ||`):**
+
+`&mut ||` creates a closure that captures variables by mutable reference instead of by value:
+
+```wado
+let mut count = 0;
+let inc = &mut || { count += 1; };
+inc();
+inc();
+println(`{count}`);  // 2
+
+// Multiple closures sharing the same mutable variable
+let mut count = 0;
+let inc = &mut || { count += 1; };
+let get = || count;
+inc();
+inc();
+println(`{get()}`);  // 2
+```
 
 ### Tagged Template Literals
 
@@ -1760,6 +1872,51 @@ type UserData = struct {
 };
 ```
 
+**Struct Construction:**
+
+```wado
+let user = User { name: "Alice", age: 30, active: true };
+
+// Shorthand (variable name matches field)
+let name = "Bob";
+let age = 25;
+let bob: User = { name, age, active: false };
+
+// Implicit struct literal (requires type annotation)
+let user: User = { name: "Alice", age: 30, active: true };
+```
+
+**Struct Destructuring:**
+
+```wado
+let p = Point { x: 10, y: 20 };
+
+// Unnamed destructuring (type inferred from RHS)
+let { x, y } = p;
+
+// Named destructuring (explicit type)
+let Point { x, y } = p;
+
+// Renaming fields
+let { x: horizontal, y: vertical } = p;
+
+// Ignore remaining fields with ..
+struct Person { name: String, age: i32, email: String }
+let { name, .. } = person;
+
+// Mutable destructuring
+let mut { x, y } = p;
+
+// Nested destructuring
+struct Line { start: Point, end: Point }
+let { start: { x: x1, y: y1 }, end: { x: x2, y: y2 } } = line;
+
+// In for-of
+for let { x, y } of points {
+    println(`{x}, {y}`);
+}
+```
+
 ### Traits
 
 Traits define shared behavior that types can implement. Wado uses **static dispatch** for trait methods - all calls are resolved at compile time.
@@ -1914,10 +2071,47 @@ pub trait IndexAssign<IndexType> {
 
 Note: `IndexAssign` takes a value parameter rather than returning `&mut T` (like Rust's `IndexMut`). This design reflects Wasm GC semantics where you cannot get a mutable reference to an array element - reading (`array.get`) and writing (`array.set`) are fundamentally different operations.
 
+**Trait Bounds:**
+
+Type parameters can have trait bounds that constrain what types can be used:
+
+```wado
+// Struct with trait bound
+struct SortedPair<T: Ord> {
+    first: T,
+    second: T,
+}
+
+// Multiple bounds with + syntax
+struct PrintableOrd<T: Ord + Printable> {
+    value: T,
+}
+
+// Bounds on function type parameters
+fn max<T: Ord>(a: T, b: T) -> T {
+    if a > b { return a; }
+    return b;
+}
+
+// Bounded impl blocks - methods only available when T: Ord
+impl Array<T: Ord> {
+    pub fn sort(&mut self) { ... }
+    pub fn sorted(&self) -> Array<T> { ... }
+}
+
+// Bounded trait implementations - Pair<T> implements Eq only when T: Eq
+impl<T: Eq> Eq for Pair<T> {
+    fn eq(&self, other: &Self) -> bool {
+        return self.first == other.first && self.second == other.second;
+    }
+}
+```
+
 **Not Yet Implemented:**
 
 - Trait objects (`dyn Trait`)
 - Fully qualified syntax for disambiguation (`<Type as Trait>::method()`)
+- Using bounds for method resolution on type parameters (calling `T.method()` where `T: Trait`)
 
 ### Iterator Traits
 
@@ -2036,6 +2230,33 @@ impl IntoIterator for Stack<T> {
 for let x of stack { ... }
 ```
 
+**Iterator Combinators:**
+
+Iterators support `map`, `filter`, and `fold` for functional-style data processing:
+
+```wado
+let arr: Array<i32> = [1, 2, 3, 4, 5];
+
+// map - transform each element
+let doubled = arr.iter().map(|x: i32| x * 2).collect();
+// [2, 4, 6, 8, 10]
+
+// filter - keep elements matching predicate
+let evens = arr.iter().filter(|x: i32| x % 2 == 0).collect();
+// [2, 4]
+
+// fold - reduce to single value
+let sum = arr.iter().fold(0, |acc: i32, x: i32| acc + x);
+// 15
+
+// Chaining combinators
+let result = arr.iter()
+    .filter(|x: i32| x > 2)
+    .map(|x: i32| x * 10)
+    .collect();
+// [30, 40, 50]
+```
+
 ### Builtin Comparison Traits
 
 The prelude defines traits for comparison operators:
@@ -2055,22 +2276,33 @@ The `==` and `!=` operators use `Eq::eq`:
 - `a == b` desugars to `Eq::eq(&a, &b)`
 - `a != b` desugars to `!Eq::eq(&a, &b)`
 
+**Ordering Enum:**
+
+```wado
+/// Result of a three-way comparison
+pub enum Ordering {
+    Less,    // first value is less than second
+    Equal,   // values are equal
+    Greater, // first value is greater than second
+}
+```
+
 **Ord - Ordering:**
 
 ```wado
 /// Types that can be ordered
 pub trait Ord {
-    /// Returns true if self is less than other
-    fn lt(&self, other: &Self) -> bool;
+    /// Compares self with other and returns an Ordering
+    fn cmp(&self, other: &Self) -> Ordering;
 }
 ```
 
-Comparison operators use `Ord::lt`:
+Comparison operators use `Ord::cmp`:
 
-- `a < b` desugars to `Ord::lt(&a, &b)`
-- `a <= b` desugars to `Ord::lt(&a, &b) || Eq::eq(&a, &b)`
-- `a > b` desugars to `Ord::lt(&b, &a)`
-- `a >= b` desugars to `Ord::lt(&b, &a) || Eq::eq(&a, &b)`
+- `a < b` desugars to `Ord::cmp(&a, &b) == Ordering::Less`
+- `a > b` desugars to `Ord::cmp(&a, &b) == Ordering::Greater`
+- `a <= b` desugars to `Ord::cmp(&a, &b) != Ordering::Greater`
+- `a >= b` desugars to `Ord::cmp(&a, &b) != Ordering::Less`
 
 **Default Implementations:**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1496,12 +1496,12 @@ let len = arr.len(); // Get length
 
 **Sorting** (stable, O(n log n) worst case):
 
-| Method      | Mutates? | Comparator        |
-| ----------- | -------- | ----------------- |
-| `sort()`    | Yes      | `<` (requires `T: Ord`) |
-| `sort_by()` | Yes      | Custom `fn(&T, &T) -> Ordering` |
-| `sorted()`  | No       | `<` (requires `T: Ord`) |
-| `sorted_by()` | No    | Custom `fn(&T, &T) -> Ordering` |
+| Method        | Mutates? | Comparator                      |
+| ------------- | -------- | ------------------------------- |
+| `sort()`      | Yes      | `<` (requires `T: Ord`)         |
+| `sort_by()`   | Yes      | Custom `fn(&T, &T) -> Ordering` |
+| `sorted()`    | No       | `<` (requires `T: Ord`)         |
+| `sorted_by()` | No       | Custom `fn(&T, &T) -> Ordering` |
 
 ```wado
 let mut nums: Array<i32> = [5, 3, 8, 1];
@@ -1654,7 +1654,7 @@ capture(5);  // Returns 15
 
 Closures capture variables by value (copy semantics) by default. Use `&mut ||` for mutable capture (see below).
 
-Note: `stores[...]` is a separate concept for declaring that a *function* stores reference *parameters* beyond the call. It is not yet implemented. See [Reference Storage](#reference-storage-stores) and [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md).
+Note: `stores[...]` is a separate concept for declaring that a _function_ stores reference _parameters_ beyond the call. It is not yet implemented. See [Reference Storage](#reference-storage-stores) and [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md).
 
 **Mutable Closures (`&mut ||`):**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1531,6 +1531,30 @@ coerced to any collection type by implementing the corresponding builder trait:
 | `[e0, e1, ...]` | `SequenceLiteralBuilder` | `Array<T>`           |
 | `{ k: v, ... }` | `KeyValueLiteralBuilder` | `TreeMap<String, V>` |
 
+**Builder Traits:**
+
+```wado
+pub trait SequenceLiteralBuilder {
+    type Element;
+    type Output;
+    fn new_literal(capacity: i32) -> Self;
+    fn push_literal(&mut self, value: Self::Element);
+    fn build(self) -> Self::Output;
+}
+
+pub trait KeyValueLiteralBuilder {
+    type Value;
+    type Output;
+    fn new_literal(capacity: i32) -> Self;
+    fn insert_literal(&mut self, key: String, value: Self::Value);
+    fn build(self) -> Self::Output;
+}
+```
+
+When a type implements `SequenceLiteralBuilder<Output = Self>` or `KeyValueLiteralBuilder<Output = Self>`, a blanket impl provides the corresponding `SequenceLiteral` / `KeyValueLiteral` trait automatically (self-as-builder pattern).
+
+**Usage:**
+
 ```wado
 let arr: Array<i32> = [1, 2, 3];
 
@@ -1538,8 +1562,10 @@ use { TreeMap } from "core:collections";
 let map: TreeMap<String, i32> = { width: 1920, height: 1080 };
 ```
 
+Coercion is literal-only — it does not apply to bound variables. If the target type is a struct with matching fields, it is interpreted as a struct literal and coercion is not attempted.
+
 See [`docs/wep-2026-01-18-iterator-based-literal-coercion.md`](./wep-2026-01-18-iterator-based-literal-coercion.md)
-for the full trait definitions, desugaring rules, and the immutable-output builder pattern.
+for desugaring rules, the immutable-output (separate builder) pattern, and concrete type validation.
 
 ### Compile-Time Location Literals
 
@@ -2052,6 +2078,33 @@ impl Container for IntBox {
 ```
 
 Within trait methods and implementations, `Self::TypeName` refers to the associated type. The type is resolved at compile time based on the implementing type.
+
+**Bounded Associated Types:**
+
+Associated types can have trait bounds that constrain what types can be used as the associated type:
+
+```wado
+trait Collection {
+    type Element;
+    type Builder: CollectionBuilder<Element = Self::Element, Output = Self>;
+}
+```
+
+Here `Builder` must implement `CollectionBuilder` with matching `Element` and `Output` types. The `Type = ConcreteType` syntax constrains associated types of the bound trait to specific types.
+
+**Blanket Implementations:**
+
+A blanket impl provides a trait implementation for all types that satisfy a given bound:
+
+```wado
+// Any type that builds itself satisfies Collection automatically
+impl<T: CollectionBuilder<Output = T>> Collection for T {
+    type Element = T::Element;
+    type Builder = T;
+}
+```
+
+This avoids the need for explicit `impl Collection for ...` on every self-building type. The compiler resolves `T::Element` via associated type projection on the type parameter.
 
 **Standard Library Traits:**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -97,17 +97,7 @@ if let Some(data) = result.module.data_section() {
 }
 ```
 
-**Future: `#[data]` Attribute (TODO):**
-
-A future `#[data]` attribute will allow injecting the data section content into code:
-
-```wado
-#[data]
-const TEST_DATA: String;  // Injected from __DATA__ section
-
-#[data("json")]
-const CONFIG: Config;     // Parsed as JSON from __DATA__ section
-```
+The data section content can be accessed at runtime using the `#data` compile-time location literal. See [Compile-Time Location Literals](#compile-time-location-literals).
 
 ### Identifiers
 
@@ -935,8 +925,8 @@ let r2 = &mut x;  // OK in Wado (no borrow checker)
 // Conceptual representation (not user-visible)
 struct String {
     data: GcArray<u8>,   // UTF-8 bytes
-    len: usize,          // Length in bytes
-    capacity: usize,     // Buffer capacity for += operations
+    len: i32,            // Length in bytes
+    capacity: i32,       // Buffer capacity for += operations
 }
 ```
 
@@ -964,7 +954,7 @@ let chars: Array<char> = s.chars();
 let first_char = chars[0];
 
 // Other methods
-s.len() -> usize           // Length in bytes
+s.len() -> i32             // Length in bytes
 s.is_empty() -> bool       // Check if empty
 ```
 
@@ -1022,7 +1012,7 @@ s += "!";          // May reallocate if capacity exceeded
 ```wado
 // Allocate capacity upfront for efficient building
 let mut result = String::with_capacity(1000);
-for item in items {
+for let item of items {
     result += item;  // No reallocations if within capacity
 }
 ```
@@ -1076,12 +1066,12 @@ This special treatment will be generalized via traits in the future, allowing us
 ```wado
 // 1. Pre-allocate when size is known
 let mut s = String::with_capacity(estimated_size);
-for item in items {
+for let item of items {
     s += item;
 }
 
 // 2. Use += for repeated concatenation
-let mut result = String::new();
+let mut result = "";
 result += "Line 1\n";
 result += "Line 2\n";
 result += "Line 3\n";
@@ -1124,7 +1114,7 @@ let missing: Option<i32> = null;  // Same as None
 let also_missing = None;          // Standard library identifier
 
 // Both are equivalent
-assert(null == None);
+assert null == None;
 ```
 
 Note: `null` is a language keyword, while `None` is an identifier from the prelude (`Option::None`). They compile to the same instructions.
@@ -1662,7 +1652,9 @@ let capture = |x: i32| x + outer;  // Captures `outer` by value
 capture(5);  // Returns 15
 ```
 
-Closures capture variables by value (copy semantics) by default. For capturing by reference, see the `stores[...]` syntax in the Effect System section.
+Closures capture variables by value (copy semantics) by default. Use `&mut ||` for mutable capture (see below).
+
+Note: `stores[...]` is a separate concept for declaring that a *function* stores reference *parameters* beyond the call. It is not yet implemented. See [Reference Storage](#reference-storage-stores) and [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md).
 
 **Mutable Closures (`&mut ||`):**
 
@@ -2108,21 +2100,7 @@ This avoids the need for explicit `impl Collection for ...` on every self-buildi
 
 **Standard Library Traits:**
 
-The prelude defines `Index` and `IndexAssign` traits using associated types:
-
-```wado
-pub trait Index<IndexType> {
-    type Output;
-    fn index(&self, index: IndexType) -> &Self::Output;
-}
-
-pub trait IndexAssign<IndexType> {
-    type Input;
-    fn index_assign(&mut self, index: IndexType, value: Self::Input);
-}
-```
-
-Note: `IndexAssign` takes a value parameter rather than returning `&mut T` (like Rust's `IndexMut`). This design reflects Wasm GC semantics where you cannot get a mutable reference to an array element - reading (`array.get`) and writing (`array.set`) are fundamentally different operations.
+The prelude defines `IndexValue`, `IndexAssign`, and `Index` traits using associated types. See [Indexing Traits](#indexing-traits) for full definitions.
 
 **Trait Bounds:**
 
@@ -2579,31 +2557,9 @@ Note: Wado's `enum` maps to Component Model's `enum` (simple enumeration), and `
 
 Object literal syntax supports unquoted keys and shorthand properties.
 
-### Syntax Rules
+For struct initialization syntax, see the [Structs](#structs) section.
 
-- Identifier keys: Quotes optional
-- Non-identifier keys: Quotes required
-- Computed key: `[expr]` syntax (dict only)
-- Shorthand: Can omit when variable name matches key
-
-### Struct Initialization
-
-```wado
-// Named struct literal
-let user = User { name: "Alice", age: 30, active: true };
-
-// Implicit struct literal (requires type annotation)
-let user: User = { name: "Alice", age: 30, active: true };
-
-// Shorthand
-let name = "Bob";
-let age = 25;
-let bob: User = { name, age, active: false };
-
-// Computed keys not allowed in structs
-```
-
-### TreeMap (Sorted Map)
+### TreeMap (Insertion-Order Map)
 
 For associative arrays, use `TreeMap` from `core:collections`:
 
@@ -2616,10 +2572,11 @@ map.insert("y", 20);
 
 // Index syntax
 map["z"] = 30;                    // assignment
-if let Some(v) = map["x"] { ... } // access returns Option<V>
+let v = map["x"];                 // panics if key not found
+let opt = map.get("x");          // returns Option<V>
 
-// Keys are stored in sorted order
-let keys = map.keys();  // returns Array<K> in sorted order
+// Keys preserve insertion order
+let keys = map.keys();  // returns Array<K> in insertion order
 ```
 
 ### Access Methods
@@ -2629,7 +2586,7 @@ let keys = map.keys();  // returns Array<K> in sorted order
 user.name
 
 // TreeMap: bracket notation or methods
-map["key"]        // returns Option<V>
+map["key"]        // panics if key not found
 map.get("key")    // returns Option<V>
 ```
 
@@ -3416,7 +3373,7 @@ pub fn println(message: String) with Stdout {
 
 pub fn env(name: String) -> Option<String> with Environment {
     let vars = get_environment();  // No need for Environment:: prefix
-    for [key, value] in vars {
+    for let [key, value] of vars {
         if key == name {
             return Some(value);
         }
@@ -3469,6 +3426,8 @@ pub fn api_function() with Http, FileSystem {
 
 ### Reference Storage (`stores[...]`)
 
+> **Not yet implemented.** See [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md) for the design.
+
 The `stores[...]` keyword declares that a function stores reference parameters beyond the function call. This enables compile-time escape analysis and automatic heap promotion.
 
 **Syntax**: `with stores[param1, param2, ...]`
@@ -3476,7 +3435,7 @@ The `stores[...]` keyword declares that a function stores reference parameters b
 ```wado
 // Function that stores a reference parameter
 fn register(data: &Data) -> Handle with stores[data] {
-    registry.push(data);  // Stores the reference
+    registry.append(data);  // Stores the reference
     return new_handle();
 }
 
@@ -3501,11 +3460,11 @@ fn store_and_log(data: &Data) -> Handle with Stdout, stores[data] {
 **Functor types** can also declare stores (positional: 0 = first parameter):
 
 ```wado
-fn take_storing(f: Fn(&Data) with stores[0]) { ... }
-fn take_pure(f: Fn(&Data) -> Result) { ... }  // cannot store
+fn take_storing(f: fn(&Data) with stores[0]) { ... }
+fn take_pure(f: fn(&Data) -> Result) { ... }  // cannot store
 ```
 
-See `docs/adr-2026-01-12-value-semantics-and-stores.md` for detailed design rationale.
+See `docs/wep-2026-01-12-value-semantics-and-stores.md` for detailed design rationale.
 
 ### Handlers
 
@@ -3575,7 +3534,7 @@ fn collect_all() -> Array<i32> {
 
     with handler Generator<i32> {
         yield(value) => |resume| {
-            result.push(value);
+            result.append(value);
             resume();
         },
     } {
@@ -3801,7 +3760,7 @@ fn App() -> Element with Dom {
 
 Wado targets **WASI Preview 3** (0.3.0-rc-2025-09-16), which introduces native `stream<T>` and `future<T>` types that map directly to Wado's `Stream<T>` and `Future<T>`.
 
-All Wado types map directly to Component Model (WIT) types. See the [Component Model Mapping](#component-model-mapping) table in the Type System section for the complete mapping reference.
+All Wado types map directly to Component Model (WIT) types. See the [Type Mapping at Component Boundaries](#type-mapping-at-component-boundaries) table in the Type System section for the complete mapping reference.
 
 ### WASI P3 CLI Interfaces
 

--- a/example/fizzbuzz.wado
+++ b/example/fizzbuzz.wado
@@ -1,0 +1,28 @@
+// Type-safe FizzBuzz with variants and pattern matching
+
+use { println, Stdout } from "core:cli";
+
+variant FizzBuzz {
+    Fizz,
+    Buzz,
+    FizzBuzz,
+    Number(i32),
+}
+
+fn classify(n: i32) -> FizzBuzz {
+    if n % 15 == 0 { return FizzBuzz::FizzBuzz; }
+    if n % 3 == 0 { return FizzBuzz::Fizz; }
+    if n % 5 == 0 { return FizzBuzz::Buzz; }
+    return FizzBuzz::Number(n);
+}
+
+export fn run() with Stdout {
+    for let mut i = 1; i <= 20; i += 1 {
+        println(match classify(i) {
+            Fizz => "Fizz",
+            Buzz => "Buzz",
+            FizzBuzz => "FizzBuzz",
+            Number(n) => `{n}`,
+        });
+    }
+}


### PR DESCRIPTION
## Summary

This PR significantly expands the Wado language specification with comprehensive documentation of language features, standard library APIs, and compiler implementation details. The changes include new sections on shebangs, control flow expressions, string operations, collection types, traits, and iterator combinators, along with updates to compiler architecture documentation.

## Key Changes

### Language Specification (docs/spec.md)
- **Shebang support**: Added documentation for `#!` at position 0 as a shebang (ignored by parser), with clarification that `#![` is an inner attribute, not a shebang
- **Control flow expressions**: Expanded `if` expression documentation with examples of if-let pattern matching and Go-style init syntax
- **String API**: Updated `String` type documentation with:
  - Changed `len()` return type from `usize` to `i32`
  - Documented `chars()` and `bytes()` returning iterator objects (`StrCharIter`, `StrUtf8ByteIter`) that work with `for-of`
  - Added `String::with_capacity()` and `String::concat()` methods
  - Documented efficient string building patterns
- **Collection operations**: Added comprehensive array sorting documentation with `sort()`, `sort_by()`, `sorted()`, `sorted_by()` methods
- **Struct operations**: Added struct construction and destructuring syntax with examples (shorthand, renaming, nested destructuring, mutable destructuring)
- **Trait system**: 
  - Documented bounded associated types and blanket implementations
  - Added trait bounds documentation with examples
  - Updated `Ord` trait to use `cmp()` returning `Ordering` instead of `lt()` boolean
  - Added `Ordering` enum documentation
- **Closures**: Documented mutable closures with `&mut ||` syntax for capturing by mutable reference
- **Iterator combinators**: Added `map()`, `filter()`, and `fold()` methods with chaining examples
- **Compile-time location literals**: Replaced future `#[data]` attribute documentation with reference to `#data` compile-time literal
- **TreeMap**: Changed documentation from "sorted order" to "insertion-order map" with updated API examples
- **Builder traits**: Added full trait definitions for `SequenceLiteralBuilder` and `KeyValueLiteralBuilder` with usage examples
- **Data section**: Simplified documentation to reference compile-time location literals instead of future attributes

### Compiler Documentation (docs/compiler.md)
- Added `WIR Optimize` phase to compilation pipeline
- Expanded module table with new entries: `Syntax`, `ConstProp`, `ConstGlobal`, and reorganized optimize modules into subdirectory structure
- Updated pipeline diagram to include WIR optimization step

### Optimizer Documentation (docs/optimizer.md)
- Added `#[inline]`, `#[inline(always)]`, and `#[inline(never)]` attribute documentation for inlining control
- Expanded SROA documentation with two-tier escape analysis (safe, soft escape, hard escape)
- Added "Library Call Optimization" section documenting potential optimizations for `String.append()` and template strings
- Added new optimization sections: IPSCCP, Function Specialization, Argument Promotion, Dead Argument Elimination, Store-to-Load Forwarding
- Simplified multi-value return scalarization documentation, removing detailed implementation phases

### Examples and Quick Reference
- Added FizzBuzz example (`example/fizzbuzz.wado`) demonstrating variants, pattern matching, and control flow
- Updated README with FizzBuzz example and compilation instructions
- Updated cheatsheet with WEP references for Global Variables, Newtype, Tuples/Arrays, Variants, and Trait Bounds

## Notable Implementation Details

- String length operations now consistently use `i32` instead of `usize` for better WebAssembly compatibility
- Iterator objects are first-class types rather than arrays, enabling efficient iteration patterns
- Mutable closures use `&mut ||` syntax to distinguish from immutable capture semantics
- Trait bounds can now be applied to impl blocks and trait implementations, enabling conditional method availability
- Struct destructuring supports nested patterns and field renaming for flexible pattern matching

https://claude.ai/code/session_01NcT5aL86oTy8mLuVuRJEWN