### PR TITLE
Prohibit `self` by value in method receivers; require `&self` or `&mut self`

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -582,6 +582,8 @@ let origin = Point::origin();
 let arr = Array::<i32>::with_capacity(10);
 ```
 
+Note: `self` by value (bare `self`) is not allowed — Wado has no ownership system, so it would be identical to `&self`. Use `&self` or `&mut self` instead.
+
 ## Associated Constants
 
 ```wado

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -582,7 +582,7 @@ let origin = Point::origin();
 let arr = Array::<i32>::with_capacity(10);
 ```
 
-Note: `self` by value (bare `self`) is not allowed — Wado has no ownership system, so it would be identical to `&self`. Use `&self` or `&mut self` instead.
+Note: bare `self` (by value) is not allowed. Use `&self` or `&mut self`.
 
 ## Associated Constants
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -564,11 +564,6 @@ impl Point {
         self.y = 0;
     }
 
-    // Instance method with self by value (copies value)
-    fn to_tuple(self) -> [i32, i32] {
-        return [self.x, self.y];
-    }
-
     // Static method (no self parameter)
     fn origin() -> Point {
         return Point { x: 0, y: 0 };

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1529,7 +1529,7 @@ pub trait SequenceLiteralBuilder {
     type Output;
     fn new_literal(capacity: i32) -> Self;
     fn push_literal(&mut self, value: Self::Element);
-    fn build(self) -> Self::Output;
+    fn build(&self) -> Self::Output;
 }
 
 pub trait KeyValueLiteralBuilder {
@@ -1537,7 +1537,7 @@ pub trait KeyValueLiteralBuilder {
     type Output;
     fn new_literal(capacity: i32) -> Self;
     fn insert_literal(&mut self, key: String, value: Self::Value);
-    fn build(self) -> Self::Output;
+    fn build(&self) -> Self::Output;
 }
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -901,6 +901,20 @@ let r2 = &mut x;  // OK in Wado (no borrow checker)
 - **Cost**: Runtime overhead from garbage collection
 - **Safety**: Memory safety guaranteed by GC, not compile-time checks
 
+**Method Receiver: `self` by Value is Prohibited**
+
+In method definitions, the `self` parameter must always be a reference (`&self` or `&mut self`). Bare `self` (by value) is a syntax error:
+
+```wado
+impl Point {
+    fn sum(&self) -> i32 { ... }          // OK: immutable reference
+    fn reset(&mut self) { ... }           // OK: mutable reference
+    // fn consume(self) -> i32 { ... }    // ERROR: `self` by value is not allowed
+}
+```
+
+In languages with ownership semantics (e.g., Rust), `self` by value transfers ownership to the method, preventing subsequent use of the receiver. In Wado, all types have value semantics with GC-managed memory and no ownership system — assignment always copies the value. This makes `self` by value semantically identical to `&self` (both receive a copy), so supporting it would only add confusion without any benefit. The parser rejects it with a clear error message guiding the user to `&self` or `&mut self`.
+
 ### String Type
 
 `String` is a built-in type representing UTF-8 encoded text with value semantics and GC management.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -913,7 +913,7 @@ impl Point {
 }
 ```
 
-In languages with ownership semantics (e.g., Rust), `self` by value transfers ownership to the method, preventing subsequent use of the receiver. In Wado, all types have value semantics with GC-managed memory and no ownership system — assignment always copies the value. This makes `self` by value semantically identical to `&self` (both receive a copy), so supporting it would only add confusion without any benefit. The parser rejects it with a clear error message guiding the user to `&self` or `&mut self`.
+In languages with ownership semantics (e.g., Rust), `self` by value transfers ownership to the method, preventing subsequent use of the receiver. Wado has no ownership system — there is no concept of "consuming" a value — so `self` by value serves no purpose. The parser rejects it with a clear error message guiding the user to `&self` or `&mut self`.
 
 ### String Type
 

--- a/wado-compiler/lib/core/collections.wado
+++ b/wado-compiler/lib/core/collections.wado
@@ -323,7 +323,7 @@ impl KeyValueLiteralBuilder for TreeMap<String, V> {
         self.insert(key, value);
     }
 
-    fn build(self) -> TreeMap<String, V> {
-        return self;
+    fn build(&self) -> TreeMap<String, V> {
+        return *self;
     }
 }

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -251,8 +251,8 @@ impl SequenceLiteralBuilder for Array<T> {
         self.append(value);
     }
 
-    fn build(self) -> Array<T> {
-        return self;
+    fn build(&self) -> Array<T> {
+        return *self;
     }
 }
 

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -484,10 +484,10 @@ fn fmt_int_base(abs_val: i64, is_negative: bool, f: &mut Formatter, base: i32, u
 
 
 impl bool {
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(5);
         let mut f = Formatter::new(&mut buf);
-        f.pad(if self { "true" } else { "false" });
+        f.pad(if *self { "true" } else { "false" });
         return buf;
     }
 }
@@ -524,23 +524,23 @@ impl char {
         return builtin::i32_as_char(value as i32);
     }
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(4);
-        buf.append_char(self);
+        buf.append_char(*self);
         return buf;
     }
 
     /// Returns true if the character is an ASCII whitespace character:
     /// space (0x20), tab (0x09), newline (0x0A), or carriage return (0x0D).
-    pub fn is_ascii_space(self) -> bool {
-        return self == ' ' || self == '\t' || self == '\n' || self == '\r';
+    pub fn is_ascii_space(&self) -> bool {
+        return *self == ' ' || *self == '\t' || *self == '\n' || *self == '\r';
     }
 
     /// Returns true if the character is a Unicode whitespace character.
     /// Covers ASCII whitespace plus form feed (0x0C), vertical tab (0x0B),
     /// and Unicode general category Zs/Zl/Zp code points.
-    pub fn is_unicode_space(self) -> bool {
-        let c = self as u32;
+    pub fn is_unicode_space(&self) -> bool {
+        let c = (*self) as u32;
         // ASCII whitespace: HT, LF, VT, FF, CR, SP
         if c <= 0x20 {
             return c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0B || c == 0x0C || c == 0x0D;
@@ -566,8 +566,8 @@ impl i8 {
 
     pub fn min(a: i8, b: i8) -> i8 { return builtin::select::<i8>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
-        return ((self) as i32).to_string();
+    pub fn to_string(&self) -> String {
+        return ((*self) as i32).to_string();
     }
 }
 
@@ -579,8 +579,8 @@ impl u8 {
 
     pub fn min(a: u8, b: u8) -> u8 { return builtin::select::<u8>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
-        return ((self) as i32).to_string();
+    pub fn to_string(&self) -> String {
+        return ((*self) as i32).to_string();
     }
 }
 
@@ -592,8 +592,8 @@ impl i16 {
 
     pub fn min(a: i16, b: i16) -> i16 { return builtin::select::<i16>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
-        return ((self) as i32).to_string();
+    pub fn to_string(&self) -> String {
+        return ((*self) as i32).to_string();
     }
 }
 
@@ -605,8 +605,8 @@ impl u16 {
 
     pub fn min(a: u16, b: u16) -> u16 { return builtin::select::<u16>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
-        return ((self) as i32).to_string();
+    pub fn to_string(&self) -> String {
+        return ((*self) as i32).to_string();
     }
 }
 
@@ -618,10 +618,10 @@ impl i32 {
 
     pub fn min(a: i32, b: i32) -> i32 { return builtin::select::<i32>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(12);
         let mut f = Formatter::new(&mut buf);
-        fmt_i32_decimal(self, &mut f);
+        fmt_i32_decimal(*self, &mut f);
         return buf;
     }
 }
@@ -634,10 +634,10 @@ impl u32 {
 
     pub fn min(a: u32, b: u32) -> u32 { return builtin::select::<u32>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(11);
         let mut f = Formatter::new(&mut buf);
-        fmt_u32_decimal(self, &mut f);
+        fmt_u32_decimal(*self, &mut f);
         return buf;
     }
 }
@@ -650,10 +650,10 @@ impl i64 {
 
     pub fn min(a: i64, b: i64) -> i64 { return builtin::select::<i64>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(21);
         let mut f = Formatter::new(&mut buf);
-        fmt_i64_decimal(self, &mut f);
+        fmt_i64_decimal(*self, &mut f);
         return buf;
     }
 }
@@ -666,10 +666,10 @@ impl u64 {
 
     pub fn min(a: u64, b: u64) -> u64 { return builtin::select::<u64>(a < b, a, b); }
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(21);
         let mut f = Formatter::new(&mut buf);
-        fmt_u64_decimal(self, &mut f);
+        fmt_u64_decimal(*self, &mut f);
         return buf;
     }
 }
@@ -690,10 +690,10 @@ impl f32 {
     pub const INFINITY: f32 = 1.0 / 0.0;
     pub const NEG_INFINITY: f32 = -1.0 / 0.0;
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(16);
         let mut f = Formatter::new(&mut buf);
-        fmt_f32(self, &mut f);
+        fmt_f32(*self, &mut f);
         return buf;
     }
 
@@ -817,10 +817,10 @@ impl f64 {
     pub const INFINITY: f64 = 1.0 / 0.0;
     pub const NEG_INFINITY: f64 = -1.0 / 0.0;
 
-    pub fn to_string(self) -> String {
+    pub fn to_string(&self) -> String {
         let mut buf = String::with_capacity(24);
         let mut f = Formatter::new(&mut buf);
-        fmt_f64(self, &mut f);
+        fmt_f64(*self, &mut f);
         return buf;
     }
 

--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -288,7 +288,7 @@ pub trait KeyValueLiteralBuilder {
     /// Record one field from the literal.
     fn insert_literal(&mut self, key: String, value: Self::Value);
     /// Consume the builder and return the finished value.
-    fn build(self) -> Self::Output;
+    fn build(&self) -> Self::Output;
 }
 
 /// Marker trait for types constructible from a key-value literal.
@@ -317,7 +317,7 @@ pub trait SequenceLiteralBuilder {
     /// Append one element from the literal.
     fn push_literal(&mut self, value: Self::Element);
     /// Consume the builder and return the finished value.
-    fn build(self) -> Self::Output;
+    fn build(&self) -> Self::Output;
 }
 
 /// Marker trait for types constructible from a sequence literal.

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -313,11 +313,10 @@ pub struct Function {
     pub span: Span,
 }
 
-/// Self parameter kind: self, &self, or &mut self
+/// Self parameter kind: &self or &mut self
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelfKind {
     None,
-    Value,
     Ref,
     MutRef,
 }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -847,22 +847,15 @@ impl Parser {
             });
         }
 
-        // Handle self by value (without `:`)
-        // Note: `self: Type` is a named self parameter handled below as a regular parameter
+        // self by value is not allowed — use &self or &mut self instead
         if let TokenKind::Ident(name) = self.peek_kind()
             && name == "self"
             && !matches!(self.peek_nth(1).kind, TokenKind::Colon)
         {
-            self.advance();
-            let self_type = Type::Named(NamedType {
-                name: "Self".to_string(),
-                span: start_span,
-            });
-            return Ok(Param {
-                name: "self".to_string(),
-                ty: self_type,
-                self_kind: SelfKind::Value,
-                span: start_span,
+            return Err(ParseError {
+                message: "`self` by value is not allowed; use `&self` or `&mut self` instead"
+                    .to_string(),
+                span: self.peek().span,
             });
         }
 

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -469,10 +469,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let mut params = Vec::new();
         for param in &func.params {
             let type_id = match param.self_kind {
-                ast::SelfKind::Value => {
-                    // self by value: use impl type directly
-                    self.resolve_type(impl_type)
-                }
                 ast::SelfKind::Ref => {
                     // &self: wrap impl type in immutable reference
                     let inner_type = self.resolve_type(impl_type);

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -963,8 +963,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let receiver_type = self.type_table.borrow().get(receiver.type_id).clone();
 
         match self_kind {
-            ast::SelfKind::None | ast::SelfKind::Value => {
-                // Method expects value (self), so deref all refs
+            ast::SelfKind::None => {
+                // No self parameter (static method context), deref all refs
                 self.deref_to_value(receiver, span)
             }
             ast::SelfKind::Ref => {

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -261,10 +261,6 @@ impl<'a> Unparser<'a> {
 
     fn unparse_param(&mut self, param: &Param) {
         match param.self_kind {
-            SelfKind::Value => {
-                self.output.push_str("self");
-                return;
-            }
             SelfKind::Ref => {
                 self.output.push_str("&self");
                 return;

--- a/wado-compiler/tests/fixtures.golden/array-sort.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array-sort.lowered.wado
@@ -110,7 +110,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_11: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_11: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_11: *self;
         };
     };
     a."Array<i32>::sort_by$__Closure_0"(&__Closure_0 {  });
@@ -145,7 +145,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_19: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_19: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_19: *self;
         };
     };
     __inline_Array_i32___sort_20: {
@@ -177,7 +177,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_27: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_27: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_27: *self;
         };
     };
     let d: Array<i32> = move c."Array<i32>::sorted_by$__Closure_2"(&__Closure_2 {  });
@@ -211,7 +211,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_35: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_35: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_35: *self;
         };
     };
     let f: Array<i32> = move e."Array<i32>::sorted"();
@@ -219,7 +219,7 @@ export fn run() with Stdout {
     print_array(&f);
     let mut empty: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __inline_Array_i32___sort_38: {
         let self: &mut Array<i32> = &mut empty;
@@ -247,7 +247,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_45: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_45: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_45: *self;
         };
     };
     __inline_Array_i32___sort_46: {
@@ -267,7 +267,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_50: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_50: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_50: *self;
         };
     };
     __inline_Array_i32___sort_51: {
@@ -303,7 +303,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_59: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_59: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_59: *self;
         };
     };
     g."Array<i32>::sort_by$__Closure_3"(&__Closure_3 {  });

--- a/wado-compiler/tests/fixtures.golden/array_append.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_append.lowered.wado
@@ -25,7 +25,7 @@ export fn run() with Stdout {
     };
     let arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i32>::append"(10);
     arr."Array<i32>::append"(20);

--- a/wado-compiler/tests/fixtures.golden/array_append_collapse.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_append_collapse.lowered.wado
@@ -42,7 +42,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     __assert_0: {
@@ -201,7 +201,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_30: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_30: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_30: *self;
         };
     };
     __assert_4: {
@@ -314,7 +314,7 @@ export fn run() with Stdout {
     }
     let c: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __assert_7: {
         let __v0: i32 = c.used;
@@ -360,7 +360,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_57: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_57: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_57: *self;
         };
     };
     __assert_8: {
@@ -451,7 +451,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i64__SequenceLiteralBuilder__build_73: {
             let self: Array<i64> = __b;
-            break __inline_Array_i64__SequenceLiteralBuilder__build_73: self;
+            break __inline_Array_i64__SequenceLiteralBuilder__build_73: *self;
         };
     };
     __assert_10: {
@@ -539,7 +539,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_SeqVec_i32__SequenceLiteralBuilder__build_89: {
             let self: SeqVec<i32> = __b;
-            break __inline_SeqVec_i32__SequenceLiteralBuilder__build_89: self;
+            break __inline_SeqVec_i32__SequenceLiteralBuilder__build_89: *self;
         };
     };
     __assert_12: {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_empty.lowered.wado
@@ -25,7 +25,7 @@ export fn run() {
     };
     let arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i32>^IndexValue::index_value"(0);
 }
@@ -41,7 +41,7 @@ export fn __cm_export__run() {
         };
         let arr: Array<i32> = __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         };
         arr."Array<i32>^IndexValue::index_value"(0);
     };

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_get.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_get.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let __pattern_temp_0: Option<i32> = move arr."Array<i32>::get"(0);

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_negative.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_negative.lowered.wado
@@ -39,7 +39,7 @@ export fn run() {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     arr."Array<i32>^IndexValue::index_value"(-1);

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_read.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_read.lowered.wado
@@ -39,7 +39,7 @@ export fn run() {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     arr."Array<i32>^IndexValue::index_value"(3);

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_write.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_write.lowered.wado
@@ -39,7 +39,7 @@ export fn run() {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     arr."Array<i32>^IndexAssign::index_assign"(3, 99);

--- a/wado-compiler/tests/fixtures.golden/array_empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_empty.lowered.wado
@@ -25,7 +25,7 @@ export fn run() with Stdout {
     };
     let a: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     core::cli::println(move "empty array ok");
 }

--- a/wado-compiler/tests/fixtures.golden/array_explicit_cast.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_explicit_cast.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_f64.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_f64__SequenceLiteralBuilder__build_5: {
             let self: Array<f64> = __b;
-            break __inline_Array_f64__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_f64__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_index_inline.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let first: i32 = arr."Array<i32>^IndexValue::index_value"(0);

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_btree.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_btree.lowered.wado
@@ -57,7 +57,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_6: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_6: *self;
         };
     }, deleted: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(4), used: 0 };
@@ -79,7 +79,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_bool__SequenceLiteralBuilder__build_12: {
             let self: Array<bool> = __b;
-            break __inline_Array_bool__SequenceLiteralBuilder__build_12: self;
+            break __inline_Array_bool__SequenceLiteralBuilder__build_12: *self;
         };
     } }, max_keys: 5 };
     let result: i32 = tree."Tree<String>::check"();

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_compare.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_compare.lowered.wado
@@ -59,7 +59,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_6: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_6: *self;
         };
     };
     let result: i32 = find_key_index(&keys, &"cherry");

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_generic.lowered.wado
@@ -43,7 +43,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let first: i32 = __sroa_c_items."Array<i32>^IndexValue::index_value"(0);

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_loop.lowered.wado
@@ -47,7 +47,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let mut sum: i32 = 0;
@@ -94,7 +94,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_16: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_16: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_16: *self;
         };
     };
     __for_1: {

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_method.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     }, values: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(3), used: 0 };
@@ -66,7 +66,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_10: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_10: *self;
         };
     }, deleted: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(3), used: 0 };
@@ -84,7 +84,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_bool__SequenceLiteralBuilder__build_15: {
             let self: Array<bool> = __b;
-            break __inline_Array_bool__SequenceLiteralBuilder__build_15: self;
+            break __inline_Array_bool__SequenceLiteralBuilder__build_15: *self;
         };
     } };
     let idx: i32 = c."Container<String,i32>::find_key_index"(&"cherry");

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_multi.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_multi.lowered.wado
@@ -47,7 +47,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     }, markers: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(3), used: 0 };
@@ -65,7 +65,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_bool__SequenceLiteralBuilder__build_10: {
             let self: Array<bool> = __b;
-            break __inline_Array_bool__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_bool__SequenceLiteralBuilder__build_10: *self;
         };
     } };
     let item0: String = move c.items."Array<String>^IndexValue::index_value"(0);

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_nested.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let __sroa_node_values: Array<i32> = __seq_lit: {
@@ -67,7 +67,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_10: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_10: *self;
         };
     };
     let __sroa_node_deleted: Array<bool> = __seq_lit: {
@@ -86,7 +86,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_bool__SequenceLiteralBuilder__build_15: {
             let self: Array<bool> = __b;
-            break __inline_Array_bool__SequenceLiteralBuilder__build_15: self;
+            break __inline_Array_bool__SequenceLiteralBuilder__build_15: *self;
         };
     };
     let mut sum: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.lowered.wado
@@ -60,7 +60,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_4: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_4: *self;
         };
     }, children: __seq_lit: {
         let mut __b: Array<&mut Node<String>> = move "Array<Node<String>>^SequenceLiteralBuilder::new_literal"(0);
@@ -80,7 +80,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_8: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_8: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_8: *self;
         };
     }, children: __seq_lit: {
         let mut __b: Array<&mut Node<String>> = move "Array<Node<String>>^SequenceLiteralBuilder::new_literal"(0);
@@ -95,7 +95,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_11: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_11: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_11: *self;
         };
     }, children: __seq_lit: {
         let mut __b: Array<&mut Node<String>> = move "Array<Node<String>>^SequenceLiteralBuilder::new_literal"(2);
@@ -177,8 +177,8 @@ pub fn "Array<Node<String>>::append"(self: &mut Array<&mut Node<String>>, value:
     self.used = (used + 1);
 }
 
-fn "Array<Node<String>>^SequenceLiteralBuilder::build"(self: Array<&mut Node<String>>) -> Array<&mut Node<String>> {
-    return self;
+fn "Array<Node<String>>^SequenceLiteralBuilder::build"(self: &Array<&mut Node<String>>) -> Array<&mut Node<String>> {
+    return *self;
 }
 
 fn "Array<Node<String>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<&mut Node<String>> {

--- a/wado-compiler/tests/fixtures.golden/array_large_literal_dynamic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_large_literal_dynamic.lowered.wado
@@ -1067,7 +1067,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_264: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_264: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_264: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/array_literal_coerce_u8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_literal_coerce_u8.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_5: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {
@@ -91,7 +91,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i64__SequenceLiteralBuilder__build_17: {
             let self: Array<i64> = __b;
-            break __inline_Array_i64__SequenceLiteralBuilder__build_17: self;
+            break __inline_Array_i64__SequenceLiteralBuilder__build_17: *self;
         };
     };
     core::cli::println(__tmpl: {
@@ -143,7 +143,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_u16__SequenceLiteralBuilder__build_29: {
             let self: Array<u16> = __b;
-            break __inline_Array_u16__SequenceLiteralBuilder__build_29: self;
+            break __inline_Array_u16__SequenceLiteralBuilder__build_29: *self;
         };
     };
     core::cli::println(__tmpl: {
@@ -195,7 +195,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_41: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_41: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_41: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_new_data_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_f64.lowered.wado
@@ -545,7 +545,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_f64__SequenceLiteralBuilder__build_130: {
             let self: Array<f64> = __b;
-            break __inline_Array_f64__SequenceLiteralBuilder__build_130: self;
+            break __inline_Array_f64__SequenceLiteralBuilder__build_130: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/array_new_data_i32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_i32.lowered.wado
@@ -545,7 +545,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_130: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_130: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_130: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/array_new_data_mixed.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_mixed.lowered.wado
@@ -545,7 +545,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_130: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_130: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_130: *self;
         };
     };
     __assert_0: {
@@ -1172,7 +1172,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_276: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_276: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_276: *self;
         };
     };
     __assert_3: {

--- a/wado-compiler/tests/fixtures.golden/array_new_data_u8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_u8.lowered.wado
@@ -555,7 +555,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_134: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_134: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_134: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/array_of_generic_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_of_generic_struct.lowered.wado
@@ -262,8 +262,8 @@ pub fn "Array<Box<i32>>::append"(self: &mut Array<Box<i32>>, value: Box<i32>) {
     self.used = (used + 1);
 }
 
-fn "Array<Box<i32>>^SequenceLiteralBuilder::build"(self: Array<Box<i32>>) -> Array<Box<i32>> {
-    return self;
+fn "Array<Box<i32>>^SequenceLiteralBuilder::build"(self: &Array<Box<i32>>) -> Array<Box<i32>> {
+    return *self;
 }
 
 fn "Array<Box<i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<Box<i32>> {

--- a/wado-compiler/tests/fixtures.golden/array_param_coercion.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_param_coercion.lowered.wado
@@ -43,7 +43,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     });
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_return.lowered.wado
@@ -32,7 +32,7 @@ fn get_numbers() -> Array<i32> {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
         };
     };
 }

--- a/wado-compiler/tests/fixtures.golden/array_specialized_bool.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_bool.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<bool> = __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<bool>::append"(true);
     arr."Array<bool>::append"(false);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_char.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_char.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<char> = __seq_lit: {
         let mut __b: Array<char> = move Array<char> { repr: core::builtin::array_new::<char>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<char>::append"('A');
     arr."Array<char>::append"('B');

--- a/wado-compiler/tests/fixtures.golden/array_specialized_f32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_f32.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<f32> = __seq_lit: {
         let mut __b: Array<f32> = move Array<f32> { repr: core::builtin::array_new::<f32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<f32>::append"(1.5 as f32);
     arr."Array<f32>::append"(2.5 as f32);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_f64.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<f64> = __seq_lit: {
         let mut __b: Array<f64> = move Array<f64> { repr: core::builtin::array_new::<f64>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<f64>::append"(1.5);
     arr."Array<f64>::append"(2.5);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i16.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i16.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<i16> = __seq_lit: {
         let mut __b: Array<i16> = move Array<i16> { repr: core::builtin::array_new::<i16>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i16>::append"(1000);
     arr."Array<i16>::append"(-2000);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i32.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i32>::append"(100000);
     arr."Array<i32>::append"(-200000);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i64.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<i64> = __seq_lit: {
         let mut __b: Array<i64> = move Array<i64> { repr: core::builtin::array_new::<i64>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i64>::append"(10000000000);
     arr."Array<i64>::append"(-20000000000);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i8.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<i8> = __seq_lit: {
         let mut __b: Array<i8> = move Array<i8> { repr: core::builtin::array_new::<i8>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i8>::append"(1);
     arr."Array<i8>::append"(-2);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_string.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<String>::append"(move "hello");
     arr."Array<String>::append"(move "world");

--- a/wado-compiler/tests/fixtures.golden/array_specialized_tuple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_tuple.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<[bool, i32, String]> = __seq_lit: {
         let mut __b: Array<[bool, i32, String]> = move Array<Tuple<bool,i32,String>> { repr: core::builtin::array_new::<[bool, i32, String]>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<Tuple<bool,i32,String>>::append"(move [true, 1, "one"]);
     arr."Array<Tuple<bool,i32,String>>::append"(move [false, 2, "two"]);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u16.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u16.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<u16> = __seq_lit: {
         let mut __b: Array<u16> = move Array<u16> { repr: core::builtin::array_new::<u16>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<u16>::append"(1000);
     arr."Array<u16>::append"(2000);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u32.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u32.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<u32> = __seq_lit: {
         let mut __b: Array<u32> = move Array<u32> { repr: core::builtin::array_new::<u32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<u32>::append"(100000);
     arr."Array<u32>::append"(200000);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u64.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<u64> = __seq_lit: {
         let mut __b: Array<u64> = move Array<u64> { repr: core::builtin::array_new::<u64>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<u64>::append"(10000000000);
     arr."Array<u64>::append"(20000000000);

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u8.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u8.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<u8> = __seq_lit: {
         let mut __b: Array<u8> = move Array<u8> { repr: core::builtin::array_new::<u8>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<u8>::append"(1);
     arr."Array<u8>::append"(2);

--- a/wado-compiler/tests/fixtures.golden/array_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string.lowered.wado
@@ -42,7 +42,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_string_cast.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string_cast.lowered.wado
@@ -37,7 +37,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_4: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_4: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/array_string_param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string_param.lowered.wado
@@ -47,7 +47,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_4: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_4: *self;
         };
     });
     core::cli::println(result);

--- a/wado-compiler/tests/fixtures.golden/array_type_annotation.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_type_annotation.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/auto_deref_for_of.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref_for_of.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut sum: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/closure_capture_fn_param.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_capture_fn_param.lowered.wado
@@ -144,7 +144,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_19: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_19: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_19: *self;
         };
     };
     let r5: i32 = scale_and_add(items, 2, 1);

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_effectful.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_effectful.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     "for_each$__Closure_0"(items, &__Closure_0 {  });

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_chain.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_chain.lowered.wado
@@ -107,7 +107,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_12: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_12: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_12: *self;
         };
     };
     let result: Array<i32> = move __inline_ArrayIter_i32___filter_14: {
@@ -203,7 +203,7 @@ pub fn "FilterIter<i32>::map<i32>"(self: &FilterIter<i32>, f: fn(i32) -> i32) ->
 pub fn "FilterMapIter<i32,i32>^Iterator::collect"(self: &mut FilterMapIter<i32,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     loop {
         let __pattern_temp_0: Option<i32> = move self."FilterMapIter<i32,i32>^Iterator::next"();

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_filter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_filter.lowered.wado
@@ -87,7 +87,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_12: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_12: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_12: *self;
         };
     };
     let evens: Array<i32> = move __inline_ArrayIter_i32___filter_14: {
@@ -167,7 +167,7 @@ fn "ArrayIter<i32>^Iterator::next"(self: &mut ArrayIter<i32>) -> Option<i32> {
 pub fn "FilterIter<i32>^Iterator::collect"(self: &mut FilterIter<i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     loop {
         let __pattern_temp_0: Option<i32> = move self."FilterIter<i32>^Iterator::next"();

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_fold.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_fold.lowered.wado
@@ -65,7 +65,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let sum: i32 = ArrayIter<i32> { repr: nums.repr, used: nums.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_0"(0, &__Closure_0 {  });

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_map.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_map.lowered.wado
@@ -67,7 +67,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let doubled: Array<i32> = move __inline_ArrayIter_i32___map_i32__9: {
@@ -147,7 +147,7 @@ fn "ArrayIter<i32>^Iterator::next"(self: &mut ArrayIter<i32>) -> Option<i32> {
 pub fn "MapIter<i32,i32>^Iterator::collect"(self: &mut MapIter<i32,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     loop {
         let __pattern_temp_0: Option<i32> = move self."MapIter<i32,i32>^Iterator::next"();

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.lowered.wado
@@ -29,7 +29,7 @@ export fn run() with Stdout {
     };
     let mut closures: Array<fn(i32) -> i32> = __seq_lit: {
         let mut __b: Array<fn(i32) -> i32> = move Array<Fn<1,i32>> { repr: core::builtin::array_new::<fn(i32) -> i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_0: {
         let mut i: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.lowered.wado
@@ -57,12 +57,12 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let mut closures: Array<fn(i32) -> i32> = __seq_lit: {
         let mut __b: Array<fn(i32) -> i32> = move Array<Fn<1,i32>> { repr: core::builtin::array_new::<fn(i32) -> i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_0: {
         let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/closure_sort_by.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_sort_by.lowered.wado
@@ -78,7 +78,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_11: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_11: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_11: *self;
         };
     };
     nums."Array<i32>::sort_by$__Closure_0"(&__Closure_0 {  });
@@ -167,7 +167,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_29: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_29: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_29: *self;
         };
     };
     let asc: Array<i32> = move original."Array<i32>::sorted_by$__Closure_2"(&__Closure_2 {  });

--- a/wado-compiler/tests/fixtures.golden/contextual_keyword.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/contextual_keyword.lowered.wado
@@ -73,7 +73,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_12: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_12: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_12: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/cross_destruct_patterns.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_destruct_patterns.lowered.wado
@@ -105,7 +105,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Tagged__SequenceLiteralBuilder__build_14: {
             let self: Array<Tagged> = __b;
-            break __inline_Array_Tagged__SequenceLiteralBuilder__build_14: self;
+            break __inline_Array_Tagged__SequenceLiteralBuilder__build_14: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/dict_mini.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/dict_mini.lowered.wado
@@ -29,7 +29,7 @@ export fn run() with Stdout {
     };
     let mut dict: MiniDict<String,String> = move MiniDict<String,String> { entries: __seq_lit: {
         let mut __b: Array<[String, String]> = move Array<Tuple<String,String>> { repr: core::builtin::array_new::<[String, String]>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     } };
     dict."MiniDict<String,String>::set"(move "name", move "Wado");
     dict."MiniDict<String,String>::set"(move "type", move "language");

--- a/wado-compiler/tests/fixtures.golden/display_all_primitives.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_all_primitives.lowered.wado
@@ -24,7 +24,7 @@ export fn run() with Stdout {
         __modules_initialized = true;
     };
     __assert_0: {
-        let __v0: String = move 127.i32::to_string();
+        let __v0: String = move Box<i32> { value: 127 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"127");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -52,7 +52,7 @@ export fn run() with Stdout {
         }
     }
     __assert_1: {
-        let __v0: String = move -128.i32::to_string();
+        let __v0: String = move Box<i32> { value: -128 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"-128");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -80,7 +80,7 @@ export fn run() with Stdout {
         }
     }
     __assert_2: {
-        let __v0: String = move 255.i32::to_string();
+        let __v0: String = move Box<i32> { value: 255 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"255");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -108,7 +108,7 @@ export fn run() with Stdout {
         }
     }
     __assert_3: {
-        let __v0: String = move 0.i32::to_string();
+        let __v0: String = move Box<i32> { value: 0 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"0");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -136,7 +136,7 @@ export fn run() with Stdout {
         }
     }
     __assert_4: {
-        let __v0: String = move 32767.i32::to_string();
+        let __v0: String = move Box<i32> { value: 32767 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"32767");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -164,7 +164,7 @@ export fn run() with Stdout {
         }
     }
     __assert_5: {
-        let __v0: String = move -32768.i32::to_string();
+        let __v0: String = move Box<i32> { value: -32768 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"-32768");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -192,7 +192,7 @@ export fn run() with Stdout {
         }
     }
     __assert_6: {
-        let __v0: String = move 65535.i32::to_string();
+        let __v0: String = move Box<i32> { value: 65535 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"65535");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -220,7 +220,7 @@ export fn run() with Stdout {
         }
     }
     __assert_7: {
-        let __v0: String = move 2147483647.i32::to_string();
+        let __v0: String = move Box<i32> { value: 2147483647 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"2147483647");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -248,7 +248,7 @@ export fn run() with Stdout {
         }
     }
     __assert_8: {
-        let __v0: String = move -2147483648.i32::to_string();
+        let __v0: String = move Box<i32> { value: -2147483648 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"-2147483648");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -276,7 +276,7 @@ export fn run() with Stdout {
         }
     }
     __assert_9: {
-        let __v0: String = move 0.i32::to_string();
+        let __v0: String = move Box<i32> { value: 0 }.i32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"0");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -304,7 +304,7 @@ export fn run() with Stdout {
         }
     }
     __assert_10: {
-        let __v0: String = move 4294967295.u32::to_string();
+        let __v0: String = move Box<u32> { value: 4294967295 }.u32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"4294967295");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -332,7 +332,7 @@ export fn run() with Stdout {
         }
     }
     __assert_11: {
-        let __v0: String = move 9223372036854775807.i64::to_string();
+        let __v0: String = move Box<i64> { value: 9223372036854775807 }.i64::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"9223372036854775807");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -360,7 +360,7 @@ export fn run() with Stdout {
         }
     }
     __assert_12: {
-        let __v0: String = move -9223372036854775808.i64::to_string();
+        let __v0: String = move Box<i64> { value: -9223372036854775808 }.i64::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"-9223372036854775808");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -388,7 +388,7 @@ export fn run() with Stdout {
         }
     }
     __assert_13: {
-        let __v0: String = move 18446744073709551615.u64::to_string();
+        let __v0: String = move Box<u64> { value: 18446744073709551615 }.u64::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"18446744073709551615");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -416,7 +416,7 @@ export fn run() with Stdout {
         }
     }
     __assert_14: {
-        let __v0: String = move 3.14.f32::to_string();
+        let __v0: String = move Box<f32> { value: 3.14 }.f32::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"3.14");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -444,7 +444,7 @@ export fn run() with Stdout {
         }
     }
     __assert_15: {
-        let __v0: String = move 3.141592653589793.f64::to_string();
+        let __v0: String = move Box<f64> { value: 3.141592653589793 }.f64::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"3.141592653589793");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -472,7 +472,7 @@ export fn run() with Stdout {
         }
     }
     __assert_16: {
-        let __v0: String = move true.bool::to_string();
+        let __v0: String = move Box<bool> { value: true }.bool::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"true");
         if !__cond {
             core::internal::panic(__tmpl: {
@@ -500,7 +500,7 @@ export fn run() with Stdout {
         }
     }
     __assert_17: {
-        let __v0: String = move false.bool::to_string();
+        let __v0: String = move Box<bool> { value: false }.bool::to_string();
         let __cond: bool = __v0."String^Eq::eq"(&"false");
         if !__cond {
             core::internal::panic(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/display_custom.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_custom.lowered.wado
@@ -25,7 +25,7 @@ pub fn "Point^Display::fmt"(self: &Point, f: &mut Formatter) {
         f.buf.String::append_char('(');
     };
     __inline_Formatter__write_str_1: {
-        let s: String = move self.x.i32::to_string();
+        let s: String = move Box<i32> { value: self.x }.i32::to_string();
         f.buf.String::append(s);
     };
     __inline_Formatter__write_str_2: {
@@ -33,7 +33,7 @@ pub fn "Point^Display::fmt"(self: &Point, f: &mut Formatter) {
         f.buf.String::append(s);
     };
     __inline_Formatter__write_str_3: {
-        let s: String = move self.y.i32::to_string();
+        let s: String = move Box<i32> { value: self.y }.i32::to_string();
         f.buf.String::append(s);
     };
     __inline_Formatter__write_char_4: {

--- a/wado-compiler/tests/fixtures.golden/for_let_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_let_basic.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/for_of_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_basic.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let mut sum: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/for_of_break.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_break.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_continue.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_continue.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_empty.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let empty: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_0: {
         let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: empty.repr, used: empty.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/for_of_generic_method.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_generic_method.lowered.wado
@@ -49,7 +49,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     } };
     c."Container<i32>::process"();

--- a/wado-compiler/tests/fixtures.golden/for_of_generic_tuple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_generic_tuple.lowered.wado
@@ -47,7 +47,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Tuple_String_i32___SequenceLiteralBuilder__build_4: {
             let self: Array<[String, i32]> = __b;
-            break __inline_Array_Tuple_String_i32___SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_Tuple_String_i32___SequenceLiteralBuilder__build_4: *self;
         };
     } };
     h."Holder<String,i32>::process"();

--- a/wado-compiler/tests/fixtures.golden/for_of_mut.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_mut.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_nested.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let inner: Array<i32> = __seq_lit: {
@@ -60,7 +60,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_9: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_9: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_9: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_side_effect.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_side_effect.lowered.wado
@@ -39,7 +39,7 @@ fn get_numbers() -> Array<i32> with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
         };
     };
 }

--- a/wado-compiler/tests/fixtures.golden/for_of_strings.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_strings.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_structs.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_structs.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Point__SequenceLiteralBuilder__build_4: {
             let self: Array<Point> = __b;
-            break __inline_Array_Point__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_Point__SequenceLiteralBuilder__build_4: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_tuple_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_tuple_array.lowered.wado
@@ -43,7 +43,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Tuple_String_i32___SequenceLiteralBuilder__build_4: {
             let self: Array<[String, i32]> = __b;
-            break __inline_Array_Tuple_String_i32___SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_Tuple_String_i32___SequenceLiteralBuilder__build_4: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/for_of_tuples.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_tuples.lowered.wado
@@ -43,7 +43,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Tuple_i32_i32___SequenceLiteralBuilder__build_4: {
             let self: Array<[i32, i32]> = __b;
-            break __inline_Array_Tuple_i32_i32___SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_Tuple_i32_i32___SequenceLiteralBuilder__build_4: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/forof-generic-array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/forof-generic-array.lowered.wado
@@ -49,7 +49,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     } };
     c."Container<i32>::process"();

--- a/wado-compiler/tests/fixtures.golden/from-literal-cast.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-cast.lowered.wado
@@ -31,16 +31,16 @@ export fn run() with Stdout {
     let m: PairList<String> = __kv_lit: {
         let mut __b: PairList<String> = move PairList<String> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."PairList<String>^KeyValueLiteralBuilder::insert_literal"(move "name", move "Alice");
         __b."PairList<String>^KeyValueLiteralBuilder::insert_literal"(move "city", move "Tokyo");
         break __kv_lit: __inline_PairList_String__KeyValueLiteralBuilder__build_2: {
             let self: PairList<String> = __b;
-            break __inline_PairList_String__KeyValueLiteralBuilder__build_2: self;
+            break __inline_PairList_String__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-custom.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-custom.lowered.wado
@@ -31,17 +31,17 @@ export fn run() with Stdout {
     let m: LinearMap<i32> = __kv_lit: {
         let mut __b: LinearMap<i32> = move LinearMap<i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."LinearMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "x", 10);
         __b."LinearMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "y", 20);
         __b."LinearMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "z", 30);
         break __kv_lit: __inline_LinearMap_i32__KeyValueLiteralBuilder__build_2: {
             let self: LinearMap<i32> = __b;
-            break __inline_LinearMap_i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_LinearMap_i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-enum-concrete.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-enum-concrete.lowered.wado
@@ -31,16 +31,16 @@ export fn run() with Stdout {
     let m: DirMap<Direction,i32> = __kv_lit: {
         let mut __b: DirMap<Direction,i32> = move DirMap<Direction,i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."DirMap<Direction,i32>^KeyValueLiteralBuilder::insert_literal"(move "north", 1);
         __b."DirMap<Direction,i32>^KeyValueLiteralBuilder::insert_literal"(move "south", 2);
         break __kv_lit: __inline_DirMap_Direction_i32__KeyValueLiteralBuilder__build_2: {
             let self: DirMap<Direction,i32> = __b;
-            break __inline_DirMap_Direction_i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_DirMap_Direction_i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-flags-concrete.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-flags-concrete.lowered.wado
@@ -36,16 +36,16 @@ export fn run() with Stdout {
     let m: PermsMap<Perms,i32> = __kv_lit: {
         let mut __b: PermsMap<Perms,i32> = move PermsMap<Perms,i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."PermsMap<Perms,i32>^KeyValueLiteralBuilder::insert_literal"(move "read", 1);
         __b."PermsMap<Perms,i32>^KeyValueLiteralBuilder::insert_literal"(move "write", 2);
         break __kv_lit: __inline_PermsMap_Perms_i32__KeyValueLiteralBuilder__build_2: {
             let self: PermsMap<Perms,i32> = __b;
-            break __inline_PermsMap_Perms_i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_PermsMap_Perms_i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-fn-arg.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-fn-arg.lowered.wado
@@ -58,17 +58,17 @@ export fn run() with Stdout {
         let m: SimpleMap<i32> = __kv_lit: {
             let mut __b: SimpleMap<i32> = move SimpleMap<i32> { keys: __seq_lit: {
                 let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-                break __seq_lit: __b;
+                break __seq_lit: *__b;
             }, values: __seq_lit: {
                 let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-                break __seq_lit: __b;
+                break __seq_lit: *__b;
             } };
             __b."SimpleMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "a", 1);
             __b."SimpleMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "b", 2);
             __b."SimpleMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "c", 3);
             break __kv_lit: __inline_SimpleMap_i32__KeyValueLiteralBuilder__build_3: {
                 let self: SimpleMap<i32> = __b;
-                break __inline_SimpleMap_i32__KeyValueLiteralBuilder__build_3: self;
+                break __inline_SimpleMap_i32__KeyValueLiteralBuilder__build_3: *self;
             };
         };
         break __inline_count_entries_1: __inline_Array_String___len_1: {
@@ -114,16 +114,16 @@ export fn run() with Stdout {
     let s: i32 = sum_values(__kv_lit: {
         let mut __b: SimpleMap<i32> = move SimpleMap<i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."SimpleMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "x", 10);
         __b."SimpleMap<i32>^KeyValueLiteralBuilder::insert_literal"(move "y", 20);
         break __kv_lit: __inline_SimpleMap_i32__KeyValueLiteralBuilder__build_11: {
             let self: SimpleMap<i32> = __b;
-            break __inline_SimpleMap_i32__KeyValueLiteralBuilder__build_11: self;
+            break __inline_SimpleMap_i32__KeyValueLiteralBuilder__build_11: *self;
         };
     });
     __assert_1: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-nested-generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-nested-generic.lowered.wado
@@ -31,16 +31,16 @@ export fn run() with Stdout {
     let m: NestedMap<Array<String>,i32> = __kv_lit: {
         let mut __b: NestedMap<Array<String>,i32> = move NestedMap<Array<String>,i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."NestedMap<Array<String>,i32>^KeyValueLiteralBuilder::insert_literal"(move "a", 1);
         __b."NestedMap<Array<String>,i32>^KeyValueLiteralBuilder::insert_literal"(move "b", 2);
         break __kv_lit: __inline_NestedMap_Array_String__i32__KeyValueLiteralBuilder__build_2: {
             let self: NestedMap<Array<String>,i32> = __b;
-            break __inline_NestedMap_Array_String__i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_NestedMap_Array_String__i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-newtype-concrete.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-newtype-concrete.lowered.wado
@@ -31,16 +31,16 @@ export fn run() with Stdout {
     let m: TagMap<Tag,i32> = __kv_lit: {
         let mut __b: TagMap<Tag,i32> = move TagMap<Tag,i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."TagMap<Tag,i32>^KeyValueLiteralBuilder::insert_literal"(move "a", 1);
         __b."TagMap<Tag,i32>^KeyValueLiteralBuilder::insert_literal"(move "b", 2);
         break __kv_lit: __inline_TagMap_Tag_i32__KeyValueLiteralBuilder__build_2: {
             let self: TagMap<Tag,i32> = __b;
-            break __inline_TagMap_Tag_i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_TagMap_Tag_i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/from-literal-return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-return.lowered.wado
@@ -57,7 +57,7 @@ fn make_map() -> TreeMap<String,i32> {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_3: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_3: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_3: *self;
         };
     };
 }
@@ -135,7 +135,7 @@ pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
 pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> {
     let mut result: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_1: {
         let mut __iter_1: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -298,8 +298,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/from-literal-variant-concrete.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-variant-concrete.lowered.wado
@@ -31,16 +31,16 @@ export fn run() with Stdout {
     let m: StatusMap<Status,i32> = __kv_lit: {
         let mut __b: StatusMap<Status,i32> = move StatusMap<Status,i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."StatusMap<Status,i32>^KeyValueLiteralBuilder::insert_literal"(move "active", 1);
         __b."StatusMap<Status,i32>^KeyValueLiteralBuilder::insert_literal"(move "inactive", 2);
         break __kv_lit: __inline_StatusMap_Status_i32__KeyValueLiteralBuilder__build_2: {
             let self: StatusMap<Status,i32> = __b;
-            break __inline_StatusMap_Status_i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_StatusMap_Status_i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {

--- a/wado-compiler/tests/fixtures.golden/generic-array-direct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-array-direct.lowered.wado
@@ -25,7 +25,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr."Array<i32>::append"(42);
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.lowered.wado
@@ -135,7 +135,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_11: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_11: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_11: *self;
         };
     };
     "quicksort$__Closure_0"(&mut arr, 0, (arr.used - 1), &__Closure_0 {  });

--- a/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.lowered.wado
@@ -29,7 +29,7 @@ export fn run() with Stdout {
     };
     let mut __sroa_container_items: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __inline_Container_i32___add_2: {
         __sroa_container_items."Array<i32>::append"(10);

--- a/wado-compiler/tests/fixtures.golden/generic-struct-import.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-import.lowered.wado
@@ -229,8 +229,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_generic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_generic.lowered.wado
@@ -82,8 +82,8 @@ fn "Array<Pair<i32,String>>^IndexValue::index_value"(self: &Array<Pair<i32, Stri
     return core::builtin::array_get::<Pair<i32, String>>(self.repr, index);
 }
 
-fn "Array<Pair<i32,String>>^SequenceLiteralBuilder::build"(self: Array<Pair<i32, String>>) -> Array<Pair<i32, String>> {
-    return self;
+fn "Array<Pair<i32,String>>^SequenceLiteralBuilder::build"(self: &Array<Pair<i32, String>>) -> Array<Pair<i32, String>> {
+    return *self;
 }
 
 fn "Array<Pair<i32,String>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Pair<i32, String>>, value: Pair<i32,String>) {

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_struct.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_struct.lowered.wado
@@ -42,7 +42,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Point__SequenceLiteralBuilder__build_4: {
             let self: Array<Point> = __b;
-            break __inline_Array_Point__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_Point__SequenceLiteralBuilder__build_4: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/global_object_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/global_object_array.lowered.wado
@@ -122,7 +122,7 @@ pub fn __initialize_module() {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
         };
     };
 }

--- a/wado-compiler/tests/fixtures.golden/http-fields.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields.lowered.wado
@@ -84,7 +84,7 @@ export fn handle(request: Request) {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_11: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_11: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_11: *self;
         };
     };
     let value: FieldValue = bytes as FieldValue;

--- a/wado-compiler/tests/fixtures.golden/http-response-headers.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/http-response-headers.lowered.wado
@@ -38,7 +38,7 @@ export fn handle(request: Request) {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_6: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_6: *self;
         };
     };
     __cm_adapter__Fields_append(&headers, "x-wado" as FieldName, value as FieldValue);

--- a/wado-compiler/tests/fixtures.golden/index_assign_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_basic.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     arr."Array<i32>^IndexAssign::index_assign"(0, 100);

--- a/wado-compiler/tests/fixtures.golden/index_assign_expression_value.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_expression_value.lowered.wado
@@ -43,7 +43,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_6: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_6: *self;
         };
     };
     arr."Array<i32>^IndexAssign::index_assign"(0, 70);
@@ -56,7 +56,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_10: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_10: *self;
         };
     };
     arr."Array<i32>^IndexAssign::index_assign"(2, (other."Array<i32>^IndexValue::index_value"(0) + 50));

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_conditional.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_conditional.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     arr."Array<i32>^IndexAssign::index_assign"(0, 111);

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_function.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_function.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     fill_array(&mut arr);
@@ -121,7 +121,7 @@ fn create_and_fill() -> Array<i32> {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_3: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_3: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_3: *self;
         };
     };
     arr."Array<i32>^IndexAssign::index_assign"(0, 42);

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_loop.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_loop.lowered.wado
@@ -47,7 +47,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     __for_0: {
@@ -132,7 +132,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_23: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_23: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_23: *self;
         };
     };
     let mut j: i32 = 0;
@@ -193,7 +193,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_35: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_35: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_35: *self;
         };
     };
     let mut k: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/index_assign_multiple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_multiple.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut b: Array<i32> = __seq_lit: {
@@ -58,7 +58,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_10: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_10: *self;
         };
     };
     let mut c: Array<i64> = __seq_lit: {
@@ -73,7 +73,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i64__SequenceLiteralBuilder__build_14: {
             let self: Array<i64> = __b;
-            break __inline_Array_i64__SequenceLiteralBuilder__build_14: self;
+            break __inline_Array_i64__SequenceLiteralBuilder__build_14: *self;
         };
     };
     let mut d: Array<f64> = __seq_lit: {
@@ -88,7 +88,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_f64__SequenceLiteralBuilder__build_18: {
             let self: Array<f64> = __b;
-            break __inline_Array_f64__SequenceLiteralBuilder__build_18: self;
+            break __inline_Array_f64__SequenceLiteralBuilder__build_18: *self;
         };
     };
     a."Array<i32>^IndexAssign::index_assign"(0, 1);

--- a/wado-compiler/tests/fixtures.golden/index_assign_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_nested.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut values: Array<i32> = __seq_lit: {
@@ -58,7 +58,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_10: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_10: *self;
         };
     };
     values."Array<i32>^IndexAssign::index_assign"(indices."Array<i32>^IndexValue::index_value"(0), 100);
@@ -113,7 +113,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_22: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_22: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_22: *self;
         };
     };
     let mut dest: Array<i32> = __seq_lit: {
@@ -132,7 +132,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_27: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_27: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_27: *self;
         };
     };
     dest."Array<i32>^IndexAssign::index_assign"(0, source."Array<i32>^IndexValue::index_value"(2));

--- a/wado-compiler/tests/fixtures.golden/index_assign_ref_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_ref_array.lowered.wado
@@ -42,7 +42,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     };
     strings."Array<String>^IndexAssign::index_assign"(0, move "hello");
@@ -70,7 +70,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_10: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_10: *self;
         };
     };
     messages."Array<String>^IndexAssign::index_assign"(0, move "first");

--- a/wado-compiler/tests/fixtures.golden/index_assign_types.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_types.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_3: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_3: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_3: *self;
         };
     };
     arr_i32."Array<i32>^IndexAssign::index_assign"(0, 42);
@@ -57,7 +57,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i64__SequenceLiteralBuilder__build_9: {
             let self: Array<i64> = __b;
-            break __inline_Array_i64__SequenceLiteralBuilder__build_9: self;
+            break __inline_Array_i64__SequenceLiteralBuilder__build_9: *self;
         };
     };
     arr_i64."Array<i64>^IndexAssign::index_assign"(0, 9999999999);
@@ -84,7 +84,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_f32__SequenceLiteralBuilder__build_15: {
             let self: Array<f32> = __b;
-            break __inline_Array_f32__SequenceLiteralBuilder__build_15: self;
+            break __inline_Array_f32__SequenceLiteralBuilder__build_15: *self;
         };
     };
     arr_f32."Array<f32>^IndexAssign::index_assign"(0, 3.14 as f32);
@@ -110,7 +110,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_f64__SequenceLiteralBuilder__build_21: {
             let self: Array<f64> = __b;
-            break __inline_Array_f64__SequenceLiteralBuilder__build_21: self;
+            break __inline_Array_f64__SequenceLiteralBuilder__build_21: *self;
         };
     };
     arr_f64."Array<f64>^IndexAssign::index_assign"(0, 2.718281828);
@@ -136,7 +136,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_bool__SequenceLiteralBuilder__build_27: {
             let self: Array<bool> = __b;
-            break __inline_Array_bool__SequenceLiteralBuilder__build_27: self;
+            break __inline_Array_bool__SequenceLiteralBuilder__build_27: *self;
         };
     };
     arr_bool."Array<bool>^IndexAssign::index_assign"(0, true);

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.lowered.wado
@@ -25,7 +25,7 @@ export fn run() with Stdout {
     };
     let mut arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_0: {
         let mut i: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_nested.lowered.wado
@@ -38,7 +38,7 @@ fn Container::add_items(self: &mut Container, count: i32) {
 fn Container::process(self: &mut Container) {
     let mut temp: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_1: {
         let mut i: i32 = 0;
@@ -82,7 +82,7 @@ export fn run() with Stdout {
     };
     let mut c: Container = move Container { items: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     } };
     c.Container::add_items(3);
     c.Container::process();

--- a/wado-compiler/tests/fixtures.golden/inline_method_minimal.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_method_minimal.lowered.wado
@@ -25,11 +25,11 @@ export fn run() with Stdout {
     };
     let mut arr1: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let mut arr2: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     arr1."Array<i32>::append"(1);
     arr1."Array<i32>::append"(2);

--- a/wado-compiler/tests/fixtures.golden/inspect_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_array.lowered.wado
@@ -44,7 +44,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {
@@ -58,7 +58,7 @@ export fn run() with Stdout {
     });
     let empty: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     core::cli::println(__tmpl: {
         let mut __r: String = move String { repr: "array_new<u8>"(16), used: 0 };
@@ -77,7 +77,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_14: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_14: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_14: *self;
         };
     };
     core::cli::println(__tmpl: {
@@ -121,7 +121,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Point__SequenceLiteralBuilder__build_24: {
             let self: Array<Point> = __b;
-            break __inline_Array_Point__SequenceLiteralBuilder__build_24: self;
+            break __inline_Array_Point__SequenceLiteralBuilder__build_24: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/inspect_array_option.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_array_option.lowered.wado
@@ -98,8 +98,8 @@ pub fn "Array<Option<i32>>::len"(self: &Array<Option<i32>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Option<i32>>^SequenceLiteralBuilder::build"(self: Array<Option<i32>>) -> Array<Option<i32>> {
-    return self;
+fn "Array<Option<i32>>^SequenceLiteralBuilder::build"(self: &Array<Option<i32>>) -> Array<Option<i32>> {
+    return *self;
 }
 
 fn "Array<Option<i32>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Option<i32>>, value: Option<i32>) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested.lowered.wado
@@ -57,7 +57,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Point__SequenceLiteralBuilder__build_6: {
             let self: Array<Point> = __b;
-            break __inline_Array_Point__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_Point__SequenceLiteralBuilder__build_6: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array3_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array3_test.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
                 };
                 break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                     let self: Array<i32> = __b;
-                    break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                    break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
                 };
             });
             __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -50,7 +50,7 @@ export fn run() with Stdout {
                 };
                 break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
                     let self: Array<i32> = __b;
-                    break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+                    break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
                 };
             });
             break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -73,7 +73,7 @@ export fn run() with Stdout {
                 };
                 break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_12: {
                     let self: Array<i32> = __b;
-                    break __inline_Array_i32__SequenceLiteralBuilder__build_12: self;
+                    break __inline_Array_i32__SequenceLiteralBuilder__build_12: *self;
                 };
             });
             break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -187,12 +187,12 @@ pub fn "Array<Array<Array<i32>>>::len"(self: &Array<Array<Array<i32>>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Array<Array<i32>>>^SequenceLiteralBuilder::build"(self: Array<Array<Array<i32>>>) -> Array<Array<Array<i32>>> {
-    return self;
+fn "Array<Array<Array<i32>>>^SequenceLiteralBuilder::build"(self: &Array<Array<Array<i32>>>) -> Array<Array<Array<i32>>> {
+    return *self;
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_option_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_option_test.lowered.wado
@@ -101,8 +101,8 @@ pub fn "Array<Option<i32>>::len"(self: &Array<Option<i32>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Option<i32>>^SequenceLiteralBuilder::build"(self: Array<Option<i32>>) -> Array<Option<i32>> {
-    return self;
+fn "Array<Option<i32>>^SequenceLiteralBuilder::build"(self: &Array<Option<i32>>) -> Array<Option<i32>> {
+    return *self;
 }
 
 fn "Array<Option<i32>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Option<i32>>, value: Option<i32>) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_string_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_string_test.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_4: {
                 let self: Array<String> = __b;
-                break __inline_Array_String__SequenceLiteralBuilder__build_4: self;
+                break __inline_Array_String__SequenceLiteralBuilder__build_4: *self;
             };
         });
         __b."Array<Array<String>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -51,7 +51,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_7: {
                 let self: Array<String> = __b;
-                break __inline_Array_String__SequenceLiteralBuilder__build_7: self;
+                break __inline_Array_String__SequenceLiteralBuilder__build_7: *self;
             };
         });
         break __seq_lit: __b."Array<Array<String>>^SequenceLiteralBuilder::build"();
@@ -154,8 +154,8 @@ pub fn "Array<Array<String>>::len"(self: &Array<Array<String>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Array<String>>^SequenceLiteralBuilder::build"(self: Array<Array<String>>) -> Array<Array<String>> {
-    return self;
+fn "Array<Array<String>>^SequenceLiteralBuilder::build"(self: &Array<Array<String>>) -> Array<Array<String>> {
+    return *self;
 }
 
 fn "Array<Array<String>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Array<String>>, value: Array<String>) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct2_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct2_test.lowered.wado
@@ -40,7 +40,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
         };
     };
     let row2: Array<i32> = __seq_lit: {
@@ -55,7 +55,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_8: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_8: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_8: *self;
         };
     };
     let data: Array<Array<i32>> = __seq_lit: {
@@ -173,8 +173,8 @@ pub fn "Array<Array<i32>>::len"(self: &Array<Array<i32>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 fn "Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Array<i32>>, value: Array<i32>) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct3_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct3_test.lowered.wado
@@ -42,7 +42,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
             };
         });
         __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -57,7 +57,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_8: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_8: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_8: *self;
             };
         });
         break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -171,8 +171,8 @@ pub fn "Array<Array<i32>>::len"(self: &Array<Array<i32>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct_test.lowered.wado
@@ -42,7 +42,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
             };
         });
         __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -57,7 +57,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_8: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_8: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_8: *self;
             };
         });
         break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -170,8 +170,8 @@ pub fn "Array<Array<i32>>::len"(self: &Array<Array<i32>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_tuple_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_tuple_test.lowered.wado
@@ -37,7 +37,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Tuple_i32_String___SequenceLiteralBuilder__build_4: {
             let self: Array<[i32, String]> = __b;
-            break __inline_Array_Tuple_i32_String___SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_Tuple_i32_String___SequenceLiteralBuilder__build_4: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_test.lowered.wado
@@ -37,7 +37,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
             };
         });
         __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -52,7 +52,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_8: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_8: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_8: *self;
             };
         });
         break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -136,8 +136,8 @@ pub fn "Array<Array<i32>>::len"(self: &Array<Array<i32>>) -> i32 {
     return self.used;
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/inspect_no_display.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_no_display.lowered.wado
@@ -125,7 +125,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Point__SequenceLiteralBuilder__build_18: {
             let self: Array<Point> = __b;
-            break __inline_Array_Point__SequenceLiteralBuilder__build_18: self;
+            break __inline_Array_Point__SequenceLiteralBuilder__build_18: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/internal_f64_to_string.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/internal_f64_to_string.lowered.wado
@@ -23,7 +23,7 @@ export fn run() with Stdout {
         "core::prelude/fpfmt.wado::__initialize_module"();
         __modules_initialized = true;
     };
-    let s: String = move 3.14.f64::to_string();
+    let s: String = move Box<f64> { value: 3.14 }.f64::to_string();
     core::cli::println(s);
 }
 

--- a/wado-compiler/tests/fixtures.golden/iterator_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_basic.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/iterator_collect.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_collect.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/iterator_empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_empty.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };
     let __pattern_temp_0: Option<i32> = move iter."ArrayIter<i32>^Iterator::next"();

--- a/wado-compiler/tests/fixtures.golden/iterator_enumerate.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_enumerate.lowered.wado
@@ -55,7 +55,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut iter: EnumerateIter<String> = __inline_ArrayIter_String___enumerate_6: {

--- a/wado-compiler/tests/fixtures.golden/iterator_filter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_filter.lowered.wado
@@ -86,7 +86,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_12: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_12: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_12: *self;
         };
     };
     let evens: Array<i32> = move __inline_ArrayIter_i32___filter_14: {
@@ -168,7 +168,7 @@ fn "ArrayIter<i32>^Iterator::next"(self: &mut ArrayIter<i32>) -> Option<i32> {
 pub fn "FilterIter<i32>^Iterator::collect"(self: &mut FilterIter<i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     loop {
         let __pattern_temp_0: Option<i32> = move self."FilterIter<i32>^Iterator::next"();

--- a/wado-compiler/tests/fixtures.golden/iterator_fold.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_fold.lowered.wado
@@ -65,7 +65,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let sum: i32 = ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_0"(0, &__Closure_0 {  });
@@ -149,7 +149,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_29: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_29: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_29: *self;
         };
     };
     let max: i32 = ArrayIter<i32> { repr: arr2.repr, used: arr2.used, index: 0 }."ArrayIter<i32>::fold<i32>$__Closure_3"(0, &__Closure_3 {  });

--- a/wado-compiler/tests/fixtures.golden/iterator_into_iter.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_into_iter.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/iterator_map.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_map.lowered.wado
@@ -66,7 +66,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let doubled: Array<i32> = move __inline_ArrayIter_i32___map_i32__9: {
@@ -147,7 +147,7 @@ fn "ArrayIter<i32>^Iterator::next"(self: &mut ArrayIter<i32>) -> Option<i32> {
 pub fn "MapIter<i32,i32>^Iterator::collect"(self: &mut MapIter<i32,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     loop {
         let __pattern_temp_0: Option<i32> = move self."MapIter<i32,i32>^Iterator::next"();

--- a/wado-compiler/tests/fixtures.golden/iterator_strings.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_strings.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_String__SequenceLiteralBuilder__build_5: {
             let self: Array<String> = __b;
-            break __inline_Array_String__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_String__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut iter: ArrayIter<String> = move ArrayIter<String> { repr: arr.repr, used: arr.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-blanket-impl.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-blanket-impl.lowered.wado
@@ -30,16 +30,16 @@ export fn run() with Stdout {
     };
     let mut b: Bag<i32> = move Bag<i32> { keys: __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, values: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     } };
     b."Bag<i32>^KeyValueLiteralBuilder::insert_literal"(move "x", 1);
     b."Bag<i32>^KeyValueLiteralBuilder::insert_literal"(move "y", 2);
     let bag: Bag<i32> = __inline_Bag_i32__KeyValueLiteralBuilder__build_2: {
-        let self: Bag<i32> = b;
-        break __inline_Bag_i32__KeyValueLiteralBuilder__build_2: self;
+        let self: &Bag<i32> = &b;
+        break __inline_Bag_i32__KeyValueLiteralBuilder__build_2: *self;
     };
     __assert_0: {
         let __v0: i32 = __inline_Array_String___len_3: {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.lowered.wado
@@ -31,17 +31,17 @@ export fn run() with Stdout {
     let named: Bag<i32> = __kv_lit: {
         let mut __b: Bag<i32> = move Bag<i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."Bag<i32>^KeyValueLiteralBuilder::insert_literal"(move "x", 10);
         __b."Bag<i32>^KeyValueLiteralBuilder::insert_literal"(move "y", 20);
         __b."Bag<i32>^KeyValueLiteralBuilder::insert_literal"(move "z", 30);
         break __kv_lit: __inline_Bag_i32__KeyValueLiteralBuilder__build_2: {
             let self: Bag<i32> = __b;
-            break __inline_Bag_i32__KeyValueLiteralBuilder__build_2: self;
+            break __inline_Bag_i32__KeyValueLiteralBuilder__build_2: *self;
         };
     };
     __assert_0: {
@@ -167,7 +167,7 @@ export fn run() with Stdout {
     let indexed: Bag<i32> = __seq_lit: {
         let mut __b: Bag<i32> = move Bag<i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: Array<i32> { repr: core::builtin::array_new::<i32>(3), used: 0 } };
         __inline_Bag_i32__SequenceLiteralBuilder__push_literal_23: {
             __b.values."Array<i32>::append"(100);
@@ -180,7 +180,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Bag_i32__SequenceLiteralBuilder__build_26: {
             let self: Bag<i32> = __b;
-            break __inline_Bag_i32__SequenceLiteralBuilder__build_26: self;
+            break __inline_Bag_i32__SequenceLiteralBuilder__build_26: *self;
         };
     };
     __assert_3: {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_3: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_3: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_3: *self;
         };
     };
     __assert_0: {
@@ -101,7 +101,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_17: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_17: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_17: *self;
         };
     };
     __assert_1: {
@@ -306,8 +306,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.lowered.wado
@@ -36,10 +36,10 @@ export fn run() with Stdout {
     let m: FrozenMap<i32> = __kv_lit: {
         let mut __b: FrozenMapBuilder<i32> = move FrozenMapBuilder<i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."FrozenMapBuilder<i32>^KeyValueLiteralBuilder::insert_literal"(move "x", 10);
         __b."FrozenMapBuilder<i32>^KeyValueLiteralBuilder::insert_literal"(move "y", 20);
@@ -208,10 +208,10 @@ export fn run() with Stdout {
     let m2: FrozenMap<i32> = __kv_lit: {
         let mut __b: FrozenMapBuilder<i32> = move FrozenMapBuilder<i32> { keys: __seq_lit: {
             let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         }, values: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __b."FrozenMapBuilder<i32>^KeyValueLiteralBuilder::insert_literal"(move "a", 1);
         __b."FrozenMapBuilder<i32>^KeyValueLiteralBuilder::insert_literal"(move "b", 2);

--- a/wado-compiler/tests/fixtures.golden/labeled_block_expr_value.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_expr_value.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
                     };
                     break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_6: {
                         let self: Array<i32> = __b;
-                        break __inline_Array_i32__SequenceLiteralBuilder__build_6: self;
+                        break __inline_Array_i32__SequenceLiteralBuilder__build_6: *self;
                     };
                 };
                 break __inline_Array_i32__IntoIterator__into_iter_1: ArrayIter<i32> { repr: self.repr, used: self.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/location_literal_line.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/location_literal_line.lowered.wado
@@ -23,7 +23,7 @@ export fn run() with Stdout {
         "core::prelude/fpfmt.wado::__initialize_module"();
         __modules_initialized = true;
     };
-    core::cli::println(move 5.i32::to_string());
+    core::cli::println(move Box<i32> { value: 5 }.i32::to_string());
 }
 
 export fn __cm_export__run() {

--- a/wado-compiler/tests/fixtures.golden/nested_array_3deep_iterate_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_3deep_iterate_test.lowered.wado
@@ -57,7 +57,7 @@ export fn run() with Stdout {
                 };
                 break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                     let self: Array<i32> = __b;
-                    break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                    break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
                 };
             });
             __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -68,7 +68,7 @@ export fn run() with Stdout {
                 };
                 break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
                     let self: Array<i32> = __b;
-                    break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+                    break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
                 };
             });
             break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -91,7 +91,7 @@ export fn run() with Stdout {
                 };
                 break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_12: {
                     let self: Array<i32> = __b;
-                    break __inline_Array_i32__SequenceLiteralBuilder__build_12: self;
+                    break __inline_Array_i32__SequenceLiteralBuilder__build_12: *self;
                 };
             });
             break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -236,12 +236,12 @@ fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
     return core::builtin::array_get::<i32>(self.repr, index);
 }
 
-fn "Array<Array<Array<i32>>>^SequenceLiteralBuilder::build"(self: Array<Array<Array<i32>>>) -> Array<Array<Array<i32>>> {
-    return self;
+fn "Array<Array<Array<i32>>>^SequenceLiteralBuilder::build"(self: &Array<Array<Array<i32>>>) -> Array<Array<Array<i32>>> {
+    return *self;
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/nested_array_iterate_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_iterate_test.lowered.wado
@@ -49,7 +49,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
             };
         });
         __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -64,7 +64,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_8: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_8: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_8: *self;
             };
         });
         break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -166,8 +166,8 @@ fn "Array<Array<i32>>^IndexValue::index_value"(self: &Array<Array<i32>>, index: 
     return core::builtin::array_get::<Array<i32>>(self.repr, index);
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/nested_array_method_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_method_test.lowered.wado
@@ -41,7 +41,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
             };
         });
         __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -56,7 +56,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_9: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_9: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_9: *self;
             };
         });
         break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -106,8 +106,8 @@ fn "Array<Array<i32>>^IndexValue::index_value"(self: &Array<Array<i32>>, index: 
     return core::builtin::array_get::<Array<i32>>(self.repr, index);
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {

--- a/wado-compiler/tests/fixtures.golden/nested_array_mutate_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_mutate_test.lowered.wado
@@ -37,7 +37,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
             };
         });
         __b."Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(__seq_lit: {
@@ -52,7 +52,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_8: {
                 let self: Array<i32> = __b;
-                break __inline_Array_i32__SequenceLiteralBuilder__build_8: self;
+                break __inline_Array_i32__SequenceLiteralBuilder__build_8: *self;
             };
         });
         break __seq_lit: __b."Array<Array<i32>>^SequenceLiteralBuilder::build"();
@@ -84,7 +84,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_15: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_15: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_15: *self;
         };
     };
     matrix."Array<Array<i32>>^IndexAssign::index_assign"(0, new_row);
@@ -197,8 +197,8 @@ fn "Array<Array<i32>>^IndexValue::index_value"(self: &Array<Array<i32>>, index: 
     return core::builtin::array_get::<Array<i32>>(self.repr, index);
 }
 
-fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: Array<Array<i32>>) -> Array<Array<i32>> {
-    return self;
+fn "Array<Array<i32>>^SequenceLiteralBuilder::build"(self: &Array<Array<i32>>) -> Array<Array<i32>> {
+    return *self;
 }
 
 fn "Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Array<i32>>, value: Array<i32>) {

--- a/wado-compiler/tests/fixtures.golden/nested_array_option_access_test.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_option_access_test.lowered.wado
@@ -118,8 +118,8 @@ fn "Array<Option<i32>>^IndexValue::index_value"(self: &Array<Option<i32>>, index
     return core::builtin::array_get::<Option<i32>>(self.repr, index);
 }
 
-fn "Array<Option<i32>>^SequenceLiteralBuilder::build"(self: Array<Option<i32>>) -> Array<Option<i32>> {
-    return self;
+fn "Array<Option<i32>>^SequenceLiteralBuilder::build"(self: &Array<Option<i32>>) -> Array<Option<i32>> {
+    return *self;
 }
 
 fn "Array<Option<i32>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Option<i32>>, value: Option<i32>) {

--- a/wado-compiler/tests/fixtures.golden/never_as_bottom_type.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/never_as_bottom_type.lowered.wado
@@ -126,7 +126,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_15: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_15: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_15: *self;
         };
     };
     __assert_2: {

--- a/wado-compiler/tests/fixtures.golden/ordering-basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ordering-basic.lowered.wado
@@ -60,7 +60,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let arr2: Array<i32> = __seq_lit: {
@@ -79,7 +79,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_10: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_10: *self;
         };
     };
     let arr3: Array<i32> = __seq_lit: {
@@ -98,7 +98,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_15: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_15: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_15: *self;
         };
     };
     if (arr1."Array<i32>^Ord::cmp"(&arr2) == Ordering::Less) {

--- a/wado-compiler/tests/fixtures.golden/ref_array_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array_basic.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let before: i32 = nums."Array<i32>^IndexValue::index_value"(0);

--- a/wado-compiler/tests/fixtures.golden/ref_array_ref_element.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array_ref_element.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let __sroa_r_value: i32 = arr."Array<i32>^IndexValue::index_value"(1);

--- a/wado-compiler/tests/fixtures.golden/ref_method_receivers.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_method_receivers.lowered.wado
@@ -27,7 +27,7 @@ export fn run() with Stdout {
         "core::prelude/fpfmt.wado::__initialize_module"();
         __modules_initialized = true;
     };
-    let mut c: Counter = move Counter { value: 0 };
+    let mut __sroa_c_value: i32 = 0;
     core::cli::println(__tmpl: {
         let mut __r: String = move String { repr: "array_new<u8>"(21), used: 0 };
         __r.String::append(move "get: ");
@@ -36,20 +36,20 @@ export fn run() with Stdout {
             break __inline_Formatter__new_3: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_4: {
-            let self: Box<i32> = move Box<i32> { value: c.value };
+            let self: Box<i32> = move Box<i32> { value: __sroa_c_value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };
         break __tmpl: __r;
     });
     __inline_Counter__increment_6: {
-        c.value = (c.value + 1);
+        __sroa_c_value = (__sroa_c_value + 1);
     };
     __inline_Counter__increment_7: {
-        c.value = (c.value + 1);
+        __sroa_c_value = (__sroa_c_value + 1);
     };
     __inline_Counter__increment_8: {
-        c.value = (c.value + 1);
+        __sroa_c_value = (__sroa_c_value + 1);
     };
     core::cli::println(__tmpl: {
         let mut __r: String = move String { repr: "array_new<u8>"(33), used: 0 };
@@ -59,39 +59,7 @@ export fn run() with Stdout {
             break __inline_Formatter__new_10: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         __inline_i32_Display__fmt_11: {
-            let self: Box<i32> = move Box<i32> { value: c.value };
-            let f: &mut Formatter = &mut __f;
-            "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
-        };
-        break __tmpl: __r;
-    });
-    let v: i32 = __inline_Counter__into_value_13: {
-        let self: Counter = c;
-        break __inline_Counter__into_value_13: self.value;
-    };
-    core::cli::println(__tmpl: {
-        let mut __r: String = move String { repr: "array_new<u8>"(28), used: 0 };
-        __r.String::append(move "into_value: ");
-        let mut __f: Formatter = __inline_Formatter__new_15: {
-            let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_15: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-        };
-        __inline_i32_Display__fmt_16: {
-            let self: Box<i32> = move Box<i32> { value: v };
-            let f: &mut Formatter = &mut __f;
-            "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
-        };
-        break __tmpl: __r;
-    });
-    core::cli::println(__tmpl: {
-        let mut __r: String = move String { repr: "array_new<u8>"(30), used: 0 };
-        __r.String::append(move "still usable: ");
-        let mut __f: Formatter = __inline_Formatter__new_18: {
-            let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_18: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
-        };
-        __inline_i32_Display__fmt_19: {
-            let self: Box<i32> = move Box<i32> { value: c.value };
+            let self: Box<i32> = move Box<i32> { value: __sroa_c_value };
             let f: &mut Formatter = &mut __f;
             "core::prelude/primitives.wado::fmt_i32_decimal"(self.value, f);
         };

--- a/wado-compiler/tests/fixtures.golden/ref_mut_array_ops.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_mut_array_ops.lowered.wado
@@ -55,7 +55,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     core::cli::println(__tmpl: {

--- a/wado-compiler/tests/fixtures.golden/ref_return.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_return.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let first: Box<i32> = __inline_get_first_6: {

--- a/wado-compiler/tests/fixtures.golden/return_array_var.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/return_array_var.lowered.wado
@@ -38,7 +38,7 @@ fn get_numbers() -> Array<i32> {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_4: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_4: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_4: *self;
         };
     };
     return arr;

--- a/wado-compiler/tests/fixtures.golden/return_empty_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/return_empty_array.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
     };
     let arr: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_0: {
         let mut __iter_0: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-custom.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-custom.lowered.wado
@@ -30,7 +30,7 @@ export fn run() with Stdout {
     let s: SeqVec<i32> = __seq_lit: {
         let mut __b: SeqVec<i32> = move SeqVec<i32> { items: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __inline_SeqVec_i32__SequenceLiteralBuilder__push_literal_2: {
             __b.items."Array<i32>::append"(10);
@@ -43,7 +43,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_SeqVec_i32__SequenceLiteralBuilder__build_5: {
             let self: SeqVec<i32> = __b;
-            break __inline_SeqVec_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_SeqVec_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     __assert_0: {
@@ -196,7 +196,7 @@ export fn run() with Stdout {
     let s2: SeqVec<i32> = __seq_lit: {
         let mut __b: SeqVec<i32> = move SeqVec<i32> { items: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
         __inline_SeqVec_i32__SequenceLiteralBuilder__push_literal_32: {
             __b.items."Array<i32>::append"(1);
@@ -209,7 +209,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_SeqVec_i32__SequenceLiteralBuilder__build_35: {
             let self: SeqVec<i32> = __b;
-            break __inline_SeqVec_i32__SequenceLiteralBuilder__build_35: self;
+            break __inline_SeqVec_i32__SequenceLiteralBuilder__build_35: *self;
         };
     };
     __assert_4: {

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-fn-arg.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-fn-arg.lowered.wado
@@ -31,7 +31,7 @@ export fn run() with Stdout {
         let v: SeqVec<i32> = __seq_lit: {
             let mut __b: SeqVec<i32> = move SeqVec<i32> { items: __seq_lit: {
                 let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-                break __seq_lit: __b;
+                break __seq_lit: *__b;
             } };
             __inline_SeqVec_i32__SequenceLiteralBuilder__push_literal_3: {
                 __b.items."Array<i32>::append"(1);
@@ -50,7 +50,7 @@ export fn run() with Stdout {
             };
             break __seq_lit: __inline_SeqVec_i32__SequenceLiteralBuilder__build_8: {
                 let self: SeqVec<i32> = __b;
-                break __inline_SeqVec_i32__SequenceLiteralBuilder__build_8: self;
+                break __inline_SeqVec_i32__SequenceLiteralBuilder__build_8: *self;
             };
         };
         break __inline_count_items_1: __inline_Array_i32___len_1: {
@@ -96,9 +96,9 @@ export fn run() with Stdout {
     let empty: SeqVec<i32> = __seq_lit: {
         let mut __b: SeqVec<i32> = move SeqVec<i32> { items: __seq_lit: {
             let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-            break __seq_lit: __b;
+            break __seq_lit: *__b;
         } };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __assert_1: {
         let __v0: i32 = __inline_Array_i32___len_18: {

--- a/wado-compiler/tests/fixtures.golden/short_circuit.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/short_circuit.lowered.wado
@@ -66,7 +66,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut i: i32 = 0;

--- a/wado-compiler/tests/fixtures.golden/static_method_nested_generics.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_nested_generics.lowered.wado
@@ -51,7 +51,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let inner: Array<i32> = arr;

--- a/wado-compiler/tests/fixtures.golden/stream-cm-stderr-write.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-cm-stderr-write.lowered.wado
@@ -63,7 +63,7 @@ export fn run() with Stderr {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_10: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_10: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_10: *self;
         };
     };
     let ptr: i32 = core::builtin::realloc(0, 0, 1, 8);

--- a/wado-compiler/tests/fixtures.golden/stream-http-response-body.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-http-response-body.lowered.wado
@@ -353,7 +353,7 @@ export fn handle(request: Request) {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_6: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_6: *self;
         };
     };
     body_tx."StreamWritable<u8>::write"(data);

--- a/wado-compiler/tests/fixtures.golden/stream-write-hello.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-write-hello.lowered.wado
@@ -54,7 +54,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_8: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_8: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_8: *self;
         };
     };
     tx."StreamWritable<u8>::write"(data);

--- a/wado-compiler/tests/fixtures.golden/stream-write-multiple.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-write-multiple.lowered.wado
@@ -46,7 +46,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_u8__SequenceLiteralBuilder__build_6: {
             let self: Array<u8> = __b;
-            break __inline_Array_u8__SequenceLiteralBuilder__build_6: self;
+            break __inline_Array_u8__SequenceLiteralBuilder__build_6: *self;
         };
     };
     tx."StreamWritable<u8>::write"(chunk);

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_for_of.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_for_of.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Point__SequenceLiteralBuilder__build_5: {
             let self: Array<Point> = __b;
-            break __inline_Array_Point__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_Point__SequenceLiteralBuilder__build_5: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/trait_default_count.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_count.lowered.wado
@@ -53,7 +53,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_7: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_7: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_7: *self;
         };
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: arr.repr, used: arr.used, index: 0 };

--- a/wado-compiler/tests/fixtures.golden/treemap-basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-basic.lowered.wado
@@ -573,8 +573,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-clear.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-clear.lowered.wado
@@ -439,8 +439,8 @@ pub fn "TreeMap<String,i32>::clear"(self: &mut TreeMap<String,i32>) {
     self.deleted_count = 0;
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-compact.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-compact.lowered.wado
@@ -717,7 +717,7 @@ fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
 pub fn "TreeMap<String,i32>::values"(self: &TreeMap<String,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_2: {
         let mut __iter_2: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -775,7 +775,7 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
 pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> {
     let mut result: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_1: {
         let mut __iter_1: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -923,8 +923,8 @@ pub fn "Array<TreeMapEntry<String,i32>>::append"(self: &mut Array<TreeMapEntry<S
     self.used = (used + 1);
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-entries.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-entries.lowered.wado
@@ -609,8 +609,8 @@ fn "Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"(self: &Array<TreeMa
     return ArrayIter<TreeMapEntry<String,i32>> { repr: self.repr, used: self.used, index: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {
@@ -664,7 +664,7 @@ fn "Array<Tuple<String,i32>>^IndexValue::index_value"(self: &Array<[String, i32]
 pub fn "TreeMap<String,i32>::entries"(self: &TreeMap<String,i32>) -> Array<[String, i32]> {
     let mut result: Array<[String, i32]> = __seq_lit: {
         let mut __b: Array<[String, i32]> = move Array<Tuple<String,i32>> { repr: core::builtin::array_new::<[String, i32]>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_3: {
         let mut __iter_3: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();

--- a/wado-compiler/tests/fixtures.golden/treemap-index.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-index.lowered.wado
@@ -548,8 +548,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-large.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-large.lowered.wado
@@ -607,8 +607,8 @@ fn "Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"(self: &Array<TreeMa
     return ArrayIter<TreeMapEntry<String,i32>> { repr: self.repr, used: self.used, index: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-basic.lowered.wado
@@ -58,7 +58,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_4: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_4: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_4: *self;
         };
     };
     __assert_0: {
@@ -421,8 +421,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-cast.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-cast.lowered.wado
@@ -63,7 +63,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_5: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_5: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_5: *self;
         };
     };
     __assert_0: {
@@ -340,8 +340,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-empty.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-empty.lowered.wado
@@ -46,7 +46,7 @@ export fn run() with Stdout {
     };
     let m: TreeMap<String,i32> = __kv_lit: {
         let mut __b: TreeMap<String,i32> = move "TreeMap<String,i32>::new"();
-        break __kv_lit: __b;
+        break __kv_lit: *__b;
     };
     __assert_0: {
         let __v0: i32 = m.size;
@@ -138,8 +138,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.lowered.wado
@@ -95,7 +95,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_5: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_5: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_5: *self;
         };
     });
     __assert_0: {
@@ -272,8 +272,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {
@@ -296,7 +296,7 @@ fn "ArrayIter<Tuple<String,i32>>^Iterator::next"(self: &mut ArrayIter<Tuple<Stri
 pub fn "TreeMap<String,i32>::entries"(self: &TreeMap<String,i32>) -> Array<[String, i32]> {
     let mut result: Array<[String, i32]> = __seq_lit: {
         let mut __b: Array<[String, i32]> = move Array<Tuple<String,i32>> { repr: core::builtin::array_new::<[String, i32]>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_3: {
         let mut __iter_3: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.lowered.wado
@@ -58,7 +58,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_4: {
             let self: TreeMap<String,i32> = __b;
-            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_4: self;
+            break __inline_TreeMap_String_i32__KeyValueLiteralBuilder__build_4: *self;
         };
     };
     __assert_0: {
@@ -345,8 +345,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.lowered.wado
@@ -66,7 +66,7 @@ export fn run() with Stdout {
         };
         break __kv_lit: __inline_TreeMap_String_String__KeyValueLiteralBuilder__build_5: {
             let self: TreeMap<String,String> = __b;
-            break __inline_TreeMap_String_String__KeyValueLiteralBuilder__build_5: self;
+            break __inline_TreeMap_String_String__KeyValueLiteralBuilder__build_5: *self;
         };
     };
     __assert_0: {
@@ -355,8 +355,8 @@ pub fn "TreeMap<String,String>::new"() -> TreeMap<String,String> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,String>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,String>>) -> Array<TreeMapEntry<String,String>> {
-    return self;
+fn "Array<TreeMapEntry<String,String>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,String>>) -> Array<TreeMapEntry<String,String>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,String>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,String>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-ordering.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-ordering.lowered.wado
@@ -617,7 +617,7 @@ fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
 pub fn "TreeMap<String,i32>::values"(self: &TreeMap<String,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_2: {
         let mut __iter_2: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -675,7 +675,7 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
 pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> {
     let mut result: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_1: {
         let mut __iter_1: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -825,8 +825,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-reinsert-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-reinsert-order.lowered.wado
@@ -564,7 +564,7 @@ fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
 pub fn "TreeMap<String,i32>::values"(self: &TreeMap<String,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_2: {
         let mut __iter_2: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -622,7 +622,7 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
 pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> {
     let mut result: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_1: {
         let mut __iter_1: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -770,8 +770,8 @@ pub fn "Array<TreeMapEntry<String,i32>>::append"(self: &mut Array<TreeMapEntry<S
     self.used = (used + 1);
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-remove-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-remove-order.lowered.wado
@@ -600,7 +600,7 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
 pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> {
     let mut result: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_1: {
         let mut __iter_1: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -761,8 +761,8 @@ pub fn "Array<TreeMapEntry<String,i32>>::append"(self: &mut Array<TreeMapEntry<S
     self.used = (used + 1);
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-remove.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-remove.lowered.wado
@@ -677,8 +677,8 @@ fn "Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"(self: &Array<TreeMa
     return ArrayIter<TreeMapEntry<String,i32>> { repr: self.repr, used: self.used, index: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap-update-order.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-update-order.lowered.wado
@@ -388,7 +388,7 @@ fn "Array<i32>^IndexValue::index_value"(self: &Array<i32>, index: i32) -> i32 {
 pub fn "TreeMap<String,i32>::values"(self: &TreeMap<String,i32>) -> Array<i32> {
     let mut result: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_2: {
         let mut __iter_2: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -446,7 +446,7 @@ fn "Array<String>^IndexValue::index_value"(self: &Array<String>, index: i32) -> 
 pub fn "TreeMap<String,i32>::keys"(self: &TreeMap<String,i32>) -> Array<String> {
     let mut result: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_of_1: {
         let mut __iter_1: ArrayIter<TreeMapEntry<String,i32>> = move self.entries."Array<TreeMapEntry<String,i32>>^IntoIterator::into_iter"();
@@ -596,8 +596,8 @@ pub fn "TreeMap<String,i32>::new"() -> TreeMap<String,i32> {
     }, size: 0, deleted_count: 0 };
 }
 
-fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
-    return self;
+fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<TreeMapEntry<String,i32>>) -> Array<TreeMapEntry<String,i32>> {
+    return *self;
 }
 
 fn "Array<TreeMapEntry<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<TreeMapEntry<String,i32>> {

--- a/wado-compiler/tests/fixtures.golden/treemap_btree.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree.lowered.wado
@@ -268,15 +268,15 @@ fn "TreeMap<String,i32>::compact"(self: &mut TreeMap<String,i32>) {
 fn "BTreeNode<String,i32>::compact"(self: &mut BTreeNode<String,i32>) {
     let new_keys: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let new_values: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let new_deleted: Array<bool> = __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_1: {
         let mut i: i32 = 0;
@@ -398,7 +398,7 @@ fn "ArrayIter<Tuple<String,i32>>^Iterator::next"(self: &mut ArrayIter<Tuple<Stri
 fn "TreeMap<String,i32>::iter"(self: &TreeMap<String,i32>) -> Array<[String, i32]> {
     let mut result: Array<[String, i32]> = __seq_lit: {
         let mut __b: Array<[String, i32]> = move Array<Tuple<String,i32>> { repr: core::builtin::array_new::<[String, i32]>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let __pattern_temp_0: Option<&mut BTreeNode<String,i32>> = self.root;
     if __variant_test(__pattern_temp_0, case=0, name=Some) {
@@ -727,21 +727,21 @@ pub fn "Array<BTreeNode<String,i32>>::append"(self: &mut Array<&mut BTreeNode<St
 fn "BTreeNode<String,i32>::new_internal"() -> BTreeNode<String,i32> {
     return BTreeNode<String,i32> { keys: __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, values: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, deleted: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, children: __seq_lit: {
         let mut __b: Array<&mut BTreeNode<String,i32>> = move "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::new_literal"(0);
         break __seq_lit: __b."Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"();
     }, is_leaf: false };
 }
 
-fn "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"(self: Array<&mut BTreeNode<String,i32>>) -> Array<&mut BTreeNode<String,i32>> {
-    return self;
+fn "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<&mut BTreeNode<String,i32>>) -> Array<&mut BTreeNode<String,i32>> {
+    return *self;
 }
 
 fn "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<&mut BTreeNode<String,i32>> {
@@ -777,13 +777,13 @@ fn "BTreeNode<String,i32>::is_full"(self: &BTreeNode<String,i32>, max_keys: i32)
 fn "BTreeNode<String,i32>::new_leaf"() -> BTreeNode<String,i32> {
     return BTreeNode<String,i32> { keys: __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, values: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, deleted: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, children: __seq_lit: {
         let mut __b: Array<&mut BTreeNode<String,i32>> = move "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::new_literal"(0);
         break __seq_lit: __b."Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"();

--- a/wado-compiler/tests/fixtures.golden/treemap_btree2.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree2.lowered.wado
@@ -276,15 +276,15 @@ fn "TreeMap<String,i32>::compact"(self: &mut TreeMap<String,i32>) {
 fn "BTreeNode<String,i32>::compact"(self: &mut BTreeNode<String,i32>) {
     let new_keys: Array<String> = __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let new_values: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let new_deleted: Array<bool> = __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     __for_1: {
         let mut i: i32 = 0;
@@ -406,7 +406,7 @@ fn "ArrayIter<Tuple<String,i32>>^Iterator::next"(self: &mut ArrayIter<Tuple<Stri
 fn "TreeMap<String,i32>::iter"(self: &TreeMap<String,i32>) -> Array<[String, i32]> {
     let mut result: Array<[String, i32]> = __seq_lit: {
         let mut __b: Array<[String, i32]> = move Array<Tuple<String,i32>> { repr: core::builtin::array_new::<[String, i32]>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let __pattern_temp_0: Option<&mut BTreeNode<String,i32>> = self.root;
     if __variant_test(__pattern_temp_0, case=0, name=Some) {
@@ -763,21 +763,21 @@ pub fn "Array<BTreeNode<String,i32>>::append"(self: &mut Array<&mut BTreeNode<St
 fn "BTreeNode<String,i32>::new_internal"() -> BTreeNode<String,i32> {
     return BTreeNode<String,i32> { keys: __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, values: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, deleted: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, children: __seq_lit: {
         let mut __b: Array<&mut BTreeNode<String,i32>> = move "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::new_literal"(0);
         break __seq_lit: __b."Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"();
     }, is_leaf: false };
 }
 
-fn "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"(self: Array<&mut BTreeNode<String,i32>>) -> Array<&mut BTreeNode<String,i32>> {
-    return self;
+fn "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"(self: &Array<&mut BTreeNode<String,i32>>) -> Array<&mut BTreeNode<String,i32>> {
+    return *self;
 }
 
 fn "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<&mut BTreeNode<String,i32>> {
@@ -813,13 +813,13 @@ fn "BTreeNode<String,i32>::is_full"(self: &BTreeNode<String,i32>, max_keys: i32)
 fn "BTreeNode<String,i32>::new_leaf"() -> BTreeNode<String,i32> {
     return BTreeNode<String,i32> { keys: __seq_lit: {
         let mut __b: Array<String> = move Array<String> { repr: core::builtin::array_new::<String>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, values: __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, deleted: __seq_lit: {
         let mut __b: Array<bool> = move Array<bool> { repr: core::builtin::array_new::<bool>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     }, children: __seq_lit: {
         let mut __b: Array<&mut BTreeNode<String,i32>> = move "Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::new_literal"(0);
         break __seq_lit: __b."Array<BTreeNode<String,i32>>^SequenceLiteralBuilder::build"();

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_for_of.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_for_of.lowered.wado
@@ -48,7 +48,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_Tuple_i32_String___SequenceLiteralBuilder__build_5: {
             let self: Array<[i32, String]> = __b;
-            break __inline_Array_Tuple_i32_String___SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_Tuple_i32_String___SequenceLiteralBuilder__build_5: *self;
         };
     };
     __for_of_0: {

--- a/wado-compiler/tests/fixtures.golden/u64_arithmetic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/u64_arithmetic.lowered.wado
@@ -25,7 +25,7 @@ export fn run() with Stdout {
     };
     let mut digits: Array<i32> = __seq_lit: {
         let mut __b: Array<i32> = move Array<i32> { repr: core::builtin::array_new::<i32>(0), used: 0 };
-        break __seq_lit: __b;
+        break __seq_lit: *__b;
     };
     let mut v: u64 = 12345;
     loop {

--- a/wado-compiler/tests/fixtures.golden/value_semantics_array.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_array.lowered.wado
@@ -39,7 +39,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut b: Array<i32> = a;

--- a/wado-compiler/tests/fixtures.golden/while_let_basic.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/while_let_basic.lowered.wado
@@ -45,7 +45,7 @@ export fn run() with Stdout {
         };
         break __seq_lit: __inline_Array_i32__SequenceLiteralBuilder__build_5: {
             let self: Array<i32> = __b;
-            break __inline_Array_i32__SequenceLiteralBuilder__build_5: self;
+            break __inline_Array_i32__SequenceLiteralBuilder__build_5: *self;
         };
     };
     let mut iter: ArrayIter<i32> = move ArrayIter<i32> { repr: items.repr, used: items.used, index: 0 };

--- a/wado-compiler/tests/fixtures/array_append_collapse.wado
+++ b/wado-compiler/tests/fixtures/array_append_collapse.wado
@@ -56,8 +56,8 @@ impl SequenceLiteralBuilder for SeqVec<T> {
         self.items.append(value);
     }
 
-    fn build(self) -> SeqVec<T> {
-        return self;
+    fn build(&self) -> SeqVec<T> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-cast.wado
+++ b/wado-compiler/tests/fixtures/from-literal-cast.wado
@@ -29,8 +29,8 @@ impl KeyValueLiteralBuilder for PairList<V> {
         self.values.append(value);
     }
 
-    fn build(self) -> PairList<V> {
-        return self;
+    fn build(&self) -> PairList<V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-custom.wado
+++ b/wado-compiler/tests/fixtures/from-literal-custom.wado
@@ -30,8 +30,8 @@ impl KeyValueLiteralBuilder for LinearMap<V> {
         self.values.append(value);
     }
 
-    fn build(self) -> LinearMap<V> {
-        return self;
+    fn build(&self) -> LinearMap<V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-enum-concrete.wado
+++ b/wado-compiler/tests/fixtures/from-literal-enum-concrete.wado
@@ -20,8 +20,8 @@ impl KeyValueLiteralBuilder for DirMap<Direction, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> DirMap<Direction, V> {
-        return self;
+    fn build(&self) -> DirMap<Direction, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-error-enum-mismatch.wado
+++ b/wado-compiler/tests/fixtures/from-literal-error-enum-mismatch.wado
@@ -21,8 +21,8 @@ impl KeyValueLiteralBuilder for DirMap<Direction, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> DirMap<Direction, V> {
-        return self;
+    fn build(&self) -> DirMap<Direction, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-error-flags-mismatch.wado
+++ b/wado-compiler/tests/fixtures/from-literal-error-flags-mismatch.wado
@@ -21,8 +21,8 @@ impl KeyValueLiteralBuilder for PermsMap<Perms, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> PermsMap<Perms, V> {
-        return self;
+    fn build(&self) -> PermsMap<Perms, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-error-nested-generic-mismatch.wado
+++ b/wado-compiler/tests/fixtures/from-literal-error-nested-generic-mismatch.wado
@@ -23,8 +23,8 @@ impl KeyValueLiteralBuilder for NestedMap<Array<String>, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> NestedMap<Array<String>, V> {
-        return self;
+    fn build(&self) -> NestedMap<Array<String>, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-error-newtype-mismatch.wado
+++ b/wado-compiler/tests/fixtures/from-literal-error-newtype-mismatch.wado
@@ -21,8 +21,8 @@ impl KeyValueLiteralBuilder for TagMap<Tag, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> TagMap<Tag, V> {
-        return self;
+    fn build(&self) -> TagMap<Tag, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-error-variant-mismatch.wado
+++ b/wado-compiler/tests/fixtures/from-literal-error-variant-mismatch.wado
@@ -21,8 +21,8 @@ impl KeyValueLiteralBuilder for StatusMap<Status, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> StatusMap<Status, V> {
-        return self;
+    fn build(&self) -> StatusMap<Status, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-flags-concrete.wado
+++ b/wado-compiler/tests/fixtures/from-literal-flags-concrete.wado
@@ -20,8 +20,8 @@ impl KeyValueLiteralBuilder for PermsMap<Perms, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> PermsMap<Perms, V> {
-        return self;
+    fn build(&self) -> PermsMap<Perms, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-fn-arg.wado
+++ b/wado-compiler/tests/fixtures/from-literal-fn-arg.wado
@@ -38,8 +38,8 @@ impl KeyValueLiteralBuilder for SimpleMap<V> {
         self.values.append(value);
     }
 
-    fn build(self) -> SimpleMap<V> {
-        return self;
+    fn build(&self) -> SimpleMap<V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-nested-generic.wado
+++ b/wado-compiler/tests/fixtures/from-literal-nested-generic.wado
@@ -26,8 +26,8 @@ impl KeyValueLiteralBuilder for NestedMap<Array<String>, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> NestedMap<Array<String>, V> {
-        return self;
+    fn build(&self) -> NestedMap<Array<String>, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-newtype-concrete.wado
+++ b/wado-compiler/tests/fixtures/from-literal-newtype-concrete.wado
@@ -20,8 +20,8 @@ impl KeyValueLiteralBuilder for TagMap<Tag, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> TagMap<Tag, V> {
-        return self;
+    fn build(&self) -> TagMap<Tag, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/from-literal-variant-concrete.wado
+++ b/wado-compiler/tests/fixtures/from-literal-variant-concrete.wado
@@ -20,8 +20,8 @@ impl KeyValueLiteralBuilder for StatusMap<Status, V> {
         self.values.append(value);
     }
 
-    fn build(self) -> StatusMap<Status, V> {
-        return self;
+    fn build(&self) -> StatusMap<Status, V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/key-value-literal-blanket-impl.wado
+++ b/wado-compiler/tests/fixtures/key-value-literal-blanket-impl.wado
@@ -8,7 +8,7 @@ trait KeyValueLiteralBuilder {
     type Output;
     fn new_literal(capacity: i32) -> Self;
     fn insert_literal(&mut self, key: String, value: Self::Value);
-    fn build(self) -> Self::Output;
+    fn build(&self) -> Self::Output;
 }
 
 trait KeyValueLiteral {
@@ -38,8 +38,8 @@ impl KeyValueLiteralBuilder for Bag<V> {
         self.keys.append(key);
         self.values.append(value);
     }
-    fn build(self) -> Bag<V> {
-        return self;
+    fn build(&self) -> Bag<V> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/key-value-literal-both-traits.wado
+++ b/wado-compiler/tests/fixtures/key-value-literal-both-traits.wado
@@ -47,8 +47,8 @@ impl KeyValueLiteralBuilder for Bag<T> {
         self.values.append(value);
     }
 
-    fn build(self) -> Bag<T> {
-        return self;
+    fn build(&self) -> Bag<T> {
+        return *self;
     }
 }
 
@@ -64,8 +64,8 @@ impl SequenceLiteralBuilder for Bag<T> {
         self.values.append(value);
     }
 
-    fn build(self) -> Bag<T> {
-        return self;
+    fn build(&self) -> Bag<T> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/key-value-literal-immutable.wado
+++ b/wado-compiler/tests/fixtures/key-value-literal-immutable.wado
@@ -42,7 +42,7 @@ impl KeyValueLiteralBuilder for FrozenMapBuilder<V> {
         self.values.append(value);
     }
 
-    fn build(self) -> FrozenMap<V> {
+    fn build(&self) -> FrozenMap<V> {
         return FrozenMap { keys: self.keys, values: self.values };
     }
 }

--- a/wado-compiler/tests/fixtures/ref_method_receivers-error-self-by-value.wado
+++ b/wado-compiler/tests/fixtures/ref_method_receivers-error-self-by-value.wado
@@ -1,0 +1,19 @@
+// self by value is not allowed — must use &self or &mut self
+
+struct Foo {
+    x: i32,
+}
+
+impl Foo {
+    fn consume(self) -> i32 {
+        return self.x;
+    }
+}
+
+export fn run() {
+    let f = Foo { x: 42 };
+    let v = f.consume();
+}
+
+__DATA__
+{"compile_error": "`self` by value is not allowed; use `&self` or `&mut self` instead"}

--- a/wado-compiler/tests/fixtures/ref_method_receivers.wado
+++ b/wado-compiler/tests/fixtures/ref_method_receivers.wado
@@ -1,4 +1,4 @@
-// All three method receiver types: &self, &mut self, self
+// Method receiver types: &self and &mut self (self by value is not allowed)
 
 use { println, Stdout } from "core:cli";
 
@@ -13,10 +13,6 @@ impl Counter {
 
     fn increment(&mut self) {
         self.value = self.value + 1;
-    }
-
-    fn into_value(self) -> i32 {
-        return self.value;
     }
 
     fn new(v: i32) -> Counter {
@@ -35,14 +31,7 @@ export fn run() with Stdout {
     c.increment();
     c.increment();
     println(`after increment: {c.get()}`);
-
-    // self by value: consume (copy)
-    let v = c.into_value();
-    println(`into_value: {v}`);
-
-    // c is still usable because of value semantics (copy)
-    println(`still usable: {c.get()}`);
 }
 
 __DATA__
-{"stdout": "get: 0\nafter increment: 3\ninto_value: 3\nstill usable: 3\n"}
+{"stdout": "get: 0\nafter increment: 3\n"}

--- a/wado-compiler/tests/fixtures/sequence-literal-custom.wado
+++ b/wado-compiler/tests/fixtures/sequence-literal-custom.wado
@@ -32,8 +32,8 @@ impl SequenceLiteralBuilder for SeqVec<T> {
         self.items.append(value);
     }
 
-    fn build(self) -> SeqVec<T> {
-        return self;
+    fn build(&self) -> SeqVec<T> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/sequence-literal-fn-arg.wado
+++ b/wado-compiler/tests/fixtures/sequence-literal-fn-arg.wado
@@ -31,8 +31,8 @@ impl SequenceLiteralBuilder for SeqVec<T> {
         self.items.append(value);
     }
 
-    fn build(self) -> SeqVec<T> {
-        return self;
+    fn build(&self) -> SeqVec<T> {
+        return *self;
     }
 }
 

--- a/wado-compiler/tests/fixtures/sequence-literal-immutable.wado
+++ b/wado-compiler/tests/fixtures/sequence-literal-immutable.wado
@@ -32,7 +32,7 @@ impl SequenceLiteralBuilder for FrozenVecBuilder<T> {
         self.items.append(value);
     }
 
-    fn build(self) -> FrozenVec<T> {
+    fn build(&self) -> FrozenVec<T> {
         return FrozenVec { items: self.items };
     }
 }


### PR DESCRIPTION
This change enforces that method receivers must always be references (`&self` or `&mut self`), prohibiting bare `self` (by value) parameters in method definitions.

## Summary
The Wado language now rejects method definitions with `self` by value as a compile error. All methods must use either `&self` (immutable reference) or `&mut self` (mutable reference) as their receiver. This aligns with the language's reference-based semantics and simplifies method dispatch.

## Key Changes

- **Parser enforcement**: Modified `src/parser.rs` to emit a compile error when `self` by value is encountered in a method parameter list, with a helpful message directing users to use `&self` or `&mut self` instead.

- **Primitive type methods**: Updated `lib/core/prelude/primitives.wado` to change method signatures for `bool`, `char`, and related types from `self` to `&self`, with corresponding dereference operations (`*self`) in method bodies.

- **Trait implementations**: Updated all `SequenceLiteralBuilder` and `KeyValueLiteralBuilder` trait implementations to use `&self` for the `build()` method instead of `self` by value.

- **AST and resolver updates**: Removed support for `SelfKind::ByValue` from the AST and resolver code, simplifying the self parameter handling to only support reference receivers.

- **Documentation**: Updated `docs/spec.md` and `docs/cheatsheet.md` to reflect that `self` by value is not allowed, with examples showing correct usage of `&self` and `&mut self`.

- **Test fixtures**: Added new error test case `ref_method_receivers-error-self-by-value.wado` demonstrating the compile error, and updated existing test fixtures to reflect the new method signatures.

## Implementation Details

The change is enforced at parse time, preventing any method with `self` by value from being accepted. The compiler now generates a clear error message: "`self` by value is not allowed; use `&self` or `&mut self` instead". This ensures type safety and consistency with the language's memory model where all method receivers are borrowed references.

https://claude.ai/code/session_0161hPHnsP27Do3t3JpKxv98