### PR TITLE
Add string trim methods and fix byte type handling

### DIFF
--- a/example/mustache.wado
+++ b/example/mustache.wado
@@ -16,7 +16,7 @@ fn trim(s: String) -> String {
     let mut found_start = false;
     for let c of s.chars() {
         if !found_start {
-            if !c.is_ascii_space() {
+            if !c.is_ascii_whitespace() {
                 found_start = true;
                 result.append_char(c);
             }
@@ -28,7 +28,7 @@ fn trim(s: String) -> String {
     // ASCII whitespace is single-byte, so byte-level reverse scan is safe.
     let mut end = result.len();
     while end > 0 {
-        if (result.get_byte(end - 1) as char).is_ascii_space() {
+        if (result.get_byte(end - 1) as char).is_ascii_whitespace() {
             end -= 1;
         } else {
             break;

--- a/example/mustache.wado
+++ b/example/mustache.wado
@@ -10,34 +10,6 @@
 use { println, Stdout } from "core:cli";
 use { TreeMap } from "core:collections";
 
-/// Trim leading and trailing ASCII whitespace.
-fn trim(s: String) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut found_start = false;
-    for let c of s.chars() {
-        if !found_start {
-            if !c.is_ascii_whitespace() {
-                found_start = true;
-                result.append_char(c);
-            }
-        } else {
-            result.append_char(c);
-        }
-    }
-    // Trim trailing ASCII whitespace in-place.
-    // ASCII whitespace is single-byte, so byte-level reverse scan is safe.
-    let mut end = result.len();
-    while end > 0 {
-        if (result.get_byte(end - 1) as char).is_ascii_whitespace() {
-            end -= 1;
-        } else {
-            break;
-        }
-    }
-    result.truncate_bytes(end);
-    return result;
-}
-
 /// Render a Mustache template with the given context.
 fn render(template: String, context: &TreeMap<String, String>) -> String {
     let mut result = String::with_capacity(template.len());
@@ -51,7 +23,7 @@ fn render(template: String, context: &TreeMap<String, String>) -> String {
             if seen_close_brace {
                 if c == '}' {
                     // Found closing `}}`  — process the tag
-                    let key = trim(tag);
+                    let key = tag.trim_ascii();
                     if !key.is_empty() {
                         let mut check = key.chars();
                         if let Some(fc) = check.next() {

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -95,10 +95,10 @@ fn select<T>(cond: bool, if_true: T, if_false: T) -> T;
 fn array_len(arr: builtin::array<u8>) -> i32;
 
 /// Get a byte from a u8 array at the given index
-fn array_get_u8(arr: builtin::array<u8>, idx: i32) -> i32;
+fn array_get_u8(arr: builtin::array<u8>, idx: i32) -> u8;
 
 /// Set a byte in a u8 array at the given index
-fn array_set_u8(arr: builtin::array<u8>, idx: i32, value: i32);
+fn array_set_u8(arr: builtin::array<u8>, idx: i32, value: u8);
 
 /// Create a new builtin::array<T> with given length, initialized to default values
 fn array_new<T>(len: i32) -> builtin::array<T>;
@@ -140,17 +140,17 @@ fn f64_load(addr: i32) -> f64;
 /// Store f64 to linear memory (Wasm f64.store)
 fn f64_store(addr: i32, value: f64);
 
-/// Load byte from linear memory, zero-extended to i32 (Wasm i32.load8_u)
-fn i32_load8_u(addr: i32) -> i32;
+/// Load byte from linear memory (Wasm i32.load8_u)
+fn i32_load8_u(addr: i32) -> u8;
 
-/// Load u16 from linear memory, zero-extended to i32 (Wasm i32.load16_u)
-fn i32_load16_u(addr: i32) -> i32;
+/// Load u16 from linear memory (Wasm i32.load16_u)
+fn i32_load16_u(addr: i32) -> u16;
 
-/// Store low byte of i32 to linear memory (Wasm i32.store8)
-fn i32_store8(addr: i32, value: i32);
+/// Store byte to linear memory (Wasm i32.store8)
+fn i32_store8(addr: i32, value: u8);
 
-/// Store low 16 bits of i32 to linear memory (Wasm i32.store16)
-fn i32_store16(addr: i32, value: i32);
+/// Store u16 to linear memory (Wasm i32.store16)
+fn i32_store16(addr: i32, value: u16);
 
 /// Allocate/reallocate memory in linear memory
 /// Standard WASI realloc signature

--- a/wado-compiler/lib/core/cli.wado
+++ b/wado-compiler/lib/core/cli.wado
@@ -30,7 +30,7 @@ pub fn write_to_stream(tx: i32, message: String, add_newline: bool) {
         builtin::i32_store8(ptr + i, byte);
     }
     if add_newline {
-        builtin::i32_store8(ptr + len, '\n');
+        builtin::i32_store8(ptr + len, '\n' as u8);
     }
     builtin::stream_write(tx, ptr, alloc_size);
     builtin::stream_drop_writable(tx);

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -14,7 +14,7 @@
 pub fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {
     let arr = builtin::array_new::<u8>(len);
     for (let mut i = 0; i < len; i += 1) {
-        builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i));
+        builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i) as u8);
     }
     return arr;
 }

--- a/wado-compiler/lib/core/prelude/int128.wado
+++ b/wado-compiler/lib/core/prelude/int128.wado
@@ -29,7 +29,7 @@ impl u128 {
         let bytes = s.internal_raw_bytes();
         while i < len {
             let byte = builtin::array_get_u8(bytes, i);
-            let digit = byte - ('0' as i32);
+            let digit = (byte as i32) - ('0' as i32);
             if 0 <= digit && digit <= 9 {
                 let digit_u64: u64 = digit as u64;
                 result = result.mul_u64(10).add(&u128::from_u64(digit_u64));
@@ -199,7 +199,7 @@ impl u128 {
             let rem: u128 = result[1];
             let digit_u64: u64 = rem.low();
             let digit: i32 = (digit_u64 as i64) as i32;
-            builtin::i32_store8(ptr + pos, ('0' as i32) + digit);
+            builtin::i32_store8(ptr + pos, (('0' as i32) + digit) as u8);
             temp = result[0];
         }
 
@@ -207,7 +207,7 @@ impl u128 {
         let len: i32 = 39 - pos;
         let arr = builtin::array_new::<u8>(len);
         for (let mut i: i32 = 0; i < len; i += 1) {
-            let byte: i32 = builtin::i32_load8_u(ptr + pos + i);
+            let byte = builtin::i32_load8_u(ptr + pos + i);
             builtin::array_set_u8(arr, i, byte);
         }
 
@@ -283,7 +283,7 @@ fn fmt_u128_base(val: &u128, f: &mut Formatter, base: i32, upper: bool) {
     let arr = f.buf.internal_raw_bytes();
 
     if is_zero {
-        builtin::array_set_u8(arr, offset, '0' as i32);
+        builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
         let mut pos = offset + digit_count;
         let mut lo: u64 = val.low();
@@ -299,7 +299,7 @@ fn fmt_u128_base(val: &u128, f: &mut Formatter, base: i32, upper: bool) {
             } else {
                 ('a' as i32) + digit - 10
             };
-            builtin::array_set_u8(arr, pos, ch);
+            builtin::array_set_u8(arr, pos, ch as u8);
             // Shift right: move bits from hi into lo
             // For shift amounts 1,3,4 this works correctly
             let hi_bits = hi << (64 - shift_u64);
@@ -586,7 +586,7 @@ impl i128 {
 
         // Check for negative sign
         let first_byte = builtin::array_get_u8(bytes, 0);
-        let is_negative = first_byte == ('-' as i32);
+        let is_negative = first_byte == ('-' as u8);
         let start_idx = if is_negative { 1 } else { 0 };
 
         // Parse the absolute value as u128
@@ -594,7 +594,7 @@ impl i128 {
         let mut i = start_idx;
         while i < len {
             let byte = builtin::array_get_u8(bytes, i);
-            let digit = byte - ('0' as i32);
+            let digit = (byte as i32) - ('0' as i32);
             if 0 <= digit && digit <= 9 {
                 abs_value = abs_value.mul_u64(10).add(&u128::from_u64(digit as u64));
             }
@@ -741,7 +741,7 @@ impl i128 {
             let len = abs_str.len();
             let abs_bytes = abs_str.internal_raw_bytes();
             let arr = builtin::array_new::<u8>(len + 1);
-            builtin::array_set_u8(arr, 0, '-' as i32);
+            builtin::array_set_u8(arr, 0, '-' as u8);
             for (let mut i = 0; i < len; i += 1) {
                 builtin::array_set_u8(arr, i + 1, builtin::array_get_u8(abs_bytes, i));
             }
@@ -817,7 +817,7 @@ fn fmt_i128_base(val: &i128, f: &mut Formatter, base: i32, upper: bool) {
     let arr = f.buf.internal_raw_bytes();
 
     if is_zero {
-        builtin::array_set_u8(arr, offset, '0' as i32);
+        builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
         let mut pos = offset + digit_count;
         let mut lo: u64 = abs_val.low();
@@ -833,7 +833,7 @@ fn fmt_i128_base(val: &i128, f: &mut Formatter, base: i32, upper: bool) {
             } else {
                 ('a' as i32) + digit - 10
             };
-            builtin::array_set_u8(arr, pos, ch);
+            builtin::array_set_u8(arr, pos, ch as u8);
             let hi_bits = hi << (64 - shift_u64);
             lo = (lo >> shift_u64) | hi_bits;
             hi = hi >> shift_u64;

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -17,7 +17,7 @@ use {
 fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {
     let arr = builtin::array_new::<u8>(len);
     for let mut i = 0; i < len; i += 1 {
-        builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i));
+        builtin::array_set_u8(arr, i, builtin::i32_load8_u(ptr + i) as u8);
     }
     return arr;
 }
@@ -43,11 +43,11 @@ fn write_decimal_digits(arr: builtin::array<u8>, offset: i32, abs_val: i64, digi
     let ten: i64 = 10;
     let mut pos = offset + digit_count;
     if abs_val == zero {
-        builtin::array_set_u8(arr, offset, '0' as i32);
+        builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
         for let mut temp: i64 = abs_val; temp > zero; temp = temp / ten {
             pos -= 1;
-            builtin::array_set_u8(arr, pos, ('0' as i32) + ((temp % ten) as i32));
+            builtin::array_set_u8(arr, pos, (('0' as i32) + ((temp % ten) as i32)) as u8);
         }
     }
 }
@@ -58,7 +58,7 @@ fn write_base_digits(arr: builtin::array<u8>, offset: i32, abs_val: i64, digit_c
     let base64: i64 = base as i64;
     let mut pos = offset + digit_count;
     if abs_val == zero {
-        builtin::array_set_u8(arr, offset, '0' as i32);
+        builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
         for let mut temp: i64 = abs_val; temp > zero; temp = temp / base64 {
             pos -= 1;
@@ -70,7 +70,7 @@ fn write_base_digits(arr: builtin::array<u8>, offset: i32, abs_val: i64, digit_c
             } else {
                 ('a' as i32) + digit - 10
             };
-            builtin::array_set_u8(arr, pos, ch);
+            builtin::array_set_u8(arr, pos, ch as u8);
         }
     }
 }
@@ -128,7 +128,7 @@ fn write_u64_base_digits(arr: builtin::array<u8>, offset: i32, val_i64: i64, dig
     let mask64: i64 = mask as i64;
     let mut pos = offset + digit_count;
     if val_i64 == zero {
-        builtin::array_set_u8(arr, offset, '0' as i32);
+        builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
         let mut temp: i64 = val_i64;
         while temp != zero {
@@ -141,7 +141,7 @@ fn write_u64_base_digits(arr: builtin::array<u8>, offset: i32, val_i64: i64, dig
             } else {
                 ('a' as i32) + digit - 10
             };
-            builtin::array_set_u8(arr, pos, ch);
+            builtin::array_set_u8(arr, pos, ch as u8);
             // Unsigned right shift: use Wasm's i64.shr_u semantics
             // In Wado, >> on i64 is arithmetic shift. For unsigned shift we need:
             // (val as u64 >> bits) as i64
@@ -214,7 +214,7 @@ fn fmt_i64_decimal(value: i64, f: &mut Formatter) {
         let repr = f.buf.internal_raw_bytes();
         // Write the remaining digits, then the last '8'
         write_decimal_digits(repr, offset, remaining, remaining_digits);
-        builtin::array_set_u8(repr, offset + remaining_digits, '8' as i32);
+        builtin::array_set_u8(repr, offset + remaining_digits, '8' as u8);
     } else {
         let abs_val: i64 = if is_negative { zero_i64 - value } else { value };
         let digit_count = count_digits_i64(abs_val);
@@ -232,7 +232,7 @@ fn fmt_u64_decimal(value: u64, f: &mut Formatter) {
 
     if val_i64 == zero {
         let offset = f.prepare_int_write(false, "", 1);
-        builtin::array_set_u8(f.buf.internal_raw_bytes(), offset, '0' as i32);
+        builtin::array_set_u8(f.buf.internal_raw_bytes(), offset, '0' as u8);
         return;
     }
 
@@ -283,7 +283,7 @@ fn fmt_u64_decimal(value: u64, f: &mut Formatter) {
             }
             temp = signed_quot + offset_div + carry;
         }
-        builtin::array_set_u8(repr, pos, ('0' as i32) + digit);
+        builtin::array_set_u8(repr, pos, (('0' as i32) + digit) as u8);
     }
 }
 

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -531,21 +531,20 @@ impl char {
     }
 
     /// Returns true if the character is an ASCII whitespace character:
-    /// space (0x20), tab (0x09), newline (0x0A), or carriage return (0x0D).
+    /// SP (0x20), HT (0x09), LF (0x0A), VT (0x0B), FF (0x0C), CR (0x0D).
+    /// Matches POSIX isspace() for the ASCII range.
     pub fn is_ascii_space(&self) -> bool {
-        return *self == ' ' || *self == '\t' || *self == '\n' || *self == '\r';
+        let c = (*self) as u32;
+        return c == 0x20 || (c >= 0x09 && c <= 0x0D);
     }
 
     /// Returns true if the character is a Unicode whitespace character.
-    /// Covers ASCII whitespace plus form feed (0x0C), vertical tab (0x0B),
-    /// and Unicode general category Zs/Zl/Zp code points.
+    /// Covers ASCII whitespace plus Unicode general category Zs/Zl/Zp code points.
     pub fn is_unicode_space(&self) -> bool {
-        let c = (*self) as u32;
-        // ASCII whitespace: HT, LF, VT, FF, CR, SP
-        if c <= 0x20 {
-            return c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0B || c == 0x0C || c == 0x0D;
+        if self.is_ascii_space() {
+            return true;
         }
-        // Non-ASCII Unicode whitespace
+        let c = (*self) as u32;
         return c == 0x85       // NEXT LINE
             || c == 0xA0       // NO-BREAK SPACE
             || c == 0x1680     // OGHAM SPACE MARK

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -548,7 +548,7 @@ impl char {
 
     /// Returns true if the character is a Unicode whitespace character.
     /// Covers ASCII whitespace plus Unicode general category Zs/Zl/Zp code points.
-    pub fn is_unicode_whitespace(&self) -> bool {
+    pub fn is_whitespace(&self) -> bool {
         if self.is_ascii_whitespace() {
             return true;
         }

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -549,31 +549,31 @@ impl char {
     /// Covers ASCII whitespace plus Unicode general category Zs/Zl/Zp code points.
     pub fn is_whitespace(&self) -> bool {
         return match *self {
-            ' ' => true,
-            '\t' => true,
-            '\n' => true,
-            '\r' => true,
-            '\u{0B}' => true,
-            '\u{0C}' => true,
-            '\u{85}' => true,
-            '\u{A0}' => true,
-            '\u{1680}' => true,
-            '\u{2000}' => true,
-            '\u{2001}' => true,
-            '\u{2002}' => true,
-            '\u{2003}' => true,
-            '\u{2004}' => true,
-            '\u{2005}' => true,
-            '\u{2006}' => true,
-            '\u{2007}' => true,
-            '\u{2008}' => true,
-            '\u{2009}' => true,
-            '\u{200A}' => true,
-            '\u{2028}' => true,
-            '\u{2029}' => true,
-            '\u{202F}' => true,
-            '\u{205F}' => true,
-            '\u{3000}' => true,
+            ' ' => true,              // SP
+            '\t' => true,             // HT
+            '\n' => true,             // LF
+            '\r' => true,             // CR
+            '\u{0B}' => true,         // VT
+            '\u{0C}' => true,         // FF
+            '\u{85}' => true,         // NEXT LINE
+            '\u{A0}' => true,         // NO-BREAK SPACE
+            '\u{1680}' => true,       // OGHAM SPACE MARK
+            '\u{2000}' => true,       // EN QUAD
+            '\u{2001}' => true,       // EM QUAD
+            '\u{2002}' => true,       // EN SPACE
+            '\u{2003}' => true,       // EM SPACE
+            '\u{2004}' => true,       // THREE-PER-EM SPACE
+            '\u{2005}' => true,       // FOUR-PER-EM SPACE
+            '\u{2006}' => true,       // SIX-PER-EM SPACE
+            '\u{2007}' => true,       // FIGURE SPACE
+            '\u{2008}' => true,       // PUNCTUATION SPACE
+            '\u{2009}' => true,       // THIN SPACE
+            '\u{200A}' => true,       // HAIR SPACE
+            '\u{2028}' => true,       // LINE SEPARATOR
+            '\u{2029}' => true,       // PARAGRAPH SEPARATOR
+            '\u{202F}' => true,       // NARROW NO-BREAK SPACE
+            '\u{205F}' => true,       // MEDIUM MATHEMATICAL SPACE
+            '\u{3000}' => true,       // IDEOGRAPHIC SPACE
             _ => false,
         };
     }

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -533,7 +533,7 @@ impl char {
     /// Returns true if the character is an ASCII whitespace character:
     /// SP (0x20), HT (0x09), LF (0x0A), VT (0x0B), FF (0x0C), CR (0x0D).
     /// Matches POSIX isspace() for the ASCII range.
-    pub fn is_ascii_space(&self) -> bool {
+    pub fn is_ascii_whitespace(&self) -> bool {
         return match *self {
             ' ' => true,
             '\t' => true,
@@ -548,8 +548,8 @@ impl char {
 
     /// Returns true if the character is a Unicode whitespace character.
     /// Covers ASCII whitespace plus Unicode general category Zs/Zl/Zp code points.
-    pub fn is_unicode_space(&self) -> bool {
-        if self.is_ascii_space() {
+    pub fn is_unicode_whitespace(&self) -> bool {
+        if self.is_ascii_whitespace() {
             return true;
         }
         let c = (*self) as u32;

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -539,29 +539,43 @@ impl char {
             '\t' => true,
             '\n' => true,
             '\r' => true,
-            _ => {
-                let c = (*self) as u32;
-                c == 0x0B || c == 0x0C
-            },
+            '\u{0B}' => true,
+            '\u{0C}' => true,
+            _ => false,
         };
     }
 
     /// Returns true if the character is a Unicode whitespace character.
     /// Covers ASCII whitespace plus Unicode general category Zs/Zl/Zp code points.
     pub fn is_whitespace(&self) -> bool {
-        if self.is_ascii_whitespace() {
-            return true;
-        }
-        let c = (*self) as u32;
-        return c == 0x85       // NEXT LINE
-            || c == 0xA0       // NO-BREAK SPACE
-            || c == 0x1680     // OGHAM SPACE MARK
-            || (c >= 0x2000 && c <= 0x200A)  // EN QUAD..HAIR SPACE
-            || c == 0x2028     // LINE SEPARATOR
-            || c == 0x2029     // PARAGRAPH SEPARATOR
-            || c == 0x202F     // NARROW NO-BREAK SPACE
-            || c == 0x205F     // MEDIUM MATHEMATICAL SPACE
-            || c == 0x3000;    // IDEOGRAPHIC SPACE
+        return match *self {
+            ' ' => true,
+            '\t' => true,
+            '\n' => true,
+            '\r' => true,
+            '\u{0B}' => true,
+            '\u{0C}' => true,
+            '\u{85}' => true,
+            '\u{A0}' => true,
+            '\u{1680}' => true,
+            '\u{2000}' => true,
+            '\u{2001}' => true,
+            '\u{2002}' => true,
+            '\u{2003}' => true,
+            '\u{2004}' => true,
+            '\u{2005}' => true,
+            '\u{2006}' => true,
+            '\u{2007}' => true,
+            '\u{2008}' => true,
+            '\u{2009}' => true,
+            '\u{200A}' => true,
+            '\u{2028}' => true,
+            '\u{2029}' => true,
+            '\u{202F}' => true,
+            '\u{205F}' => true,
+            '\u{3000}' => true,
+            _ => false,
+        };
     }
 }
 

--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -534,8 +534,16 @@ impl char {
     /// SP (0x20), HT (0x09), LF (0x0A), VT (0x0B), FF (0x0C), CR (0x0D).
     /// Matches POSIX isspace() for the ASCII range.
     pub fn is_ascii_space(&self) -> bool {
-        let c = (*self) as u32;
-        return c == 0x20 || (c >= 0x09 && c <= 0x0D);
+        return match *self {
+            ' ' => true,
+            '\t' => true,
+            '\n' => true,
+            '\r' => true,
+            _ => {
+                let c = (*self) as u32;
+                c == 0x0B || c == 0x0C
+            },
+        };
     }
 
     /// Returns true if the character is a Unicode whitespace character.

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -37,7 +37,7 @@ impl String {
 
     /// Get a byte at the given index (low-level - prefer bytes() iterator)
     pub fn get_byte(&self, index: i32) -> u8 {
-        return builtin::array_get_u8(self.repr, index) as u8;
+        return builtin::array_get_u8(self.repr, index);
     }
 
     /// Set a byte at the given index (low-level)
@@ -247,7 +247,7 @@ impl Iterator for StrUtf8ByteIter {
         }
         let byte = builtin::array_get_u8(self.repr, self.index);
         self.index += 1;
-        return Option::<u8>::Some(byte as u8);
+        return Option::<u8>::Some(byte);
     }
 }
 
@@ -353,22 +353,22 @@ impl String {
         }
 
         if code < 0x80 {
-            builtin::array_set_u8(self.repr, self.used, code);
+            builtin::array_set_u8(self.repr, self.used, code as u8);
             self.used += 1;
         } else if code < 0x800 {
-            builtin::array_set_u8(self.repr, self.used, 0xC0 | (code >> 6));
-            builtin::array_set_u8(self.repr, self.used + 1, 0x80 | (code & 0x3F));
+            builtin::array_set_u8(self.repr, self.used, (0xC0 | (code >> 6)) as u8);
+            builtin::array_set_u8(self.repr, self.used + 1, (0x80 | (code & 0x3F)) as u8);
             self.used += 2;
         } else if code < 0x10000 {
-            builtin::array_set_u8(self.repr, self.used, 0xE0 | (code >> 12));
-            builtin::array_set_u8(self.repr, self.used + 1, 0x80 | ((code >> 6) & 0x3F));
-            builtin::array_set_u8(self.repr, self.used + 2, 0x80 | (code & 0x3F));
+            builtin::array_set_u8(self.repr, self.used, (0xE0 | (code >> 12)) as u8);
+            builtin::array_set_u8(self.repr, self.used + 1, (0x80 | ((code >> 6) & 0x3F)) as u8);
+            builtin::array_set_u8(self.repr, self.used + 2, (0x80 | (code & 0x3F)) as u8);
             self.used += 3;
         } else {
-            builtin::array_set_u8(self.repr, self.used, 0xF0 | (code >> 18));
-            builtin::array_set_u8(self.repr, self.used + 1, 0x80 | ((code >> 12) & 0x3F));
-            builtin::array_set_u8(self.repr, self.used + 2, 0x80 | ((code >> 6) & 0x3F));
-            builtin::array_set_u8(self.repr, self.used + 3, 0x80 | (code & 0x3F));
+            builtin::array_set_u8(self.repr, self.used, (0xF0 | (code >> 18)) as u8);
+            builtin::array_set_u8(self.repr, self.used + 1, (0x80 | ((code >> 12) & 0x3F)) as u8);
+            builtin::array_set_u8(self.repr, self.used + 2, (0x80 | ((code >> 6) & 0x3F)) as u8);
+            builtin::array_set_u8(self.repr, self.used + 3, (0x80 | (code & 0x3F)) as u8);
             self.used += 4;
         }
     }
@@ -414,7 +414,7 @@ impl String {
     pub fn trim_ascii_start(&self) -> String {
         let mut start = 0;
         while start < self.used {
-            let c = (builtin::array_get_u8(self.repr, start) as u8) as char;
+            let c = builtin::array_get_u8(self.repr, start) as char;
             if c.is_ascii_whitespace() {
                 start += 1;
             } else {
@@ -428,7 +428,7 @@ impl String {
     pub fn trim_ascii_end(&self) -> String {
         let mut end = self.used;
         while end > 0 {
-            let c = (builtin::array_get_u8(self.repr, end - 1) as u8) as char;
+            let c = builtin::array_get_u8(self.repr, end - 1) as char;
             if c.is_ascii_whitespace() {
                 end -= 1;
             } else {

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -409,4 +409,123 @@ impl String {
         }
         self.used = byte_pos;
     }
+
+    /// Returns a new string with leading ASCII whitespace removed.
+    pub fn trim_ascii_start(&self) -> String {
+        let mut start = 0;
+        while start < self.used {
+            let c = (builtin::array_get_u8(self.repr, start) as u8) as char;
+            if c.is_ascii_whitespace() {
+                start += 1;
+            } else {
+                break;
+            }
+        }
+        return self.internal_substr_bytes(start, self.used);
+    }
+
+    /// Returns a new string with trailing ASCII whitespace removed.
+    pub fn trim_ascii_end(&self) -> String {
+        let mut end = self.used;
+        while end > 0 {
+            let c = (builtin::array_get_u8(self.repr, end - 1) as u8) as char;
+            if c.is_ascii_whitespace() {
+                end -= 1;
+            } else {
+                break;
+            }
+        }
+        return self.internal_substr_bytes(0, end);
+    }
+
+    /// Returns a new string with leading and trailing ASCII whitespace removed.
+    pub fn trim_ascii(&self) -> String {
+        return self.trim_ascii_start().trim_ascii_end();
+    }
+
+    /// Returns a new string with leading Unicode whitespace removed.
+    pub fn trim_start(&self) -> String {
+        let mut iter = self.chars();
+        let mut start = 0;
+        loop {
+            if let Some(c) = iter.next() {
+                if c.is_whitespace() {
+                    let code = c as u32;
+                    if code < 0x80 {
+                        start += 1;
+                    } else if code < 0x800 {
+                        start += 2;
+                    } else if code < 0x10000 {
+                        start += 3;
+                    } else {
+                        start += 4;
+                    }
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        return self.internal_substr_bytes(start, self.used);
+    }
+
+    /// Returns a new string with trailing Unicode whitespace removed.
+    pub fn trim_end(&self) -> String {
+        let mut end = self.used;
+        while end > 0 {
+            // Find the start of the last character by scanning back past continuation bytes
+            let mut pos = end - 1;
+            while pos > 0 {
+                let b = builtin::array_get_u8(self.repr, pos);
+                if b >= 0x80 && b < 0xC0 {
+                    pos -= 1;
+                } else {
+                    break;
+                }
+            }
+            // Decode the character at pos
+            let b0 = builtin::array_get_u8(self.repr, pos);
+            let code = if b0 < 0x80 {
+                b0 as u32
+            } else if b0 < 0xE0 {
+                let b1 = builtin::array_get_u8(self.repr, pos + 1);
+                (((b0 & 0x1F) << 6) | (b1 & 0x3F)) as u32
+            } else if b0 < 0xF0 {
+                let b1 = builtin::array_get_u8(self.repr, pos + 1);
+                let b2 = builtin::array_get_u8(self.repr, pos + 2);
+                (((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F)) as u32
+            } else {
+                let b1 = builtin::array_get_u8(self.repr, pos + 1);
+                let b2 = builtin::array_get_u8(self.repr, pos + 2);
+                let b3 = builtin::array_get_u8(self.repr, pos + 3);
+                (((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)) as u32
+            };
+            let ch = char::from_u32_unchecked(code);
+            if ch.is_whitespace() {
+                end = pos;
+            } else {
+                break;
+            }
+        }
+        return self.internal_substr_bytes(0, end);
+    }
+
+    /// Returns a new string with leading and trailing Unicode whitespace removed.
+    pub fn trim(&self) -> String {
+        return self.trim_start().trim_end();
+    }
+
+    /// Internal: extract a substring by byte range [start, end).
+    fn internal_substr_bytes(&self, start: i32, end: i32) -> String {
+        let len = end - start;
+        if len <= 0 {
+            return String::with_capacity(0);
+        }
+        let repr = builtin::array_new::<u8>(len);
+        for let mut i = 0; i < len; i += 1 {
+            builtin::array_set_u8(repr, i, builtin::array_get_u8(self.repr, start + i));
+        }
+        return String { repr, used: len };
+    }
 }

--- a/wado-compiler/lib/core/string_test.wado
+++ b/wado-compiler/lib/core/string_test.wado
@@ -268,18 +268,16 @@ test "is_ascii_whitespace true cases" {
     assert '\t'.is_ascii_whitespace();
     assert '\n'.is_ascii_whitespace();
     assert '\r'.is_ascii_whitespace();
-    // VT (0x0B) and FF (0x0C)
-    assert char::from_u32_unchecked(0x0B as u32).is_ascii_whitespace();
-    assert char::from_u32_unchecked(0x0C as u32).is_ascii_whitespace();
+    assert '\u{0B}'.is_ascii_whitespace();  // VT
+    assert '\u{0C}'.is_ascii_whitespace();  // FF
 }
 
 test "is_ascii_whitespace false cases" {
     assert !'a'.is_ascii_whitespace();
     assert !'0'.is_ascii_whitespace();
     assert !'\0'.is_ascii_whitespace();
-    // 0x08 (BS) and 0x0E (SO) are adjacent to the 0x09..0x0D range
-    assert !char::from_u32_unchecked(0x08 as u32).is_ascii_whitespace();
-    assert !char::from_u32_unchecked(0x0E as u32).is_ascii_whitespace();
+    assert !'\u{08}'.is_ascii_whitespace();  // BS (adjacent to range)
+    assert !'\u{0E}'.is_ascii_whitespace();  // SO (adjacent to range)
 }
 
 test "is_whitespace covers ASCII" {
@@ -287,28 +285,27 @@ test "is_whitespace covers ASCII" {
     assert '\t'.is_whitespace();
     assert '\n'.is_whitespace();
     assert '\r'.is_whitespace();
-    assert char::from_u32_unchecked(0x0B as u32).is_whitespace();
-    assert char::from_u32_unchecked(0x0C as u32).is_whitespace();
+    assert '\u{0B}'.is_whitespace();
+    assert '\u{0C}'.is_whitespace();
 }
 
 test "is_whitespace non-ASCII spaces" {
-    assert char::from_u32_unchecked(0x85 as u32).is_whitespace();    // NEXT LINE
-    assert char::from_u32_unchecked(0xA0 as u32).is_whitespace();    // NO-BREAK SPACE
-    assert char::from_u32_unchecked(0x1680 as u32).is_whitespace();  // OGHAM SPACE MARK
-    assert char::from_u32_unchecked(0x2000 as u32).is_whitespace();  // EN QUAD
-    assert char::from_u32_unchecked(0x200A as u32).is_whitespace();  // HAIR SPACE
-    assert char::from_u32_unchecked(0x2028 as u32).is_whitespace();  // LINE SEPARATOR
-    assert char::from_u32_unchecked(0x2029 as u32).is_whitespace();  // PARAGRAPH SEPARATOR
-    assert char::from_u32_unchecked(0x202F as u32).is_whitespace();  // NARROW NO-BREAK SPACE
-    assert char::from_u32_unchecked(0x205F as u32).is_whitespace();  // MEDIUM MATHEMATICAL SPACE
-    assert char::from_u32_unchecked(0x3000 as u32).is_whitespace();  // IDEOGRAPHIC SPACE
+    assert '\u{85}'.is_whitespace();    // NEXT LINE
+    assert '\u{A0}'.is_whitespace();    // NO-BREAK SPACE
+    assert '\u{1680}'.is_whitespace();  // OGHAM SPACE MARK
+    assert '\u{2000}'.is_whitespace();  // EN QUAD
+    assert '\u{200A}'.is_whitespace();  // HAIR SPACE
+    assert '\u{2028}'.is_whitespace();  // LINE SEPARATOR
+    assert '\u{2029}'.is_whitespace();  // PARAGRAPH SEPARATOR
+    assert '\u{202F}'.is_whitespace();  // NARROW NO-BREAK SPACE
+    assert '\u{205F}'.is_whitespace();  // MEDIUM MATHEMATICAL SPACE
+    assert '\u{3000}'.is_whitespace();  // IDEOGRAPHIC SPACE
 }
 
 test "is_whitespace false for non-space" {
     assert !'A'.is_whitespace();
     assert !'あ'.is_whitespace();
-    // ZERO WIDTH SPACE (0x200B) is NOT whitespace
-    assert !char::from_u32_unchecked(0x200B as u32).is_whitespace();
+    assert !'\u{200B}'.is_whitespace();  // ZERO WIDTH SPACE is NOT whitespace
 }
 
 test "trim_ascii both sides" {
@@ -334,9 +331,8 @@ test "trim_ascii_end" {
 }
 
 test "trim_ascii preserves non-ASCII" {
-    // NO-BREAK SPACE (0xA0) is not ASCII whitespace
-    let nbsp = char::from_u32_unchecked(0xA0 as u32).to_string();
-    let s = String::concat(nbsp, "hello");
+    // NO-BREAK SPACE (U+00A0) is not ASCII whitespace
+    let s = String::concat('\u{A0}'.to_string(), "hello");
     assert s.trim_ascii() == s;
 }
 
@@ -363,20 +359,19 @@ test "trim_end" {
 }
 
 test "trim Unicode whitespace" {
-    // NO-BREAK SPACE (0xA0) is Unicode whitespace
-    let nbsp = char::from_u32_unchecked(0xA0 as u32).to_string();
+    let nbsp = '\u{A0}'.to_string();
     let s = String::concat(String::concat(nbsp, "hello"), nbsp);
     assert s.trim() == "hello";
 }
 
 test "trim IDEOGRAPHIC SPACE" {
-    let ideographic = char::from_u32_unchecked(0x3000 as u32).to_string();
+    let ideographic = '\u{3000}'.to_string();
     let s = String::concat(String::concat(ideographic, "日本語"), ideographic);
     assert s.trim() == "日本語";
 }
 
 test "trim mixed ASCII and Unicode whitespace" {
-    let nbsp = char::from_u32_unchecked(0xA0 as u32).to_string();
+    let nbsp = '\u{A0}'.to_string();
     let s = String::concat(String::concat(" ", String::concat(nbsp, "hello")), " ");
     assert s.trim() == "hello";
 }

--- a/wado-compiler/lib/core/string_test.wado
+++ b/wado-compiler/lib/core/string_test.wado
@@ -282,31 +282,101 @@ test "is_ascii_whitespace false cases" {
     assert !char::from_u32_unchecked(0x0E as u32).is_ascii_whitespace();
 }
 
-test "is_unicode_whitespace covers ASCII" {
-    assert ' '.is_unicode_whitespace();
-    assert '\t'.is_unicode_whitespace();
-    assert '\n'.is_unicode_whitespace();
-    assert '\r'.is_unicode_whitespace();
-    assert char::from_u32_unchecked(0x0B as u32).is_unicode_whitespace();
-    assert char::from_u32_unchecked(0x0C as u32).is_unicode_whitespace();
+test "is_whitespace covers ASCII" {
+    assert ' '.is_whitespace();
+    assert '\t'.is_whitespace();
+    assert '\n'.is_whitespace();
+    assert '\r'.is_whitespace();
+    assert char::from_u32_unchecked(0x0B as u32).is_whitespace();
+    assert char::from_u32_unchecked(0x0C as u32).is_whitespace();
 }
 
-test "is_unicode_whitespace non-ASCII spaces" {
-    assert char::from_u32_unchecked(0x85 as u32).is_unicode_whitespace();    // NEXT LINE
-    assert char::from_u32_unchecked(0xA0 as u32).is_unicode_whitespace();    // NO-BREAK SPACE
-    assert char::from_u32_unchecked(0x1680 as u32).is_unicode_whitespace();  // OGHAM SPACE MARK
-    assert char::from_u32_unchecked(0x2000 as u32).is_unicode_whitespace();  // EN QUAD
-    assert char::from_u32_unchecked(0x200A as u32).is_unicode_whitespace();  // HAIR SPACE
-    assert char::from_u32_unchecked(0x2028 as u32).is_unicode_whitespace();  // LINE SEPARATOR
-    assert char::from_u32_unchecked(0x2029 as u32).is_unicode_whitespace();  // PARAGRAPH SEPARATOR
-    assert char::from_u32_unchecked(0x202F as u32).is_unicode_whitespace();  // NARROW NO-BREAK SPACE
-    assert char::from_u32_unchecked(0x205F as u32).is_unicode_whitespace();  // MEDIUM MATHEMATICAL SPACE
-    assert char::from_u32_unchecked(0x3000 as u32).is_unicode_whitespace();  // IDEOGRAPHIC SPACE
+test "is_whitespace non-ASCII spaces" {
+    assert char::from_u32_unchecked(0x85 as u32).is_whitespace();    // NEXT LINE
+    assert char::from_u32_unchecked(0xA0 as u32).is_whitespace();    // NO-BREAK SPACE
+    assert char::from_u32_unchecked(0x1680 as u32).is_whitespace();  // OGHAM SPACE MARK
+    assert char::from_u32_unchecked(0x2000 as u32).is_whitespace();  // EN QUAD
+    assert char::from_u32_unchecked(0x200A as u32).is_whitespace();  // HAIR SPACE
+    assert char::from_u32_unchecked(0x2028 as u32).is_whitespace();  // LINE SEPARATOR
+    assert char::from_u32_unchecked(0x2029 as u32).is_whitespace();  // PARAGRAPH SEPARATOR
+    assert char::from_u32_unchecked(0x202F as u32).is_whitespace();  // NARROW NO-BREAK SPACE
+    assert char::from_u32_unchecked(0x205F as u32).is_whitespace();  // MEDIUM MATHEMATICAL SPACE
+    assert char::from_u32_unchecked(0x3000 as u32).is_whitespace();  // IDEOGRAPHIC SPACE
 }
 
-test "is_unicode_whitespace false for non-space" {
-    assert !'A'.is_unicode_whitespace();
-    assert !'あ'.is_unicode_whitespace();
+test "is_whitespace false for non-space" {
+    assert !'A'.is_whitespace();
+    assert !'あ'.is_whitespace();
     // ZERO WIDTH SPACE (0x200B) is NOT whitespace
-    assert !char::from_u32_unchecked(0x200B as u32).is_unicode_whitespace();
+    assert !char::from_u32_unchecked(0x200B as u32).is_whitespace();
+}
+
+test "trim_ascii both sides" {
+    assert "  hello  ".trim_ascii() == "hello";
+    assert "\t\nhello\r\n".trim_ascii() == "hello";
+    assert "hello".trim_ascii() == "hello";
+    assert "   ".trim_ascii() == "";
+    assert "".trim_ascii() == "";
+}
+
+test "trim_ascii_start" {
+    assert "  hello  ".trim_ascii_start() == "hello  ";
+    assert "\t\nhello".trim_ascii_start() == "hello";
+    assert "hello".trim_ascii_start() == "hello";
+    assert "   ".trim_ascii_start() == "";
+}
+
+test "trim_ascii_end" {
+    assert "  hello  ".trim_ascii_end() == "  hello";
+    assert "hello\t\n".trim_ascii_end() == "hello";
+    assert "hello".trim_ascii_end() == "hello";
+    assert "   ".trim_ascii_end() == "";
+}
+
+test "trim_ascii preserves non-ASCII" {
+    // NO-BREAK SPACE (0xA0) is not ASCII whitespace
+    let nbsp = char::from_u32_unchecked(0xA0 as u32).to_string();
+    let s = String::concat(nbsp, "hello");
+    assert s.trim_ascii() == s;
+}
+
+test "trim both sides" {
+    assert "  hello  ".trim() == "hello";
+    assert "\t\nhello\r\n".trim() == "hello";
+    assert "hello".trim() == "hello";
+    assert "   ".trim() == "";
+    assert "".trim() == "";
+}
+
+test "trim_start" {
+    assert "  hello  ".trim_start() == "hello  ";
+    assert "\t\nhello".trim_start() == "hello";
+    assert "hello".trim_start() == "hello";
+    assert "   ".trim_start() == "";
+}
+
+test "trim_end" {
+    assert "  hello  ".trim_end() == "  hello";
+    assert "hello\t\n".trim_end() == "hello";
+    assert "hello".trim_end() == "hello";
+    assert "   ".trim_end() == "";
+}
+
+test "trim Unicode whitespace" {
+    // NO-BREAK SPACE (0xA0) is Unicode whitespace
+    let nbsp = char::from_u32_unchecked(0xA0 as u32).to_string();
+    let s = String::concat(String::concat(nbsp, "hello"), nbsp);
+    assert s.trim() == "hello";
+}
+
+test "trim IDEOGRAPHIC SPACE" {
+    let ideographic = char::from_u32_unchecked(0x3000 as u32).to_string();
+    let s = String::concat(String::concat(ideographic, "日本語"), ideographic);
+    assert s.trim() == "日本語";
+}
+
+test "trim mixed ASCII and Unicode whitespace" {
+    let nbsp = char::from_u32_unchecked(0xA0 as u32).to_string();
+    let s = String::concat(String::concat(" ", String::concat(nbsp, "hello")), " ");
+    assert s.trim() == "hello";
 }

--- a/wado-compiler/lib/core/string_test.wado
+++ b/wado-compiler/lib/core/string_test.wado
@@ -262,3 +262,51 @@ test "truncate_chars exact count" {
     s.truncate_chars(3);
     assert s == "abc";
 }
+
+test "is_ascii_whitespace true cases" {
+    assert ' '.is_ascii_whitespace();
+    assert '\t'.is_ascii_whitespace();
+    assert '\n'.is_ascii_whitespace();
+    assert '\r'.is_ascii_whitespace();
+    // VT (0x0B) and FF (0x0C)
+    assert char::from_u32_unchecked(0x0B as u32).is_ascii_whitespace();
+    assert char::from_u32_unchecked(0x0C as u32).is_ascii_whitespace();
+}
+
+test "is_ascii_whitespace false cases" {
+    assert !'a'.is_ascii_whitespace();
+    assert !'0'.is_ascii_whitespace();
+    assert !'\0'.is_ascii_whitespace();
+    // 0x08 (BS) and 0x0E (SO) are adjacent to the 0x09..0x0D range
+    assert !char::from_u32_unchecked(0x08 as u32).is_ascii_whitespace();
+    assert !char::from_u32_unchecked(0x0E as u32).is_ascii_whitespace();
+}
+
+test "is_unicode_whitespace covers ASCII" {
+    assert ' '.is_unicode_whitespace();
+    assert '\t'.is_unicode_whitespace();
+    assert '\n'.is_unicode_whitespace();
+    assert '\r'.is_unicode_whitespace();
+    assert char::from_u32_unchecked(0x0B as u32).is_unicode_whitespace();
+    assert char::from_u32_unchecked(0x0C as u32).is_unicode_whitespace();
+}
+
+test "is_unicode_whitespace non-ASCII spaces" {
+    assert char::from_u32_unchecked(0x85 as u32).is_unicode_whitespace();    // NEXT LINE
+    assert char::from_u32_unchecked(0xA0 as u32).is_unicode_whitespace();    // NO-BREAK SPACE
+    assert char::from_u32_unchecked(0x1680 as u32).is_unicode_whitespace();  // OGHAM SPACE MARK
+    assert char::from_u32_unchecked(0x2000 as u32).is_unicode_whitespace();  // EN QUAD
+    assert char::from_u32_unchecked(0x200A as u32).is_unicode_whitespace();  // HAIR SPACE
+    assert char::from_u32_unchecked(0x2028 as u32).is_unicode_whitespace();  // LINE SEPARATOR
+    assert char::from_u32_unchecked(0x2029 as u32).is_unicode_whitespace();  // PARAGRAPH SEPARATOR
+    assert char::from_u32_unchecked(0x202F as u32).is_unicode_whitespace();  // NARROW NO-BREAK SPACE
+    assert char::from_u32_unchecked(0x205F as u32).is_unicode_whitespace();  // MEDIUM MATHEMATICAL SPACE
+    assert char::from_u32_unchecked(0x3000 as u32).is_unicode_whitespace();  // IDEOGRAPHIC SPACE
+}
+
+test "is_unicode_whitespace false for non-space" {
+    assert !'A'.is_unicode_whitespace();
+    assert !'あ'.is_unicode_whitespace();
+    // ZERO WIDTH SPACE (0x200B) is NOT whitespace
+    assert !char::from_u32_unchecked(0x200B as u32).is_unicode_whitespace();
+}

--- a/wado-compiler/src/synthesis/cm_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_adapter.rs
@@ -156,10 +156,10 @@ fn synthesize_lift_inner(
             "i64" | "u64" => builtin_call("i64_load", vec![addr], TypeTable::I64),
             "f32" => builtin_call("f32_load", vec![addr], TypeTable::F32),
             "f64" => builtin_call("f64_load", vec![addr], TypeTable::F64),
-            "i8" | "u8" => builtin_call("i32_load8_u", vec![addr], TypeTable::I32),
-            "i16" | "u16" => builtin_call("i32_load16_u", vec![addr], TypeTable::I32),
+            "i8" | "u8" => builtin_call("i32_load8_u", vec![addr], TypeTable::U8),
+            "i16" | "u16" => builtin_call("i32_load16_u", vec![addr], TypeTable::U16),
             "bool" => {
-                let raw = builtin_call("i32_load8_u", vec![addr], TypeTable::I32);
+                let raw = builtin_call("i32_load8_u", vec![addr], TypeTable::U8);
                 binary(
                     crate::tir::TirBinaryOp::NotEq,
                     raw,

--- a/wado-compiler/tests/fixtures.golden.wir/array_append.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/array_append.wir.wado
@@ -298,7 +298,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -497,7 +497,7 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
                     };
                     block {
                         pos = pos - 1;
-                        builtin::array_set_u8(arr, pos, 48 + builtin::i32_wrap_i64(temp % 10_i64));
+                        builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     };
                     temp = temp / 10_i64;
                     continue l18;
@@ -592,7 +592,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -649,7 +649,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -691,22 +691,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/cli_print.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/cli_print.wir.wado
@@ -97,7 +97,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;

--- a/wado-compiler/tests/fixtures.golden.wir/closure_fn_param_capture.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/closure_fn_param_capture.wir.wado
@@ -165,7 +165,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -302,7 +302,7 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
                     };
                     block {
                         pos = pos - 1;
-                        builtin::array_set_u8(arr, pos, 48 + builtin::i32_wrap_i64(temp % 10_i64));
+                        builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     };
                     temp = temp / 10_i64;
                     continue l13;
@@ -367,7 +367,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -424,7 +424,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -466,22 +466,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/enum-match-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/enum-match-basic.wir.wado
@@ -144,7 +144,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;

--- a/wado-compiler/tests/fixtures.golden.wir/flags_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/flags_basic.wir.wado
@@ -157,7 +157,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;

--- a/wado-compiler/tests/fixtures.golden.wir/generic_struct_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/generic_struct_nested.wir.wado
@@ -153,7 +153,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -290,7 +290,7 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
                     };
                     block {
                         pos = pos - 1;
-                        builtin::array_set_u8(arr, pos, 48 + builtin::i32_wrap_i64(temp % 10_i64));
+                        builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     };
                     temp = temp / 10_i64;
                     continue l13;
@@ -355,7 +355,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -412,7 +412,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -454,22 +454,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/match_variant_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/match_variant_basic.wir.wado
@@ -293,7 +293,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -1118,7 +1118,7 @@ fn format_decimal(d, p, nd) {
                     __local_27 = i;
                     __local_28 = __inline_String__get_byte_10: block -> u8 {
                         __local_30 = i - 1;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr, __local_30) & 255;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr, __local_30);
                     };
                     builtin::array_set_u8(_licm_repr, __local_27, __local_28);
                 };
@@ -1182,7 +1182,7 @@ fn format_exp(d, p, nd, upper) {
                     __local_12 = i;
                     __local_13 = __inline_String__get_byte_3: block -> u8 {
                         __local_15 = i - 1;
-                        break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr, __local_15) & 255;
+                        break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr, __local_15);
                     };
                     builtin::array_set_u8(_licm_repr, __local_12, __local_13);
                 };
@@ -1409,7 +1409,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -1467,7 +1467,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -1509,10 +1509,10 @@ fn String::concat(a, b) {
     let repr: ref null array<u8>;
     let a_repr: ref null array<u8>;
     let i_7: i32;
-    let byte_8: i32;
+    let byte_8: u8;
     let b_repr: ref null array<u8>;
     let i_10: i32;
-    let byte_11: i32;
+    let byte_11: u8;
     let __local_12: ref null String;
     let __local_13: ref null String;
     let __local_14: ref null String;
@@ -1565,22 +1565,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/newtype_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/newtype_basic.wir.wado
@@ -301,7 +301,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -1126,7 +1126,7 @@ fn format_decimal(d, p, nd) {
                     __local_27 = i;
                     __local_28 = __inline_String__get_byte_10: block -> u8 {
                         __local_30 = i - 1;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr, __local_30) & 255;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr, __local_30);
                     };
                     builtin::array_set_u8(_licm_repr, __local_27, __local_28);
                 };
@@ -1190,7 +1190,7 @@ fn format_exp(d, p, nd, upper) {
                     __local_12 = i;
                     __local_13 = __inline_String__get_byte_3: block -> u8 {
                         __local_15 = i - 1;
-                        break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr, __local_15) & 255;
+                        break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr, __local_15);
                     };
                     builtin::array_set_u8(_licm_repr, __local_12, __local_13);
                 };
@@ -1417,7 +1417,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -1475,7 +1475,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -1517,10 +1517,10 @@ fn String::concat(a, b) {
     let repr: ref null array<u8>;
     let a_repr: ref null array<u8>;
     let i_7: i32;
-    let byte_8: i32;
+    let byte_8: u8;
     let b_repr: ref null array<u8>;
     let i_10: i32;
-    let byte_11: i32;
+    let byte_11: u8;
     let __local_12: ref null String;
     let __local_13: ref null String;
     let __local_14: ref null String;
@@ -1573,22 +1573,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/ref_struct_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/ref_struct_basic.wir.wado
@@ -170,7 +170,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -307,7 +307,7 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
                     };
                     block {
                         pos = pos - 1;
-                        builtin::array_set_u8(arr, pos, 48 + builtin::i32_wrap_i64(temp % 10_i64));
+                        builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     };
                     temp = temp / 10_i64;
                     continue l13;
@@ -372,7 +372,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -429,7 +429,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -471,22 +471,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/trait_default_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/trait_default_basic.wir.wado
@@ -145,7 +145,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -282,7 +282,7 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
                     };
                     block {
                         pos = pos - 1;
-                        builtin::array_set_u8(arr, pos, 48 + builtin::i32_wrap_i64(temp % 10_i64));
+                        builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     };
                     temp = temp / 10_i64;
                     continue l13;
@@ -347,7 +347,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -404,7 +404,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -446,22 +446,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }

--- a/wado-compiler/tests/fixtures.golden.wir/treemap-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/treemap-basic.wir.wado
@@ -726,7 +726,7 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {  // from core:cli
     let alloc_size: i32;
     let ptr: i32;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_9: ref null String;
     let __local_10: ref null String;
     len = message.used;
@@ -994,7 +994,7 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
                     };
                     block {
                         pos = pos - 1;
-                        builtin::array_set_u8(arr, pos, 48 + builtin::i32_wrap_i64(temp % 10_i64));
+                        builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     };
                     temp = temp / 10_i64;
                     continue l38;
@@ -1059,7 +1059,7 @@ fn String::grow(self, min_capacity) {
     let new_capacity: i32;
     let new_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: i32;
     let __local_8: i32;
     let __local_9: i32;
@@ -1116,7 +1116,7 @@ fn String::append(self, other) {
     let new_used: i32;
     let other_repr: ref null array<u8>;
     let i: i32;
-    let byte: i32;
+    let byte: u8;
     let __local_7: ref null String;
     let __local_8: ref null String;
     let _licm_repr: ref null array<u8>;
@@ -1195,8 +1195,8 @@ fn String^Ord::cmp(self, other) {
     let a_repr: ref null array<u8>;
     let b_repr: ref null array<u8>;
     let i: i32;
-    let a_byte: i32;
-    let b_byte: i32;
+    let a_byte: u8;
+    let b_byte: u8;
     let __local_10: ref null String;
     let __local_11: ref null String;
     let __local_12: i32;
@@ -1218,10 +1218,10 @@ fn String^Ord::cmp(self, other) {
                 block {
                     a_byte = builtin::array_get_u8(a_repr, i);
                     b_byte = builtin::array_get_u8(b_repr, i);
-                    if a_byte < b_byte {
+                    if a_byte <u b_byte {
                         return 0;
                     };
-                    if a_byte > b_byte {
+                    if a_byte >u b_byte {
                         return 2;
                     };
                 };
@@ -1240,16 +1240,16 @@ fn String^Ord::cmp(self, other) {
 }
 
 fn StrCharIter^Iterator::next(self) {
-    let b0: i32;
-    let b1_2: i32;
-    let code_3: i32;
-    let b1_4: i32;
-    let b2_5: i32;
-    let code_6: i32;
-    let b1_7: i32;
-    let b2_8: i32;
-    let b3: i32;
-    let code_10: i32;
+    let b0: u8;
+    let b1_2: u8;
+    let code_3: u8;
+    let b1_4: u8;
+    let b2_5: u8;
+    let code_6: u8;
+    let b1_7: u8;
+    let b2_8: u8;
+    let b3: u8;
+    let code_10: u8;
     let __local_11: u32;
     let __local_12: u32;
     let __local_13: u32;
@@ -1259,13 +1259,13 @@ fn StrCharIter^Iterator::next(self) {
     };
     b0 = builtin::array_get_u8(self.repr, self.byte_index);
     self.byte_index = self.byte_index + 1;
-    if b0 < 128 {
+    if b0 <u 128 {
         return Option<char>::Some { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
             __local_11 = b0;
             break __inline_char__from_u32_unchecked_0: __local_11;
         } };
     };
-    if b0 < 224 {
+    if b0 <u 224 {
         b1_2 = builtin::array_get_u8(self.repr, self.byte_index);
         self.byte_index = self.byte_index + 1;
         code_3 = ((b0 & 31) << 6) | (b1_2 & 63);
@@ -1274,7 +1274,7 @@ fn StrCharIter^Iterator::next(self) {
             break __inline_char__from_u32_unchecked_1: __local_12;
         } };
     };
-    if b0 < 240 {
+    if b0 <u 240 {
         b1_4 = builtin::array_get_u8(self.repr, self.byte_index);
         b2_5 = builtin::array_get_u8(self.repr, self.byte_index + 1);
         self.byte_index = self.byte_index + 2;
@@ -1302,22 +1302,22 @@ fn String::append_char(self, c) {
         String::grow(self, self.used + 4);
     };
     if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code);
+        builtin::array_set_u8(self.repr, self.used, code & 255);
         self.used = self.used + 1;
     } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, 192 | (code >>u 6));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
         self.used = self.used + 2;
     } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, 224 | (code >>u 12));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, 240 | (code >>u 18));
-        builtin::array_set_u8(self.repr, self.used + 1, 128 | ((code >>u 12) & 63));
-        builtin::array_set_u8(self.repr, self.used + 2, 128 | ((code >>u 6) & 63));
-        builtin::array_set_u8(self.repr, self.used + 3, 128 | (code & 63));
+        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
         self.used = self.used + 4;
     };
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive string trimming functionality to the Wado standard library and fixes type consistency issues with byte handling throughout the codebase.

## Key Changes

### String Trimming Methods
- Added `trim_ascii()`, `trim_ascii_start()`, and `trim_ascii_end()` methods for ASCII whitespace trimming
- Added `trim()`, `trim_start()`, and `trim_end()` methods for Unicode whitespace trimming
- Added internal helper `internal_substr_bytes()` for efficient substring extraction by byte range
- Implemented proper UTF-8 character boundary detection for Unicode trimming

### Character Whitespace Methods
- Renamed `is_ascii_space()` to `is_ascii_whitespace()` for consistency with Rust naming conventions
- Expanded ASCII whitespace detection to include VT (0x0B) and FF (0x0C) characters, matching POSIX `isspace()`
- Renamed `is_unicode_space()` to `is_whitespace()` and improved Unicode whitespace character coverage

### Type System Fixes
- Changed `builtin::array_get_u8()` return type from `i32` to `u8`
- Changed `builtin::array_set_u8()` parameter type from `i32` to `u8`
- Changed `builtin::i32_load8_u()` return type from `i32` to `u8`
- Changed `builtin::i32_load16_u()` return type from `i32` to `u16`
- Changed `builtin::i32_store8()` parameter type from `i32` to `u8`
- Updated all call sites to use proper type casts where needed (e.g., `code as u8`)
- Fixed variable declarations throughout to use `u8` instead of `i32` for byte values

### Example Code Updates
- Removed custom `trim()` implementation from `example/mustache.wado` in favor of using the new standard library method

## Implementation Details
- Unicode trimming uses forward iteration for `trim_start()` and backward UTF-8 boundary scanning for `trim_end()`
- Proper UTF-8 decoding is implemented to handle multi-byte characters correctly
- All type changes maintain backward compatibility through explicit casts at the boundaries
- Comprehensive test coverage added for all new trimming methods and whitespace detection

https://claude.ai/code/session_01LxC5DtncBoed8YUKTddmaU