### PR TITLE
Add float-to-string benchmark and expand benchmark suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,10 @@ benchmark-sieve:
 benchmark-zlib:
 	mise run -C benchmark zlib
 
+.PHONY: benchmark-fts
+benchmark-fts:
+	mise run -C benchmark fts
+
 .PHONY: report-wasm-size
 report-wasm-size:
 	mise run -C wasm-size report-wasm-size

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -3,4 +3,8 @@
 */count_prime_c
 */mandelbrot_c
 */sieve_c
+*/fts_c
+*/fts_rs
+*/fts_zig
+*/fts_zig.o
 */target/

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -93,71 +93,71 @@ make benchmark-fts
 
 ### Environment
 
-| Component  | Version                      |
-| ---------- | ---------------------------- |
-| Wado       | commit `ef75dd1`             |
-| wasmtime   | 41.0.4                       |
-| Node.js    | v24.14.0                     |
-| Python     | 3.14.3 (CPython, no JIT)     |
-| Ruby       | 4.0.1 (CRuby)               |
-| C compiler | gcc 13.3.0                   |
-| Rust       | rustc 1.93.1                 |
-| Zig        | 0.15.2                       |
-| Platform   | Linux x86_64                 |
+| Component  | Version                  |
+| ---------- | ------------------------ |
+| Wado       | commit `ef75dd1`         |
+| wasmtime   | 41.0.4                   |
+| Node.js    | v24.14.0                 |
+| Python     | 3.14.3 (CPython, no JIT) |
+| Ruby       | 4.0.1 (CRuby)            |
+| C compiler | gcc 13.3.0               |
+| Rust       | rustc 1.93.1             |
+| Zig        | 0.15.2                   |
+| Platform   | Linux x86_64             |
 
 ### Mandelbrot (1024x768, max_iter=256)
 
-| Runtime       | Time (ms) | Relative |
-| ------------- | --------- | -------- |
-| C (gcc -O3)   | 130       | 1.00x    |
-| **Wado**      | 139       | 1.07x    |
-| JavaScript    | 201       | 1.55x    |
-| Python        | 3,371     | 25.93x   |
-| Ruby          | 4,240     | 32.62x   |
+| Runtime     | Time (ms) | Relative |
+| ----------- | --------- | -------- |
+| C (gcc -O3) | 130       | 1.00x    |
+| **Wado**    | 139       | 1.07x    |
+| JavaScript  | 201       | 1.55x    |
+| Python      | 3,371     | 25.93x   |
+| Ruby        | 4,240     | 32.62x   |
 
 All implementations produce the same result: 47,407,790 total iterations.
 
 ### Prime Counting (limit=10,000,000)
 
-| Runtime       | Time (ms) | Relative |
-| ------------- | --------- | -------- |
-| C (gcc -O3)   | 3,190     | 1.00x    |
-| **Wado**      | 3,276     | 1.03x    |
-| JavaScript    | 3,384     | 1.06x    |
-| Ruby          | 41,941    | 13.15x   |
-| Python        | 69,825    | 21.89x   |
+| Runtime     | Time (ms) | Relative |
+| ----------- | --------- | -------- |
+| C (gcc -O3) | 3,190     | 1.00x    |
+| **Wado**    | 3,276     | 1.03x    |
+| JavaScript  | 3,384     | 1.06x    |
+| Ruby        | 41,941    | 13.15x   |
+| Python      | 69,825    | 21.89x   |
 
 All implementations produce the same result: 664,579 primes.
 
 ### Sieve of Eratosthenes (limit=10,000,000)
 
-| Runtime       | Time (ms) | Relative |
-| ------------- | --------- | -------- |
-| C (gcc -O3)   | 49        | 1.00x    |
-| JavaScript    | 74        | 1.51x    |
-| **Wado**      | 164       | 3.35x    |
-| Python        | 727       | 14.84x   |
-| Ruby          | 1,113     | 22.71x   |
+| Runtime     | Time (ms) | Relative |
+| ----------- | --------- | -------- |
+| C (gcc -O3) | 49        | 1.00x    |
+| JavaScript  | 74        | 1.51x    |
+| **Wado**    | 164       | 3.35x    |
+| Python      | 727       | 14.84x   |
+| Ruby        | 1,113     | 22.71x   |
 
 All implementations produce the same result: 664,579 primes.
 
 ### zlib Compression (100KB x 10 iterations)
 
-| Runtime                | Compress (ms) | Decompress (ms) | Total (ms) |
-| ---------------------- | ------------- | --------------- | ---------- |
-| zlib-rs (native Rust)  | 2             | 0.2             | 2          |
-| **Wado** (pure Wado)    | 519           | 148,482         | 149,002    |
+| Runtime               | Compress (ms) | Decompress (ms) | Total (ms) |
+| --------------------- | ------------- | --------------- | ---------- |
+| zlib-rs (native Rust) | 2             | 0.2             | 2          |
+| **Wado** (pure Wado)  | 519           | 148,482         | 149,002    |
 
 Wado's `core:zlib` is a pure Wado implementation compiled to Wasm, so significant overhead is expected compared to native. The decompression path is especially slow due to byte-at-a-time array operations.
 
 ### Float-to-String (500,000 conversions, 6 decimal places)
 
-| Runtime              | Time (ms) | Relative  |
-| -------------------- | --------- | --------- |
-| Zig (-OReleaseFast)  | 25        | 1.00x     |
-| Rust (rustc -O)      | 35        | 1.40x     |
-| C (gcc -O3)          | 57        | 2.28x     |
-| **Wado**             | 97,979    | 3,919.16x |
+| Runtime             | Time (ms) | Relative  |
+| ------------------- | --------- | --------- |
+| Zig (-OReleaseFast) | 25        | 1.00x     |
+| Rust (rustc -O)     | 35        | 1.40x     |
+| C (gcc -O3)         | 57        | 2.28x     |
+| **Wado**            | 97,979    | 3,919.16x |
 
 All implementations produce: Total bytes: 4,000,000. Byte sums are nearly identical (Wado's fts has minor last-digit rounding differences in some values).
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -58,7 +58,7 @@ Converts 500,000 random f64 values (0.0–1.0) to decimal strings with 6 decimal
 
 - **Use case**: Float formatting, string allocation throughput
 - **Operations**: Float-to-string conversion, byte iteration, string buffer management
-- **Comparison**: C (`snprintf`), Rust (`write!`), Zig (`std.fmt`), Wado (bundled fts via template literal)
+- **Comparison**: C (`snprintf`), Rust (`write!`), Zig (`std.fmt`), Wado (pure Wado via template literal)
 
 ```bash
 make benchmark-fts
@@ -159,9 +159,9 @@ Wado's `core:zlib` is a pure Wado implementation compiled to Wasm, so significan
 | C (gcc -O3)          | 57        | 2.28x     |
 | **Wado**             | 97,979    | 3,919.16x |
 
-All implementations produce: Total bytes: 4,000,000. Byte sums are nearly identical (Wado's bundled fts has minor last-digit rounding differences in some values).
+All implementations produce: Total bytes: 4,000,000. Byte sums are nearly identical (Wado's fts has minor last-digit rounding differences in some values).
 
-The large overhead in Wado is due to the float-to-string conversion going through the bundled fts library (compiled Rust→Wasm), which involves cross-module calls and GC-managed string allocation per conversion.
+The large overhead in Wado is due to the float-to-string conversion going through the pure Wado fts implementation, which involves GC-managed string allocation per conversion.
 
 ## Profiling Wado Programs
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -40,6 +40,18 @@ Counts prime numbers up to 10,000,000 using the sieve algorithm.
 make benchmark-sieve
 ```
 
+### zlib Compression (`zlib/`)
+
+Compresses and decompresses 100KB of patterned data (bytes `i % 256`) for 10 iterations.
+
+- **Use case**: Compression library performance, byte array throughput
+- **Operations**: zlib compress/decompress, large byte array manipulation
+- **Comparison**: Wado (`core:zlib` bundled in Wasm) vs zlib-rs (native Rust)
+
+```bash
+make benchmark-zlib
+```
+
 ## Prerequisites
 
 To run all benchmarks, ensure you have the following tools installed:
@@ -52,36 +64,39 @@ To run all benchmarks, ensure you have the following tools installed:
 ## Running Benchmarks
 
 ```bash
-# Run all benchmarks
+# Run all benchmarks at once
+make benchmark-all
+
+# Or run individually
 make benchmark-mandelbrot
 make benchmark-count-prime
 make benchmark-sieve
-
-# Or run them individually (see comments in each source file)
+make benchmark-zlib
 ```
 
 ## Recent Results
 
 ### Environment
 
-| Component  | Version                              |
-| ---------- | ------------------------------------ |
-| Wado       | commit `8f2537f`                     |
-| wasmtime   | 40.0.0 (0807b003e 2025-12-22)        |
-| Node.js    | v24.11.0                             |
-| Python     | 3.14.2 (CPython, no JIT)             |
-| Ruby       | 3.4.7 (CRuby)                        |
-| C compiler | Apple clang 17.0.0                   |
-| Platform   | macOS (Darwin 24.6.0), Apple Silicon |
+| Component  | Version                      |
+| ---------- | ---------------------------- |
+| Wado       | commit `ef75dd1`             |
+| wasmtime   | 41.0.4                       |
+| Node.js    | v24.14.0                     |
+| Python     | 3.14.3 (CPython, no JIT)     |
+| Ruby       | 4.0.1 (CRuby)               |
+| C compiler | gcc 13.3.0                   |
+| Platform   | Linux x86_64                 |
 
 ### Mandelbrot (1024x768, max_iter=256)
 
 | Runtime       | Time (ms) | Relative |
 | ------------- | --------- | -------- |
-| C (clang -O3) | 136       | 1.00x    |
-| JavaScript    | 143       | 1.05x    |
-| **Wado**      | 173       | 1.27x    |
-| Python        | 4,137     | 30.42x   |
+| C (gcc -O3)   | 130       | 1.00x    |
+| **Wado**      | 139       | 1.07x    |
+| JavaScript    | 201       | 1.55x    |
+| Python        | 3,371     | 25.93x   |
+| Ruby          | 4,240     | 32.62x   |
 
 All implementations produce the same result: 47,407,790 total iterations.
 
@@ -89,12 +104,34 @@ All implementations produce the same result: 47,407,790 total iterations.
 
 | Runtime       | Time (ms) | Relative |
 | ------------- | --------- | -------- |
-| **Wado**      | 1,363     | 1.00x    |
-| C (clang -O3) | 1,496     | 1.10x    |
-| JavaScript    | 2,427     | 1.78x    |
-| Python        | 74,360    | 54.56x   |
+| C (gcc -O3)   | 3,190     | 1.00x    |
+| **Wado**      | 3,276     | 1.03x    |
+| JavaScript    | 3,384     | 1.06x    |
+| Ruby          | 41,941    | 13.15x   |
+| Python        | 69,825    | 21.89x   |
 
 All implementations produce the same result: 664,579 primes.
+
+### Sieve of Eratosthenes (limit=10,000,000)
+
+| Runtime       | Time (ms) | Relative |
+| ------------- | --------- | -------- |
+| C (gcc -O3)   | 49        | 1.00x    |
+| JavaScript    | 74        | 1.51x    |
+| **Wado**      | 164       | 3.35x    |
+| Python        | 727       | 14.84x   |
+| Ruby          | 1,113     | 22.71x   |
+
+All implementations produce the same result: 664,579 primes.
+
+### zlib Compression (100KB x 10 iterations)
+
+| Runtime                | Compress (ms) | Decompress (ms) | Total (ms) |
+| ---------------------- | ------------- | --------------- | ---------- |
+| zlib-rs (native Rust)  | 2             | 0.2             | 2          |
+| **Wado** (bundled Wasm) | 519           | 148,482         | 149,002    |
+
+Wado's `core:zlib` runs the compression library inside Wasm, so significant overhead is expected compared to native. The decompression path is especially slow due to byte-at-a-time array operations.
 
 ## Profiling Wado Programs
 
@@ -192,6 +229,7 @@ samply record wado run --profile perfmap benchmark/count_prime/count_prime.wado
 - Ruby uses CRuby
 - Times include program initialization overhead
 - Wado benchmarks use `MonotonicClock::now()` from `core:clocks` for timing
+- zlib benchmark compares Wado's bundled Wasm zlib against native zlib-rs (Rust)
 
 ## File Structure
 
@@ -201,5 +239,5 @@ benchmark/
 ├── count_prime/count_prime.{wado,c,js,py,rb}
 ├── mandelbrot/mandelbrot.{wado,c,js,py,rb}
 ├── sieve/sieve.{wado,c,js,py,rb}
-└── zlib/
+└── zlib/{zlib_bench.wado,zlib_rs.rs}
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # Wado Benchmarks
 
-This directory contains performance benchmarks comparing Wado against C, JavaScript, Python, and Ruby.
+This directory contains performance benchmarks comparing Wado against C, Rust, Zig, JavaScript, Python, and Ruby.
 
 ## Benchmarks
 
@@ -46,10 +46,22 @@ Compresses and decompresses 100KB of patterned data (bytes `i % 256`) for 10 ite
 
 - **Use case**: Compression library performance, byte array throughput
 - **Operations**: zlib compress/decompress, large byte array manipulation
-- **Comparison**: Wado (`core:zlib` bundled in Wasm) vs zlib-rs (native Rust)
+- **Comparison**: Wado (`core:zlib`, pure Wado implementation) vs zlib-rs (native Rust)
 
 ```bash
 make benchmark-zlib
+```
+
+### Float-to-String (`fts.*`)
+
+Converts 500,000 random f64 values (0.0–1.0) to decimal strings with 6 decimal places. Uses a linear congruential generator (seed=42) for a deterministic float sequence, ensuring all implementations produce identical output.
+
+- **Use case**: Float formatting, string allocation throughput
+- **Operations**: Float-to-string conversion, byte iteration, string buffer management
+- **Comparison**: C (`snprintf`), Rust (`write!`), Zig (`std.fmt`), Wado (bundled fts via template literal)
+
+```bash
+make benchmark-fts
 ```
 
 ## Prerequisites
@@ -57,6 +69,8 @@ make benchmark-zlib
 To run all benchmarks, ensure you have the following tools installed:
 
 - `cc` (C compiler, e.g., clang or gcc)
+- `rustc` (Rust compiler — for fts benchmark)
+- `zig` (Zig compiler — for fts benchmark)
 - `node` (Node.js)
 - `python3` (Python 3)
 - `ruby` (Ruby)
@@ -72,6 +86,7 @@ make benchmark-mandelbrot
 make benchmark-count-prime
 make benchmark-sieve
 make benchmark-zlib
+make benchmark-fts
 ```
 
 ## Recent Results
@@ -86,6 +101,8 @@ make benchmark-zlib
 | Python     | 3.14.3 (CPython, no JIT)     |
 | Ruby       | 4.0.1 (CRuby)               |
 | C compiler | gcc 13.3.0                   |
+| Rust       | rustc 1.93.1                 |
+| Zig        | 0.15.2                       |
 | Platform   | Linux x86_64                 |
 
 ### Mandelbrot (1024x768, max_iter=256)
@@ -129,9 +146,22 @@ All implementations produce the same result: 664,579 primes.
 | Runtime                | Compress (ms) | Decompress (ms) | Total (ms) |
 | ---------------------- | ------------- | --------------- | ---------- |
 | zlib-rs (native Rust)  | 2             | 0.2             | 2          |
-| **Wado** (bundled Wasm) | 519           | 148,482         | 149,002    |
+| **Wado** (pure Wado)    | 519           | 148,482         | 149,002    |
 
-Wado's `core:zlib` runs the compression library inside Wasm, so significant overhead is expected compared to native. The decompression path is especially slow due to byte-at-a-time array operations.
+Wado's `core:zlib` is a pure Wado implementation compiled to Wasm, so significant overhead is expected compared to native. The decompression path is especially slow due to byte-at-a-time array operations.
+
+### Float-to-String (500,000 conversions, 6 decimal places)
+
+| Runtime              | Time (ms) | Relative  |
+| -------------------- | --------- | --------- |
+| Zig (-OReleaseFast)  | 25        | 1.00x     |
+| Rust (rustc -O)      | 35        | 1.40x     |
+| C (gcc -O3)          | 57        | 2.28x     |
+| **Wado**             | 97,979    | 3,919.16x |
+
+All implementations produce: Total bytes: 4,000,000. Byte sums are nearly identical (Wado's bundled fts has minor last-digit rounding differences in some values).
+
+The large overhead in Wado is due to the float-to-string conversion going through the bundled fts library (compiled Rust→Wasm), which involves cross-module calls and GC-managed string allocation per conversion.
 
 ## Profiling Wado Programs
 
@@ -229,7 +259,10 @@ samply record wado run --profile perfmap benchmark/count_prime/count_prime.wado
 - Ruby uses CRuby
 - Times include program initialization overhead
 - Wado benchmarks use `MonotonicClock::now()` from `core:clocks` for timing
-- zlib benchmark compares Wado's bundled Wasm zlib against native zlib-rs (Rust)
+- zlib benchmark compares Wado's pure Wado zlib against native zlib-rs (Rust)
+- fts benchmark compares Wado, C (`snprintf`), Rust (`write!`), and Zig (`std.fmt`)
+- Rust benchmarks use `rustc -O` (release optimization)
+- Zig benchmarks use `-OReleaseFast`
 
 ## File Structure
 
@@ -237,6 +270,7 @@ samply record wado run --profile perfmap benchmark/count_prime/count_prime.wado
 benchmark/
 ├── README.md
 ├── count_prime/count_prime.{wado,c,js,py,rb}
+├── fts/fts.{wado,c,rs,zig}
 ├── mandelbrot/mandelbrot.{wado,c,js,py,rb}
 ├── sieve/sieve.{wado,c,js,py,rb}
 └── zlib/{zlib_bench.wado,zlib_rs.rs}

--- a/benchmark/fts/fts.c
+++ b/benchmark/fts/fts.c
@@ -1,0 +1,39 @@
+// Float-to-string benchmark
+// Converts 500K random f64 values to decimal strings using %.6f format.
+// Uses a linear congruential generator for deterministic float sequence.
+//
+// How to run:
+//   make benchmark-fts
+
+#include <stdio.h>
+#include <time.h>
+
+int main(void) {
+    const int n = 500000;
+    unsigned int state = 42;
+    char buf[32];
+    long total_bytes = 0;
+    unsigned long byte_sum = 0;
+
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+
+    for (int i = 0; i < n; i++) {
+        state = (state * 1103515245u + 12345u) & 0x7FFFFFFFu;
+        double x = (double)state / 2147483648.0;
+        int len = snprintf(buf, sizeof(buf), "%.6f", x);
+        total_bytes += len;
+        for (int j = 0; j < len; j++) {
+            byte_sum += (unsigned char)buf[j];
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    long elapsed_ms = (t1.tv_sec - t0.tv_sec) * 1000 +
+                      (t1.tv_nsec - t0.tv_nsec) / 1000000;
+
+    printf("fts: 500000 f64 conversions (%%.6f)\n");
+    printf("Total bytes: %ld, byte sum: %lu\n", total_bytes, byte_sum);
+    printf("Elapsed: %ld ms\n", elapsed_ms);
+    return 0;
+}

--- a/benchmark/fts/fts.rs
+++ b/benchmark/fts/fts.rs
@@ -1,0 +1,36 @@
+// Float-to-string benchmark
+// Converts 500K random f64 values to decimal strings using {:.6} format.
+// Uses a linear congruential generator for deterministic float sequence.
+//
+// How to run:
+//   make benchmark-fts
+
+use std::fmt::Write;
+use std::time::Instant;
+
+fn main() {
+    let n = 500_000u32;
+    let mut state: u32 = 42;
+    let mut total_bytes: u64 = 0;
+    let mut byte_sum: u64 = 0;
+    let mut buf = String::with_capacity(16);
+
+    let t0 = Instant::now();
+
+    for _ in 0..n {
+        state = (state.wrapping_mul(1103515245).wrapping_add(12345)) & 0x7FFFFFFF;
+        let x = state as f64 / 2147483648.0;
+        buf.clear();
+        write!(buf, "{:.6}", x).unwrap();
+        total_bytes += buf.len() as u64;
+        for b in buf.bytes() {
+            byte_sum += b as u64;
+        }
+    }
+
+    let elapsed_ms = t0.elapsed().as_millis();
+
+    println!("fts: {n} f64 conversions (%.6f)");
+    println!("Total bytes: {total_bytes}, byte sum: {byte_sum}");
+    println!("Elapsed: {elapsed_ms} ms");
+}

--- a/benchmark/fts/fts.wado
+++ b/benchmark/fts/fts.wado
@@ -1,0 +1,35 @@
+// Float-to-string benchmark
+// Converts 500K random f64 values to decimal strings using :0.6f format.
+// Uses a linear congruential generator for deterministic float sequence.
+//
+// How to run:
+//   make benchmark-fts
+
+use { println, Stdout } from "core:cli";
+use { now, MonotonicClock } from "core:clocks";
+
+export fn run() with Stdout, MonotonicClock {
+    let n = 500000;
+    let mut state: u32 = 42;
+    let mut total_bytes: u64 = 0;
+    let mut byte_sum: u64 = 0;
+
+    let t0 = now();
+
+    for let mut i = 0; i < n; i += 1 {
+        state = (state * 1103515245 + 12345) & 0x7FFFFFFF;
+        let x = (state as f64) / 2147483648.0;
+        let s = `{x:0.6f}`;
+        total_bytes += s.len() as u64;
+        for let b of s.bytes() {
+            byte_sum += b as u64;
+        }
+    }
+
+    let elapsed_ns = (now() - t0) as u64;
+    let elapsed_ms = elapsed_ns / 1000000;
+
+    println(`fts: {n} f64 conversions (%.6f)`);
+    println(`Total bytes: {total_bytes}, byte sum: {byte_sum}`);
+    println(`Elapsed: {elapsed_ms} ms`);
+}

--- a/benchmark/fts/fts.zig
+++ b/benchmark/fts/fts.zig
@@ -1,0 +1,44 @@
+// Float-to-string benchmark
+// Converts 500K random f64 values to decimal strings using {d:.6} format.
+// Uses a linear congruential generator for deterministic float sequence.
+//
+// How to run:
+//   make benchmark-fts
+
+const std = @import("std");
+
+pub fn main() !void {
+    const n: u32 = 500_000;
+    var state: u32 = 42;
+    var total_bytes: u64 = 0;
+    var byte_sum: u64 = 0;
+    var fmt_buf: [32]u8 = undefined;
+
+    const t0 = std.time.nanoTimestamp();
+
+    for (0..n) |_| {
+        state = (state *% 1103515245 +% 12345) & 0x7FFFFFFF;
+        const x: f64 = @as(f64, @floatFromInt(state)) / 2147483648.0;
+        const slice = std.fmt.bufPrint(&fmt_buf, "{d:.6}", .{x}) catch unreachable;
+        total_bytes += slice.len;
+        for (slice) |b| {
+            byte_sum += b;
+        }
+    }
+
+    const t1 = std.time.nanoTimestamp();
+    const elapsed_ms = @divFloor(t1 - t0, 1_000_000);
+
+    const file = std.fs.File.stdout();
+    var out_buf: [256]u8 = undefined;
+    var len: usize = 0;
+
+    len = (std.fmt.bufPrint(&out_buf, "fts: {d} f64 conversions (%.6f)\n", .{n}) catch unreachable).len;
+    try file.writeAll(out_buf[0..len]);
+
+    len = (std.fmt.bufPrint(&out_buf, "Total bytes: {d}, byte sum: {d}\n", .{ total_bytes, byte_sum }) catch unreachable).len;
+    try file.writeAll(out_buf[0..len]);
+
+    len = (std.fmt.bufPrint(&out_buf, "Elapsed: {d} ms\n", .{elapsed_ms}) catch unreachable).len;
+    try file.writeAll(out_buf[0..len]);
+}

--- a/benchmark/mise.toml
+++ b/benchmark/mise.toml
@@ -8,6 +8,7 @@
 node = "latest"
 python = "latest"
 ruby = "latest"
+zig = "latest"
 
 [tasks.count-prime]
 description = "Run count_prime benchmark (integer arithmetic)"
@@ -109,14 +110,45 @@ echo "=== Wado ==="
 cargo run --manifest-path ../wado-cli/Cargo.toml --quiet -- run -O2 zlib/zlib_bench.wado
 """
 
+[tasks.fts]
+description = "Run fts benchmark (float-to-string conversion)"
+run = """
+#!/usr/bin/env bash
+set -e
+
+echo "=== Compiling C benchmark ==="
+cc -O3 -o fts/fts_c fts/fts.c
+
+echo "=== Compiling Rust benchmark ==="
+rustc -O -o fts/fts_rs fts/fts.rs
+
+echo "=== Compiling Zig benchmark ==="
+zig build-exe fts/fts.zig -OReleaseFast --name fts_zig 2>/dev/null
+mv fts_zig fts/fts_zig
+rm -f fts_zig.o
+
+echo "=== C ==="
+./fts/fts_c
+
+echo "=== Rust ==="
+./fts/fts_rs
+
+echo "=== Zig ==="
+./fts/fts_zig
+
+echo "=== Wado ==="
+cargo run --manifest-path ../wado-cli/Cargo.toml --quiet -- run -O2 fts/fts.wado
+"""
+
 [tasks.all]
 description = "Run all benchmarks"
-depends = ["count-prime", "mandelbrot", "sieve", "zlib"]
+depends = ["count-prime", "mandelbrot", "sieve", "zlib", "fts"]
 
 [tasks.clean]
 description = "Clean benchmark artifacts"
 run = """
 rm -f count_prime/*.wasm mandelbrot/*.wasm sieve/*.wasm
 rm -f count_prime/count_prime_c mandelbrot/mandelbrot_c sieve/sieve_c
+rm -f fts/fts_c fts/fts_rs fts/fts_zig fts/fts_zig.o
 rm -rf zlib/target
 """


### PR DESCRIPTION
## Summary
This PR expands the benchmark suite with a new float-to-string (fts) conversion benchmark and updates documentation to reflect recent benchmark results across an expanded set of languages (Rust and Zig).

## Key Changes

- **New Float-to-String Benchmark**: Added `benchmark/fts/` with implementations in Wado, C, Rust, and Zig
  - Converts 500,000 random f64 values to decimal strings with 6 decimal places
  - Uses a deterministic linear congruential generator (seed=42) to ensure identical output across all implementations
  - Compares performance of float formatting and string allocation strategies

- **Benchmark Infrastructure Updates**:
  - Added `fts` task to `benchmark/mise.toml` with compilation and execution for all four languages
  - Added `benchmark-fts` target to `Makefile`
  - Updated `benchmark-all` to include the new fts benchmark
  - Added Zig to `mise.toml` tool requirements

- **Documentation Updates**:
  - Updated README to mention Rust and Zig as comparison languages
  - Added fts benchmark documentation with use case and operations description
  - Updated environment table with current versions (Wado commit `ef75dd1`, wasmtime 41.0.4, Rust 1.93.1, Zig 0.15.2)
  - Added new benchmark results tables for sieve, zlib, and fts benchmarks
  - Updated prerequisites section to include Rust and Zig compilers
  - Added notes about zlib and fts benchmark comparisons

- **Build Artifacts**: Updated `.gitignore` to exclude compiled fts binaries (`fts_c`, `fts_rs`, `fts_zig`)

## Implementation Details

The fts benchmark demonstrates significant performance differences:
- Zig: 25ms (baseline)
- Rust: 35ms (1.40x)
- C: 57ms (2.28x)
- Wado: 97,979ms (3,919.16x)

The large Wado overhead is attributed to pure Wado string allocation and GC overhead per conversion, highlighting the cost of high-level abstractions in interpreted/JIT scenarios.

https://claude.ai/code/session_018GpvLt7bA89Te3A4Qp2Zv1