### PR TITLE
Improve diagnostic error reporting with file, line, and column info

### DIFF
--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -447,6 +447,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         modules: &indexmap::IndexMap<ModuleSource, Module>,
     ) -> Result<(), Bail> {
         for (source, module) in modules {
+            self.logger.set_file(source.diagnostic_filename());
             self.validate_imports(module, source, modules)?;
         }
         Ok(())

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -644,6 +644,8 @@ pub enum CompileError {
     /// Semantic analysis error
     Analyzer {
         message: String,
+        line: usize,
+        column: usize,
         filename: Option<String>,
     },
 }
@@ -685,9 +687,16 @@ impl std::fmt::Display for CompileError {
                     write!(f, "{message}")
                 }
             }
-            CompileError::Analyzer { message, filename } => {
+            CompileError::Analyzer {
+                message,
+                line,
+                column,
+                filename,
+            } => {
                 if let Some(file) = filename {
-                    write!(f, "{file}: analysis error: {message}")
+                    write!(f, "{file}:{line}:{column}: analysis error: {message}")
+                } else if *line > 0 {
+                    write!(f, "{line}:{column}: analysis error: {message}")
                 } else {
                     write!(f, "analysis error: {message}")
                 }

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -111,16 +111,16 @@ impl From<LoadError> for crate::compiler_host::Diagnostic {
         use crate::compiler_host::{Code, DiagnosticSpan, Severity};
         match e {
             LoadError::LexError {
+                module_source,
                 message,
                 line,
                 column,
-                ..
             } => Self {
                 severity: Severity::Error,
                 code: Code::InvalidSyntax,
                 message: format!("lexer error: {message}"),
                 span: Some(DiagnosticSpan {
-                    file: String::new(),
+                    file: module_source.diagnostic_filename(),
                     line,
                     column,
                     end_line: None,
@@ -128,16 +128,16 @@ impl From<LoadError> for crate::compiler_host::Diagnostic {
                 }),
             },
             LoadError::ParseError {
+                module_source,
                 message,
                 line,
                 column,
-                ..
             } => Self {
                 severity: Severity::Error,
                 code: Code::InvalidSyntax,
                 message: format!("parse error: {message}"),
                 span: Some(DiagnosticSpan {
-                    file: String::new(),
+                    file: module_source.diagnostic_filename(),
                     line,
                     column,
                     end_line: None,
@@ -585,6 +585,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Bind errors are emitted directly to the host via Logger.
         // We use a temporary logger per module so error counting is per-module.
         let logger = Logger::new(self.host, self.log_level);
+        logger.set_file(module_source.diagnostic_filename());
         bind::bind_module(module, &logger).map_err(|_bail| {
             let error_count = logger.error_count();
             LoadError::BindError {

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -358,6 +358,24 @@ impl ModuleSource {
     pub fn qualify_name(&self, name: &str) -> String {
         format!("{self}//{name}")
     }
+
+    /// Return a filename suitable for diagnostic messages.
+    ///
+    /// Returns an empty string for entry points without real filenames
+    /// (e.g., `<stdin>`, `<entry>`) so that `Logger::apply_file_context`
+    /// can fill in the correct file from the logger's current file context.
+    #[must_use]
+    pub fn diagnostic_filename(&self) -> String {
+        match self {
+            Self::EntryPoint { filename } => {
+                match filename.as_deref() {
+                    Some(name) if !name.starts_with('<') => name.to_string(),
+                    _ => String::new(), // synthetic names like <stdin>, <entry>
+                }
+            }
+            other => other.to_string(),
+        }
+    }
 }
 
 impl fmt::Display for ModuleSource {

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -500,6 +500,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 trait_decl_index: Arc::clone(&trait_decl_index),
             };
 
+            // Set file context so diagnostics emitted during resolution
+            // carry the correct module filename (not the entry module).
+            logger.set_file(module_source.diagnostic_filename());
+
             // Errors are emitted to the logger; if resolve_module returns Bail,
             // we continue to resolve remaining modules to collect more errors
             if let Ok(tir_module) = resolver.resolve_module(module, module_source.clone()) {

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -104,15 +104,19 @@ pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>)
         .collect();
 
     if let Some(d) = errors.first() {
-        let fname = filename.map(String::from).or_else(|| {
-            d.span.as_ref().and_then(|s| {
+        // Prefer the diagnostic's span file (the actual error location) over
+        // the passed-in filename (which is the entry module).
+        let fname = d
+            .span
+            .as_ref()
+            .and_then(|s| {
                 if s.file.is_empty() {
                     None
                 } else {
                     Some(s.file.clone())
                 }
             })
-        });
+            .or_else(|| filename.map(String::from));
         let code = d.code;
         let message = d.message.clone();
         let line = d.span.as_ref().map_or(0, |s| s.line);
@@ -144,12 +148,16 @@ pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>)
             let all_messages: Vec<String> = errors.iter().map(|d| d.message.clone()).collect();
             CompileError::Analyzer {
                 message: all_messages.join("; "),
+                line,
+                column,
                 filename: fname,
             }
         }
     } else {
         CompileError::Analyzer {
             message: "compilation failed".to_string(),
+            line: 0,
+            column: 0,
             filename: filename.map(String::from),
         }
     }

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -235,7 +235,7 @@ fn main() {
 
     let err = result.unwrap_err();
     match err {
-        CompileError::Analyzer { message, filename } => {
+        CompileError::Analyzer { message, filename, .. } => {
             assert!(
                 message.contains("unknown") || message.contains("not found"),
                 "Unexpected message: {message}"
@@ -261,7 +261,7 @@ fn main() {
 
     let err = result.unwrap_err();
     match err {
-        CompileError::Analyzer { message, filename } => {
+        CompileError::Analyzer { message, filename, .. } => {
             assert!(
                 message.contains("nonexistent_function") || message.contains("not found"),
                 "Unexpected message: {message}"
@@ -513,11 +513,13 @@ fn test_error_display_io() {
 fn test_error_display_analyzer_with_filename() {
     let err = CompileError::Analyzer {
         message: "undefined variable 'x'".to_string(),
+        line: 5,
+        column: 10,
         filename: Some("main.wado".to_string()),
     };
 
     let display = format!("{err}");
-    assert!(display.contains("main.wado"));
+    assert!(display.contains("main.wado:5:10"));
     assert!(display.contains("undefined variable 'x'"));
     assert!(display.contains("analysis error"));
 }
@@ -526,6 +528,8 @@ fn test_error_display_analyzer_with_filename() {
 fn test_error_display_analyzer_without_filename() {
     let err = CompileError::Analyzer {
         message: "type mismatch".to_string(),
+        line: 0,
+        column: 0,
         filename: None,
     };
 

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -235,7 +235,9 @@ fn main() {
 
     let err = result.unwrap_err();
     match err {
-        CompileError::Analyzer { message, filename, .. } => {
+        CompileError::Analyzer {
+            message, filename, ..
+        } => {
             assert!(
                 message.contains("unknown") || message.contains("not found"),
                 "Unexpected message: {message}"
@@ -261,7 +263,9 @@ fn main() {
 
     let err = result.unwrap_err();
     match err {
-        CompileError::Analyzer { message, filename, .. } => {
+        CompileError::Analyzer {
+            message, filename, ..
+        } => {
             assert!(
                 message.contains("nonexistent_function") || message.contains("not found"),
                 "Unexpected message: {message}"

--- a/wado-compiler/tests/fixtures/error_submodule_generic_type_mismatch.wado
+++ b/wado-compiler/tests/fixtures/error_submodule_generic_type_mismatch.wado
@@ -1,0 +1,9 @@
+// Test: type mismatch error in a generic function in a sub-module reports correct file, line, column
+use { bad_generic_let } from "./sub/error_generic_type_mismatch.wado";
+
+export fn run() {
+    let x = bad_generic_let::<String>("hello");
+}
+
+__DATA__
+{"compile_error": "./sub/error_generic_type_mismatch.wado:4:18: analysis error: type mismatch: expected 'i32', found 'T'"}

--- a/wado-compiler/tests/fixtures/error_submodule_type_mismatch.wado
+++ b/wado-compiler/tests/fixtures/error_submodule_type_mismatch.wado
@@ -1,0 +1,9 @@
+// Test: type mismatch error in a sub-module reports correct file, line, column
+use { bad_let } from "./sub/error_type_mismatch.wado";
+
+export fn run() {
+    let x = bad_let();
+}
+
+__DATA__
+{"compile_error": "./sub/error_type_mismatch.wado:4:18: analysis error: type mismatch: expected 'i32', found 'String'"}

--- a/wado-compiler/tests/fixtures/sub/error_generic_type_mismatch.wado
+++ b/wado-compiler/tests/fixtures/sub/error_generic_type_mismatch.wado
@@ -1,0 +1,6 @@
+// Sub-module with a type mismatch error in a generic function.
+
+pub fn bad_generic_let<T>(x: T) -> i32 {
+    let n: i32 = x;
+    return n;
+}

--- a/wado-compiler/tests/fixtures/sub/error_type_mismatch.wado
+++ b/wado-compiler/tests/fixtures/sub/error_type_mismatch.wado
@@ -1,0 +1,6 @@
+// Sub-module with a type mismatch error in a regular function.
+
+pub fn bad_let() -> i32 {
+    let x: i32 = "hello";
+    return x;
+}


### PR DESCRIPTION
## Summary
This PR enhances diagnostic error reporting by ensuring that compilation errors include accurate file, line, and column information, particularly for errors occurring in sub-modules. Previously, errors in imported modules would lose their source location context.

## Key Changes

- **Added `diagnostic_filename()` method to `ModuleSource`**: Returns a filename suitable for diagnostics, returning an empty string for synthetic entry points (like `<stdin>`, `<entry>`) so the logger's file context can be used instead.

- **Enhanced `CompileError::Analyzer` struct**: Added `line` and `column` fields to capture error location information, and updated the `Display` implementation to format errors as `file:line:column: analysis error: message`.

- **Updated error reporting in `bail_to_compile_error()`**: Now prioritizes the diagnostic's span file (actual error location) over the entry module filename, ensuring sub-module errors report the correct file.

- **Set file context in module processing**: Added `logger.set_file()` calls in three key locations:
  - `ModuleLoader::load_module()` during binding phase
  - `Resolver::resolve_modules()` during resolution phase
  - `Analyzer::validate_imports()` during analysis phase
  
  This ensures each module's diagnostics carry the correct filename context.

- **Updated `LoadError` conversion**: Modified the `From<LoadError>` implementation to use `module_source.diagnostic_filename()` instead of empty strings for lex and parse errors.

- **Added test fixtures**: Created test cases for type mismatch errors in sub-modules to verify correct file, line, and column reporting.

## Notable Implementation Details

- The `diagnostic_filename()` method filters out synthetic names (those starting with `<`) to allow the logger's file context to take precedence, improving error messages for entry points without real filenames.
- Error location information now flows through the entire compilation pipeline, from lexing through analysis, providing users with precise error locations even in complex multi-module projects.

https://claude.ai/code/session_01TVF2VyogZe7EckDkV1WtDu