### PR TITLE
WEP: Base64 Encoding API for core:base64 module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,19 @@ touch wado-compiler/tests/e2e.rs
 
 Without this, `cargo test` will not detect the new fixture because `datatest_mini` discovers files at compile time.
 
+### Standard Library Tests
+
+Logic tests for standard library modules live alongside implementations in `wado-compiler/lib/`, using `test` blocks with `__DATA__` `{"test": {}}`. These test the library's own logic rather than compiler features.
+
+| Module | Test File |
+|--------|-----------|
+| `core:zlib` | `wado-compiler/lib/core/zlib_test.wado` |
+| `core:*` (strings) | `wado-compiler/lib/core/string_test.wado` |
+| prelude (iterators) | `wado-compiler/lib/core/prelude/iterator_test.wado` |
+| prelude (primitives) | `wado-compiler/lib/core/prelude/primitive_test.wado` |
+
+Use this style for new stdlib modules (e.g., `base64_test.wado` for `core:base64`). E2E fixtures in `tests/fixtures/` are for testing **compiler** behavior (codegen, error messages, optimization).
+
 ### The `wasi:*` Modules
 
 `wasi:*` modules are part of the Wado standard library.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Without this, `cargo test` will not detect the new fixture because `datatest_min
 
 ### Standard Library Tests
 
-Logic tests for standard library modules live alongside implementations in `wado-compiler/lib/`, using `test` blocks with `__DATA__` `{"test": {}}`. These test the library's own logic rather than compiler features.
+Logic tests for standard library modules live alongside implementations in `wado-compiler/lib/`, using `test` blocks. No `__DATA__` section is needed — these files are run directly with `wado test`. They test the library's own logic rather than compiler features.
 
 | Module | Test File |
 |--------|-----------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [CLI Subcommands for Package Management](./docs/wep-2026-02-22-cli-subcommands.md)
 - [Struct Destructuring](./docs/wep-2026-02-22-struct-destructuring.md)
 - [Tuple Destructuring](./docs/wep-2026-02-22-tuple-destructuring.md)
+- [Base64 Encoding API](./docs/wep-2026-02-27-base64-api.md)
 
 ### Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Without this, `cargo test` will not detect the new fixture because `datatest_min
 
 ### Standard Library Tests (Library Logic)
 
-Tests for **standard library logic** (e.g., `zlib_test.wado`, `string_test.wado`) live alongside implementations in `wado-compiler/lib/`. These are plain `.wado` files with `test` blocks — no `__DATA__` section — run directly with `wado test`.
+Tests for **standard library logic** (e.g., `zlib_test.wado`, `string_test.wado`) live alongside implementations in `wado-compiler/lib/`. These are `.wado` files with `test` blocks, run with `wado test`.
 
 ### The `wasi:*` Modules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@ Internal functions that are used to provide language features are implemented in
 
 `wado-compiler` must compile for `wasm32-unknown-unknown`. Do not use OS-dependent `std` modules in production code. CI enforces this via `cargo check -p wado-compiler --target wasm32-unknown-unknown`.
 
-### E2E Test Specification
+### E2E Test Specification (Compiler Tests)
 
-E2E tests are `.wado` files in `wado-compiler/tests/fixtures/` with a `__DATA__` section containing JSON test expectations.
+E2E tests verify **compiler behavior** (codegen, error messages, optimization). They are `.wado` files in `wado-compiler/tests/fixtures/` with a `__DATA__` section containing JSON test expectations.
 
 Each test fixture group has the same prefix in their filenames.
 
@@ -161,9 +161,9 @@ touch wado-compiler/tests/e2e.rs
 
 Without this, `cargo test` will not detect the new fixture because `datatest_mini` discovers files at compile time.
 
-### Standard Library Tests
+### Standard Library Tests (Library Logic)
 
-Logic tests for standard library modules (e.g., `zlib_test.wado`, `string_test.wado`) live alongside implementations in `wado-compiler/lib/`. These are plain `.wado` files with `test` blocks — no `__DATA__` section — run directly with `wado test`. Use this style for library logic tests; use E2E fixtures (`tests/fixtures/`) for compiler behavior tests.
+Tests for **standard library logic** (e.g., `zlib_test.wado`, `string_test.wado`) live alongside implementations in `wado-compiler/lib/`. These are plain `.wado` files with `test` blocks — no `__DATA__` section — run directly with `wado test`.
 
 ### The `wasi:*` Modules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,16 +163,7 @@ Without this, `cargo test` will not detect the new fixture because `datatest_min
 
 ### Standard Library Tests
 
-Logic tests for standard library modules live alongside implementations in `wado-compiler/lib/`, using `test` blocks. No `__DATA__` section is needed — these files are run directly with `wado test`. They test the library's own logic rather than compiler features.
-
-| Module | Test File |
-|--------|-----------|
-| `core:zlib` | `wado-compiler/lib/core/zlib_test.wado` |
-| `core:*` (strings) | `wado-compiler/lib/core/string_test.wado` |
-| prelude (iterators) | `wado-compiler/lib/core/prelude/iterator_test.wado` |
-| prelude (primitives) | `wado-compiler/lib/core/prelude/primitive_test.wado` |
-
-Use this style for new stdlib modules (e.g., `base64_test.wado` for `core:base64`). E2E fixtures in `tests/fixtures/` are for testing **compiler** behavior (codegen, error messages, optimization).
+Logic tests for standard library modules (e.g., `zlib_test.wado`, `string_test.wado`) live alongside implementations in `wado-compiler/lib/`. These are plain `.wado` files with `test` blocks — no `__DATA__` section — run directly with `wado test`. Use this style for library logic tests; use E2E fixtures (`tests/fixtures/`) for compiler behavior tests.
 
 ### The `wasi:*` Modules
 

--- a/docs/wep-2026-02-27-base64-api.md
+++ b/docs/wep-2026-02-27-base64-api.md
@@ -186,7 +186,13 @@ Whitespace (newlines, spaces) is **not** stripped automatically. Callers handlin
 
 ### Implementation Notes
 
-The implementation will be pure Wado in `wado-compiler/lib/core/base64.wado`, following the same pattern as `core:zlib` and `core:collections`. No new compiler features are required.
+The implementation will be pure Wado, following the same pattern as `core:zlib` and `core:collections`. No new compiler features are required.
+
+| File | Description |
+|------|-------------|
+| `wado-compiler/lib/core/base64.wado` | Implementation — `Encoding` flags, encode/decode functions |
+| `wado-compiler/lib/core/base64_test.wado` | Tests — encode/decode round-trips, edge cases, error cases |
+| `wado-compiler/src/stdlib.rs` | Registration — `core:base64` module entry |
 
 Internally, the encode/decode loop operates on `Array<u8>` with the standard 3-byte-to-4-character mapping. Lookup tables are `global` arrays initialized at module load.
 
@@ -217,18 +223,6 @@ Internally, the encode/decode loop operates on `Array<u8>` with the standard 3-b
 | Decode lenient | Always | Lenient by default | Strict by default | `"loose"` by default | Always |
 | Auto-detect alphabet | Yes | No | No | No | No |
 | From bytes | `decode_bytes(&b)` | `Decode(dst, src)` | `decode(&data)` (takes `AsRef<[u8]>`) | N/A (string only) | `b64decode(s)` (takes bytes) |
-
-## Implementation Status
-
-- [ ] Create `wado-compiler/lib/core/base64.wado`
-- [ ] Register module in `stdlib.rs` as `core:base64`
-- [ ] Implement encode (standard, padded)
-- [ ] Implement encode_url (URL-safe, no padding)
-- [ ] Implement encode_with (flags-based)
-- [ ] Implement decode (auto-detect, lenient)
-- [ ] Implement decode_bytes
-- [ ] Add E2E test fixtures
-- [ ] Update `docs/cheatsheet.md` with Base64 section
 
 ## Related WEPs
 

--- a/docs/wep-2026-02-27-base64-api.md
+++ b/docs/wep-2026-02-27-base64-api.md
@@ -192,7 +192,6 @@ The implementation will be pure Wado, following the same pattern as `core:zlib` 
 |------|-------------|
 | `wado-compiler/lib/core/base64.wado` | Implementation — `Encoding` flags, encode/decode functions |
 | `wado-compiler/lib/core/base64_test.wado` | Tests — encode/decode round-trips, edge cases, error cases |
-| `wado-compiler/src/stdlib.rs` | Registration — `core:base64` module entry |
 
 Internally, the encode/decode loop operates on `Array<u8>` with the standard 3-byte-to-4-character mapping. Lookup tables are `global` arrays initialized at module load.
 

--- a/docs/wep-2026-02-27-base64-api.md
+++ b/docs/wep-2026-02-27-base64-api.md
@@ -1,0 +1,241 @@
+# WEP: Base64 Encoding API
+
+## Context
+
+Base64 is a fundamental encoding used across web, security, and data interchange contexts — JWT tokens, data URIs, HTTP authentication, S3 object metadata, PEM certificates, and more. A standard library without Base64 support forces every project to implement its own, leading to subtle bugs (padding handling, alphabet confusion) and unnecessary dependency overhead.
+
+### Design Goals
+
+1. **Simple things simple**: The common cases (standard Base64 encode/decode) should be one function call with no configuration
+2. **Complex things possible**: Edge cases (URL-safe alphabet, padding control) should be expressible without separate function names for every combination
+3. **Lenient decode**: Decoding should accept all reasonable inputs — padding or no padding, standard or URL-safe alphabet — auto-detected from the input
+4. **Wasm-friendly**: Pure computation, no I/O, no effects — suitable for any world
+
+### Prior Art
+
+| Language | API Shape | Standard vs URL-safe | Decode Padding | Decode Alphabet |
+|----------|-----------|---------------------|----------------|-----------------|
+| **Rust** (`base64` crate) | `Engine` object with `Config` | 4 engine constants: `STANDARD`, `STANDARD_NO_PAD`, `URL_SAFE`, `URL_SAFE_NO_PAD` | Configurable: `Indifferent` or `RequireCanonical` (strict by default) | Must match engine |
+| **Go** (`encoding/base64`) | `*Encoding` object | 4 globals: `StdEncoding`, `URLEncoding`, `RawStdEncoding`, `RawURLEncoding` | Lenient by default; `.Strict()` for canonical | Must match encoding |
+| **Python** (`base64`) | Module functions | Separate functions: `b64encode`/`urlsafe_b64encode` | Lenient (auto-pads); `validate=True` for strict | Must call correct function |
+| **JavaScript** (TC39 2025) | `Uint8Array` methods + options bag | `{ alphabet: "base64url" }` option | `lastChunkHandling`: `"loose"` (default) / `"strict"` / `"stop-before-partial"` | Must specify option |
+| **Swift** (`Foundation`) | `Data` methods + `OptionSet` | No built-in URL-safe (pitch pending) | Lenient by default | N/A |
+
+**Observations:**
+
+- The 2×2 matrix (standard/URL-safe × padded/unpadded) is the fundamental design space. **Go** covers it with 4 globals, **Rust** with 4 engine constants — both lead to combinatorial explosion of named objects
+- **JavaScript**'s modern TC39 API (`Uint8Array.toBase64()`, 2025) uses an options bag — closest to Wado's flags approach, but still requires the caller to specify the alphabet for decoding
+- **Python** keeps it simple with module functions but requires calling the correct decode function for the alphabet
+- **Rust** (`base64` v0.22+) uses an `Engine` trait with `GeneralPurpose` config — powerful but verbose for simple cases (`BASE64_STANDARD.encode(b"hello")`)
+- **No mainstream language auto-detects the alphabet on decode**, even though the character set is unambiguous: `+/` never appears in URL-safe and `-_` never appears in standard
+
+### Key Insight: Asymmetric API
+
+Encoding requires the caller to specify the output format — you must choose between `+/` and `-_`, padding or no padding. But decoding can auto-detect:
+
+- If the input contains `+` or `/` → standard alphabet
+- If the input contains `-` or `_` → URL-safe alphabet
+- If neither is present → either alphabet (the remaining characters are shared)
+- If both are present → invalid input
+
+Padding detection is trivially lenient — just ignore trailing `=` and compute the expected output length from the remaining characters.
+
+No mainstream language takes advantage of this. Wado can do better.
+
+## Decision
+
+### Module: `core:base64`
+
+```wado
+use { encode, decode, Encoding } from "core:base64";
+```
+
+### `Encoding` Flags
+
+Use Wado's `flags` type to control encoding variants:
+
+```wado
+pub flags Encoding {
+    UrlSafe,    // use -_ alphabet instead of +/
+    NoPadding,  // omit trailing = padding
+}
+```
+
+| Flags | Alphabet | Padding | Use Case |
+|-------|----------|---------|----------|
+| `Encoding::none()` | `+/` | Yes | PEM, MIME, email (RFC 4648 §4) |
+| `UrlSafe \| NoPadding` | `-_` | No | JWT, URL query params (RFC 4648 §5) |
+| `NoPadding` | `+/` | No | Rare; some binary protocols |
+| `UrlSafe` | `-_` | Yes | Rare; some storage systems |
+
+### Encode Functions
+
+Encoding requires explicit format specification — the caller must decide the output format:
+
+```wado
+/// Standard Base64 (RFC 4648 §4, padded).
+pub fn encode(data: &Array<u8>) -> String
+
+/// URL-safe Base64 (RFC 4648 §5, no padding).
+/// Equivalent to `encode_with(data, Encoding::UrlSafe | Encoding::NoPadding)`.
+pub fn encode_url(data: &Array<u8>) -> String
+
+/// Encode with custom flags.
+pub fn encode_with(data: &Array<u8>, encoding: Encoding) -> String
+```
+
+### Decode Functions
+
+Decoding is always lenient — auto-detects alphabet and accepts padding regardless:
+
+```wado
+/// Decode Base64 from a string.
+/// Auto-detects standard (+/) vs URL-safe (-_) alphabet.
+/// Accepts with or without padding.
+/// Returns null on invalid input (non-Base64 characters, mixed alphabets).
+pub fn decode(encoded: String) -> Option<Array<u8>>
+
+/// Decode Base64 from raw bytes (e.g., HTTP body, file content).
+/// Same lenient behavior as `decode`.
+pub fn decode_bytes(encoded: &Array<u8>) -> Option<Array<u8>>
+```
+
+No `Encoding` parameter on decode — there is no configuration to pass.
+
+### Complete API Summary
+
+| Function | Input | Output | Description |
+|----------|-------|--------|-------------|
+| `encode` | `&Array<u8>` | `String` | Standard, padded |
+| `encode_url` | `&Array<u8>` | `String` | URL-safe, no padding |
+| `encode_with` | `&Array<u8>`, `Encoding` | `String` | Custom flags |
+| `decode` | `String` | `Option<Array<u8>>` | Auto-detect, lenient |
+| `decode_bytes` | `&Array<u8>` | `Option<Array<u8>>` | Auto-detect, lenient (from bytes) |
+
+5 public functions. 1 flags type.
+
+### Usage Examples
+
+```wado
+use { encode, decode, encode_url, encode_with, decode_bytes, Encoding } from "core:base64";
+
+export fn run() {
+    let data: Array<u8> = [72, 101, 108, 108, 111] as Array<u8>;
+
+    // Standard encode/decode
+    let b64 = encode(&data);
+    assert b64 == "SGVsbG8=";
+
+    if let Some(decoded) = decode(b64) {
+        assert decoded.len() == 5;
+        assert decoded[0] == 72 as u8;
+    }
+
+    // Padding-less input works too
+    if let Some(decoded) = decode("SGVsbG8") {
+        assert decoded.len() == 5;
+    }
+
+    // URL-safe encode
+    let url = encode_url(&data);
+    // decode auto-detects — no separate decode_url needed
+    if let Some(decoded) = decode(url) {
+        assert decoded.len() == 5;
+    }
+
+    // Decode from raw bytes (e.g., HTTP response body)
+    let raw: Array<u8> = [83, 71, 86, 115, 98, 71, 56, 61] as Array<u8>;
+    if let Some(decoded) = decode_bytes(&raw) {
+        assert decoded.len() == 5;
+    }
+
+    // Custom: standard alphabet, no padding
+    let no_pad = encode_with(&data, Encoding::NoPadding);
+    assert no_pad == "SGVsbG8";
+
+    // Invalid input returns null
+    assert decode("!!!") matches { None };
+    // Mixed alphabets return null
+    assert decode("abc+def_ghi") matches { None };
+}
+```
+
+### Decode Auto-Detection Algorithm
+
+```
+scan input characters (skipping trailing '='):
+    if char in {'+', '/'}: mark standard
+    if char in {'-', '_'}: mark url-safe
+    if both marked: return None (mixed alphabets)
+
+if neither marked: use standard table (shared charset)
+decode using the detected table
+```
+
+This is an O(n) single-pass scan that can be fused with the actual decode loop.
+
+### Error Cases
+
+`decode` / `decode_bytes` return `None` for:
+
+- Non-Base64 characters (control chars, spaces, symbols outside the alphabet)
+- Mixed alphabets (`+` and `_` in the same input)
+- Truncated input (length mod 4 == 1 after stripping padding, which is structurally invalid)
+
+Whitespace (newlines, spaces) is **not** stripped automatically. Callers handling MIME-formatted Base64 (76-character lines) should strip whitespace before calling decode. This keeps the core implementation simple and predictable.
+
+### Implementation Notes
+
+The implementation will be pure Wado in `wado-compiler/lib/core/base64.wado`, following the same pattern as `core:zlib` and `core:collections`. No new compiler features are required.
+
+Internally, the encode/decode loop operates on `Array<u8>` with the standard 3-byte-to-4-character mapping. Lookup tables are `global` arrays initialized at module load.
+
+## Consequences
+
+### Positive
+
+- **5 functions cover all use cases** — compared to Go's 4 encoding objects or Rust's engine configuration
+- **Lenient decode eliminates a class of bugs** — callers never need to worry about padding or choosing the wrong alphabet for decoding
+- **`flags` type is idiomatic** — reuses Wado's existing `flags` feature, bitwise combinable, zero overhead
+- **`decode_bytes` serves real-world needs** — HTTP bodies, file contents, and network buffers arrive as bytes, not strings
+- **No effects** — pure functions, usable in any context
+
+### Negative
+
+- **Auto-detection has a marginal cost** — scanning for `+/-/_` adds a small constant per character, but this is negligible compared to the actual decode work
+- **No streaming API** — the entire input must be in memory. Streaming Base64 (e.g., for multi-gigabyte files) is out of scope; it can be added later as `core:base64/stream` if needed
+- **Whitespace not stripped** — MIME Base64 users must pre-strip newlines. This is intentional (explicit > implicit) but may surprise users coming from lenient implementations like Python's
+
+### Comparison
+
+| Feature | Wado | Go | Rust (`base64`) | JS (TC39) | Python |
+|---------|------|----|-----------------|-----------|--------|
+| Encode standard | `encode(&data)` | `StdEncoding.EncodeToString(data)` | `STANDARD.encode(&data)` | `arr.toBase64()` | `b64encode(data)` |
+| Encode URL-safe | `encode_url(&data)` | `RawURLEncoding.EncodeToString(data)` | `URL_SAFE_NO_PAD.encode(&data)` | `arr.toBase64({alphabet:"base64url",omitPadding:true})` | `urlsafe_b64encode(data)` |
+| Custom encode | `encode_with(&data, flags)` | Create new `Encoding` | Build `GeneralPurpose` engine | Options bag | N/A |
+| Decode (any) | `decode(s)` | Must pick correct `Encoding` | Must pick correct `Engine` | Must specify `alphabet` option | Must pick correct function |
+| Decode lenient | Always | Lenient by default | Strict by default | `"loose"` by default | Always |
+| Auto-detect alphabet | Yes | No | No | No | No |
+| From bytes | `decode_bytes(&b)` | `Decode(dst, src)` | `decode(&data)` (takes `AsRef<[u8]>`) | N/A (string only) | `b64decode(s)` (takes bytes) |
+
+## Implementation Status
+
+- [ ] Create `wado-compiler/lib/core/base64.wado`
+- [ ] Register module in `stdlib.rs` as `core:base64`
+- [ ] Implement encode (standard, padded)
+- [ ] Implement encode_url (URL-safe, no padding)
+- [ ] Implement encode_with (flags-based)
+- [ ] Implement decode (auto-detect, lenient)
+- [ ] Implement decode_bytes
+- [ ] Add E2E test fixtures
+- [ ] Update `docs/cheatsheet.md` with Base64 section
+
+## Related WEPs
+
+- [Tuple and Array Literal Syntax](./wep-2026-01-15-tuple-and-array-literals.md) — `Array<u8>` usage
+- [Global Variables](./wep-2026-01-27-global-variables.md) — lookup tables as module globals
+
+## References
+
+- [RFC 4648 — The Base16, Base32, and Base64 Data Encodings](https://datatracker.ietf.org/doc/html/rfc4648)
+- [RFC 7515 — JSON Web Signature (JWS)](https://datatracker.ietf.org/doc/html/rfc7515) — uses Base64url without padding

--- a/docs/wep-2026-02-27-base64-api.md
+++ b/docs/wep-2026-02-27-base64-api.md
@@ -13,13 +13,13 @@ Base64 is a fundamental encoding used across web, security, and data interchange
 
 ### Prior Art
 
-| Language | API Shape | Standard vs URL-safe | Decode Padding | Decode Alphabet |
-|----------|-----------|---------------------|----------------|-----------------|
-| **Rust** (`base64` crate) | `Engine` object with `Config` | 4 engine constants: `STANDARD`, `STANDARD_NO_PAD`, `URL_SAFE`, `URL_SAFE_NO_PAD` | Configurable: `Indifferent` or `RequireCanonical` (strict by default) | Must match engine |
-| **Go** (`encoding/base64`) | `*Encoding` object | 4 globals: `StdEncoding`, `URLEncoding`, `RawStdEncoding`, `RawURLEncoding` | Lenient by default; `.Strict()` for canonical | Must match encoding |
-| **Python** (`base64`) | Module functions | Separate functions: `b64encode`/`urlsafe_b64encode` | Lenient (auto-pads); `validate=True` for strict | Must call correct function |
-| **JavaScript** (TC39 2025) | `Uint8Array` methods + options bag | `{ alphabet: "base64url" }` option | `lastChunkHandling`: `"loose"` (default) / `"strict"` / `"stop-before-partial"` | Must specify option |
-| **Swift** (`Foundation`) | `Data` methods + `OptionSet` | No built-in URL-safe (pitch pending) | Lenient by default | N/A |
+| Language                   | API Shape                          | Standard vs URL-safe                                                             | Decode Padding                                                                  | Decode Alphabet            |
+| -------------------------- | ---------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------- |
+| **Rust** (`base64` crate)  | `Engine` object with `Config`      | 4 engine constants: `STANDARD`, `STANDARD_NO_PAD`, `URL_SAFE`, `URL_SAFE_NO_PAD` | Configurable: `Indifferent` or `RequireCanonical` (strict by default)           | Must match engine          |
+| **Go** (`encoding/base64`) | `*Encoding` object                 | 4 globals: `StdEncoding`, `URLEncoding`, `RawStdEncoding`, `RawURLEncoding`      | Lenient by default; `.Strict()` for canonical                                   | Must match encoding        |
+| **Python** (`base64`)      | Module functions                   | Separate functions: `b64encode`/`urlsafe_b64encode`                              | Lenient (auto-pads); `validate=True` for strict                                 | Must call correct function |
+| **JavaScript** (TC39 2025) | `Uint8Array` methods + options bag | `{ alphabet: "base64url" }` option                                               | `lastChunkHandling`: `"loose"` (default) / `"strict"` / `"stop-before-partial"` | Must specify option        |
+| **Swift** (`Foundation`)   | `Data` methods + `OptionSet`       | No built-in URL-safe (pitch pending)                                             | Lenient by default                                                              | N/A                        |
 
 **Observations:**
 
@@ -61,12 +61,12 @@ pub flags Encoding {
 }
 ```
 
-| Flags | Alphabet | Padding | Use Case |
-|-------|----------|---------|----------|
-| `Encoding::none()` | `+/` | Yes | PEM, MIME, email (RFC 4648 §4) |
-| `UrlSafe \| NoPadding` | `-_` | No | JWT, URL query params (RFC 4648 §5) |
-| `NoPadding` | `+/` | No | Rare; some binary protocols |
-| `UrlSafe` | `-_` | Yes | Rare; some storage systems |
+| Flags                  | Alphabet | Padding | Use Case                            |
+| ---------------------- | -------- | ------- | ----------------------------------- |
+| `Encoding::none()`     | `+/`     | Yes     | PEM, MIME, email (RFC 4648 §4)      |
+| `UrlSafe \| NoPadding` | `-_`     | No      | JWT, URL query params (RFC 4648 §5) |
+| `NoPadding`            | `+/`     | No      | Rare; some binary protocols         |
+| `UrlSafe`              | `-_`     | Yes     | Rare; some storage systems          |
 
 ### Encode Functions
 
@@ -104,13 +104,13 @@ No `Encoding` parameter on decode — there is no configuration to pass.
 
 ### Complete API Summary
 
-| Function | Input | Output | Description |
-|----------|-------|--------|-------------|
-| `encode` | `&Array<u8>` | `String` | Standard, padded |
-| `encode_url` | `&Array<u8>` | `String` | URL-safe, no padding |
-| `encode_with` | `&Array<u8>`, `Encoding` | `String` | Custom flags |
-| `decode` | `String` | `Option<Array<u8>>` | Auto-detect, lenient |
-| `decode_bytes` | `&Array<u8>` | `Option<Array<u8>>` | Auto-detect, lenient (from bytes) |
+| Function       | Input                    | Output              | Description                       |
+| -------------- | ------------------------ | ------------------- | --------------------------------- |
+| `encode`       | `&Array<u8>`             | `String`            | Standard, padded                  |
+| `encode_url`   | `&Array<u8>`             | `String`            | URL-safe, no padding              |
+| `encode_with`  | `&Array<u8>`, `Encoding` | `String`            | Custom flags                      |
+| `decode`       | `String`                 | `Option<Array<u8>>` | Auto-detect, lenient              |
+| `decode_bytes` | `&Array<u8>`             | `Option<Array<u8>>` | Auto-detect, lenient (from bytes) |
 
 5 public functions. 1 flags type.
 
@@ -188,9 +188,9 @@ Whitespace (newlines, spaces) is **not** stripped automatically. Callers handlin
 
 The implementation will be pure Wado, following the same pattern as `core:zlib` and `core:collections`. No new compiler features are required.
 
-| File | Description |
-|------|-------------|
-| `wado-compiler/lib/core/base64.wado` | Implementation — `Encoding` flags, encode/decode functions |
+| File                                      | Description                                                |
+| ----------------------------------------- | ---------------------------------------------------------- |
+| `wado-compiler/lib/core/base64.wado`      | Implementation — `Encoding` flags, encode/decode functions |
 | `wado-compiler/lib/core/base64_test.wado` | Tests — encode/decode round-trips, edge cases, error cases |
 
 Internally, the encode/decode loop operates on `Array<u8>` with the standard 3-byte-to-4-character mapping. Lookup tables are `global` arrays initialized at module load.
@@ -213,15 +213,15 @@ Internally, the encode/decode loop operates on `Array<u8>` with the standard 3-b
 
 ### Comparison
 
-| Feature | Wado | Go | Rust (`base64`) | JS (TC39) | Python |
-|---------|------|----|-----------------|-----------|--------|
-| Encode standard | `encode(&data)` | `StdEncoding.EncodeToString(data)` | `STANDARD.encode(&data)` | `arr.toBase64()` | `b64encode(data)` |
-| Encode URL-safe | `encode_url(&data)` | `RawURLEncoding.EncodeToString(data)` | `URL_SAFE_NO_PAD.encode(&data)` | `arr.toBase64({alphabet:"base64url",omitPadding:true})` | `urlsafe_b64encode(data)` |
-| Custom encode | `encode_with(&data, flags)` | Create new `Encoding` | Build `GeneralPurpose` engine | Options bag | N/A |
-| Decode (any) | `decode(s)` | Must pick correct `Encoding` | Must pick correct `Engine` | Must specify `alphabet` option | Must pick correct function |
-| Decode lenient | Always | Lenient by default | Strict by default | `"loose"` by default | Always |
-| Auto-detect alphabet | Yes | No | No | No | No |
-| From bytes | `decode_bytes(&b)` | `Decode(dst, src)` | `decode(&data)` (takes `AsRef<[u8]>`) | N/A (string only) | `b64decode(s)` (takes bytes) |
+| Feature              | Wado                        | Go                                    | Rust (`base64`)                       | JS (TC39)                                               | Python                       |
+| -------------------- | --------------------------- | ------------------------------------- | ------------------------------------- | ------------------------------------------------------- | ---------------------------- |
+| Encode standard      | `encode(&data)`             | `StdEncoding.EncodeToString(data)`    | `STANDARD.encode(&data)`              | `arr.toBase64()`                                        | `b64encode(data)`            |
+| Encode URL-safe      | `encode_url(&data)`         | `RawURLEncoding.EncodeToString(data)` | `URL_SAFE_NO_PAD.encode(&data)`       | `arr.toBase64({alphabet:"base64url",omitPadding:true})` | `urlsafe_b64encode(data)`    |
+| Custom encode        | `encode_with(&data, flags)` | Create new `Encoding`                 | Build `GeneralPurpose` engine         | Options bag                                             | N/A                          |
+| Decode (any)         | `decode(s)`                 | Must pick correct `Encoding`          | Must pick correct `Engine`            | Must specify `alphabet` option                          | Must pick correct function   |
+| Decode lenient       | Always                      | Lenient by default                    | Strict by default                     | `"loose"` by default                                    | Always                       |
+| Auto-detect alphabet | Yes                         | No                                    | No                                    | No                                                      | No                           |
+| From bytes           | `decode_bytes(&b)`          | `Decode(dst, src)`                    | `decode(&data)` (takes `AsRef<[u8]>`) | N/A (string only)                                       | `b64decode(s)` (takes bytes) |
 
 ## Related WEPs
 


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive design specification for a Base64 encoding/decoding API in the Wado standard library via a new WEP (Wado Enhancement Proposal). The proposal defines a `core:base64` module with a clean, idiomatic API that leverages Wado's `flags` type and includes lenient, auto-detecting decode functions.

## Key Changes

- **New WEP document** (`docs/wep-2026-02-27-base64-api.md`): Complete specification for Base64 support including:
  - Design goals emphasizing simplicity for common cases and flexibility for edge cases
  - Comprehensive prior art analysis comparing APIs across Rust, Go, Python, JavaScript, and Swift
  - Key insight: asymmetric API design where encoding requires explicit format specification but decoding auto-detects alphabet and padding
  
- **API Design**:
  - `Encoding` flags type with `UrlSafe` and `NoPadding` variants
  - Five public functions: `encode()`, `encode_url()`, `encode_with()`, `decode()`, `decode_bytes()`
  - Lenient decode that auto-detects standard (`+/`) vs URL-safe (`-_`) alphabets
  - Support for both string and byte array inputs/outputs
  
- **Implementation Strategy**:
  - Pure Wado implementation (no compiler changes needed)
  - Lookup tables as module globals
  - Single-pass O(n) alphabet auto-detection algorithm
  - Explicit error handling (returns `Option<Array<u8>>`)
  
- **Documentation updates** (`AGENTS.md`):
  - Clarified distinction between E2E compiler tests and standard library tests
  - Added section on standard library test organization (`.wado` files with `test` blocks)
  - Updated WEP index to include the new Base64 API proposal

## Notable Design Decisions

- **Auto-detecting decode**: Unlike Go, Rust, Python, and JavaScript, Wado's decode functions automatically detect which alphabet was used, eliminating a class of bugs where callers choose the wrong decode function
- **Lenient by default**: Accepts input with or without padding, following Python and Go's approach rather than Rust's strict-by-default
- **No whitespace stripping**: MIME Base64 users must pre-strip newlines (explicit over implicit)
- **Flags-based configuration**: Uses Wado's idiomatic `flags` type for encoding variants rather than separate function names or engine objects
- **Dual input support**: Both `decode(String)` and `decode_bytes(&Array<u8>)` for real-world use cases (HTTP bodies, file contents)

https://claude.ai/code/session_01RTmqLFDwJYT8JwwACHrpbc