### PR TITLE
WEP: Serialization and Deserialization (Serde) Framework Design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Struct Destructuring](./docs/wep-2026-02-22-struct-destructuring.md)
 - [Tuple Destructuring](./docs/wep-2026-02-22-tuple-destructuring.md)
 - [Base64 Encoding API](./docs/wep-2026-02-27-base64-api.md)
+- [Serialization and Deserialization (Serde)](./docs/wep-2026-02-28-serde.md)
 
 ### Structure
 

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -51,17 +51,17 @@ This mechanism will also be used for future auto-derivable traits (e.g., `impl I
 Serialization and deserialization use separate fixed error types. This eliminates `type Error;` associated types across the trait hierarchy while keeping each error type focused on its domain.
 
 ```wado
-enum SerErrorKind {
+enum SerializeErrorKind {
     UnsupportedValue,   // e.g., NaN in JSON
     Custom,             // format-specific error
 }
 
-struct SerError {
-    kind: SerErrorKind,
+struct SerializeError {
+    kind: SerializeErrorKind,
     message: String,
 }
 
-enum DeErrorKind {
+enum DeserializeErrorKind {
     UnexpectedType,     // expected number, got string
     MissingField,       // required field not present
     UnknownVariant,     // variant case not recognized
@@ -74,8 +74,8 @@ enum DeErrorKind {
     Custom,             // format-specific error
 }
 
-struct DeError {
-    kind: DeErrorKind,
+struct DeserializeError {
+    kind: DeserializeErrorKind,
     message: String,
     offset: i64,        // byte offset in input, -1 if unavailable
 }
@@ -83,8 +83,8 @@ struct DeError {
 
 Rationale:
 - **Domain separation**: Serialization rarely fails (mainly `UnsupportedValue`). Deserialization has many failure modes (malformed input, missing fields, type mismatches). Separate types make each domain's error space explicit. Same approach as Swift Codable (`EncodingError` / `DecodingError`).
-- **Simplicity**: No `type Error;` associated types needed. Serialize methods return `Result<T, SerError>`, deserialize methods return `Result<T, DeError>`.
-- **`offset` only on `DeError`**: Byte offset is meaningful for deserialization (locating errors in input). Serialization has no input to offset into.
+- **Simplicity**: No `type Error;` associated types needed. Serialize methods return `Result<T, SerializeError>`, deserialize methods return `Result<T, DeserializeError>`.
+- **`offset` only on `DeserializeError`**: Byte offset is meaningful for deserialization (locating errors in input). Serialization has no input to offset into.
 - **YAGNI**: `offset` is `i64` (not a full source location struct) — sufficient for error reporting without over-engineering.
 
 ### Data Model
@@ -183,7 +183,7 @@ Wado variants always have at most one payload value. When multiple values are ne
 
 ```wado
 trait Serialize {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerError>;
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError>;
 }
 ```
 
@@ -197,31 +197,31 @@ trait Serializer {
     type VariantSerializer;  // : SerializeVariant
 
     // Integers
-    fn serialize_i32(&mut self, v: i32) -> Result<(), SerError>;
-    fn serialize_i64(&mut self, v: i64) -> Result<(), SerError>;
-    fn serialize_i128(&mut self, v: i128) -> Result<(), SerError>;
-    fn serialize_u32(&mut self, v: u32) -> Result<(), SerError>;
-    fn serialize_u64(&mut self, v: u64) -> Result<(), SerError>;
-    fn serialize_u128(&mut self, v: u128) -> Result<(), SerError>;
+    fn serialize_i32(&mut self, v: i32) -> Result<(), SerializeError>;
+    fn serialize_i64(&mut self, v: i64) -> Result<(), SerializeError>;
+    fn serialize_i128(&mut self, v: i128) -> Result<(), SerializeError>;
+    fn serialize_u32(&mut self, v: u32) -> Result<(), SerializeError>;
+    fn serialize_u64(&mut self, v: u64) -> Result<(), SerializeError>;
+    fn serialize_u128(&mut self, v: u128) -> Result<(), SerializeError>;
 
     // Floats
-    fn serialize_f32(&mut self, v: f32) -> Result<(), SerError>;
-    fn serialize_f64(&mut self, v: f64) -> Result<(), SerError>;
+    fn serialize_f32(&mut self, v: f32) -> Result<(), SerializeError>;
+    fn serialize_f64(&mut self, v: f64) -> Result<(), SerializeError>;
 
     // Atoms
-    fn serialize_bool(&mut self, v: bool) -> Result<(), SerError>;
-    fn serialize_char(&mut self, v: char) -> Result<(), SerError>;
-    fn serialize_string(&mut self, v: &String) -> Result<(), SerError>;
-    fn serialize_null(&mut self) -> Result<(), SerError>;
+    fn serialize_bool(&mut self, v: bool) -> Result<(), SerializeError>;
+    fn serialize_char(&mut self, v: char) -> Result<(), SerializeError>;
+    fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError>;
+    fn serialize_null(&mut self) -> Result<(), SerializeError>;
 
     // Compounds
-    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerError>;
-    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerError>;
-    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, SerError>;
+    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerializeError>;
+    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerializeError>;
+    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, SerializeError>;
 
     // Variants
-    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerError>;
-    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, SerError>;
+    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerializeError>;
+    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, SerializeError>;
 }
 ```
 
@@ -229,23 +229,23 @@ trait Serializer {
 
 ```wado
 trait SerializeSeq {
-    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerError>;
-    fn end(&mut self) -> Result<(), SerError>;
+    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+    fn end(&mut self) -> Result<(), SerializeError>;
 }
 
 trait SerializeMap {
-    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), SerError>;
-    fn end(&mut self) -> Result<(), SerError>;
+    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), SerializeError>;
+    fn end(&mut self) -> Result<(), SerializeError>;
 }
 
 trait SerializeStruct {
-    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerError>;
-    fn end(&mut self) -> Result<(), SerError>;
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError>;
+    fn end(&mut self) -> Result<(), SerializeError>;
 }
 
 trait SerializeVariant {
-    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerError>;
-    fn end(&mut self) -> Result<(), SerError>;
+    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+    fn end(&mut self) -> Result<(), SerializeError>;
 }
 ```
 
@@ -253,7 +253,7 @@ trait SerializeVariant {
 
 ```wado
 trait Deserialize {
-    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, DeError>;
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, DeserializeError>;
 }
 ```
 
@@ -269,31 +269,31 @@ trait Deserializer {
     type VariantAccess;   // : DeserializeVariant
 
     // Integers
-    fn deserialize_i32(&mut self) -> Result<i32, DeError>;
-    fn deserialize_i64(&mut self) -> Result<i64, DeError>;
-    fn deserialize_i128(&mut self) -> Result<i128, DeError>;
-    fn deserialize_u32(&mut self) -> Result<u32, DeError>;
-    fn deserialize_u64(&mut self) -> Result<u64, DeError>;
-    fn deserialize_u128(&mut self) -> Result<u128, DeError>;
+    fn deserialize_i32(&mut self) -> Result<i32, DeserializeError>;
+    fn deserialize_i64(&mut self) -> Result<i64, DeserializeError>;
+    fn deserialize_i128(&mut self) -> Result<i128, DeserializeError>;
+    fn deserialize_u32(&mut self) -> Result<u32, DeserializeError>;
+    fn deserialize_u64(&mut self) -> Result<u64, DeserializeError>;
+    fn deserialize_u128(&mut self) -> Result<u128, DeserializeError>;
 
     // Floats
-    fn deserialize_f32(&mut self) -> Result<f32, DeError>;
-    fn deserialize_f64(&mut self) -> Result<f64, DeError>;
+    fn deserialize_f32(&mut self) -> Result<f32, DeserializeError>;
+    fn deserialize_f64(&mut self) -> Result<f64, DeserializeError>;
 
     // Atoms
-    fn deserialize_bool(&mut self) -> Result<bool, DeError>;
-    fn deserialize_char(&mut self) -> Result<char, DeError>;
-    fn deserialize_string(&mut self) -> Result<String, DeError>;
-    fn is_null(&mut self) -> Result<bool, DeError>;
+    fn deserialize_bool(&mut self) -> Result<bool, DeserializeError>;
+    fn deserialize_char(&mut self) -> Result<char, DeserializeError>;
+    fn deserialize_string(&mut self) -> Result<String, DeserializeError>;
+    fn is_null(&mut self) -> Result<bool, DeserializeError>;
 
     // Compounds
-    fn begin_seq(&mut self) -> Result<Self::SeqAccess, DeError>;
-    fn begin_map(&mut self) -> Result<Self::MapAccess, DeError>;
+    fn begin_seq(&mut self) -> Result<Self::SeqAccess, DeserializeError>;
+    fn begin_map(&mut self) -> Result<Self::MapAccess, DeserializeError>;
     fn begin_struct(&mut self, name: &String, num_fields: i32,
-                    lookup: fn(&String) -> Option<i32>) -> Result<Self::StructAccess, DeError>;
+                    lookup: fn(&String) -> Option<i32>) -> Result<Self::StructAccess, DeserializeError>;
 
     // Variants
-    fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<Self::VariantAccess, DeError>;
+    fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<Self::VariantAccess, DeserializeError>;
 }
 ```
 
@@ -310,30 +310,30 @@ The `begin_variant` method receives:
 
 ```wado
 trait DeserializeSeq {
-    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeError>;
-    fn end(&mut self) -> Result<(), DeError>;
+    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError>;
+    fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
 trait DeserializeMap {
-    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, DeError>;
-    fn next_value<V: Deserialize>(&mut self) -> Result<V, DeError>;
-    fn end(&mut self) -> Result<(), DeError>;
+    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, DeserializeError>;
+    fn next_value<V: Deserialize>(&mut self) -> Result<V, DeserializeError>;
+    fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
 trait DeserializeStruct {
     type Key;
-    fn next_field(&mut self) -> Result<Option<Self::Key>, DeError>;
-    fn value<T: Deserialize>(&mut self) -> Result<T, DeError>;
-    fn skip(&mut self) -> Result<(), DeError>;
-    fn end(&mut self) -> Result<(), DeError>;
+    fn next_field(&mut self) -> Result<Option<Self::Key>, DeserializeError>;
+    fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
+    fn skip(&mut self) -> Result<(), DeserializeError>;
+    fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
 trait DeserializeVariant {
-    fn variant_name(&mut self) -> Result<String, DeError>;
-    fn disc(&mut self) -> Result<i32, DeError>;
-    fn payload<T: Deserialize>(&mut self) -> Result<T, DeError>;
-    fn is_unit(&mut self) -> Result<bool, DeError>;
-    fn end(&mut self) -> Result<(), DeError>;
+    fn variant_name(&mut self) -> Result<String, DeserializeError>;
+    fn disc(&mut self) -> Result<i32, DeserializeError>;
+    fn payload<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
+    fn is_unit(&mut self) -> Result<bool, DeserializeError>;
+    fn end(&mut self) -> Result<(), DeserializeError>;
 }
 ```
 
@@ -350,7 +350,7 @@ For `struct User { name: String, age: i32 }` with `impl Serialize for User;`:
 ```wado
 // Compiler generates:
 impl Serialize for User {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError> {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError> {
         let mut st = s.begin_struct("User", 2)?;
         st.field("userName", &self.name)?;
         st.field("age", &self.age)?;
@@ -374,9 +374,11 @@ enum UserFields {
 }
 
 fn _user_field_lookup(key: &String) -> Option<i32> {
-    if key == "userName" { return Option::<i32>::Some(0); }
-    if key == "age" { return Option::<i32>::Some(1); }
-    return null;
+    return match key {
+        "userName" => Option::<i32>::Some(0),
+        "age" => Option::<i32>::Some(1),
+        _ => null,
+    };
 }
 ```
 
@@ -389,16 +391,18 @@ The generated deserialization code uses index-based field matching. The same gen
 ```wado
 // Compiler generates:
 impl Deserialize for User {
-    fn deserialize<D: Deserializer>(d: &mut D) -> Result<User, SerdeError> {
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<User, DeserializeError> {
         let mut sd = d.begin_struct("User", 2, _user_field_lookup)?;
         let mut seen: u32 = 0;
         let mut name: String = "";
         let mut age: i32 = 0;
 
         while let Some(field) = sd.next_field()? {
-            if field == 0 { name = sd.value()?; seen |= 1; }       // UserFields::UserName
-            else if field == 1 { age = sd.value()?; seen |= 2; }   // UserFields::Age
-            else { sd.skip()?; }                                    // unknown field
+            match field {
+                0 => { name = sd.value()?; seen |= 1; },      // UserFields::UserName
+                1 => { age = sd.value()?; seen |= 2; },       // UserFields::Age
+                _ => { sd.skip()?; },                          // unknown field
+            }
         }
 
         if seen & 3 != 3 {
@@ -427,7 +431,7 @@ For `enum Color { Red, Green, Blue }` with `impl Serialize for Color;`:
 ```wado
 // Compiler generates:
 impl Serialize for Color {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError> {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError> {
         return match *self {
             Red => s.serialize_unit_variant("Color", "Red", 0),
             Green => s.serialize_unit_variant("Color", "Green", 1),
@@ -444,7 +448,7 @@ For `variant Shape { Circle(f64), Rectangle([f64, f64]), Point }` with `impl Ser
 ```wado
 // Compiler generates:
 impl Serialize for Shape {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError> {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError> {
         return match *self {
             Circle(r) => {
                 let mut v = s.begin_variant("Shape", "Circle", 0)?;
@@ -586,7 +590,7 @@ Type is inferred during deserialization by trying each case in order.
 
 ### Default Values for Missing Fields
 
-By default, a missing required field during deserialization produces a `SerdeError` with `MissingField` kind.
+By default, a missing required field during deserialization produces a `DeserializeError` with `MissingField` kind.
 
 The `#[serde(default)]` attribute on a field uses the type's zero-value when the field is absent from input:
 
@@ -621,7 +625,7 @@ Zero-values by type:
 Self-describing (SD) and non-self-describing (NSD) formats are separate modules. Each module is a standalone `Serializer`/`Deserializer` implementation. The generated `Serialize`/`Deserialize` code is format-agnostic and works with any of them:
 
 ```
-core:serde         — Serialize/Deserialize traits, SerdeError
+core:serde         — Serialize/Deserialize traits, SerializeError, DeserializeError
 core:json          — SD JSON (structs as objects with field names)
 core:json_nsd      — NSD JSON (structs as arrays, positional)
 core:cbor          — SD CBOR (structs as maps with string keys)
@@ -645,7 +649,7 @@ impl Deserializer for JsonDeserializer {
     // ...
 
     fn begin_struct(&mut self, name: &String, num_fields: i32,
-                    lookup: fn(&String) -> Option<i32>) -> Result<JsonStructAccess, SerdeError> {
+                    lookup: fn(&String) -> Option<i32>) -> Result<JsonStructAccess, DeserializeError> {
         self.expect_char('{')?;
         return Result::Ok(JsonStructAccess { deserializer: *self, lookup });
     }
@@ -654,7 +658,7 @@ impl Deserializer for JsonDeserializer {
 impl DeserializeStruct for JsonStructAccess {
     type Key = i32;
 
-    fn next_field(&mut self) -> Result<Option<i32>, SerdeError> {
+    fn next_field(&mut self) -> Result<Option<i32>, DeserializeError> {
         // Read next key string from JSON object
         let key = self.deserializer.read_object_key()?;
         if let Some(k) = key {
@@ -668,15 +672,15 @@ impl DeserializeStruct for JsonStructAccess {
         return Result::Ok(null);  // end of object
     }
 
-    fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError> {
+    fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError> {
         return T::deserialize(&mut self.deserializer);
     }
 
-    fn skip(&mut self) -> Result<(), SerdeError> {
+    fn skip(&mut self) -> Result<(), DeserializeError> {
         return self.deserializer.skip_value();
     }
 
-    fn end(&mut self) -> Result<(), SerdeError> {
+    fn end(&mut self) -> Result<(), DeserializeError> {
         return self.deserializer.expect_char('}');
     }
 }
@@ -703,7 +707,7 @@ impl Deserializer for JsonNsdDeserializer {
     // ...
 
     fn begin_struct(&mut self, name: &String, num_fields: i32,
-                    lookup: fn(&String) -> Option<i32>) -> Result<JsonNsdStructAccess, SerdeError> {
+                    lookup: fn(&String) -> Option<i32>) -> Result<JsonNsdStructAccess, DeserializeError> {
         // NSD: ignore lookup, read as array
         self.expect_char('[')?;
         return Result::Ok(JsonNsdStructAccess { deserializer: *self, num_fields, pos: 0 });
@@ -713,7 +717,7 @@ impl Deserializer for JsonNsdDeserializer {
 impl DeserializeStruct for JsonNsdStructAccess {
     type Key = i32;
 
-    fn next_field(&mut self) -> Result<Option<i32>, SerdeError> {
+    fn next_field(&mut self) -> Result<Option<i32>, DeserializeError> {
         if self.pos >= self.num_fields {
             return Result::Ok(null);
         }
@@ -722,15 +726,15 @@ impl DeserializeStruct for JsonNsdStructAccess {
         return Result::Ok(Option::<i32>::Some(idx));
     }
 
-    fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError> {
+    fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError> {
         return T::deserialize(&mut self.deserializer);
     }
 
-    fn skip(&mut self) -> Result<(), SerdeError> {
+    fn skip(&mut self) -> Result<(), DeserializeError> {
         return self.deserializer.skip_value();
     }
 
-    fn end(&mut self) -> Result<(), SerdeError> {
+    fn end(&mut self) -> Result<(), DeserializeError> {
         return self.deserializer.expect_char(']');
     }
 }
@@ -750,7 +754,7 @@ For serialization, the NSD format's `SerializeStruct` implementation ignores fie
 ```wado
 // core:json_nsd — SerializeStruct ignores field names
 impl SerializeStruct for JsonNsdStructSerializer {
-    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerdeError> {
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError> {
         // Ignore name, write value as next array element
         if self.count > 0 { self.writer.write_byte(','); }
         value.serialize(&mut self.serializer)?;
@@ -758,7 +762,7 @@ impl SerializeStruct for JsonNsdStructSerializer {
         return Result::Ok(());
     }
 
-    fn end(&mut self) -> Result<(), SerdeError> {
+    fn end(&mut self) -> Result<(), SerializeError> {
         return self.writer.write_byte(']');
     }
 }
@@ -799,7 +803,7 @@ Example:
 3. **struct/map separation**: Enables pre-encoded field name fragments in JSON, integer-indexed fields in CBOR. Measurable throughput improvement for struct-heavy workloads.
 4. **Compiler synthesis**: `impl Serialize for Type;` requires no procedural macro system. The compiler has full type information for optimal code generation (golden mask, field ordering, etc.).
 5. **Format-agnostic**: JSON, CBOR, and future formats use the same trait pair. No format-specific compiler knowledge required.
-6. **Fixed error type**: `SerdeError` eliminates 9 `type Error;` associated type declarations, simplifying trait bounds and generic signatures. Format authors don't need to define custom error types.
+6. **Separate fixed error types**: `SerializeError` and `DeserializeError` eliminate `type Error;` associated type declarations while keeping each domain's error space focused. Format authors don't need to define custom error types.
 7. **Index-based field matching**: Generated deserialization code uses integer comparison instead of string comparison. The lookup function moves string matching to the format layer (SD only). NSD formats skip string matching entirely.
 8. **NSD as separate modules**: SD and NSD formats are separate `Deserializer` implementations. No runtime branching in generated code — the format controls behavior through its `DeserializeStruct` implementation.
 
@@ -820,7 +824,7 @@ Example:
 | Derive mechanism | proc_macro | `impl Trait for Type;` |
 | Field identification | String-based (`&'static [&'static str]`) | Index-based (i32 via lookup function) |
 | SD/NSD support | Visitor hints | Separate format modules |
-| Error type | Associated (`Self::Error`) | Fixed (`SerdeError`) |
+| Error type | Associated (`Self::Error`) | Fixed (`SerializeError` / `DeserializeError`) |
 | Option handling | serialize_some/none | serialize_null + delegate |
 | Default field naming | Identity | camelCase for struct fields |
 | Total Serializer methods | ~28 | 17 |

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -16,7 +16,7 @@ Wado needs a serialization framework for JSON, CBOR, and other data interchange 
 | Rust serde | ~28 methods | Visitor pattern, maximum format flexibility |
 | Kotlin serialization | ~20 methods | Compiler plugin, element-index based |
 | Swift Codable | ~16 methods | Compiler-synthesized, keyed containers |
-| **Wado serde** | **15 methods** | Compiler-synthesized, format-agnostic |
+| **Wado serde** | **17 methods** | Compiler-synthesized, format-agnostic |
 
 ### Prerequisites
 
@@ -45,6 +45,37 @@ The compiler inspects the type definition (fields, variants, etc.) and synthesiz
 - The trait is not recognized as synthesis-capable by the compiler.
 
 This mechanism will also be used for future auto-derivable traits (e.g., `impl Inspect for Type;`).
+
+### Error Type
+
+All serde traits use a single fixed error type instead of associated error types. This eliminates 9 `type Error;` declarations across the trait hierarchy and simplifies generic signatures.
+
+```wado
+enum SerdeErrorKind {
+    UnsupportedValue,   // e.g., NaN in JSON
+    UnexpectedType,     // expected number, got string
+    MissingField,       // required field not present
+    UnknownVariant,     // variant case not recognized
+    DuplicateField,     // same field appears twice
+    InvalidValue,       // value out of range or unparseable
+    Overflow,           // number too large for target type
+    MalformedInput,     // format syntax error (invalid JSON, etc.)
+    TrailingData,       // unexpected data after valid input
+    Eof,                // premature end of input
+    Custom,             // format-specific error
+}
+
+struct SerdeError {
+    kind: SerdeErrorKind,
+    message: String,
+    offset: i64,        // byte offset in input, -1 if unavailable
+}
+```
+
+Rationale:
+- **Simplicity**: No `type Error;` associated types needed. Every method returns `Result<T, SerdeError>`.
+- **Consistency**: All formats produce the same error type. Error handling code is not generic over error types.
+- **YAGNI**: `offset` is `i64` (not a full source location struct) — sufficient for error reporting without over-engineering.
 
 ### Data Model
 
@@ -142,7 +173,7 @@ Wado variants always have at most one payload value. When multiple values are ne
 
 ```wado
 trait Serialize {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error>;
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError>;
 }
 ```
 
@@ -150,38 +181,37 @@ trait Serialize {
 
 ```wado
 trait Serializer {
-    type Error;
     type SeqSerializer;      // : SerializeSeq
     type MapSerializer;      // : SerializeMap
     type StructSerializer;   // : SerializeStruct
     type VariantSerializer;  // : SerializeVariant
 
     // Integers
-    fn serialize_i32(&mut self, v: i32) -> Result<(), Self::Error>;
-    fn serialize_i64(&mut self, v: i64) -> Result<(), Self::Error>;
-    fn serialize_i128(&mut self, v: i128) -> Result<(), Self::Error>;
-    fn serialize_u32(&mut self, v: u32) -> Result<(), Self::Error>;
-    fn serialize_u64(&mut self, v: u64) -> Result<(), Self::Error>;
-    fn serialize_u128(&mut self, v: u128) -> Result<(), Self::Error>;
+    fn serialize_i32(&mut self, v: i32) -> Result<(), SerdeError>;
+    fn serialize_i64(&mut self, v: i64) -> Result<(), SerdeError>;
+    fn serialize_i128(&mut self, v: i128) -> Result<(), SerdeError>;
+    fn serialize_u32(&mut self, v: u32) -> Result<(), SerdeError>;
+    fn serialize_u64(&mut self, v: u64) -> Result<(), SerdeError>;
+    fn serialize_u128(&mut self, v: u128) -> Result<(), SerdeError>;
 
     // Floats
-    fn serialize_f32(&mut self, v: f32) -> Result<(), Self::Error>;
-    fn serialize_f64(&mut self, v: f64) -> Result<(), Self::Error>;
+    fn serialize_f32(&mut self, v: f32) -> Result<(), SerdeError>;
+    fn serialize_f64(&mut self, v: f64) -> Result<(), SerdeError>;
 
     // Atoms
-    fn serialize_bool(&mut self, v: bool) -> Result<(), Self::Error>;
-    fn serialize_char(&mut self, v: char) -> Result<(), Self::Error>;
-    fn serialize_string(&mut self, v: &String) -> Result<(), Self::Error>;
-    fn serialize_null(&mut self) -> Result<(), Self::Error>;
+    fn serialize_bool(&mut self, v: bool) -> Result<(), SerdeError>;
+    fn serialize_char(&mut self, v: char) -> Result<(), SerdeError>;
+    fn serialize_string(&mut self, v: &String) -> Result<(), SerdeError>;
+    fn serialize_null(&mut self) -> Result<(), SerdeError>;
 
     // Compounds
-    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, Self::Error>;
-    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, Self::Error>;
-    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, Self::Error>;
+    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerdeError>;
+    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerdeError>;
+    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, SerdeError>;
 
     // Variants
-    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), Self::Error>;
-    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, Self::Error>;
+    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerdeError>;
+    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, SerdeError>;
 }
 ```
 
@@ -189,27 +219,23 @@ trait Serializer {
 
 ```wado
 trait SerializeSeq {
-    type Error;
-    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 
 trait SerializeMap {
-    type Error;
-    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 
 trait SerializeStruct {
-    type Error;
-    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 
 trait SerializeVariant {
-    type Error;
-    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 ```
 
@@ -217,7 +243,7 @@ trait SerializeVariant {
 
 ```wado
 trait Deserialize {
-    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, D::Error>;
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, SerdeError>;
 }
 ```
 
@@ -227,72 +253,80 @@ Note: `Deserialize::deserialize` is a static method (no `&self`) that constructs
 
 ```wado
 trait Deserializer {
-    type Error;
     type SeqAccess;       // : DeserializeSeq
     type MapAccess;       // : DeserializeMap
     type StructAccess;    // : DeserializeStruct
     type VariantAccess;   // : DeserializeVariant
 
     // Integers
-    fn deserialize_i32(&mut self) -> Result<i32, Self::Error>;
-    fn deserialize_i64(&mut self) -> Result<i64, Self::Error>;
-    fn deserialize_i128(&mut self) -> Result<i128, Self::Error>;
-    fn deserialize_u32(&mut self) -> Result<u32, Self::Error>;
-    fn deserialize_u64(&mut self) -> Result<u64, Self::Error>;
-    fn deserialize_u128(&mut self) -> Result<u128, Self::Error>;
+    fn deserialize_i32(&mut self) -> Result<i32, SerdeError>;
+    fn deserialize_i64(&mut self) -> Result<i64, SerdeError>;
+    fn deserialize_i128(&mut self) -> Result<i128, SerdeError>;
+    fn deserialize_u32(&mut self) -> Result<u32, SerdeError>;
+    fn deserialize_u64(&mut self) -> Result<u64, SerdeError>;
+    fn deserialize_u128(&mut self) -> Result<u128, SerdeError>;
 
     // Floats
-    fn deserialize_f32(&mut self) -> Result<f32, Self::Error>;
-    fn deserialize_f64(&mut self) -> Result<f64, Self::Error>;
+    fn deserialize_f32(&mut self) -> Result<f32, SerdeError>;
+    fn deserialize_f64(&mut self) -> Result<f64, SerdeError>;
 
     // Atoms
-    fn deserialize_bool(&mut self) -> Result<bool, Self::Error>;
-    fn deserialize_char(&mut self) -> Result<char, Self::Error>;
-    fn deserialize_string(&mut self) -> Result<String, Self::Error>;
-    fn is_null(&mut self) -> Result<bool, Self::Error>;
+    fn deserialize_bool(&mut self) -> Result<bool, SerdeError>;
+    fn deserialize_char(&mut self) -> Result<char, SerdeError>;
+    fn deserialize_string(&mut self) -> Result<String, SerdeError>;
+    fn is_null(&mut self) -> Result<bool, SerdeError>;
 
     // Compounds
-    fn begin_seq(&mut self) -> Result<Self::SeqAccess, Self::Error>;
-    fn begin_map(&mut self) -> Result<Self::MapAccess, Self::Error>;
-    fn begin_struct(&mut self) -> Result<Self::StructAccess, Self::Error>;
+    fn begin_seq(&mut self) -> Result<Self::SeqAccess, SerdeError>;
+    fn begin_map(&mut self) -> Result<Self::MapAccess, SerdeError>;
+    fn begin_struct(&mut self, name: &String, num_fields: i32) -> Result<Self::StructAccess, SerdeError>;
 
     // Variants
-    fn begin_variant(&mut self) -> Result<Self::VariantAccess, Self::Error>;
+    fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<Self::VariantAccess, SerdeError>;
 }
 ```
+
+The `begin_struct` and `begin_variant` methods receive metadata hints:
+- **name / type_name**: The type name (for error messages and format-specific behavior).
+- **num_fields / num_cases**: The count of expected fields/cases. Self-describing formats may ignore this; non-self-describing formats use it to know how many values to read sequentially.
 
 ### Sub-Deserializer Traits
 
 ```wado
 trait DeserializeSeq {
-    type Error;
-    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 
 trait DeserializeMap {
-    type Error;
-    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, Self::Error>;
-    fn next_value<V: Deserialize>(&mut self) -> Result<V, Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, SerdeError>;
+    fn next_value<V: Deserialize>(&mut self) -> Result<V, SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 
 trait DeserializeStruct {
-    type Error;
-    fn next_field(&mut self) -> Result<Option<String>, Self::Error>;
-    fn value<T: Deserialize>(&mut self) -> Result<T, Self::Error>;
-    fn skip(&mut self) -> Result<(), Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn is_sequential(&self) -> bool;
+    fn next_field(&mut self) -> Result<Option<String>, SerdeError>;
+    fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError>;
+    fn skip(&mut self) -> Result<(), SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 
 trait DeserializeVariant {
-    type Error;
-    fn variant_name(&mut self) -> Result<String, Self::Error>;
-    fn payload<T: Deserialize>(&mut self) -> Result<T, Self::Error>;
-    fn is_unit(&mut self) -> Result<bool, Self::Error>;
-    fn end(&mut self) -> Result<(), Self::Error>;
+    fn variant_name(&mut self) -> Result<String, SerdeError>;
+    fn disc(&mut self) -> Result<i32, SerdeError>;
+    fn payload<T: Deserialize>(&mut self) -> Result<T, SerdeError>;
+    fn is_unit(&mut self) -> Result<bool, SerdeError>;
+    fn end(&mut self) -> Result<(), SerdeError>;
 }
 ```
+
+**`DeserializeStruct::is_sequential()`** — Follows the Kotlin serialization `decodeSequentially()` pattern. When `true`, the format provides values in field declaration order (positional encoding). When `false`, the format provides key-value pairs via `next_field()`.
+
+- Self-describing formats (JSON objects, CBOR maps): `is_sequential()` returns `false`. `next_field()` reads field names from the input.
+- Non-self-describing formats (JSON arrays, CBOR arrays, binary): `is_sequential()` returns `true`. The generated code reads values in declaration order without calling `next_field()`.
+
+**`DeserializeVariant::disc()`** — Returns the integer discriminant. Non-self-describing formats that encode variants by discriminant (e.g., CBOR integer tags) use this instead of `variant_name()`.
 
 ### Compiler-Synthesized Implementations
 
@@ -303,28 +337,42 @@ For `struct User { name: String, age: i32 }` with `impl Serialize for User;`:
 ```wado
 // Compiler generates:
 impl Serialize for User {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError> {
         let mut st = s.begin_struct("User", 2)?;
-        st.field("name", &self.name)?;
+        st.field("userName", &self.name)?;
         st.field("age", &self.age)?;
         return st.end();
     }
 }
 ```
 
+Note: the field name `name` is serialized as `"userName"` per the default camelCase convention (see [Serialization Names](#serialization-names)).
+
 #### Struct Deserialization (Golden Mask)
+
+The generated deserialization code branches on `is_sequential()` to support both self-describing and non-self-describing formats with a single implementation:
 
 ```wado
 // Compiler generates:
 impl Deserialize for User {
-    fn deserialize<D: Deserializer>(d: &mut D) -> Result<User, D::Error> {
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<User, SerdeError> {
+        let mut sd = d.begin_struct("User", 2)?;
+
+        if sd.is_sequential() {
+            // Non-self-describing path: read values in field declaration order
+            let name: String = sd.value()?;
+            let age: i32 = sd.value()?;
+            sd.end()?;
+            return Result::Ok(User { name, age });
+        }
+
+        // Self-describing path: match fields by name (any order)
         let mut seen: u32 = 0;
         let mut name: String = "";
         let mut age: i32 = 0;
 
-        let mut sd = d.begin_struct()?;
         while let Some(field) = sd.next_field()? {
-            if field == "name" { name = sd.value()?; seen |= 1; }
+            if field == "userName" { name = sd.value()?; seen |= 1; }
             else if field == "age" { age = sd.value()?; seen |= 2; }
             else { sd.skip()?; }
         }
@@ -332,6 +380,7 @@ impl Deserialize for User {
         if seen & 3 != 3 {
             return Result::Err(/* missing required field */);
         }
+        sd.end()?;
         return Result::Ok(User { name, age });
     }
 }
@@ -349,7 +398,7 @@ For `enum Color { Red, Green, Blue }` with `impl Serialize for Color;`:
 ```wado
 // Compiler generates:
 impl Serialize for Color {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError> {
         return match *self {
             Red => s.serialize_unit_variant("Color", "Red", 0),
             Green => s.serialize_unit_variant("Color", "Green", 1),
@@ -366,7 +415,7 @@ For `variant Shape { Circle(f64), Rectangle([f64, f64]), Point }` with `impl Ser
 ```wado
 // Compiler generates:
 impl Serialize for Shape {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError> {
         return match *self {
             Circle(r) => {
                 let mut v = s.begin_variant("Shape", "Circle", 0)?;
@@ -414,24 +463,168 @@ Primitive and stdlib types have hand-written `Serialize`/`Deserialize` impls:
 | `TreeMap<K, V>` | `begin_map` + entry loop |
 | Tuples `[T, U, ...]` | `begin_seq` + per-element |
 
-### Serialization Names (TBD)
+### Serialization Names
 
-How struct field names and variant case names map to serialized strings is not yet decided. Options under consideration:
+#### Default Conventions
 
-1. **Identity**: Field/case names used as-is (`my_field` → `"my_field"`)
-2. **Attributes**: Per-field/per-type renaming via attributes (`#[serde(rename = "myField")]`)
-3. **Convention attributes**: Type-level case conversion (`#[serde(rename_all = "camelCase")]`)
+| Element | Wado source | Serialized name | Rule |
+|---------|-------------|-----------------|------|
+| Struct fields | `snake_case` | `camelCase` | `user_name` → `"userName"` |
+| Enum members | `PascalCase` | `PascalCase` (identity) | `Red` → `"Red"` |
+| Flags members | `PascalCase` | `PascalCase` (identity) | `Read` → `"Read"` |
+| Variant cases | `PascalCase` | `PascalCase` (identity) | `Circle` → `"Circle"` |
 
-This will be specified in a follow-up WEP or an amendment to this one.
+Struct fields convert from `snake_case` to `camelCase` by default because JSON/JavaScript convention uses camelCase for object keys. Enum, flags, and variant case names remain as-is (PascalCase identity) because they represent type-level or constant-level identifiers.
+
+#### Attribute-Based Customization
+
+Per-field or per-case rename:
+
+```wado
+struct ApiResponse {
+    #[serde(rename = "status_code")]
+    status_code: i32,               // overrides camelCase default → "status_code"
+
+    #[serde(rename = "data")]
+    response_data: String,          // "data" instead of "responseData"
+}
+```
+
+Type-level rename-all:
+
+```wado
+#[serde(rename_all = "snake_case")]
+struct Config {
+    max_retries: i32,    // "max_retries" (snake_case preserved)
+    timeout_ms: i64,     // "timeout_ms"
+}
+```
+
+Supported case styles for `rename_all`: `camelCase`, `snake_case`, `UPPER_SNAKE`, `PascalCase`, `kebab-case`.
+
+### Variant Representation
+
+The default variant representation is **externally tagged** (same as Rust serde):
+
+| Wado value | JSON output |
+|------------|-------------|
+| `Color::Red` | `"Red"` |
+| `Shape::Point` | `"Point"` |
+| `Shape::Circle(5.0)` | `{"Circle": 5.0}` |
+| `Shape::Rectangle([10.0, 20.0])` | `{"Rectangle": [10.0, 20.0]}` |
+
+#### Alternative Representations via Attributes
+
+**Internally tagged** — `#[serde(tag = "type")]`:
+
+```wado
+#[serde(tag = "type")]
+variant Message {
+    Text(TextData),
+    Image(ImageData),
+}
+// Message::Text(data) → {"type": "Text", "content": "hello", ...}
+```
+
+Only works when the payload is a struct (fields merge with the tag).
+
+**Adjacently tagged** — `#[serde(tag = "type", content = "data")]`:
+
+```wado
+#[serde(tag = "type", content = "data")]
+variant Shape {
+    Circle(f64),
+    Rectangle([f64, f64]),
+    Point,
+}
+// Shape::Circle(5.0) → {"type": "Circle", "data": 5.0}
+// Shape::Point → {"type": "Point"}
+```
+
+**Untagged** — `#[serde(untagged)]`:
+
+```wado
+#[serde(untagged)]
+variant Input {
+    Number(f64),
+    Text(String),
+}
+// Input::Number(42.0) → 42.0
+// Input::Text("hi") → "hi"
+```
+
+Type is inferred during deserialization by trying each case in order.
+
+### Default Values for Missing Fields
+
+By default, a missing required field during deserialization produces a `SerdeError` with `MissingField` kind.
+
+The `#[serde(default)]` attribute on a field uses the type's zero-value when the field is absent from input:
+
+```wado
+struct Config {
+    host: String,                     // required — error if missing
+    #[serde(default)]
+    port: i32,                        // defaults to 0 if missing
+    #[serde(default)]
+    verbose: bool,                    // defaults to false if missing
+    #[serde(default)]
+    tags: Array<String>,              // defaults to [] if missing
+    #[serde(default)]
+    description: Option<String>,      // defaults to null if missing
+}
+```
+
+Zero-values by type:
+
+| Type | Zero-value |
+|------|------------|
+| Integer types | `0` |
+| Float types | `0.0` |
+| `bool` | `false` |
+| `char` | `'\0'` |
+| `String` | `""` |
+| `Array<T>` | `[]` |
+| `Option<T>` | `null` |
 
 ### Reference Format Implementations
 
-The standard library will provide two format implementations:
+The standard library provides two format implementations, each supporting both self-describing and non-self-describing modes:
 
-- **`core:json`** — JSON serializer/deserializer
-- **`core:cbor`** — CBOR serializer/deserializer
+**`core:json`** — JSON serializer/deserializer
 
-These serve as reference implementations validating the trait design. Third-party formats implement the same `Serializer`/`Deserializer` traits.
+- **Self-describing mode** (default): Structs as objects (`{"userName": "Alice", "age": 30}`), variants as externally tagged values.
+- **Schemaless mode**: Structs as arrays (`["Alice", 30]`), variants as `[discriminant, payload]`. Compact and positional — validates the NSD code path without requiring a separate binary format.
+
+**`core:cbor`** — CBOR serializer/deserializer
+
+- **Self-describing mode** (default): Structs as CBOR maps (major type 5), variants as text-keyed maps.
+- **Schemaless mode**: Structs as CBOR arrays (major type 4), variants as integer-tagged arrays. Compact binary encoding for performance-sensitive use cases.
+
+The schemaless modes exercise the `is_sequential()` code path in generated deserialization code, ensuring both paths are well-tested within the standard library.
+
+### Large Integer JSON Handling
+
+This is a JSON format implementation detail, not a trait design concern.
+
+JavaScript's `Number` type uses IEEE 754 double-precision, which can only represent integers exactly up to 2^53 - 1 (`Number.MAX_SAFE_INTEGER = 9007199254740991`). The `core:json` implementation handles this:
+
+**Serialization:**
+
+| Type | Strategy |
+|------|----------|
+| i32, u32 | Always JSON number (fits in f64 exactly) |
+| i64, u64, i128, u128 | JSON number when \|value\| ≤ 2^53 - 1; JSON string otherwise |
+
+**Deserialization:**
+
+- All integer types accept both JSON number and JSON string representations.
+- String representation: decimal digits with optional leading `-` (e.g., `"9007199254740992"`).
+
+Example:
+```json
+{"small": 42, "large": "18446744073709551615"}
+```
 
 ## Consequences
 
@@ -442,6 +635,8 @@ These serve as reference implementations validating the trait design. Third-part
 3. **struct/map separation**: Enables pre-encoded field name fragments in JSON, integer-indexed fields in CBOR. Measurable throughput improvement for struct-heavy workloads.
 4. **Compiler synthesis**: `impl Serialize for Type;` requires no procedural macro system. The compiler has full type information for optimal code generation (golden mask, field ordering, etc.).
 5. **Format-agnostic**: JSON, CBOR, and future formats use the same trait pair. No format-specific compiler knowledge required.
+6. **Fixed error type**: `SerdeError` eliminates 9 `type Error;` associated type declarations, simplifying trait bounds and generic signatures. Format authors don't need to define custom error types.
+7. **SD/NSD dual support**: The `is_sequential()` pattern (from Kotlin serialization) enables non-self-describing formats without adding field name hint arrays to the API. SD formats return `false` and provide field names from input; NSD formats return `true` and read values positionally.
 
 ### Negative
 
@@ -449,6 +644,7 @@ These serve as reference implementations validating the trait design. Third-part
 2. **No bytes type**: `Array<u8>` serializes as a sequence of integers, not as a binary blob. CBOR loses its compact byte string encoding. This can be added later if needed.
 3. **Nested Option ambiguity**: `Option<Option<T>>` — `Some(None)` and `None` are indistinguishable in JSON (both are `null`). This is a fundamental JSON limitation, not a framework issue.
 4. **Golden mask field limit**: u32 bitmask limits synthesized deserialization to 32 fields (u64 for 64). Structs exceeding this need a different strategy.
+5. **Dual code paths in generated code**: `is_sequential()` branching produces two deserialization paths per struct. This increases generated code size, but the compiler generates it transparently and both paths are exercised by the JSON/CBOR schemaless modes.
 
 ### Comparison with Rust serde
 
@@ -458,17 +654,19 @@ These serve as reference implementations validating the trait design. Third-part
 | bytes/byte_buf | Yes | No |
 | Visitor pattern | Yes (deserialize) | No (pull-based) |
 | Derive mechanism | proc_macro | `impl Trait for Type;` |
-| Self-describing | Optional | Required (pull-based) |
+| SD/NSD support | Visitor hints (`&'static [&'static str]`) | `is_sequential()` branching |
+| Error type | Associated (`Self::Error`) | Fixed (`SerdeError`) |
 | Option handling | serialize_some/none | serialize_null + delegate |
+| Default field naming | Identity | camelCase for struct fields |
 | Total Serializer methods | ~28 | 17 |
 
 ### Future Extensions
 
-- **Serialization name conventions**: Attribute-based field renaming and case conversion.
 - **`bytes` data model entry**: For CBOR byte string optimization if binary-heavy workloads arise.
 - **`impl Inspect for Type;`**: Reuse the same compiler synthesis mechanism for debug output.
 - **Streaming serialization**: Write to `&mut Stream` instead of in-memory buffer.
 - **Schema generation**: Compiler synthesis could also generate JSON Schema or CBOR CDDL from type definitions.
+- **Index-based field deserialization**: `next_field() → Option<i32>` for zero-string-comparison deserialization. Upgrade path from current string-based approach, following the Kotlin serialization `decodeElementIndex` pattern.
 
 ## References
 

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -46,13 +46,22 @@ The compiler inspects the type definition (fields, variants, etc.) and synthesiz
 
 This mechanism will also be used for future auto-derivable traits (e.g., `impl Inspect for Type;`).
 
-### Error Type
+### Error Types
 
-All serde traits use a single fixed error type instead of associated error types. This eliminates 9 `type Error;` declarations across the trait hierarchy and simplifies generic signatures.
+Serialization and deserialization use separate fixed error types. This eliminates `type Error;` associated types across the trait hierarchy while keeping each error type focused on its domain.
 
 ```wado
-enum SerdeErrorKind {
+enum SerErrorKind {
     UnsupportedValue,   // e.g., NaN in JSON
+    Custom,             // format-specific error
+}
+
+struct SerError {
+    kind: SerErrorKind,
+    message: String,
+}
+
+enum DeErrorKind {
     UnexpectedType,     // expected number, got string
     MissingField,       // required field not present
     UnknownVariant,     // variant case not recognized
@@ -65,16 +74,17 @@ enum SerdeErrorKind {
     Custom,             // format-specific error
 }
 
-struct SerdeError {
-    kind: SerdeErrorKind,
+struct DeError {
+    kind: DeErrorKind,
     message: String,
     offset: i64,        // byte offset in input, -1 if unavailable
 }
 ```
 
 Rationale:
-- **Simplicity**: No `type Error;` associated types needed. Every method returns `Result<T, SerdeError>`.
-- **Consistency**: All formats produce the same error type. Error handling code is not generic over error types.
+- **Domain separation**: Serialization rarely fails (mainly `UnsupportedValue`). Deserialization has many failure modes (malformed input, missing fields, type mismatches). Separate types make each domain's error space explicit. Same approach as Swift Codable (`EncodingError` / `DecodingError`).
+- **Simplicity**: No `type Error;` associated types needed. Serialize methods return `Result<T, SerError>`, deserialize methods return `Result<T, DeError>`.
+- **`offset` only on `DeError`**: Byte offset is meaningful for deserialization (locating errors in input). Serialization has no input to offset into.
 - **YAGNI**: `offset` is `i64` (not a full source location struct) — sufficient for error reporting without over-engineering.
 
 ### Data Model
@@ -173,7 +183,7 @@ Wado variants always have at most one payload value. When multiple values are ne
 
 ```wado
 trait Serialize {
-    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerdeError>;
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerError>;
 }
 ```
 
@@ -187,31 +197,31 @@ trait Serializer {
     type VariantSerializer;  // : SerializeVariant
 
     // Integers
-    fn serialize_i32(&mut self, v: i32) -> Result<(), SerdeError>;
-    fn serialize_i64(&mut self, v: i64) -> Result<(), SerdeError>;
-    fn serialize_i128(&mut self, v: i128) -> Result<(), SerdeError>;
-    fn serialize_u32(&mut self, v: u32) -> Result<(), SerdeError>;
-    fn serialize_u64(&mut self, v: u64) -> Result<(), SerdeError>;
-    fn serialize_u128(&mut self, v: u128) -> Result<(), SerdeError>;
+    fn serialize_i32(&mut self, v: i32) -> Result<(), SerError>;
+    fn serialize_i64(&mut self, v: i64) -> Result<(), SerError>;
+    fn serialize_i128(&mut self, v: i128) -> Result<(), SerError>;
+    fn serialize_u32(&mut self, v: u32) -> Result<(), SerError>;
+    fn serialize_u64(&mut self, v: u64) -> Result<(), SerError>;
+    fn serialize_u128(&mut self, v: u128) -> Result<(), SerError>;
 
     // Floats
-    fn serialize_f32(&mut self, v: f32) -> Result<(), SerdeError>;
-    fn serialize_f64(&mut self, v: f64) -> Result<(), SerdeError>;
+    fn serialize_f32(&mut self, v: f32) -> Result<(), SerError>;
+    fn serialize_f64(&mut self, v: f64) -> Result<(), SerError>;
 
     // Atoms
-    fn serialize_bool(&mut self, v: bool) -> Result<(), SerdeError>;
-    fn serialize_char(&mut self, v: char) -> Result<(), SerdeError>;
-    fn serialize_string(&mut self, v: &String) -> Result<(), SerdeError>;
-    fn serialize_null(&mut self) -> Result<(), SerdeError>;
+    fn serialize_bool(&mut self, v: bool) -> Result<(), SerError>;
+    fn serialize_char(&mut self, v: char) -> Result<(), SerError>;
+    fn serialize_string(&mut self, v: &String) -> Result<(), SerError>;
+    fn serialize_null(&mut self) -> Result<(), SerError>;
 
     // Compounds
-    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerdeError>;
-    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerdeError>;
-    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, SerdeError>;
+    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerError>;
+    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerError>;
+    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, SerError>;
 
     // Variants
-    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerdeError>;
-    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, SerdeError>;
+    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerError>;
+    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, SerError>;
 }
 ```
 
@@ -219,23 +229,23 @@ trait Serializer {
 
 ```wado
 trait SerializeSeq {
-    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerError>;
+    fn end(&mut self) -> Result<(), SerError>;
 }
 
 trait SerializeMap {
-    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), SerError>;
+    fn end(&mut self) -> Result<(), SerError>;
 }
 
 trait SerializeStruct {
-    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerError>;
+    fn end(&mut self) -> Result<(), SerError>;
 }
 
 trait SerializeVariant {
-    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerError>;
+    fn end(&mut self) -> Result<(), SerError>;
 }
 ```
 
@@ -243,7 +253,7 @@ trait SerializeVariant {
 
 ```wado
 trait Deserialize {
-    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, SerdeError>;
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, DeError>;
 }
 ```
 
@@ -259,31 +269,31 @@ trait Deserializer {
     type VariantAccess;   // : DeserializeVariant
 
     // Integers
-    fn deserialize_i32(&mut self) -> Result<i32, SerdeError>;
-    fn deserialize_i64(&mut self) -> Result<i64, SerdeError>;
-    fn deserialize_i128(&mut self) -> Result<i128, SerdeError>;
-    fn deserialize_u32(&mut self) -> Result<u32, SerdeError>;
-    fn deserialize_u64(&mut self) -> Result<u64, SerdeError>;
-    fn deserialize_u128(&mut self) -> Result<u128, SerdeError>;
+    fn deserialize_i32(&mut self) -> Result<i32, DeError>;
+    fn deserialize_i64(&mut self) -> Result<i64, DeError>;
+    fn deserialize_i128(&mut self) -> Result<i128, DeError>;
+    fn deserialize_u32(&mut self) -> Result<u32, DeError>;
+    fn deserialize_u64(&mut self) -> Result<u64, DeError>;
+    fn deserialize_u128(&mut self) -> Result<u128, DeError>;
 
     // Floats
-    fn deserialize_f32(&mut self) -> Result<f32, SerdeError>;
-    fn deserialize_f64(&mut self) -> Result<f64, SerdeError>;
+    fn deserialize_f32(&mut self) -> Result<f32, DeError>;
+    fn deserialize_f64(&mut self) -> Result<f64, DeError>;
 
     // Atoms
-    fn deserialize_bool(&mut self) -> Result<bool, SerdeError>;
-    fn deserialize_char(&mut self) -> Result<char, SerdeError>;
-    fn deserialize_string(&mut self) -> Result<String, SerdeError>;
-    fn is_null(&mut self) -> Result<bool, SerdeError>;
+    fn deserialize_bool(&mut self) -> Result<bool, DeError>;
+    fn deserialize_char(&mut self) -> Result<char, DeError>;
+    fn deserialize_string(&mut self) -> Result<String, DeError>;
+    fn is_null(&mut self) -> Result<bool, DeError>;
 
     // Compounds
-    fn begin_seq(&mut self) -> Result<Self::SeqAccess, SerdeError>;
-    fn begin_map(&mut self) -> Result<Self::MapAccess, SerdeError>;
+    fn begin_seq(&mut self) -> Result<Self::SeqAccess, DeError>;
+    fn begin_map(&mut self) -> Result<Self::MapAccess, DeError>;
     fn begin_struct(&mut self, name: &String, num_fields: i32,
-                    lookup: fn(&String) -> Option<i32>) -> Result<Self::StructAccess, SerdeError>;
+                    lookup: fn(&String) -> Option<i32>) -> Result<Self::StructAccess, DeError>;
 
     // Variants
-    fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<Self::VariantAccess, SerdeError>;
+    fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<Self::VariantAccess, DeError>;
 }
 ```
 
@@ -300,30 +310,30 @@ The `begin_variant` method receives:
 
 ```wado
 trait DeserializeSeq {
-    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeError>;
+    fn end(&mut self) -> Result<(), DeError>;
 }
 
 trait DeserializeMap {
-    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, SerdeError>;
-    fn next_value<V: Deserialize>(&mut self) -> Result<V, SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, DeError>;
+    fn next_value<V: Deserialize>(&mut self) -> Result<V, DeError>;
+    fn end(&mut self) -> Result<(), DeError>;
 }
 
 trait DeserializeStruct {
     type Key;
-    fn next_field(&mut self) -> Result<Option<Self::Key>, SerdeError>;
-    fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError>;
-    fn skip(&mut self) -> Result<(), SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn next_field(&mut self) -> Result<Option<Self::Key>, DeError>;
+    fn value<T: Deserialize>(&mut self) -> Result<T, DeError>;
+    fn skip(&mut self) -> Result<(), DeError>;
+    fn end(&mut self) -> Result<(), DeError>;
 }
 
 trait DeserializeVariant {
-    fn variant_name(&mut self) -> Result<String, SerdeError>;
-    fn disc(&mut self) -> Result<i32, SerdeError>;
-    fn payload<T: Deserialize>(&mut self) -> Result<T, SerdeError>;
-    fn is_unit(&mut self) -> Result<bool, SerdeError>;
-    fn end(&mut self) -> Result<(), SerdeError>;
+    fn variant_name(&mut self) -> Result<String, DeError>;
+    fn disc(&mut self) -> Result<i32, DeError>;
+    fn payload<T: Deserialize>(&mut self) -> Result<T, DeError>;
+    fn is_unit(&mut self) -> Result<bool, DeError>;
+    fn end(&mut self) -> Result<(), DeError>;
 }
 ```
 

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -11,12 +11,12 @@ Wado needs a serialization framework for JSON, CBOR, and other data interchange 
 
 ### Prior Art
 
-| Framework | Data Model Size | Approach |
-|-----------|----------------|----------|
-| Rust serde | ~28 methods | Visitor pattern, maximum format flexibility |
-| Kotlin serialization | ~20 methods | Compiler plugin, element-index based |
-| Swift Codable | ~16 methods | Compiler-synthesized, keyed containers |
-| **Wado serde** | **17 methods** | Compiler-synthesized, format-agnostic |
+| Framework            | Data Model Size | Approach                                    |
+| -------------------- | --------------- | ------------------------------------------- |
+| Rust serde           | ~28 methods     | Visitor pattern, maximum format flexibility |
+| Kotlin serialization | ~20 methods     | Compiler plugin, element-index based        |
+| Swift Codable        | ~16 methods     | Compiler-synthesized, keyed containers      |
+| **Wado serde**       | **17 methods**  | Compiler-synthesized, format-agnostic       |
 
 ### Prerequisites
 
@@ -82,6 +82,7 @@ struct DeserializeError {
 ```
 
 Rationale:
+
 - **Domain separation**: Serialization rarely fails (mainly `UnsupportedValue`). Deserialization has many failure modes (malformed input, missing fields, type mismatches). Separate types make each domain's error space explicit. Same approach as Swift Codable (`EncodingError` / `DecodingError`).
 - **Simplicity**: No `type Error;` associated types needed. Serialize methods return `Result<T, SerializeError>`, deserialize methods return `Result<T, DeserializeError>`.
 - **`offset` only on `DeserializeError`**: Byte offset is meaningful for deserialization (locating errors in input). Serialization has no input to offset into.
@@ -103,6 +104,7 @@ serialize_u128(u128)     // u128
 ```
 
 Rationale:
+
 - Wasm operates natively on i32 and i64. Smaller types (i8, i16, u8, u16) are already stored as i32 in Wasm, so widening to i32/u32 has zero cost.
 - i64 and u64 are separate from i32/u32 because they are distinct Wasm value types.
 - i128/u128 don't fit in i64/u64 and need separate handling.
@@ -117,6 +119,7 @@ serialize_f64(f64)
 ```
 
 Rationale:
+
 - JSON: f32 produces fewer significant digits than f64, yielding shorter output and faster serialization.
 - CBOR: explicitly distinguishes f32 and f64 encoding. Without separate methods, the CBOR serializer would need a runtime "does this f64 fit in f32?" check.
 
@@ -142,11 +145,11 @@ begin_struct(name: &String, fields: i32)             → StructSerializer
 
 **seq vs struct vs map separation**: These are meaningfully different for performance:
 
-| Compound | Field names | JSON output | Optimization opportunity |
-|----------|-----------|-------------|--------------------------|
-| seq | None | `[1, 2, 3]` | Length prefix for CBOR |
-| struct | Compile-time constants | `{"name": "Alice"}` | Pre-encode `"name":` fragments |
-| map | Runtime strings | `{"key": "val"}` | Must escape keys at runtime |
+| Compound | Field names            | JSON output         | Optimization opportunity       |
+| -------- | ---------------------- | ------------------- | ------------------------------ |
+| seq      | None                   | `[1, 2, 3]`         | Length prefix for CBOR         |
+| struct   | Compile-time constants | `{"name": "Alice"}` | Pre-encode `"name":` fragments |
+| map      | Runtime strings        | `{"key": "val"}`    | Must escape keys at runtime    |
 
 Tuples use `begin_seq` — JSON and CBOR make no distinction between tuples and sequences, so a separate method would be dead weight.
 
@@ -158,11 +161,13 @@ begin_variant(type_name: &String, variant_name: &String, disc: i32)  → Variant
 ```
 
 Each method receives three pieces of information:
+
 - **type_name**: The variant type name (e.g., `"Shape"`)
 - **variant_name**: The case name (e.g., `"Circle"`)
 - **disc**: The integer discriminant (e.g., `0`)
 
 Formats choose what to use:
+
 - JSON: variant_name for keys → `"Red"` or `{"Circle": 5.0}`
 - CBOR: disc for compact encoding → integer tag + payload
 
@@ -170,14 +175,14 @@ Wado variants always have at most one payload value. When multiple values are ne
 
 #### Summary Table
 
-| Category | Methods | Count |
-|----------|---------|-------|
-| Integers | `serialize_i32`, `serialize_i64`, `serialize_i128`, `serialize_u32`, `serialize_u64`, `serialize_u128` | 6 |
-| Floats | `serialize_f32`, `serialize_f64` | 2 |
-| Atoms | `serialize_bool`, `serialize_char`, `serialize_string`, `serialize_null` | 4 |
-| Compounds | `begin_seq`, `begin_map`, `begin_struct` | 3 |
-| Variants | `serialize_unit_variant`, `begin_variant` | 2 |
-| **Total** | | **17** |
+| Category  | Methods                                                                                                | Count  |
+| --------- | ------------------------------------------------------------------------------------------------------ | ------ |
+| Integers  | `serialize_i32`, `serialize_i64`, `serialize_i128`, `serialize_u32`, `serialize_u64`, `serialize_u128` | 6      |
+| Floats    | `serialize_f32`, `serialize_f64`                                                                       | 2      |
+| Atoms     | `serialize_bool`, `serialize_char`, `serialize_string`, `serialize_null`                               | 4      |
+| Compounds | `begin_seq`, `begin_map`, `begin_struct`                                                               | 3      |
+| Variants  | `serialize_unit_variant`, `begin_variant`                                                              | 2      |
+| **Total** |                                                                                                        | **17** |
 
 ### Serialize Trait
 
@@ -298,11 +303,13 @@ trait Deserializer {
 ```
 
 The `begin_struct` method receives:
+
 - **name**: The type name (for error messages and format-specific behavior).
 - **num_fields**: The count of expected fields. Non-self-describing formats use this to know how many values to read sequentially.
 - **lookup**: A function that maps field names (from the input) to field indices. Self-describing formats call this to convert input key strings to field indices. Non-self-describing formats ignore it.
 
 The `begin_variant` method receives:
+
 - **type_name**: The variant type name (for error messages).
 - **num_cases**: The count of variant cases.
 
@@ -420,6 +427,7 @@ How it works with different format types:
 - **NSD format** (e.g., `core:json_nsd`): `begin_struct` ignores the lookup function. `next_field()` returns sequential indices `0`, `1`, ..., `num_fields - 1`.
 
 The golden mask pattern (from Kotlin serialization):
+
 - Each field gets one bit in a `u32` (up to 32 fields) or `u64` (up to 64 fields).
 - Unknown fields (index not recognized) are skipped via `skip()`.
 - A single bitwise check `seen & mask != mask` verifies all required fields are present.
@@ -467,6 +475,7 @@ impl Serialize for Shape {
 ```
 
 JSON output examples:
+
 - `Shape::Circle(5.0)` → `{"Circle": 5.0}`
 - `Shape::Rectangle([10.0, 20.0])` → `{"Rectangle": [10.0, 20.0]}`
 - `Shape::Point` → `"Point"`
@@ -475,37 +484,37 @@ JSON output examples:
 
 Primitive and stdlib types have hand-written `Serialize`/`Deserialize` impls:
 
-| Type | Serialize strategy |
-|------|--------------------|
-| `i8`, `i16` | `s.serialize_i32(*self as i32)` |
-| `i32` | `s.serialize_i32(*self)` |
-| `i64` | `s.serialize_i64(*self)` |
-| `i128` | `s.serialize_i128(*self)` |
-| `u8`, `u16` | `s.serialize_u32(*self as u32)` |
-| `u32` | `s.serialize_u32(*self)` |
-| `u64` | `s.serialize_u64(*self)` |
-| `u128` | `s.serialize_u128(*self)` |
-| `f32` | `s.serialize_f32(*self)` |
-| `f64` | `s.serialize_f64(*self)` |
-| `bool` | `s.serialize_bool(*self)` |
-| `char` | `s.serialize_char(*self)` |
-| `String` | `s.serialize_string(self)` |
-| `Option<T: Serialize>` | `null` or delegate to inner |
-| `Result<T, E>` | variant pattern (Ok/Err) |
-| `Array<T: Serialize>` | `begin_seq` + element loop |
-| `TreeMap<K, V>` | `begin_map` + entry loop |
-| Tuples `[T, U, ...]` | `begin_seq` + per-element |
+| Type                   | Serialize strategy              |
+| ---------------------- | ------------------------------- |
+| `i8`, `i16`            | `s.serialize_i32(*self as i32)` |
+| `i32`                  | `s.serialize_i32(*self)`        |
+| `i64`                  | `s.serialize_i64(*self)`        |
+| `i128`                 | `s.serialize_i128(*self)`       |
+| `u8`, `u16`            | `s.serialize_u32(*self as u32)` |
+| `u32`                  | `s.serialize_u32(*self)`        |
+| `u64`                  | `s.serialize_u64(*self)`        |
+| `u128`                 | `s.serialize_u128(*self)`       |
+| `f32`                  | `s.serialize_f32(*self)`        |
+| `f64`                  | `s.serialize_f64(*self)`        |
+| `bool`                 | `s.serialize_bool(*self)`       |
+| `char`                 | `s.serialize_char(*self)`       |
+| `String`               | `s.serialize_string(self)`      |
+| `Option<T: Serialize>` | `null` or delegate to inner     |
+| `Result<T, E>`         | variant pattern (Ok/Err)        |
+| `Array<T: Serialize>`  | `begin_seq` + element loop      |
+| `TreeMap<K, V>`        | `begin_map` + entry loop        |
+| Tuples `[T, U, ...]`   | `begin_seq` + per-element       |
 
 ### Serialization Names
 
 #### Default Conventions
 
-| Element | Wado source | Serialized name | Rule |
-|---------|-------------|-----------------|------|
-| Struct fields | `snake_case` | `camelCase` | `user_name` → `"userName"` |
-| Enum members | `PascalCase` | `PascalCase` (identity) | `Red` → `"Red"` |
-| Flags members | `PascalCase` | `PascalCase` (identity) | `Read` → `"Read"` |
-| Variant cases | `PascalCase` | `PascalCase` (identity) | `Circle` → `"Circle"` |
+| Element       | Wado source  | Serialized name         | Rule                       |
+| ------------- | ------------ | ----------------------- | -------------------------- |
+| Struct fields | `snake_case` | `camelCase`             | `user_name` → `"userName"` |
+| Enum members  | `PascalCase` | `PascalCase` (identity) | `Red` → `"Red"`            |
+| Flags members | `PascalCase` | `PascalCase` (identity) | `Read` → `"Read"`          |
+| Variant cases | `PascalCase` | `PascalCase` (identity) | `Circle` → `"Circle"`      |
 
 Struct fields convert from `snake_case` to `camelCase` by default because JSON/JavaScript convention uses camelCase for object keys. Enum, flags, and variant case names remain as-is (PascalCase identity) because they represent type-level or constant-level identifiers.
 
@@ -539,11 +548,11 @@ Supported case styles for `rename_all`: `camelCase`, `snake_case`, `UPPER_SNAKE`
 
 The default variant representation is **externally tagged** (same as Rust serde):
 
-| Wado value | JSON output |
-|------------|-------------|
-| `Color::Red` | `"Red"` |
-| `Shape::Point` | `"Point"` |
-| `Shape::Circle(5.0)` | `{"Circle": 5.0}` |
+| Wado value                       | JSON output                   |
+| -------------------------------- | ----------------------------- |
+| `Color::Red`                     | `"Red"`                       |
+| `Shape::Point`                   | `"Point"`                     |
+| `Shape::Circle(5.0)`             | `{"Circle": 5.0}`             |
 | `Shape::Rectangle([10.0, 20.0])` | `{"Rectangle": [10.0, 20.0]}` |
 
 #### Alternative Representations via Attributes
@@ -610,15 +619,15 @@ struct Config {
 
 Zero-values by type:
 
-| Type | Zero-value |
-|------|------------|
-| Integer types | `0` |
-| Float types | `0.0` |
-| `bool` | `false` |
-| `char` | `'\0'` |
-| `String` | `""` |
-| `Array<T>` | `[]` |
-| `Option<T>` | `null` |
+| Type          | Zero-value |
+| ------------- | ---------- |
+| Integer types | `0`        |
+| Float types   | `0.0`      |
+| `bool`        | `false`    |
+| `char`        | `'\0'`     |
+| `String`      | `""`       |
+| `Array<T>`    | `[]`       |
+| `Option<T>`   | `null`     |
 
 ### Reference Format Implementations
 
@@ -687,6 +696,7 @@ impl DeserializeStruct for JsonStructAccess {
 ```
 
 Input `{"age": 30, "userName": "Alice"}`:
+
 1. `next_field()` → reads `"age"` → `lookup("age")` → `Some(1)`, then `value()` reads `30`
 2. `next_field()` → reads `"userName"` → `lookup("userName")` → `Some(0)`, then `value()` reads `"Alice"`
 3. `next_field()` → end of object → `None`
@@ -741,6 +751,7 @@ impl DeserializeStruct for JsonNsdStructAccess {
 ```
 
 Input `["Alice", 30]`:
+
 1. `next_field()` → `Some(0)` (UserFields::UserName), then `value()` reads `"Alice"`
 2. `next_field()` → `Some(1)` (UserFields::Age), then `value()` reads `30`
 3. `next_field()` → `None`
@@ -779,9 +790,9 @@ JavaScript's `Number` type uses IEEE 754 double-precision, which can only repres
 
 **Serialization:**
 
-| Type | Strategy |
-|------|----------|
-| i32, u32 | Always JSON number (fits in f64 exactly) |
+| Type                 | Strategy                                                     |
+| -------------------- | ------------------------------------------------------------ |
+| i32, u32             | Always JSON number (fits in f64 exactly)                     |
 | i64, u64, i128, u128 | JSON number when \|value\| ≤ 2^53 - 1; JSON string otherwise |
 
 **Deserialization:**
@@ -790,6 +801,7 @@ JavaScript's `Number` type uses IEEE 754 double-precision, which can only repres
 - String representation: decimal digits with optional leading `-` (e.g., `"9007199254740992"`).
 
 Example:
+
 ```json
 {"small": 42, "large": "18446744073709551615"}
 ```
@@ -816,18 +828,18 @@ Example:
 
 ### Comparison with Rust serde
 
-| Aspect | Rust serde | Wado serde |
-|--------|-----------|------------|
-| Integer types | 10 (i8–i64, u8–u64) | 6 (i32/i64/i128, u32/u64/u128) |
-| bytes/byte_buf | Yes | No |
-| Visitor pattern | Yes (deserialize) | No (pull-based) |
-| Derive mechanism | proc_macro | `impl Trait for Type;` |
-| Field identification | String-based (`&'static [&'static str]`) | Index-based (i32 via lookup function) |
-| SD/NSD support | Visitor hints | Separate format modules |
-| Error type | Associated (`Self::Error`) | Fixed (`SerializeError` / `DeserializeError`) |
-| Option handling | serialize_some/none | serialize_null + delegate |
-| Default field naming | Identity | camelCase for struct fields |
-| Total Serializer methods | ~28 | 17 |
+| Aspect                   | Rust serde                               | Wado serde                                    |
+| ------------------------ | ---------------------------------------- | --------------------------------------------- |
+| Integer types            | 10 (i8–i64, u8–u64)                      | 6 (i32/i64/i128, u32/u64/u128)                |
+| bytes/byte_buf           | Yes                                      | No                                            |
+| Visitor pattern          | Yes (deserialize)                        | No (pull-based)                               |
+| Derive mechanism         | proc_macro                               | `impl Trait for Type;`                        |
+| Field identification     | String-based (`&'static [&'static str]`) | Index-based (i32 via lookup function)         |
+| SD/NSD support           | Visitor hints                            | Separate format modules                       |
+| Error type               | Associated (`Self::Error`)               | Fixed (`SerializeError` / `DeserializeError`) |
+| Option handling          | serialize_some/none                      | serialize_null + delegate                     |
+| Default field naming     | Identity                                 | camelCase for struct fields                   |
+| Total Serializer methods | ~28                                      | 17                                            |
 
 ### Future Extensions
 

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -1,0 +1,481 @@
+# WEP: Serialization and Deserialization (Serde)
+
+## Context
+
+Wado needs a serialization framework for JSON, CBOR, and other data interchange formats. The design must be:
+
+- **Format-agnostic**: A single `Serialize`/`Deserialize` trait pair works across all formats.
+- **Performance-first**: Optimized for JSON and CBOR as reference implementations. The data model should avoid unnecessary abstraction layers that hurt throughput.
+- **Compiler-synthesized**: User-defined types get automatic implementations via `impl Trait for Type;` syntax, with the compiler generating the method body.
+- **Wasm-native**: The data model aligns with Wasm's type system (i32/i64 as native integer widths).
+
+### Prior Art
+
+| Framework | Data Model Size | Approach |
+|-----------|----------------|----------|
+| Rust serde | ~28 methods | Visitor pattern, maximum format flexibility |
+| Kotlin serialization | ~20 methods | Compiler plugin, element-index based |
+| Swift Codable | ~16 methods | Compiler-synthesized, keyed containers |
+| **Wado serde** | **15 methods** | Compiler-synthesized, format-agnostic |
+
+### Prerequisites
+
+- [WEP: Trait Bounds Enforcement](./wep-2026-02-07-trait-bounds.md) — Generic methods like `element<T: Serialize>` require resolved trait bounds.
+- [WEP: Associated Types in Traits](./wep-2026-01-20-associated-types.md) — Sub-serializer types are associated types on `Serializer`.
+
+## Decision
+
+### Compiler-Synthesized `impl` Syntax
+
+A new syntax `impl Trait for Type;` (semicolon instead of block) signals that the compiler generates the method body. This is a general mechanism, not serde-specific.
+
+```wado
+struct User {
+    name: String,
+    age: i32,
+}
+
+impl Serialize for User;      // compiler generates serialize method
+impl Deserialize for User;    // compiler generates deserialize method
+```
+
+The compiler inspects the type definition (fields, variants, etc.) and synthesizes the appropriate method body at compile time. This is a compile error if:
+
+- The type contains fields that don't implement the required trait (e.g., a resource handle in a `Serialize` impl).
+- The trait is not recognized as synthesis-capable by the compiler.
+
+This mechanism will also be used for future auto-derivable traits (e.g., `impl Inspect for Type;`).
+
+### Data Model
+
+The data model defines what kinds of values a `Serializer` can accept. It is designed for optimal JSON/CBOR throughput while covering Wado's type system.
+
+#### Integers: 6 Types
+
+```
+serialize_i32(i32)       // i8, i16, i32 (Wasm native width)
+serialize_i64(i64)       // i64
+serialize_i128(i128)     // i128
+serialize_u32(u32)       // u8, u16, u32 (Wasm native width)
+serialize_u64(u64)       // u64
+serialize_u128(u128)     // u128
+```
+
+Rationale:
+- Wasm operates natively on i32 and i64. Smaller types (i8, i16, u8, u16) are already stored as i32 in Wasm, so widening to i32/u32 has zero cost.
+- i64 and u64 are separate from i32/u32 because they are distinct Wasm value types.
+- i128/u128 don't fit in i64/u64 and need separate handling.
+- JSON: integer-to-decimal conversion adapts to value magnitude, not type width. No performance loss from consolidation.
+- CBOR: varint encoding is value-based. Signedness matters (major type 0 vs 1), so signed/unsigned remain separate.
+
+#### Floats: 2 Types
+
+```
+serialize_f32(f32)
+serialize_f64(f64)
+```
+
+Rationale:
+- JSON: f32 produces fewer significant digits than f64, yielding shorter output and faster serialization.
+- CBOR: explicitly distinguishes f32 and f64 encoding. Without separate methods, the CBOR serializer would need a runtime "does this f64 fit in f32?" check.
+
+#### Atoms
+
+```
+serialize_bool(bool)
+serialize_char(char)
+serialize_string(&String)
+serialize_null()
+```
+
+- `serialize_char`: Avoids allocating a 1-character String. The JSON serializer writes `"A"` directly.
+- `serialize_null`: Represents `Option::None`, unit type `()`, and any null-like value.
+
+#### Compounds
+
+```
+begin_seq(len: i32)                                  → SeqSerializer
+begin_map(len: i32)                                  → MapSerializer
+begin_struct(name: &String, fields: i32)             → StructSerializer
+```
+
+**seq vs struct vs map separation**: These are meaningfully different for performance:
+
+| Compound | Field names | JSON output | Optimization opportunity |
+|----------|-----------|-------------|--------------------------|
+| seq | None | `[1, 2, 3]` | Length prefix for CBOR |
+| struct | Compile-time constants | `{"name": "Alice"}` | Pre-encode `"name":` fragments |
+| map | Runtime strings | `{"key": "val"}` | Must escape keys at runtime |
+
+Tuples use `begin_seq` — JSON and CBOR make no distinction between tuples and sequences, so a separate method would be dead weight.
+
+#### Variants
+
+```
+serialize_unit_variant(type_name: &String, variant_name: &String, disc: i32)
+begin_variant(type_name: &String, variant_name: &String, disc: i32)  → VariantSerializer
+```
+
+Each method receives three pieces of information:
+- **type_name**: The variant type name (e.g., `"Shape"`)
+- **variant_name**: The case name (e.g., `"Circle"`)
+- **disc**: The integer discriminant (e.g., `0`)
+
+Formats choose what to use:
+- JSON: variant_name for keys → `"Red"` or `{"Circle": 5.0}`
+- CBOR: disc for compact encoding → integer tag + payload
+
+Wado variants always have at most one payload value. When multiple values are needed, an explicit tuple is used: `Rectangle([f64, f64])`. This maps cleanly to JSON — `{"Rectangle": [10.0, 20.0]}` — with no ambiguity between single values and tuples.
+
+#### Summary Table
+
+| Category | Methods | Count |
+|----------|---------|-------|
+| Integers | `serialize_i32`, `serialize_i64`, `serialize_i128`, `serialize_u32`, `serialize_u64`, `serialize_u128` | 6 |
+| Floats | `serialize_f32`, `serialize_f64` | 2 |
+| Atoms | `serialize_bool`, `serialize_char`, `serialize_string`, `serialize_null` | 4 |
+| Compounds | `begin_seq`, `begin_map`, `begin_struct` | 3 |
+| Variants | `serialize_unit_variant`, `begin_variant` | 2 |
+| **Total** | | **17** |
+
+### Serialize Trait
+
+```wado
+trait Serialize {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error>;
+}
+```
+
+### Serializer Trait
+
+```wado
+trait Serializer {
+    type Error;
+    type SeqSerializer;      // : SerializeSeq
+    type MapSerializer;      // : SerializeMap
+    type StructSerializer;   // : SerializeStruct
+    type VariantSerializer;  // : SerializeVariant
+
+    // Integers
+    fn serialize_i32(&mut self, v: i32) -> Result<(), Self::Error>;
+    fn serialize_i64(&mut self, v: i64) -> Result<(), Self::Error>;
+    fn serialize_i128(&mut self, v: i128) -> Result<(), Self::Error>;
+    fn serialize_u32(&mut self, v: u32) -> Result<(), Self::Error>;
+    fn serialize_u64(&mut self, v: u64) -> Result<(), Self::Error>;
+    fn serialize_u128(&mut self, v: u128) -> Result<(), Self::Error>;
+
+    // Floats
+    fn serialize_f32(&mut self, v: f32) -> Result<(), Self::Error>;
+    fn serialize_f64(&mut self, v: f64) -> Result<(), Self::Error>;
+
+    // Atoms
+    fn serialize_bool(&mut self, v: bool) -> Result<(), Self::Error>;
+    fn serialize_char(&mut self, v: char) -> Result<(), Self::Error>;
+    fn serialize_string(&mut self, v: &String) -> Result<(), Self::Error>;
+    fn serialize_null(&mut self) -> Result<(), Self::Error>;
+
+    // Compounds
+    fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, Self::Error>;
+    fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, Self::Error>;
+    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<Self::StructSerializer, Self::Error>;
+
+    // Variants
+    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), Self::Error>;
+    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<Self::VariantSerializer, Self::Error>;
+}
+```
+
+### Sub-Serializer Traits
+
+```wado
+trait SerializeSeq {
+    type Error;
+    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+
+trait SerializeMap {
+    type Error;
+    fn entry<K: Serialize, V: Serialize>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+
+trait SerializeStruct {
+    type Error;
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+
+trait SerializeVariant {
+    type Error;
+    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+```
+
+### Deserialize Trait
+
+```wado
+trait Deserialize {
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Self, D::Error>;
+}
+```
+
+Note: `Deserialize::deserialize` is a static method (no `&self`) that constructs a new value from the deserializer.
+
+### Deserializer Trait
+
+```wado
+trait Deserializer {
+    type Error;
+    type SeqAccess;       // : DeserializeSeq
+    type MapAccess;       // : DeserializeMap
+    type StructAccess;    // : DeserializeStruct
+    type VariantAccess;   // : DeserializeVariant
+
+    // Integers
+    fn deserialize_i32(&mut self) -> Result<i32, Self::Error>;
+    fn deserialize_i64(&mut self) -> Result<i64, Self::Error>;
+    fn deserialize_i128(&mut self) -> Result<i128, Self::Error>;
+    fn deserialize_u32(&mut self) -> Result<u32, Self::Error>;
+    fn deserialize_u64(&mut self) -> Result<u64, Self::Error>;
+    fn deserialize_u128(&mut self) -> Result<u128, Self::Error>;
+
+    // Floats
+    fn deserialize_f32(&mut self) -> Result<f32, Self::Error>;
+    fn deserialize_f64(&mut self) -> Result<f64, Self::Error>;
+
+    // Atoms
+    fn deserialize_bool(&mut self) -> Result<bool, Self::Error>;
+    fn deserialize_char(&mut self) -> Result<char, Self::Error>;
+    fn deserialize_string(&mut self) -> Result<String, Self::Error>;
+    fn is_null(&mut self) -> Result<bool, Self::Error>;
+
+    // Compounds
+    fn begin_seq(&mut self) -> Result<Self::SeqAccess, Self::Error>;
+    fn begin_map(&mut self) -> Result<Self::MapAccess, Self::Error>;
+    fn begin_struct(&mut self) -> Result<Self::StructAccess, Self::Error>;
+
+    // Variants
+    fn begin_variant(&mut self) -> Result<Self::VariantAccess, Self::Error>;
+}
+```
+
+### Sub-Deserializer Traits
+
+```wado
+trait DeserializeSeq {
+    type Error;
+    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+
+trait DeserializeMap {
+    type Error;
+    fn next_key<K: Deserialize>(&mut self) -> Result<Option<K>, Self::Error>;
+    fn next_value<V: Deserialize>(&mut self) -> Result<V, Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+
+trait DeserializeStruct {
+    type Error;
+    fn next_field(&mut self) -> Result<Option<String>, Self::Error>;
+    fn value<T: Deserialize>(&mut self) -> Result<T, Self::Error>;
+    fn skip(&mut self) -> Result<(), Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+
+trait DeserializeVariant {
+    type Error;
+    fn variant_name(&mut self) -> Result<String, Self::Error>;
+    fn payload<T: Deserialize>(&mut self) -> Result<T, Self::Error>;
+    fn is_unit(&mut self) -> Result<bool, Self::Error>;
+    fn end(&mut self) -> Result<(), Self::Error>;
+}
+```
+
+### Compiler-Synthesized Implementations
+
+#### Struct Serialization
+
+For `struct User { name: String, age: i32 }` with `impl Serialize for User;`:
+
+```wado
+// Compiler generates:
+impl Serialize for User {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+        let mut st = s.begin_struct("User", 2)?;
+        st.field("name", &self.name)?;
+        st.field("age", &self.age)?;
+        return st.end();
+    }
+}
+```
+
+#### Struct Deserialization (Golden Mask)
+
+```wado
+// Compiler generates:
+impl Deserialize for User {
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<User, D::Error> {
+        let mut seen: u32 = 0;
+        let mut name: String = "";
+        let mut age: i32 = 0;
+
+        let mut sd = d.begin_struct()?;
+        while let Some(field) = sd.next_field()? {
+            if field == "name" { name = sd.value()?; seen |= 1; }
+            else if field == "age" { age = sd.value()?; seen |= 2; }
+            else { sd.skip()?; }
+        }
+
+        if seen & 3 != 3 {
+            return Result::Err(/* missing required field */);
+        }
+        return Result::Ok(User { name, age });
+    }
+}
+```
+
+The golden mask pattern (from Kotlin serialization):
+- Each field gets one bit in a `u32` (up to 32 fields) or `u64` (up to 64 fields).
+- Unknown fields are skipped via `skip()`.
+- A single bitwise check `seen & mask != mask` verifies all required fields are present.
+
+#### Enum Serialization
+
+For `enum Color { Red, Green, Blue }` with `impl Serialize for Color;`:
+
+```wado
+// Compiler generates:
+impl Serialize for Color {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+        return match *self {
+            Red => s.serialize_unit_variant("Color", "Red", 0),
+            Green => s.serialize_unit_variant("Color", "Green", 1),
+            Blue => s.serialize_unit_variant("Color", "Blue", 2),
+        };
+    }
+}
+```
+
+#### Variant Serialization
+
+For `variant Shape { Circle(f64), Rectangle([f64, f64]), Point }` with `impl Serialize for Shape;`:
+
+```wado
+// Compiler generates:
+impl Serialize for Shape {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+        return match *self {
+            Circle(r) => {
+                let mut v = s.begin_variant("Shape", "Circle", 0)?;
+                v.payload(&r)?;
+                v.end()
+            },
+            Rectangle(dims) => {
+                let mut v = s.begin_variant("Shape", "Rectangle", 1)?;
+                v.payload(&dims)?;
+                v.end()
+            },
+            Point => s.serialize_unit_variant("Shape", "Point", 2),
+        };
+    }
+}
+```
+
+JSON output examples:
+- `Shape::Circle(5.0)` → `{"Circle": 5.0}`
+- `Shape::Rectangle([10.0, 20.0])` → `{"Rectangle": [10.0, 20.0]}`
+- `Shape::Point` → `"Point"`
+
+### Standard Library Implementations
+
+Primitive and stdlib types have hand-written `Serialize`/`Deserialize` impls:
+
+| Type | Serialize strategy |
+|------|--------------------|
+| `i8`, `i16` | `s.serialize_i32(*self as i32)` |
+| `i32` | `s.serialize_i32(*self)` |
+| `i64` | `s.serialize_i64(*self)` |
+| `i128` | `s.serialize_i128(*self)` |
+| `u8`, `u16` | `s.serialize_u32(*self as u32)` |
+| `u32` | `s.serialize_u32(*self)` |
+| `u64` | `s.serialize_u64(*self)` |
+| `u128` | `s.serialize_u128(*self)` |
+| `f32` | `s.serialize_f32(*self)` |
+| `f64` | `s.serialize_f64(*self)` |
+| `bool` | `s.serialize_bool(*self)` |
+| `char` | `s.serialize_char(*self)` |
+| `String` | `s.serialize_string(self)` |
+| `Option<T: Serialize>` | `null` or delegate to inner |
+| `Result<T, E>` | variant pattern (Ok/Err) |
+| `Array<T: Serialize>` | `begin_seq` + element loop |
+| `TreeMap<K, V>` | `begin_map` + entry loop |
+| Tuples `[T, U, ...]` | `begin_seq` + per-element |
+
+### Serialization Names (TBD)
+
+How struct field names and variant case names map to serialized strings is not yet decided. Options under consideration:
+
+1. **Identity**: Field/case names used as-is (`my_field` → `"my_field"`)
+2. **Attributes**: Per-field/per-type renaming via attributes (`#[serde(rename = "myField")]`)
+3. **Convention attributes**: Type-level case conversion (`#[serde(rename_all = "camelCase")]`)
+
+This will be specified in a follow-up WEP or an amendment to this one.
+
+### Reference Format Implementations
+
+The standard library will provide two format implementations:
+
+- **`core:json`** — JSON serializer/deserializer
+- **`core:cbor`** — CBOR serializer/deserializer
+
+These serve as reference implementations validating the trait design. Third-party formats implement the same `Serializer`/`Deserializer` traits.
+
+## Consequences
+
+### Positive
+
+1. **Minimal data model (17 methods)**: Fewer methods than serde (~28), Kotlin (~20), or Swift (~16). Less implementation burden for format authors.
+2. **Zero-cost integer consolidation**: i8/i16/u8/u16 widen to i32/u32 at no Wasm cost (already stored as i32). 6 integer methods balance Wasm alignment with format expressiveness.
+3. **struct/map separation**: Enables pre-encoded field name fragments in JSON, integer-indexed fields in CBOR. Measurable throughput improvement for struct-heavy workloads.
+4. **Compiler synthesis**: `impl Serialize for Type;` requires no procedural macro system. The compiler has full type information for optimal code generation (golden mask, field ordering, etc.).
+5. **Format-agnostic**: JSON, CBOR, and future formats use the same trait pair. No format-specific compiler knowledge required.
+
+### Negative
+
+1. **Trait bounds prerequisite**: The full design cannot be implemented until trait bounds are complete.
+2. **No bytes type**: `Array<u8>` serializes as a sequence of integers, not as a binary blob. CBOR loses its compact byte string encoding. This can be added later if needed.
+3. **Nested Option ambiguity**: `Option<Option<T>>` — `Some(None)` and `None` are indistinguishable in JSON (both are `null`). This is a fundamental JSON limitation, not a framework issue.
+4. **Golden mask field limit**: u32 bitmask limits synthesized deserialization to 32 fields (u64 for 64). Structs exceeding this need a different strategy.
+
+### Comparison with Rust serde
+
+| Aspect | Rust serde | Wado serde |
+|--------|-----------|------------|
+| Integer types | 10 (i8–i64, u8–u64) | 6 (i32/i64/i128, u32/u64/u128) |
+| bytes/byte_buf | Yes | No |
+| Visitor pattern | Yes (deserialize) | No (pull-based) |
+| Derive mechanism | proc_macro | `impl Trait for Type;` |
+| Self-describing | Optional | Required (pull-based) |
+| Option handling | serialize_some/none | serialize_null + delegate |
+| Total Serializer methods | ~28 | 17 |
+
+### Future Extensions
+
+- **Serialization name conventions**: Attribute-based field renaming and case conversion.
+- **`bytes` data model entry**: For CBOR byte string optimization if binary-heavy workloads arise.
+- **`impl Inspect for Type;`**: Reuse the same compiler synthesis mechanism for debug output.
+- **Streaming serialization**: Write to `&mut Stream` instead of in-memory buffer.
+- **Schema generation**: Compiler synthesis could also generate JSON Schema or CBOR CDDL from type definitions.
+
+## References
+
+- [WEP: Trait Bounds Enforcement](./wep-2026-02-07-trait-bounds.md)
+- [WEP: Associated Types in Traits](./wep-2026-01-20-associated-types.md)
+- [WEP: Variant Payload Design](./wep-2026-01-25-variant-payload-design.md)
+- [WEP: Format Traits](./wep-2026-02-01-format-traits.md)
+- [WEP: Inspect (Debug Output)](./wep-2026-02-21-inspect-debug-output.md)
+- [Rust serde](https://serde.rs/)
+- [Kotlin Serialization](https://github.com/Kotlin/kotlinx.serialization)

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -279,16 +279,22 @@ trait Deserializer {
     // Compounds
     fn begin_seq(&mut self) -> Result<Self::SeqAccess, SerdeError>;
     fn begin_map(&mut self) -> Result<Self::MapAccess, SerdeError>;
-    fn begin_struct(&mut self, name: &String, num_fields: i32) -> Result<Self::StructAccess, SerdeError>;
+    fn begin_struct(&mut self, name: &String, num_fields: i32,
+                    lookup: fn(&String) -> Option<i32>) -> Result<Self::StructAccess, SerdeError>;
 
     // Variants
     fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<Self::VariantAccess, SerdeError>;
 }
 ```
 
-The `begin_struct` and `begin_variant` methods receive metadata hints:
-- **name / type_name**: The type name (for error messages and format-specific behavior).
-- **num_fields / num_cases**: The count of expected fields/cases. Self-describing formats may ignore this; non-self-describing formats use it to know how many values to read sequentially.
+The `begin_struct` method receives:
+- **name**: The type name (for error messages and format-specific behavior).
+- **num_fields**: The count of expected fields. Non-self-describing formats use this to know how many values to read sequentially.
+- **lookup**: A function that maps field names (from the input) to field indices. Self-describing formats call this to convert input key strings to field indices. Non-self-describing formats ignore it.
+
+The `begin_variant` method receives:
+- **type_name**: The variant type name (for error messages).
+- **num_cases**: The count of variant cases.
 
 ### Sub-Deserializer Traits
 
@@ -305,8 +311,8 @@ trait DeserializeMap {
 }
 
 trait DeserializeStruct {
-    fn is_sequential(&self) -> bool;
-    fn next_field(&mut self) -> Result<Option<String>, SerdeError>;
+    type Key;
+    fn next_field(&mut self) -> Result<Option<Self::Key>, SerdeError>;
     fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError>;
     fn skip(&mut self) -> Result<(), SerdeError>;
     fn end(&mut self) -> Result<(), SerdeError>;
@@ -321,10 +327,7 @@ trait DeserializeVariant {
 }
 ```
 
-**`DeserializeStruct::is_sequential()`** — Follows the Kotlin serialization `decodeSequentially()` pattern. When `true`, the format provides values in field declaration order (positional encoding). When `false`, the format provides key-value pairs via `next_field()`.
-
-- Self-describing formats (JSON objects, CBOR maps): `is_sequential()` returns `false`. `next_field()` reads field names from the input.
-- Non-self-describing formats (JSON arrays, CBOR arrays, binary): `is_sequential()` returns `true`. The generated code reads values in declaration order without calling `next_field()`.
+**`DeserializeStruct::next_field()`** — Returns the next field as an index (enum discriminant). All current format implementations use `type Key = i32;`. Self-describing formats convert field names to indices using a lookup function provided by the generated code; non-self-describing formats return sequential indices (0, 1, 2, ...).
 
 **`DeserializeVariant::disc()`** — Returns the integer discriminant. Non-self-describing formats that encode variants by discriminant (e.g., CBOR integer tags) use this instead of `variant_name()`.
 
@@ -348,33 +351,44 @@ impl Serialize for User {
 
 Note: the field name `name` is serialized as `"userName"` per the default camelCase convention (see [Serialization Names](#serialization-names)).
 
-#### Struct Deserialization (Golden Mask)
+#### Compiler-Synthesized Field Enum
 
-The generated deserialization code branches on `is_sequential()` to support both self-describing and non-self-describing formats with a single implementation:
+For each struct with `impl Deserialize for Type;`, the compiler synthesizes a field enum and a lookup function. These are internal to the generated code and not user-visible:
+
+```wado
+// For struct User { name: String, age: i32 }, the compiler synthesizes:
+
+enum UserFields {
+    UserName,   // discriminant 0
+    Age,        // discriminant 1
+}
+
+fn _user_field_lookup(key: &String) -> Option<i32> {
+    if key == "userName" { return Option::<i32>::Some(0); }
+    if key == "age" { return Option::<i32>::Some(1); }
+    return null;
+}
+```
+
+The field enum documents the mapping between field names and indices. The lookup function converts serialized names (camelCase by default) to field indices, and is passed to `begin_struct` for use by self-describing formats.
+
+#### Struct Deserialization (Index-Based Golden Mask)
+
+The generated deserialization code uses index-based field matching. The same generated code works for both self-describing and non-self-describing formats — the format controls behavior through its `DeserializeStruct` implementation:
 
 ```wado
 // Compiler generates:
 impl Deserialize for User {
     fn deserialize<D: Deserializer>(d: &mut D) -> Result<User, SerdeError> {
-        let mut sd = d.begin_struct("User", 2)?;
-
-        if sd.is_sequential() {
-            // Non-self-describing path: read values in field declaration order
-            let name: String = sd.value()?;
-            let age: i32 = sd.value()?;
-            sd.end()?;
-            return Result::Ok(User { name, age });
-        }
-
-        // Self-describing path: match fields by name (any order)
+        let mut sd = d.begin_struct("User", 2, _user_field_lookup)?;
         let mut seen: u32 = 0;
         let mut name: String = "";
         let mut age: i32 = 0;
 
         while let Some(field) = sd.next_field()? {
-            if field == "userName" { name = sd.value()?; seen |= 1; }
-            else if field == "age" { age = sd.value()?; seen |= 2; }
-            else { sd.skip()?; }
+            if field == 0 { name = sd.value()?; seen |= 1; }       // UserFields::UserName
+            else if field == 1 { age = sd.value()?; seen |= 2; }   // UserFields::Age
+            else { sd.skip()?; }                                    // unknown field
         }
 
         if seen & 3 != 3 {
@@ -386,9 +400,14 @@ impl Deserialize for User {
 }
 ```
 
+How it works with different format types:
+
+- **SD format** (e.g., `core:json`): `begin_struct` stores the lookup function. `next_field()` reads a key string from input (e.g., `"userName"`), calls `lookup("userName")` → `Some(0)`, returns `0`.
+- **NSD format** (e.g., `core:json_nsd`): `begin_struct` ignores the lookup function. `next_field()` returns sequential indices `0`, `1`, ..., `num_fields - 1`.
+
 The golden mask pattern (from Kotlin serialization):
 - Each field gets one bit in a `u32` (up to 32 fields) or `u64` (up to 64 fields).
-- Unknown fields are skipped via `skip()`.
+- Unknown fields (index not recognized) are skipped via `skip()`.
 - A single bitwise check `seen & mask != mask` verifies all required fields are present.
 
 #### Enum Serialization
@@ -589,19 +608,154 @@ Zero-values by type:
 
 ### Reference Format Implementations
 
-The standard library provides two format implementations, each supporting both self-describing and non-self-describing modes:
+Self-describing (SD) and non-self-describing (NSD) formats are separate modules. Each module is a standalone `Serializer`/`Deserializer` implementation. The generated `Serialize`/`Deserialize` code is format-agnostic and works with any of them:
 
-**`core:json`** — JSON serializer/deserializer
+```
+core:serde         — Serialize/Deserialize traits, SerdeError
+core:json          — SD JSON (structs as objects with field names)
+core:json_nsd      — NSD JSON (structs as arrays, positional)
+core:cbor          — SD CBOR (structs as maps with string keys)
+core:cbor_nsd      — NSD CBOR (structs as arrays, integer-tagged variants)
+```
 
-- **Self-describing mode** (default): Structs as objects (`{"userName": "Alice", "age": 30}`), variants as externally tagged values.
-- **Schemaless mode**: Structs as arrays (`["Alice", 30]`), variants as `[discriminant, payload]`. Compact and positional — validates the NSD code path without requiring a separate binary format.
+Shared implementation (number parsing, string escaping, UTF-8 handling) are `pub` functions in `core:json` reused by `core:json_nsd`, and similarly for CBOR.
 
-**`core:cbor`** — CBOR serializer/deserializer
+#### JSON SD Implementation Sketch (`core:json`)
 
-- **Self-describing mode** (default): Structs as CBOR maps (major type 5), variants as text-keyed maps.
-- **Schemaless mode**: Structs as CBOR arrays (major type 4), variants as integer-tagged arrays. Compact binary encoding for performance-sensitive use cases.
+```wado
+struct JsonDeserializer { /* input buffer, position, ... */ }
 
-The schemaless modes exercise the `is_sequential()` code path in generated deserialization code, ensuring both paths are well-tested within the standard library.
+struct JsonStructAccess {
+    deserializer: JsonDeserializer,
+    lookup: fn(&String) -> Option<i32>,
+}
+
+impl Deserializer for JsonDeserializer {
+    type StructAccess = JsonStructAccess;
+    // ...
+
+    fn begin_struct(&mut self, name: &String, num_fields: i32,
+                    lookup: fn(&String) -> Option<i32>) -> Result<JsonStructAccess, SerdeError> {
+        self.expect_char('{')?;
+        return Result::Ok(JsonStructAccess { deserializer: *self, lookup });
+    }
+}
+
+impl DeserializeStruct for JsonStructAccess {
+    type Key = i32;
+
+    fn next_field(&mut self) -> Result<Option<i32>, SerdeError> {
+        // Read next key string from JSON object
+        let key = self.deserializer.read_object_key()?;
+        if let Some(k) = key {
+            let idx = (self.lookup)(&k);
+            if let Some(i) = idx {
+                return Result::Ok(Option::<i32>::Some(i));
+            }
+            // Unknown field — return sentinel for skip
+            return Result::Ok(Option::<i32>::Some(-1));
+        }
+        return Result::Ok(null);  // end of object
+    }
+
+    fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError> {
+        return T::deserialize(&mut self.deserializer);
+    }
+
+    fn skip(&mut self) -> Result<(), SerdeError> {
+        return self.deserializer.skip_value();
+    }
+
+    fn end(&mut self) -> Result<(), SerdeError> {
+        return self.deserializer.expect_char('}');
+    }
+}
+```
+
+Input `{"age": 30, "userName": "Alice"}`:
+1. `next_field()` → reads `"age"` → `lookup("age")` → `Some(1)`, then `value()` reads `30`
+2. `next_field()` → reads `"userName"` → `lookup("userName")` → `Some(0)`, then `value()` reads `"Alice"`
+3. `next_field()` → end of object → `None`
+
+#### JSON NSD Implementation Sketch (`core:json_nsd`)
+
+```wado
+struct JsonNsdDeserializer { /* input buffer, position, ... */ }
+
+struct JsonNsdStructAccess {
+    deserializer: JsonNsdDeserializer,
+    num_fields: i32,
+    pos: i32,
+}
+
+impl Deserializer for JsonNsdDeserializer {
+    type StructAccess = JsonNsdStructAccess;
+    // ...
+
+    fn begin_struct(&mut self, name: &String, num_fields: i32,
+                    lookup: fn(&String) -> Option<i32>) -> Result<JsonNsdStructAccess, SerdeError> {
+        // NSD: ignore lookup, read as array
+        self.expect_char('[')?;
+        return Result::Ok(JsonNsdStructAccess { deserializer: *self, num_fields, pos: 0 });
+    }
+}
+
+impl DeserializeStruct for JsonNsdStructAccess {
+    type Key = i32;
+
+    fn next_field(&mut self) -> Result<Option<i32>, SerdeError> {
+        if self.pos >= self.num_fields {
+            return Result::Ok(null);
+        }
+        let idx = self.pos;
+        self.pos += 1;
+        return Result::Ok(Option::<i32>::Some(idx));
+    }
+
+    fn value<T: Deserialize>(&mut self) -> Result<T, SerdeError> {
+        return T::deserialize(&mut self.deserializer);
+    }
+
+    fn skip(&mut self) -> Result<(), SerdeError> {
+        return self.deserializer.skip_value();
+    }
+
+    fn end(&mut self) -> Result<(), SerdeError> {
+        return self.deserializer.expect_char(']');
+    }
+}
+```
+
+Input `["Alice", 30]`:
+1. `next_field()` → `Some(0)` (UserFields::UserName), then `value()` reads `"Alice"`
+2. `next_field()` → `Some(1)` (UserFields::Age), then `value()` reads `30`
+3. `next_field()` → `None`
+
+The **same generated `Deserialize` code** works for both — the format controls field iteration through its `DeserializeStruct` implementation.
+
+#### NSD Serialization
+
+For serialization, the NSD format's `SerializeStruct` implementation ignores field names and writes values positionally. The same generated `Serialize` code works for both SD and NSD:
+
+```wado
+// core:json_nsd — SerializeStruct ignores field names
+impl SerializeStruct for JsonNsdStructSerializer {
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerdeError> {
+        // Ignore name, write value as next array element
+        if self.count > 0 { self.writer.write_byte(','); }
+        value.serialize(&mut self.serializer)?;
+        self.count += 1;
+        return Result::Ok(());
+    }
+
+    fn end(&mut self) -> Result<(), SerdeError> {
+        return self.writer.write_byte(']');
+    }
+}
+```
+
+SD serialization: `{"userName":"Alice","age":30}`
+NSD serialization: `["Alice",30]`
 
 ### Large Integer JSON Handling
 
@@ -636,7 +790,8 @@ Example:
 4. **Compiler synthesis**: `impl Serialize for Type;` requires no procedural macro system. The compiler has full type information for optimal code generation (golden mask, field ordering, etc.).
 5. **Format-agnostic**: JSON, CBOR, and future formats use the same trait pair. No format-specific compiler knowledge required.
 6. **Fixed error type**: `SerdeError` eliminates 9 `type Error;` associated type declarations, simplifying trait bounds and generic signatures. Format authors don't need to define custom error types.
-7. **SD/NSD dual support**: The `is_sequential()` pattern (from Kotlin serialization) enables non-self-describing formats without adding field name hint arrays to the API. SD formats return `false` and provide field names from input; NSD formats return `true` and read values positionally.
+7. **Index-based field matching**: Generated deserialization code uses integer comparison instead of string comparison. The lookup function moves string matching to the format layer (SD only). NSD formats skip string matching entirely.
+8. **NSD as separate modules**: SD and NSD formats are separate `Deserializer` implementations. No runtime branching in generated code — the format controls behavior through its `DeserializeStruct` implementation.
 
 ### Negative
 
@@ -644,7 +799,6 @@ Example:
 2. **No bytes type**: `Array<u8>` serializes as a sequence of integers, not as a binary blob. CBOR loses its compact byte string encoding. This can be added later if needed.
 3. **Nested Option ambiguity**: `Option<Option<T>>` — `Some(None)` and `None` are indistinguishable in JSON (both are `null`). This is a fundamental JSON limitation, not a framework issue.
 4. **Golden mask field limit**: u32 bitmask limits synthesized deserialization to 32 fields (u64 for 64). Structs exceeding this need a different strategy.
-5. **Dual code paths in generated code**: `is_sequential()` branching produces two deserialization paths per struct. This increases generated code size, but the compiler generates it transparently and both paths are exercised by the JSON/CBOR schemaless modes.
 
 ### Comparison with Rust serde
 
@@ -654,7 +808,8 @@ Example:
 | bytes/byte_buf | Yes | No |
 | Visitor pattern | Yes (deserialize) | No (pull-based) |
 | Derive mechanism | proc_macro | `impl Trait for Type;` |
-| SD/NSD support | Visitor hints (`&'static [&'static str]`) | `is_sequential()` branching |
+| Field identification | String-based (`&'static [&'static str]`) | Index-based (i32 via lookup function) |
+| SD/NSD support | Visitor hints | Separate format modules |
 | Error type | Associated (`Self::Error`) | Fixed (`SerdeError`) |
 | Option handling | serialize_some/none | serialize_null + delegate |
 | Default field naming | Identity | camelCase for struct fields |
@@ -666,7 +821,6 @@ Example:
 - **`impl Inspect for Type;`**: Reuse the same compiler synthesis mechanism for debug output.
 - **Streaming serialization**: Write to `&mut Stream` instead of in-memory buffer.
 - **Schema generation**: Compiler synthesis could also generate JSON Schema or CBOR CDDL from type definitions.
-- **Index-based field deserialization**: `next_field() → Option<i32>` for zero-string-comparison deserialization. Upgrade path from current string-based approach, following the Kotlin serialization `decodeElementIndex` pattern.
 
 ## References
 

--- a/docs/wep-2026-02-28-serde.md
+++ b/docs/wep-2026-02-28-serde.md
@@ -821,6 +821,7 @@ Example:
 - **`impl Inspect for Type;`**: Reuse the same compiler synthesis mechanism for debug output.
 - **Streaming serialization**: Write to `&mut Stream` instead of in-memory buffer.
 - **Schema generation**: Compiler synthesis could also generate JSON Schema or CBOR CDDL from type definitions.
+- **GAT + enum-based field keys**: Once Wado supports Generic Associated Types (`type StructAccess<K>: DeserializeStruct`), the `DeserializeStruct::Key` can be the actual synthesized field enum (e.g., `UserFields`) instead of `i32`. This enables `match field { UserName => ..., Age => ... }` in generated code. The migration is backward-compatible since enum discriminants are i32.
 
 ## References
 


### PR DESCRIPTION
## Summary

This PR introduces WEP-2026-02-28, a comprehensive design for Wado's serialization and deserialization framework. The proposal defines a format-agnostic serde system optimized for JSON and CBOR with a minimal 17-method data model, compiler-synthesized trait implementations, and separate fixed error types.

## Key Changes

- **New WEP document** (`docs/wep-2026-02-28-serde.md`): Complete specification covering:
  - Compiler-synthesized `impl Trait for Type;` syntax for automatic trait implementations
  - Minimal data model with 17 methods (6 integer types, 2 float types, 4 atoms, 3 compound types, 2 variant methods)
  - Separate `SerializeError` and `DeserializeError` types eliminating associated error type declarations
  - Index-based field matching with golden mask pattern for efficient struct deserialization
  - Support for both self-describing (SD) and non-self-describing (NSD) formats as separate modules
  - Default naming conventions (camelCase for struct fields, PascalCase for enum/variant cases)
  - Variant representation strategies (externally tagged, internally tagged, adjacently tagged, untagged)

- **Design rationale** includes:
  - Wasm-native integer consolidation (i8/i16/u8/u16 → i32/u32 at zero cost)
  - struct/map/seq separation for format-specific optimizations
  - Pull-based deserialization instead of visitor pattern
  - Lookup function approach for field name resolution in SD formats
  - Large integer JSON handling (string representation for values > 2^53-1)

- **Reference implementations sketched** for JSON SD/NSD and CBOR variants demonstrating format-agnostic trait usage

- **Updated AGENTS.md** to reference the new WEP in the documentation index

## Notable Implementation Details

- The design depends on two prerequisite WEPs: trait bounds enforcement and associated types in traits
- Compiler synthesis is a general mechanism applicable to future auto-derivable traits (e.g., `impl Inspect for Type;`)
- Field enum synthesis and lookup functions are compiler-generated internals, not user-visible
- Golden mask pattern limits struct deserialization to 32-64 fields depending on bitmask width
- Same generated code works for both SD and NSD formats—the format controls behavior through its `DeserializeStruct`/`SerializeStruct` implementations

https://claude.ai/code/session_018h9wtrYRKNNvHbAmG261kF