### PR TITLE
Fix CI integrity check to detect staged changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,16 @@ jobs:
       - run: make update-golden-wir-fixtures
       - run: make format
 
-      - name: Check for uncommitted changes
+      - name: Check working tree is clean
         id: diff
         run: |
-          if git diff --exit-code; then
+          git add -A
+          if git diff --cached --exit-code; then
             echo "clean=true" >> $GITHUB_OUTPUT
           else
             echo "clean=false" >> $GITHUB_OUTPUT
-            echo "::error::Uncommitted changes detected. Run 'make on-task-done' locally and commit the changes."
+            echo "::error::Working tree is dirty. Run 'make on-task-done' locally and commit the changes."
+            git diff --cached --stat
             exit 1
           fi
 
@@ -51,9 +53,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MARKER="<!-- integrity-check-comment -->"
-          DIFF_STAT=$(git diff --stat)
+          DIFF_STAT=$(git diff --cached --stat)
           BODY="${MARKER}
-          ## Uncommitted changes detected
+          ## Working tree is dirty
 
           Integrity checks produced the following changes:
 


### PR DESCRIPTION
## Summary
Updated the CI integrity check workflow to properly detect staged changes in the working tree by using `git add -A` and `git diff --cached` instead of just `git diff`.

## Key Changes
- Modified the integrity check to stage all changes with `git add -A` before checking for differences
- Changed diff detection from `git diff --exit-code` to `git diff --cached --exit-code` to check staged changes
- Updated error messaging from "Uncommitted changes" to "Working tree is dirty" for clarity
- Added `git diff --cached --stat` output to the error message for better visibility of what changed
- Updated the comment body in the GitHub comment to reflect the new terminology

## Implementation Details
The previous approach only checked unstaged changes, which could miss files that were already staged. By staging all changes first and then checking the cached diff, the workflow now properly detects all modifications that would need to be committed, ensuring the integrity check catches all deviations from the expected state after running `make on-task-done`.

https://claude.ai/code/session_01B35spLYFkR7kApH7rfa94U