### PR TITLE
Add WEP for documentation generation (`wado doc` command)

### DIFF
--- a/docs/wep-2026-02-28-doc-command.md
+++ b/docs/wep-2026-02-28-doc-command.md
@@ -254,13 +254,18 @@ Rules for full format:
 
 #### Simple (`--simple`)
 
-Compact Wado pseudo-code showing the public API surface. No prose, no doc comments — just signatures. Designed for generating cheatsheets (like `docs/cheatsheet.md` stdlib sections).
+Compressed markdown in the style of `docs/cheatsheet.md`. Uses `##` headings and ` ```wado ` code blocks to pack signatures densely. Designed for generating stdlib cheatsheets.
 
 Output (`wado doc --simple file.wado`):
 
-```
-// core trait definitions for equality and ordering.
+````markdown
+# file
 
+Core trait definitions for equality and ordering.
+
+## Traits
+
+```wado
 pub trait Eq {
     fn eq(&self, other: &Self) -> bool;
 }
@@ -268,37 +273,64 @@ pub trait Eq {
 pub trait Ord {
     fn cmp(&self, other: &Self) -> Ordering;
 }
+```
 
+## Structs
+
+```wado
 pub struct Point { x: i32, y: i32 }
 pub struct Config { name: String, .. }
+```
 
+```wado
 impl Point {
     pub fn origin() -> Point;
     pub fn distance(&self, other: &Point) -> f64;
 }
+```
 
+## Types
+
+```wado
 pub type Meters = f64;
+```
+
+## Globals
+
+```wado
 pub global PI: f64;
+```
 
+## Enums
+
+```wado
 pub enum Color { Red, Green, Blue }
+```
 
+## Variants
+
+```wado
 pub variant Shape {
     Circle(f64),
     Rectangle([f64, f64]),
     Point,
 }
-
-export fn run();
 ```
 
+## Functions
+
+```wado
+export fn run();
+```
+````
+
 Rules for simple format:
-- Module doc (`//!`) becomes a `//` comment at the top (lowercased first char)
-- Item doc comments are omitted entirely
-- Function bodies replaced with `;`
-- Private fields replaced with `..`
-- Private items and methods omitted
-- `impl` blocks show only pub/export methods
-- Globals omit initializers
+- Same markdown structure as full (`#` module, `##` categories) but no `###` per item
+- All items of the same category grouped into a single ` ```wado ` block
+- Doc comments omitted entirely — signatures only
+- `impl` blocks rendered as separate code blocks under their type's category
+- Function bodies replaced with `;`, globals omit initializers
+- Private fields replaced with `..`, private items omitted
 - Source order preserved
 
 ### Signature Rendering
@@ -318,17 +350,14 @@ pub global PI: f64;                                        // no initializer
 
 ### Multi-File Output
 
-When multiple files are given, their outputs are concatenated into a single document. Each file becomes a top-level section:
-
-- **Full format**: each file gets a `# module_name` heading, then its items follow. Multiple files produce a single markdown document with multiple `#` sections.
-- **Simple format**: files are separated by a `// --- module_name ---` comment line.
+When multiple files are given, their outputs are concatenated into a single markdown document. Each file gets a `# module_name` heading, then its items follow.
 
 ```sh
 # Concatenates all core library docs into one document
 wado doc lib/core/**/*.wado > stdlib-reference.md
 
 # Cheatsheet for the entire stdlib
-wado doc --simple lib/core/**/*.wado > stdlib-cheatsheet.wado
+wado doc --simple lib/core/**/*.wado > stdlib-cheatsheet.md
 ```
 
 Files are output in the order they are given (or glob-expanded).

--- a/docs/wep-2026-02-28-doc-command.md
+++ b/docs/wep-2026-02-28-doc-command.md
@@ -64,23 +64,27 @@ The `..` signals that the struct cannot be constructed externally (some fields a
 ### CLI Interface
 
 ```sh
-wado doc [options] [file.wado...]
+wado doc [file.wado...]
 
 # Single file
-wado doc lib/core/prelude/traits.wado     # print docs for one file
+wado doc lib/core/prelude/traits.wado
 
 # Multiple files / glob
-wado doc lib/core/**/*.wado               # print docs for matching files
+wado doc lib/core/**/*.wado
 
 # Project mode (with wado.toml)
-wado doc                                  # document all project source files
+wado doc
+
+# Simple format (cheatsheet-style pseudo-code)
+wado doc --simple lib/core/**/*.wado
 ```
 
-| Flag     | Description |
-| -------- | ----------- |
-| `--help` | Show usage  |
+| Flag       | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `--simple` | Compact pseudo-code output (for cheatsheet generation) |
+| `--help`   | Show usage                                         |
 
-Output goes to stdout. Redirect with shell (`> file.md`) for file output.
+Default output is `full` (structured markdown). Output goes to stdout.
 
 ### Extraction Strategy: CommentMap-Based (No AST Changes)
 
@@ -114,109 +118,220 @@ pub enum CommentKind {
 
 The lexer detects `///` and `//!` patterns after the initial `//` and assigns the appropriate kind. This enables the formatter to preserve doc comment style and the doc tool to efficiently filter for doc comments.
 
-### Markdown Output Format
+### Output Formats
 
-```markdown
-# module_name
+Both formats use the same source as input:
 
-Module-level doc from `//!` comments.
+```wado
+//! Core trait definitions for equality and ordering.
 
-## Functions
+/// Equality comparisons (== and !=).
+pub trait Eq {
+    /// Returns true if self equals other.
+    fn eq(&self, other: &Self) -> bool;
+}
 
-### `pub fn foo(x: i32) -> String`
+/// Ordering comparisons (<, <=, >, >=).
+pub trait Ord {
+    fn cmp(&self, other: &Self) -> Ordering;
+}
 
-Doc comment for foo.
+/// A 2D point.
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
 
-### `export fn run()`
+pub struct Config {
+    pub name: String,
+    secret: i32,
+}
 
-Doc comment for run.
+impl Point {
+    pub fn origin() -> Point { ... }
+    pub fn distance(&self, other: &Point) -> f64 { ... }
+    fn internal_helper(&self) { ... }
+}
 
-## Structs
+pub type Meters = f64;
+pub global PI: f64 = 3.14159;
 
-### `pub struct Point { x: i32, y: i32 }`
+pub enum Color { Red, Green, Blue }
 
-Doc comment for Point.
+pub variant Shape {
+    Circle(f64),
+    Rectangle([f64, f64]),
+    Point,
+}
 
-#### Fields
+export fn run() { ... }
+```
 
-- `x: i32` — The x coordinate.
-- `y: i32` — The y coordinate.
+#### Full (default)
 
-### `pub struct Config { name: String, .. }`
+Structured markdown with doc comments, field descriptions, and method documentation. Suitable for reference documentation and static site generation.
 
-Doc comment for Config. Private fields are hidden with `..`.
+Output (`wado doc file.wado`):
 
-#### Fields
+````markdown
+# file
 
-- `name: String` — The config name.
+Core trait definitions for equality and ordering.
 
 ## Traits
 
 ### `pub trait Eq`
 
-Doc comment for Eq.
+Equality comparisons (== and !=).
 
 #### Methods
 
-- `fn eq(&self, other: &Self) -> bool` — Doc comment for eq.
+- `fn eq(&self, other: &Self) -> bool` — Returns true if self equals other.
 
-## Enums
+### `pub trait Ord`
 
-### `pub enum Color`
+Ordering comparisons (<, <=, >, >=).
 
-Doc comment for Color.
+#### Methods
 
-#### Cases
+- `fn cmp(&self, other: &Self) -> Ordering`
 
-- `Red` — Doc for Red.
-- `Green` — Doc for Green.
+## Structs
 
-## Variants
+### `pub struct Point { x: i32, y: i32 }`
 
-### `pub variant Shape`
+A 2D point.
 
-Doc comment for Shape.
+#### Fields
 
-#### Cases
+- `x: i32`
+- `y: i32`
 
-- `Circle(f64)` — radius
-- `Rectangle([f64, f64])` — width, height
-- `Point` — no payload
+#### Methods
 
-## Effects
+- `pub fn origin() -> Point`
+- `pub fn distance(&self, other: &Point) -> f64`
 
-### `pub effect Stdout`
+### `pub struct Config { name: String, .. }`
 
-Doc comment for Stdout.
+#### Fields
+
+- `name: String`
 
 ## Types
 
 ### `pub type Meters = f64`
 
-Doc comment for Meters.
-
 ## Globals
 
 ### `pub global PI: f64`
 
-Doc comment for PI.
+## Enums
+
+### `pub enum Color { Red, Green, Blue }`
+
+## Variants
+
+### `pub variant Shape`
+
+#### Cases
+
+- `Circle(f64)`
+- `Rectangle([f64, f64])`
+- `Point`
+
+## Functions
+
+### `export fn run()`
+````
+
+Rules for full format:
+- Module doc becomes the description under the `#` heading
+- Item doc comments appear as prose under their heading
+- Fields and methods listed with doc if present, without if absent
+- Same visibility rules (pub/export only, `..` for private fields)
+- `impl` methods folded into their type's section
+
+#### Simple (`--simple`)
+
+Compact Wado pseudo-code showing the public API surface. No prose, no doc comments — just signatures. Designed for generating cheatsheets (like `docs/cheatsheet.md` stdlib sections).
+
+Output (`wado doc --simple file.wado`):
+
+```
+// core trait definitions for equality and ordering.
+
+pub trait Eq {
+    fn eq(&self, other: &Self) -> bool;
+}
+
+pub trait Ord {
+    fn cmp(&self, other: &Self) -> Ordering;
+}
+
+pub struct Point { x: i32, y: i32 }
+pub struct Config { name: String, .. }
+
+impl Point {
+    pub fn origin() -> Point;
+    pub fn distance(&self, other: &Point) -> f64;
+}
+
+pub type Meters = f64;
+pub global PI: f64;
+
+pub enum Color { Red, Green, Blue }
+
+pub variant Shape {
+    Circle(f64),
+    Rectangle([f64, f64]),
+    Point,
+}
+
+export fn run();
 ```
 
-Items without doc comments are still listed (with their signature) but have no description body.
+Rules for simple format:
+- Module doc (`//!`) becomes a `//` comment at the top (lowercased first char)
+- Item doc comments are omitted entirely
+- Function bodies replaced with `;`
+- Private fields replaced with `..`
+- Private items and methods omitted
+- `impl` blocks show only pub/export methods
+- Globals omit initializers
+- Source order preserved
 
 ### Signature Rendering
 
-Item signatures are rendered using the existing unparser infrastructure with a "signature-only" mode — function bodies, struct field initializers, and trait method bodies are omitted.
+Both formats share the same signature rendering rules, using the existing unparser infrastructure with a "signature-only" mode:
 
 ```
-pub fn foo(x: i32, y: String) -> Result<i32, String>     // parameters + return type
+pub fn foo(x: i32, y: String) -> Result<i32, String>;    // no body
 pub struct Point { x: i32, y: i32 }                       // all fields public
 pub struct Config { name: String, .. }                     // private fields hidden
-pub trait Eq                                               // trait name + type params
+pub trait Eq { ... }                                       // methods inside
 pub enum Color { Red, Green, Blue }                        // all cases
 pub variant Shape { Circle(f64), Point }                   // cases with payloads
-pub type Meters = f64                                      // base type
+pub type Meters = f64;                                     // base type
+pub global PI: f64;                                        // no initializer
 ```
+
+### Multi-File Output
+
+When multiple files are given, their outputs are concatenated into a single document. Each file becomes a top-level section:
+
+- **Full format**: each file gets a `# module_name` heading, then its items follow. Multiple files produce a single markdown document with multiple `#` sections.
+- **Simple format**: files are separated by a `// --- module_name ---` comment line.
+
+```sh
+# Concatenates all core library docs into one document
+wado doc lib/core/**/*.wado > stdlib-reference.md
+
+# Cheatsheet for the entire stdlib
+wado doc --simple lib/core/**/*.wado > stdlib-cheatsheet.wado
+```
+
+Files are output in the order they are given (or glob-expanded).
 
 ### Scope and Item Ordering
 
@@ -239,7 +354,8 @@ Nested items (struct fields, trait methods, enum/variant cases, effect methods) 
 1. Add `Doc` to `Cmd` enum in `main.rs`
 2. Create `wado-cli/src/doc.rs` with `DocOptions`, `parse_args()`, `run()`
 3. Implement doc extraction using `CommentMap::leading_comments()`
-4. Implement markdown output (pub/export items only, `..` for private fields)
+4. Implement full format (default): structured markdown with doc comments
+5. Implement simple format (`--simple`): compact Wado pseudo-code for cheatsheets
 
 ### Future
 
@@ -257,7 +373,7 @@ Nested items (struct fields, trait methods, enum/variant cases, effect methods) 
 
 - Zero AST changes — the existing `CommentMap` infrastructure handles everything
 - 571 existing `///` lines in the stdlib work immediately
-- Markdown output is both human-readable and pipeline-friendly
+- Two formats serve different needs: simple for quick API lookup, full for reference docs
 - `//!` module docs establish a file-level documentation convention early
 - `..` for private fields clearly communicates construction constraints
 
@@ -269,5 +385,5 @@ Nested items (struct fields, trait methods, enum/variant cases, effect methods) 
 ### Trade-offs
 
 - **CommentMap vs AST embedding**: CommentMap avoids touching the parser and AST, keeping the change surface minimal. AST embedding would be more robust but requires modifying every item struct. CommentMap is the right choice for Phase 1; AST embedding can be added later if needed.
-- **Markdown-first vs HTML-first**: Markdown is simpler to implement, renders well in terminals, and can be converted to HTML later. Starting with HTML would delay the initial release.
+- **Full-default vs simple-default**: Full is the expected behavior for a `doc` command — complete documentation. Simple exists for a specific use case (cheatsheet generation) and is opt-in via `--simple`.
 - **Source order vs alphabetical**: Source order respects author intent. Alphabetical is better for reference lookup. Source order is the default; alphabetical can be added as `--sort` later.

--- a/docs/wep-2026-02-28-doc-command.md
+++ b/docs/wep-2026-02-28-doc-command.md
@@ -1,0 +1,303 @@
+# WEP: Documentation Generation (`wado doc`)
+
+## Context
+
+Wado source files already use `///` doc comments extensively — the WASI stdlib alone has 500+ doc comment lines generated from WIT files, and core library files document builtins, traits, and type methods. However, these comments are currently treated as regular line comments by the lexer and have no semantic meaning to the compiler.
+
+Languages with first-class doc tooling (Rust's `rustdoc`, Go's `go doc`, Elixir's `ex_doc`) enable a documentation culture from day one. Adding `wado doc` early ensures the stdlib ships with proper docs and sets conventions before the ecosystem grows.
+
+### Current State
+
+- The lexer collects all comments into a `CommentMap` (Go-style, indexed by byte position)
+- `CommentKind` has `Line` and `Block` variants — no distinction for `///` or `//!`
+- AST items have `attrs: Vec<Attribute>` and `span: Span` but no `doc` field
+- The `CommentMap` already provides `leading_comments(span)` to find comments before an AST node
+
+## Decision
+
+### Doc Comment Syntax
+
+```wado
+//! Module-level documentation.
+//! Appears at the top of a file, before any items.
+
+/// Documents the following item (function, struct, trait, enum, variant, etc.)
+/// Supports **markdown** formatting.
+///
+/// # Examples
+///
+/// ```wado
+/// let p = Point { x: 1, y: 2 };
+/// assert p.x == 1;
+/// ```
+pub struct Point {
+    /// The x coordinate.
+    x: i32,
+    /// The y coordinate.
+    y: i32,
+}
+```
+
+**`///` (item doc):** Attaches to the immediately following item. Consecutive `///` lines are joined into a single doc string.
+
+**`//!` (module doc):** Attaches to the enclosing module (file). Must appear before any items.
+
+Doc comment text is extracted with the `/// ` prefix stripped (including the single space after `///`). A line containing only `///` becomes an empty line in the output.
+
+### CLI Interface
+
+```sh
+wado doc [options] [file.wado...]
+
+# Single file
+wado doc lib/core/prelude/traits.wado     # print docs for one file
+
+# Multiple files / glob
+wado doc lib/core/**/*.wado               # print docs for matching files
+
+# Project mode (with wado.toml)
+wado doc                                  # document all project source files
+
+# Output format
+wado doc --format markdown file.wado      # markdown output (default)
+wado doc --format json file.wado          # structured JSON output
+
+# Filtering
+wado doc --filter "TreeMap" file.wado     # show only items matching pattern
+wado doc --pub-only file.wado             # show only pub/export items
+```
+
+| Flag                  | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| `--format <fmt>`      | Output format: `markdown` (default), `json`        |
+| `--filter <pattern>`  | Show only items whose name contains the pattern    |
+| `--pub-only`          | Show only `pub` and `export` items                 |
+| `--no-private`        | Alias for `--pub-only`                             |
+| `-o <file>`           | Write output to file instead of stdout             |
+| `--help`              | Show usage                                         |
+
+### Extraction Strategy: CommentMap-Based (No AST Changes)
+
+Doc comments are extracted **post-parse** using the existing `CommentMap` infrastructure. No changes to AST node structures are required.
+
+The extraction algorithm:
+
+1. Parse the source file (get AST + `CommentMap`)
+2. For each top-level item, call `comment_map.leading_comments(&item.span)`
+3. Filter results to consecutive `///` lines immediately before the item
+4. Strip the `/// ` prefix and join into a markdown string
+5. For `//!` lines, scan comments at the file start (before the first item's span)
+
+This approach:
+- Requires **zero changes** to the parser, AST, or any compilation phase
+- Reuses the battle-tested `CommentMap` that the formatter already depends on
+- Works with existing `///` comments in the WASI stdlib without any source changes
+
+### CommentKind Extension
+
+Extend `CommentKind` to distinguish doc comments from regular comments:
+
+```rust
+pub enum CommentKind {
+    Line,         // `// ...`
+    Block,        // `/* ... */`
+    DocLine,      // `/// ...`
+    ModuleDoc,    // `//! ...`
+}
+```
+
+The lexer detects `///` and `//!` patterns after the initial `//` and assigns the appropriate kind. This enables the formatter to preserve doc comment style and the doc tool to efficiently filter for doc comments.
+
+### Markdown Output Format
+
+```markdown
+# module_name
+
+Module-level doc from `//!` comments.
+
+## Functions
+
+### `pub fn foo(x: i32) -> String`
+
+Doc comment for foo.
+
+### `export fn run()`
+
+Doc comment for run.
+
+## Structs
+
+### `pub struct Point`
+
+Doc comment for Point.
+
+#### Fields
+
+| Field | Type  | Description         |
+| ----- | ----- | ------------------- |
+| `x`   | `i32` | The x coordinate.   |
+| `y`   | `i32` | The y coordinate.   |
+
+## Traits
+
+### `trait Eq`
+
+Doc comment for Eq.
+
+#### Methods
+
+##### `fn eq(&self, other: &Self) -> bool`
+
+Doc comment for eq.
+
+## Enums
+
+### `enum Color`
+
+Doc comment for Color.
+
+#### Cases
+
+- `Red` — Doc for Red.
+- `Green` — Doc for Green.
+
+## Variants
+
+### `variant Shape`
+
+Doc comment for Shape.
+
+#### Cases
+
+- `Circle(f64)` — radius
+- `Rectangle([f64, f64])` — width, height
+- `Point` — no payload
+
+## Effects
+
+### `pub effect Stdout`
+
+Doc comment for Stdout.
+
+## Types
+
+### `type Meters = f64`
+
+Doc comment for Meters.
+
+## Globals
+
+### `pub global PI: f64`
+
+Doc comment for PI.
+```
+
+Items without doc comments are still listed (with their signature) but have no description body.
+
+### JSON Output Format
+
+```json
+{
+  "module": "core/prelude/traits",
+  "module_doc": "Core trait definitions.",
+  "items": [
+    {
+      "kind": "trait",
+      "name": "Eq",
+      "visibility": "pub",
+      "signature": "trait Eq",
+      "doc": "Equality comparisons (== and !=).",
+      "methods": [
+        {
+          "name": "eq",
+          "signature": "fn eq(&self, other: &Self) -> bool",
+          "doc": "Returns true if self equals other."
+        }
+      ]
+    },
+    {
+      "kind": "struct",
+      "name": "Point",
+      "visibility": "pub",
+      "signature": "struct Point",
+      "doc": "A 2D point.",
+      "fields": [
+        { "name": "x", "type": "i32", "doc": "The x coordinate." },
+        { "name": "y", "type": "i32", "doc": "The y coordinate." }
+      ]
+    }
+  ]
+}
+```
+
+JSON output enables downstream tools (static site generators, IDE tooltips, search indexes).
+
+### Signature Rendering
+
+Item signatures are rendered using the existing unparser infrastructure with a "signature-only" mode — function bodies, struct field initializers, and trait method bodies are omitted.
+
+```
+fn foo(x: i32, y: String) -> Result<i32, String>    // parameters + return type
+struct Point { x: i32, y: i32 }                      // fields with types
+trait Eq                                              // trait name + type params
+enum Color { Red, Green, Blue }                       // all cases
+variant Shape { Circle(f64), Point }                  // cases with payloads
+type Meters = f64                                     // base type
+```
+
+### Scope and Item Ordering
+
+Items in the output follow their source order (not alphabetical). This respects the author's intentional arrangement — often the most important item comes first.
+
+Nested items (struct fields, trait methods, enum/variant cases, effect methods) are included under their parent.
+
+`impl` blocks are folded into their target type's section. If `struct Point` has methods defined across multiple `impl Point` blocks, they appear together under the Point section.
+
+## Implementation Plan
+
+### Phase 1: CommentKind + Lexer (Minimal)
+
+1. Add `DocLine` and `ModuleDoc` to `CommentKind`
+2. Update lexer's `lex_line_comment()` to detect `///` and `//!`
+3. Update formatter to preserve doc comment style (emit `///` not `//`)
+
+### Phase 2: `wado doc` CLI (Core)
+
+1. Add `Doc` to `Cmd` enum in `main.rs`
+2. Create `wado-cli/src/doc.rs` with `DocOptions`, `parse_args()`, `run()`
+3. Implement doc extraction using `CommentMap::leading_comments()`
+4. Implement markdown output
+
+### Phase 3: JSON Output + Filtering
+
+1. Add `--format json` output
+2. Add `--filter` and `--pub-only` options
+3. Add `-o` file output
+
+### Future
+
+- HTML output with cross-references and search
+- `wado doc --serve` for local doc server
+- Integration with package registry for published docs
+- Intra-doc links: `` [`Point`] `` resolves to the Point section
+
+## Consequences
+
+### Positive
+
+- Zero AST changes — the existing `CommentMap` infrastructure handles everything
+- 571 existing `///` lines in the stdlib work immediately
+- Markdown output is both human-readable and pipeline-friendly
+- JSON output enables IDE integration and static site generation
+- `//!` module docs establish a file-level documentation convention early
+
+### Negative
+
+- Position-based doc extraction is fragile if comments are separated from items by blank lines (mitigated: require consecutive lines immediately before the item)
+- No type-resolved links in Phase 1 (e.g., linking `Point` in a doc comment to the Point definition)
+
+### Trade-offs
+
+- **CommentMap vs AST embedding**: CommentMap avoids touching the parser and AST, keeping the change surface minimal. AST embedding would be more robust but requires modifying every item struct. CommentMap is the right choice for Phase 1; AST embedding can be added later if needed.
+- **Markdown-first vs HTML-first**: Markdown is simpler to implement, renders well in terminals, and can be converted to HTML later. Starting with HTML would delay the initial release.
+- **Source order vs alphabetical**: Source order respects author intent. Alphabetical is better for reference lookup. Source order is the default; alphabetical can be added as `--sort` later.

--- a/docs/wep-2026-02-28-doc-command.md
+++ b/docs/wep-2026-02-28-doc-command.md
@@ -17,7 +17,7 @@ Languages with first-class doc tooling (Rust's `rustdoc`, Go's `go doc`, Elixir'
 
 ### Doc Comment Syntax
 
-```wado
+````wado
 //! Module-level documentation.
 //! Appears at the top of a file, before any items.
 
@@ -36,13 +36,13 @@ pub struct Point {
     /// The y coordinate.
     y: i32,
 }
-```
+````
 
 **`///` (item doc):** Attaches to the immediately following item. Consecutive `///` lines are joined into a single doc string.
 
 **`//!` (module doc):** Attaches to the enclosing module (file). Must appear before any items.
 
-Doc comment text is extracted with the `/// ` prefix stripped (including the single space after `///`). A line containing only `///` becomes an empty line in the output.
+Doc comment text is extracted with the `///` prefix stripped (including the single space after `///`). A line containing only `///` becomes an empty line in the output.
 
 ### Visibility: Public API Only
 
@@ -79,10 +79,10 @@ wado doc
 wado doc --simple lib/core/**/*.wado
 ```
 
-| Flag       | Description                                        |
-| ---------- | -------------------------------------------------- |
+| Flag       | Description                                            |
+| ---------- | ------------------------------------------------------ |
 | `--simple` | Compact pseudo-code output (for cheatsheet generation) |
-| `--help`   | Show usage                                         |
+| `--help`   | Show usage                                             |
 
 Default output is `full` (structured markdown). Output goes to stdout.
 
@@ -95,10 +95,11 @@ The extraction algorithm:
 1. Parse the source file (get AST + `CommentMap`)
 2. For each top-level item, call `comment_map.leading_comments(&item.span)`
 3. Filter results to consecutive `///` lines immediately before the item
-4. Strip the `/// ` prefix and join into a markdown string
+4. Strip the `///` prefix and join into a markdown string
 5. For `//!` lines, scan comments at the file start (before the first item's span)
 
 This approach:
+
 - Requires **zero changes** to the parser, AST, or any compilation phase
 - Reuses the battle-tested `CommentMap` that the formatter already depends on
 - Works with existing `///` comments in the WASI stdlib without any source changes
@@ -173,7 +174,7 @@ Structured markdown with doc comments, field descriptions, and method documentat
 
 Output (`wado doc file.wado`):
 
-````markdown
+```markdown
 # file
 
 Core trait definitions for equality and ordering.
@@ -243,9 +244,10 @@ A 2D point.
 ## Functions
 
 ### `export fn run()`
-````
+```
 
 Rules for full format:
+
 - Module doc becomes the description under the `#` heading
 - Item doc comments appear as prose under their heading
 - Fields and methods listed with doc if present, without if absent
@@ -254,7 +256,7 @@ Rules for full format:
 
 #### Simple (`--simple`)
 
-Compressed markdown in the style of `docs/cheatsheet.md`. Uses `##` headings and ` ```wado ` code blocks to pack signatures densely. Designed for generating stdlib cheatsheets.
+Compressed markdown in the style of `docs/cheatsheet.md`. Uses `##` headings and `` ```wado `` code blocks to pack signatures densely. Designed for generating stdlib cheatsheets.
 
 Output (`wado doc --simple file.wado`):
 
@@ -325,8 +327,9 @@ export fn run();
 ````
 
 Rules for simple format:
+
 - Same markdown structure as full (`#` module, `##` categories) but no `###` per item
-- All items of the same category grouped into a single ` ```wado ` block
+- All items of the same category grouped into a single `` ```wado `` block
 - Doc comments omitted entirely — signatures only
 - `impl` blocks rendered as separate code blocks under their type's category
 - Function bodies replaced with `;`, globals omit initializers
@@ -394,7 +397,7 @@ Nested items (struct fields, trait methods, enum/variant cases, effect methods) 
 - HTML output with cross-references and search
 - `wado doc --serve` for local doc server
 - Integration with package registry for published docs
-- Intra-doc links: `` [`Point`] `` resolves to the Point section
+- Intra-doc links: ``[`Point`]`` resolves to the Point section
 
 ## Consequences
 

--- a/docs/wep-2026-02-28-doc-command.md
+++ b/docs/wep-2026-02-28-doc-command.md
@@ -44,6 +44,23 @@ pub struct Point {
 
 Doc comment text is extracted with the `/// ` prefix stripped (including the single space after `///`). A line containing only `///` becomes an empty line in the output.
 
+### Visibility: Public API Only
+
+`wado doc` outputs **only `pub` and `export` items**. Private items are implementation details and are excluded — there is no flag to include them.
+
+For structs with private fields, the struct is documented but private fields are represented as `..`:
+
+```wado
+pub struct Config {
+    pub name: String,
+    secret: i32,       // private
+}
+```
+
+Output signature: `pub struct Config { name: String, .. }`
+
+The `..` signals that the struct cannot be constructed externally (some fields are hidden). Public fields are still documented individually.
+
 ### CLI Interface
 
 ```sh
@@ -57,24 +74,13 @@ wado doc lib/core/**/*.wado               # print docs for matching files
 
 # Project mode (with wado.toml)
 wado doc                                  # document all project source files
-
-# Output format
-wado doc --format markdown file.wado      # markdown output (default)
-wado doc --format json file.wado          # structured JSON output
-
-# Filtering
-wado doc --filter "TreeMap" file.wado     # show only items matching pattern
-wado doc --pub-only file.wado             # show only pub/export items
 ```
 
-| Flag                  | Description                                        |
-| --------------------- | -------------------------------------------------- |
-| `--format <fmt>`      | Output format: `markdown` (default), `json`        |
-| `--filter <pattern>`  | Show only items whose name contains the pattern    |
-| `--pub-only`          | Show only `pub` and `export` items                 |
-| `--no-private`        | Alias for `--pub-only`                             |
-| `-o <file>`           | Write output to file instead of stdout             |
-| `--help`              | Show usage                                         |
+| Flag     | Description |
+| -------- | ----------- |
+| `--help` | Show usage  |
+
+Output goes to stdout. Redirect with shell (`> file.md`) for file output.
 
 ### Extraction Strategy: CommentMap-Based (No AST Changes)
 
@@ -127,32 +133,36 @@ Doc comment for run.
 
 ## Structs
 
-### `pub struct Point`
+### `pub struct Point { x: i32, y: i32 }`
 
 Doc comment for Point.
 
 #### Fields
 
-| Field | Type  | Description         |
-| ----- | ----- | ------------------- |
-| `x`   | `i32` | The x coordinate.   |
-| `y`   | `i32` | The y coordinate.   |
+- `x: i32` — The x coordinate.
+- `y: i32` — The y coordinate.
+
+### `pub struct Config { name: String, .. }`
+
+Doc comment for Config. Private fields are hidden with `..`.
+
+#### Fields
+
+- `name: String` — The config name.
 
 ## Traits
 
-### `trait Eq`
+### `pub trait Eq`
 
 Doc comment for Eq.
 
 #### Methods
 
-##### `fn eq(&self, other: &Self) -> bool`
-
-Doc comment for eq.
+- `fn eq(&self, other: &Self) -> bool` — Doc comment for eq.
 
 ## Enums
 
-### `enum Color`
+### `pub enum Color`
 
 Doc comment for Color.
 
@@ -163,7 +173,7 @@ Doc comment for Color.
 
 ## Variants
 
-### `variant Shape`
+### `pub variant Shape`
 
 Doc comment for Shape.
 
@@ -181,7 +191,7 @@ Doc comment for Stdout.
 
 ## Types
 
-### `type Meters = f64`
+### `pub type Meters = f64`
 
 Doc comment for Meters.
 
@@ -194,55 +204,18 @@ Doc comment for PI.
 
 Items without doc comments are still listed (with their signature) but have no description body.
 
-### JSON Output Format
-
-```json
-{
-  "module": "core/prelude/traits",
-  "module_doc": "Core trait definitions.",
-  "items": [
-    {
-      "kind": "trait",
-      "name": "Eq",
-      "visibility": "pub",
-      "signature": "trait Eq",
-      "doc": "Equality comparisons (== and !=).",
-      "methods": [
-        {
-          "name": "eq",
-          "signature": "fn eq(&self, other: &Self) -> bool",
-          "doc": "Returns true if self equals other."
-        }
-      ]
-    },
-    {
-      "kind": "struct",
-      "name": "Point",
-      "visibility": "pub",
-      "signature": "struct Point",
-      "doc": "A 2D point.",
-      "fields": [
-        { "name": "x", "type": "i32", "doc": "The x coordinate." },
-        { "name": "y", "type": "i32", "doc": "The y coordinate." }
-      ]
-    }
-  ]
-}
-```
-
-JSON output enables downstream tools (static site generators, IDE tooltips, search indexes).
-
 ### Signature Rendering
 
 Item signatures are rendered using the existing unparser infrastructure with a "signature-only" mode — function bodies, struct field initializers, and trait method bodies are omitted.
 
 ```
-fn foo(x: i32, y: String) -> Result<i32, String>    // parameters + return type
-struct Point { x: i32, y: i32 }                      // fields with types
-trait Eq                                              // trait name + type params
-enum Color { Red, Green, Blue }                       // all cases
-variant Shape { Circle(f64), Point }                  // cases with payloads
-type Meters = f64                                     // base type
+pub fn foo(x: i32, y: String) -> Result<i32, String>     // parameters + return type
+pub struct Point { x: i32, y: i32 }                       // all fields public
+pub struct Config { name: String, .. }                     // private fields hidden
+pub trait Eq                                               // trait name + type params
+pub enum Color { Red, Green, Blue }                        // all cases
+pub variant Shape { Circle(f64), Point }                   // cases with payloads
+pub type Meters = f64                                      // base type
 ```
 
 ### Scope and Item Ordering
@@ -261,21 +234,18 @@ Nested items (struct fields, trait methods, enum/variant cases, effect methods) 
 2. Update lexer's `lex_line_comment()` to detect `///` and `//!`
 3. Update formatter to preserve doc comment style (emit `///` not `//`)
 
-### Phase 2: `wado doc` CLI (Core)
+### Phase 2: `wado doc` CLI
 
 1. Add `Doc` to `Cmd` enum in `main.rs`
 2. Create `wado-cli/src/doc.rs` with `DocOptions`, `parse_args()`, `run()`
 3. Implement doc extraction using `CommentMap::leading_comments()`
-4. Implement markdown output
-
-### Phase 3: JSON Output + Filtering
-
-1. Add `--format json` output
-2. Add `--filter` and `--pub-only` options
-3. Add `-o` file output
+4. Implement markdown output (pub/export items only, `..` for private fields)
 
 ### Future
 
+- `--filter <pattern>` to show only items matching a name pattern
+- `-o <file>` to write output to a file
+- JSON output format for programmatic consumption
 - HTML output with cross-references and search
 - `wado doc --serve` for local doc server
 - Integration with package registry for published docs
@@ -288,8 +258,8 @@ Nested items (struct fields, trait methods, enum/variant cases, effect methods) 
 - Zero AST changes — the existing `CommentMap` infrastructure handles everything
 - 571 existing `///` lines in the stdlib work immediately
 - Markdown output is both human-readable and pipeline-friendly
-- JSON output enables IDE integration and static site generation
 - `//!` module docs establish a file-level documentation convention early
+- `..` for private fields clearly communicates construction constraints
 
 ### Negative
 


### PR DESCRIPTION
## Summary

This PR introduces a Wado Enhancement Proposal (WEP) that specifies the design and implementation strategy for a documentation generation tool (`wado doc`). The proposal establishes conventions for doc comments, output formats, and CLI interface to enable first-class documentation support in the Wado ecosystem.

## Key Changes

- **Doc Comment Syntax**: Defines `///` for item documentation and `//!` for module-level documentation, following conventions established by Rust and other modern languages
- **CommentKind Extension**: Proposes extending the `CommentKind` enum to distinguish doc comments (`DocLine`, `ModuleDoc`) from regular comments, enabling efficient filtering and formatter preservation
- **Extraction Strategy**: Specifies a post-parse, CommentMap-based approach that requires zero changes to the parser or AST, reusing existing infrastructure
- **Output Formats**: 
  - **Full format** (default): Structured markdown with doc comments, field descriptions, and method documentation
  - **Simple format** (`--simple`): Compact pseudo-code output for cheatsheet generation
- **Visibility Rules**: Documents that only `pub` and `export` items are included; private fields in public structs are represented as `..`
- **CLI Interface**: Specifies command syntax, flags (`--simple`, `--help`), and multi-file handling
- **Implementation Plan**: Phases out the minimal lexer changes needed (Phase 1) and the CLI tool implementation (Phase 2), with future enhancements identified

## Notable Details

- The proposal leverages the existing `CommentMap` infrastructure already used by the formatter, avoiding parser modifications
- Works immediately with 571+ existing `///` doc comment lines in the WASI stdlib without source changes
- Establishes clear conventions for module documentation (`//!`), item documentation (`///`), and field documentation
- Addresses handling of mixed visibility (public structs with private fields) through the `..` notation
- Preserves source order in output, respecting author intent for item arrangement

https://claude.ai/code/session_01WDBvEqRrq3uumJT9Y5hmJE