### PR TITLE
Fix pattern binding local variable naming to use counters

### DIFF
--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -4190,7 +4190,7 @@ impl FunctionTranslator<'_, '_> {
 
     /// Emit pattern bindings (local.set for bound variables).
     fn emit_pattern_bindings(
-        &self,
+        &mut self,
         pattern: &TirPattern,
         scrut_local: &str,
         scrut_type: TypeId,
@@ -4248,7 +4248,8 @@ impl FunctionTranslator<'_, '_> {
                 // Try to get the case type for ref.cast + struct.get
                 if let Some(case_type_id) = self.ctx.type_map.get(&case_fq).cloned() {
                     // Use a temp local to hold the cast result (avoids repeated ref.cast)
-                    let cast_local = format!("__cast_{case_fq}");
+                    self.local_counter += 1;
+                    let cast_local = format!("__cast_{}", self.local_counter);
                     instrs.push(WirInstr::DeclareLocal {
                         name: cast_local.clone(),
                         ty: WirType::Ref {
@@ -4286,7 +4287,9 @@ impl FunctionTranslator<'_, '_> {
                             if let Some(tuple_type_id) =
                                 self.get_case_payload_ref_type(&case_type_id, i)
                             {
-                                let tuple_local = format!("__tuple_payload_{case_fq}_{i}");
+                                self.local_counter += 1;
+                                let tuple_local =
+                                    format!("__tuple_payload_{}", self.local_counter);
                                 instrs.push(WirInstr::DeclareLocal {
                                     name: tuple_local.clone(),
                                     ty: WirType::Ref {
@@ -4359,7 +4362,9 @@ impl FunctionTranslator<'_, '_> {
                             TirPattern::Wildcard => {}
                             _ => {
                                 // Nested pattern: store in temp and recurse
-                                let temp_name = format!("__tuple_elem_{i}");
+                                self.local_counter += 1;
+                                let temp_name =
+                                    format!("__tuple_elem_{}", self.local_counter);
                                 let elem_type =
                                     element_types.get(i).copied().unwrap_or(TypeTable::UNKNOWN);
                                 let elem_wir_type =
@@ -4405,7 +4410,9 @@ impl FunctionTranslator<'_, '_> {
                             TirPattern::Wildcard => {}
                             _ => {
                                 // For nested patterns, store in a temp and recurse
-                                let temp_name = format!("__struct_field_{}", field.field_name);
+                                self.local_counter += 1;
+                                let temp_name =
+                                    format!("__struct_field_{}", self.local_counter);
                                 let field_type =
                                     self.resolve_struct_field_type(scrut_type, &field.field_name);
                                 let field_wir_type =

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -4288,8 +4288,7 @@ impl FunctionTranslator<'_, '_> {
                                 self.get_case_payload_ref_type(&case_type_id, i)
                             {
                                 self.local_counter += 1;
-                                let tuple_local =
-                                    format!("__tuple_payload_{}", self.local_counter);
+                                let tuple_local = format!("__tuple_payload_{}", self.local_counter);
                                 instrs.push(WirInstr::DeclareLocal {
                                     name: tuple_local.clone(),
                                     ty: WirType::Ref {
@@ -4363,8 +4362,7 @@ impl FunctionTranslator<'_, '_> {
                             _ => {
                                 // Nested pattern: store in temp and recurse
                                 self.local_counter += 1;
-                                let temp_name =
-                                    format!("__tuple_elem_{}", self.local_counter);
+                                let temp_name = format!("__tuple_elem_{}", self.local_counter);
                                 let elem_type =
                                     element_types.get(i).copied().unwrap_or(TypeTable::UNKNOWN);
                                 let elem_wir_type =
@@ -4411,8 +4409,7 @@ impl FunctionTranslator<'_, '_> {
                             _ => {
                                 // For nested patterns, store in a temp and recurse
                                 self.local_counter += 1;
-                                let temp_name =
-                                    format!("__struct_field_{}", self.local_counter);
+                                let temp_name = format!("__struct_field_{}", self.local_counter);
                                 let field_type =
                                     self.resolve_struct_field_type(scrut_type, &field.field_name);
                                 let field_wir_type =

--- a/wado-compiler/tests/fixtures.golden.wir/match_variant_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/match_variant_basic.wir.wado
@@ -225,9 +225,9 @@ fn run() with Stdout {
     let __match_scrut_0: ref null Shape;
     __match_scrut_0 = circle;
     area1 = if ref.test Shape::Circle(__match_scrut_0) -> f64 {
-        let __cast_wado-compiler/tests/fixtures/match_variant_basic.wado//Shape::Circle: ref Shape::Circle;
-        __cast_wado-compiler/tests/fixtures/match_variant_basic.wado//Shape::Circle = ref.cast Shape::Circle(__match_scrut_0);
-        __local_2 = __cast_wado-compiler/tests/fixtures/match_variant_basic.wado//Shape::Circle.payload_0;
+        let __cast_1: ref Shape::Circle;
+        __cast_1 = ref.cast Shape::Circle(__match_scrut_0);
+        __local_2 = __cast_1.payload_0;
         (3.14159 * __local_2) * __local_2;
     } else if __match_scrut_0.discriminant == 1 -> f64 {
         0;
@@ -251,9 +251,9 @@ fn run() with Stdout {
     let __match_scrut_1: ref null Shape;
     __match_scrut_1 = point;
     area2 = if ref.test Shape::Circle(__match_scrut_1) -> f64 {
-        let __cast_wado-compiler/tests/fixtures/match_variant_basic.wado//Shape::Circle: ref Shape::Circle;
-        __cast_wado-compiler/tests/fixtures/match_variant_basic.wado//Shape::Circle = ref.cast Shape::Circle(__match_scrut_1);
-        __local_6 = __cast_wado-compiler/tests/fixtures/match_variant_basic.wado//Shape::Circle.payload_0;
+        let __cast_2: ref Shape::Circle;
+        __cast_2 = ref.cast Shape::Circle(__match_scrut_1);
+        __local_6 = __cast_2.payload_0;
         (3.14159 * __local_6) * __local_6;
     } else if __match_scrut_1.discriminant == 1 -> f64 {
         0;


### PR DESCRIPTION
## Summary
Changed the `emit_pattern_bindings` method to use a counter-based naming scheme for temporary local variables instead of embedding fully-qualified names or field names directly in variable names. This ensures unique, collision-free variable names and makes the generated code more maintainable.

## Key Changes
- Changed `emit_pattern_bindings` from `&self` to `&mut self` to allow mutation of `local_counter`
- Replaced hardcoded temporary variable names with counter-based names:
  - `__cast_{case_fq}` → `__cast_{counter}`
  - `__tuple_payload_{case_fq}_{i}` → `__tuple_payload_{counter}`
  - `__tuple_elem_{i}` → `__tuple_elem_{counter}`
  - `__struct_field_{field_name}` → `__struct_field_{counter}`
- Each temporary variable declaration now increments `self.local_counter` before generating the name

## Implementation Details
This change prevents potential variable name collisions that could occur when using fully-qualified names or field names directly. The counter-based approach ensures each temporary variable gets a unique identifier, improving code generation reliability and making the generated WebAssembly IR more predictable.

https://claude.ai/code/session_01SJW1EPKPQhUWo4ngC3kWAu