### PR TITLE
Validate trait bounds on inferred generic type arguments

### DIFF
--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1699,13 +1699,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         for bound in bounds {
                             if !self.type_implements_trait(type_arg, bound) {
                                 let type_name = self.type_id_to_string(type_arg);
-                                let _ =
-                                    self.logger.error(TypeError::TraitBoundNotSatisfied {
-                                        type_name,
-                                        trait_name: bound.clone(),
-                                        param_name: param_name.clone(),
-                                        span: struct_lit.span,
-                                    });
+                                let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
+                                    type_name,
+                                    trait_name: bound.clone(),
+                                    param_name: param_name.clone(),
+                                    span: struct_lit.span,
+                                });
                             }
                         }
                     }

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1692,6 +1692,26 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             }
 
+            // Check trait bounds on inferred type arguments
+            if let Some(struct_info) = self.struct_fields.get(&struct_name).cloned() {
+                for (i, (param_name, bounds)) in struct_info.type_param_bounds.iter().enumerate() {
+                    if let Some(&type_arg) = type_args.get(i) {
+                        for bound in bounds {
+                            if !self.type_implements_trait(type_arg, bound) {
+                                let type_name = self.type_id_to_string(type_arg);
+                                let _ =
+                                    self.logger.error(TypeError::TraitBoundNotSatisfied {
+                                        type_name,
+                                        trait_name: bound.clone(),
+                                        param_name: param_name.clone(),
+                                        span: struct_lit.span,
+                                    });
+                            }
+                        }
+                    }
+                }
+            }
+
             let struct_type = self.type_table.borrow_mut().make_generic_instance(
                 struct_name.clone(),
                 struct_module_source.clone(),

--- a/wado-compiler/tests/fixtures/trait_bound_crossmod_violation.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_crossmod_violation.wado
@@ -11,4 +11,4 @@ export fn run() {
 }
 
 __DATA__
-{"TODO": true, "compile_error": "does not implement trait 'Summable'"}
+{"compile_error": "does not implement trait 'Summable'"}

--- a/wado-compiler/tests/fixtures/trait_bound_multi_violation.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_multi_violation.wado
@@ -28,4 +28,4 @@ export fn run() {
 }
 
 __DATA__
-{"TODO": true, "compile_error": "does not implement trait 'Clickable'"}
+{"compile_error": "does not implement trait 'Clickable'"}


### PR DESCRIPTION
## Summary
This PR adds validation of trait bounds on inferred generic type arguments during struct literal resolution. Previously, trait bound violations on generic type parameters were not being caught during compilation, allowing invalid code to pass type checking.

## Key Changes
- Added trait bound validation logic in the struct literal resolver that checks each inferred type argument against the declared bounds of its corresponding type parameter
- When a type argument fails to satisfy a trait bound, a `TraitBoundNotSatisfied` error is now properly reported with the type name, trait name, parameter name, and source span
- Updated test fixtures to remove `TODO` markers, indicating these previously-failing test cases now correctly detect and report trait bound violations

## Implementation Details
The validation is performed after type argument inference but before creating the generic instance. For each type parameter with declared bounds, the resolver:
1. Retrieves the struct's type parameter bounds from `struct_fields`
2. Iterates through each bound for the corresponding type argument
3. Calls `type_implements_trait()` to verify the type argument satisfies the bound
4. Reports a `TraitBoundNotSatisfied` error if validation fails

This ensures trait bounds are enforced consistently across module boundaries and complex generic scenarios.

https://claude.ai/code/session_014duEfW34avNDKLrksFezgj