### PR TITLE
Document Wasm Component Model async primitives and resource redesign

### DIFF
--- a/docs/research-wasm-cm.md
+++ b/docs/research-wasm-cm.md
@@ -246,6 +246,28 @@ Same pattern as stream close operations.
 - **Core signature**: `(subtask: i32) -> i32`
 - **Returns**: status code or BLOCKED (if async flag set)
 
+### 4.4 task.cancel
+
+```
+(canon task.cancel (core func $f))
+```
+
+- **Core signature**: `() -> ()`
+- **Semantics**: cancels the current task (self-cancellation). No parameters because
+  it implicitly applies to the task executing this call.
+
+### 4.5 backpressure.inc / backpressure.dec
+
+```
+(canon backpressure.inc (core func $f))
+(canon backpressure.dec (core func $f))
+```
+
+- **Core signature**: `() -> ()`
+- **Semantics**: increment/decrement the backpressure counter for the current component
+  instance. While the counter is > 0, the runtime will not schedule new calls into
+  this instance, providing flow control for async exports.
+
 ---
 
 ## 5. Waitable Set Operations
@@ -835,19 +857,21 @@ From `vendor/wasm-tools/crates/wasm-encoder/src/component/canonicals.rs`:
 |                 | write             | `...::stream_write`             |
 |                 | cancel-read       | `...::stream_cancel_read`       |
 |                 | cancel-write      | `...::stream_cancel_write`      |
-|                 | close-readable    | `...::stream_close_readable`    |
-|                 | close-writable    | `...::stream_close_writable`    |
+|                 | close-readable    | `...::stream_drop_readable`     |
+|                 | close-writable    | `...::stream_drop_writable`     |
 | **Future**      | new               | `...::future_new`               |
 |                 | read              | `...::future_read`              |
 |                 | write             | `...::future_write`             |
 |                 | cancel-read       | `...::future_cancel_read`       |
 |                 | cancel-write      | `...::future_cancel_write`      |
-|                 | close-readable    | `...::future_close_readable`    |
-|                 | close-writable    | `...::future_close_writable`    |
+|                 | close-readable    | `...::future_drop_readable`     |
+|                 | close-writable    | `...::future_drop_writable`     |
 | **Task**        | return            | `...::task_return`              |
 |                 | cancel            | `...::task_cancel`              |
 | **Subtask**     | drop              | `...::subtask_drop`             |
 |                 | cancel            | `...::subtask_cancel`           |
+| **Backpressure**| inc               | `...::backpressure_inc`         |
+|                 | dec               | `...::backpressure_dec`         |
 | **Waitable**    | set.new           | `...::waitable_set_new`         |
 |                 | set.wait          | `...::waitable_set_wait`        |
 |                 | set.poll          | `...::waitable_set_poll`        |

--- a/docs/research-wasm-cm.md
+++ b/docs/research-wasm-cm.md
@@ -24,6 +24,7 @@ wasmtime v41+.
 9. [WASI P3 Interface Patterns](#9-wasi-p3-interface-patterns)
 10. [Stream/Future Lifecycle Patterns](#10-streamfuture-lifecycle-patterns)
 11. [Pitfalls and Ordering Constraints](#11-pitfalls-and-ordering-constraints)
+12. [Wado-Level Error Handling Mapping](#12-wado-level-error-handling-mapping)
 
 ---
 
@@ -768,6 +769,58 @@ subtask_drop(handle)              // safe after completion
 
 `future.write` can only be called once per future. A second call will trap.
 This is unlike streams, which support multiple writes.
+
+---
+
+## 12. Wado-Level Error Handling Mapping
+
+This section documents how CM ReturnCode values map to Wado-level types
+in the resource method signatures.
+
+### 12.1 ReturnCode → Wado Type Mapping
+
+| Operation | CM Return | Wado Mapping |
+|-----------|-----------|-------------|
+| `future.read` — COMPLETED | Value at ptr | `Option::Some(value)` |
+| `future.read` — DROPPED | No value | `Option::None` |
+| `future.read` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
+| `future.write` — COMPLETED | Value delivered | Returns normally |
+| `future.write` — DROPPED | Reader gone | Returns normally (no-op, value discarded) |
+| `future.write` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
+| `stream.read` — COMPLETED | `count` items | `Array<T>` with `count` elements |
+| `stream.read` — DROPPED | EOF, last items | Empty `Array<T>` (EOF signal) |
+| `stream.read` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
+| `stream.write` — COMPLETED | `count` items | Returns normally |
+| `stream.write` — DROPPED | Reader gone | Returns normally (no-op) |
+| `stream.write` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
+
+### 12.2 Future::read Returns Option<T>
+
+`Future::read(&self) -> Option<T>`:
+
+- `Some(value)` — writer fulfilled the future (COMPLETED)
+- `None` — writer dropped without fulfilling (DROPPED)
+
+DROPPED is a **normal condition**: the writer may be cancelled, or close the writable
+end without calling `future.write`. Returning `Option<T>` rather than bare `T` avoids
+trapping on a recoverable situation.
+
+### 12.3 Application Errors vs Transfer Errors
+
+Application-level errors are encoded in the **payload type**, not in ReturnCode:
+
+```
+Future<Result<Response, ErrorCode>>
+       ~~~~~~~~~~~~~~~~~~~~~~~~
+       This is the payload type T. ErrorCode is application-level.
+```
+
+ReturnCode only indicates the **transfer status** — did the CM transfer succeed?
+A COMPLETED return with `Result::Err(ErrorCode)` means: "the future was fulfilled,
+and the fulfillment value is an error."
+
+`ErrorContext` is a separate CM resource for carrying debug messages across component
+boundaries. It is not used for stream/future operational errors.
 
 ---
 

--- a/docs/research-wasm-cm.md
+++ b/docs/research-wasm-cm.md
@@ -1,0 +1,870 @@
+# Wasm Component Model Async Primitives — Research Reference
+
+This document is a permanent reference for the Wasm Component Model (CM) async primitives
+used by the Wado compiler. It covers `stream`, `future`, `error-context`, and the async
+calling convention as specified by WASI P3 (0.3.0-rc-2026-01-06) and implemented in
+wasmtime v41+.
+
+> **Source**: `vendor/wasmtime/` (wasmtime implementation),
+> `vendor/wasm-tools/` (wasm-encoder canonical opcodes),
+> `vendor/wasi/` (WASI proposals).
+
+---
+
+## Table of Contents
+
+1. [Core Concepts](#1-core-concepts)
+2. [Stream Operations](#2-stream-operations)
+3. [Future Operations](#3-future-operations)
+4. [Task and Subtask Operations](#4-task-and-subtask-operations)
+5. [Waitable Set Operations](#5-waitable-set-operations)
+6. [Error Context Operations](#6-error-context-operations)
+7. [Return Value Encoding](#7-return-value-encoding)
+8. [Async Calling Convention](#8-async-calling-convention)
+9. [WASI P3 Interface Patterns](#9-wasi-p3-interface-patterns)
+10. [Stream/Future Lifecycle Patterns](#10-streamfuture-lifecycle-patterns)
+11. [Pitfalls and Ordering Constraints](#11-pitfalls-and-ordering-constraints)
+
+---
+
+## 1. Core Concepts
+
+### stream\<T\>
+
+A unidirectional, typed data channel between two ends:
+- **Readable end** (rx): the consumer reads data from this handle.
+- **Writable end** (tx): the producer writes data to this handle.
+
+Created as a pair via `stream.new`. Closing the writable end signals EOF to readers.
+Closing the readable end signals cancellation to writers.
+
+Streams transfer data through **linear memory** — the CM runtime copies items between
+the guest's memory and the host's internal buffers. The element type `T` determines the
+layout (size, alignment) of each item in memory.
+
+### future\<T\>
+
+A one-shot async value:
+- **Readable end** (rx): the consumer waits for the value.
+- **Writable end** (tx): the producer fulfills the value exactly once.
+
+Created as a pair via `future.new`. Dropping the writable end without writing cancels
+the future.
+
+### Subtask
+
+When a guest calls an `async func` import, the CM runtime creates a **subtask** that
+represents the in-flight async operation. The subtask handle is a waitable — it can be
+joined to a waitable set to wait for completion.
+
+### Waitable Set
+
+A multiplexing primitive. Multiple waitables (streams, futures, subtasks) can be joined
+to a set. `waitable-set.wait` blocks until any member becomes ready.
+
+### Error Context
+
+An opaque handle carrying debug information about errors. Used for structured error
+propagation across component boundaries.
+
+---
+
+## 2. Stream Operations
+
+All stream operations are **canonical built-in functions** emitted by the Wasm component
+encoder. They do NOT appear in WIT — they are part of the canonical ABI.
+
+### 2.1 stream.new
+
+```
+(canon stream.new $stream_type (core func $f))
+```
+
+- **Core signature**: `() -> i64`
+- **Returns**: packed `(rx: u32, tx: u32)` — `rx` in low 32 bits, `tx` in high 32 bits.
+- **Semantics**: creates a fresh stream pair of the given element type.
+
+### 2.2 stream.read
+
+```
+(canon stream.read $stream_type $options (core func $f))
+```
+
+- **Core signature**: `(rx: i32, ptr: i32, count: i32) -> i32`
+- **Parameters**:
+  - `rx`: readable stream handle
+  - `ptr`: guest memory address to write items into
+  - `count`: maximum number of items to read
+- **Returns**: `ReturnCode` (see [§7](#7-return-value-encoding))
+  - `BLOCKED (0xFFFF_FFFF)`: no data available yet, stream still open
+  - `COMPLETED | (n << 4)`: read `n` items successfully
+  - `DROPPED | (n << 4)`: writer closed, last `n` items available
+  - `CANCELLED | (n << 4)`: operation cancelled
+- **Semantics**: non-blocking. Tries to read up to `count` items. If no data is
+  available and the writer hasn't closed, returns BLOCKED. The caller must then
+  use a waitable set to wait for readiness.
+
+### 2.3 stream.write
+
+```
+(canon stream.write $stream_type $options (core func $f))
+```
+
+- **Core signature**: `(tx: i32, ptr: i32, count: i32) -> i32`
+- **Parameters**:
+  - `tx`: writable stream handle
+  - `ptr`: guest memory address to read items from
+  - `count`: number of items to write
+- **Returns**: `ReturnCode`
+  - `BLOCKED`: reader's buffer is full, try again later
+  - `COMPLETED | (n << 4)`: wrote `n` items
+  - `DROPPED | (n << 4)`: reader was dropped
+  - `CANCELLED | (n << 4)`: operation cancelled
+- **Semantics**: non-blocking. Writes items from memory to the stream.
+
+### 2.4 stream.cancel-read / stream.cancel-write
+
+```
+(canon stream.cancel-read $stream_type async? (core func $f))
+(canon stream.cancel-write $stream_type async? (core func $f))
+```
+
+- **Core signature**: `(handle: i32) -> i32`
+- **Parameters**: the stream handle (rx for cancel-read, tx for cancel-write)
+- **Returns**: `ReturnCode` — `CANCELLED | (n << 4)` or `BLOCKED`
+- **`async` flag**: if set, may return BLOCKED; if unset, blocks until cancelled.
+
+### 2.5 stream.close-readable / stream.close-writable
+
+```
+(canon stream.close-readable $stream_type (core func $f))
+(canon stream.close-writable $stream_type (core func $f))
+```
+
+- **Core signature**: `(handle: i32)` → no return (trap on invalid handle)
+- **Semantics**:
+  - `close-writable`: signals EOF to readers. Future reads return DROPPED.
+  - `close-readable`: signals cancellation to writers. Future writes return DROPPED.
+
+> **Note on naming**: In Wado's `builtin.wado`, these are named `stream-drop-readable`
+> and `stream-drop-writable` following the wasmtime naming. The canonical spec uses
+> `stream.close-readable` / `stream.close-writable`.
+
+---
+
+## 3. Future Operations
+
+### 3.1 future.new
+
+```
+(canon future.new $future_type (core func $f))
+```
+
+- **Core signature**: `() -> i64`
+- **Returns**: packed `(rx: u32, tx: u32)` — same encoding as stream.new.
+
+### 3.2 future.write
+
+```
+(canon future.write $future_type $options (core func $f))
+```
+
+- **Core signature**: `(tx: i32, ptr: i32) -> i32`
+- **Parameters**:
+  - `tx`: writable future handle
+  - `ptr`: guest memory address containing the value to write
+- **Returns**: `ReturnCode`
+  - `COMPLETED | (0 << 4)`: value written successfully (count is always 0 for futures)
+  - `BLOCKED`: reader not ready (rare; typically completes immediately)
+  - `DROPPED`: reader was dropped
+- **Semantics**: fulfills the future with the value at `ptr`. Can only be called once.
+
+### 3.3 future.read
+
+```
+(canon future.read $future_type $options (core func $f))
+```
+
+- **Core signature**: `(rx: i32, ptr: i32) -> i32`
+- **Parameters**:
+  - `rx`: readable future handle
+  - `ptr`: guest memory address to write the result into
+- **Returns**: `ReturnCode`
+  - `BLOCKED`: future not yet fulfilled
+  - `COMPLETED`: value available at `ptr`
+  - `DROPPED`: writer dropped without fulfilling
+
+### 3.4 future.cancel-read / future.cancel-write
+
+Same pattern as stream cancel operations.
+
+### 3.5 future.close-readable / future.close-writable
+
+Same pattern as stream close operations.
+
+- `close-writable` without prior `future.write` = **cancel** the future.
+- `close-readable` = stop waiting, signal disinterest to writer.
+
+---
+
+## 4. Task and Subtask Operations
+
+### 4.1 task.return
+
+```
+(canon task.return $result_type $options (core func $f))
+```
+
+- **Core signature**: `(flat_args...) -> ()`
+  The number and types of flat args depend on the result type.
+- **Semantics**: delivers the async function's return value to the CM runtime
+  **without terminating the Wasm function**. The function continues executing
+  after `task.return` — this is essential for fulfilling outstanding futures
+  and closing streams.
+- **Constraints**:
+  - Only valid inside an `async`-lifted export.
+  - Must be called exactly once per task.
+  - Regular `return` is forbidden in async function bodies.
+
+### 4.2 subtask.drop
+
+```
+(canon subtask.drop (core func $f))
+```
+
+- **Core signature**: `(subtask: i32) -> ()`
+- **Semantics**: drops a completed subtask handle. Must be called after the subtask
+  reaches `Returned` status. Traps if called on a still-running subtask.
+
+### 4.3 subtask.cancel
+
+```
+(canon subtask.cancel async? (core func $f))
+```
+
+- **Core signature**: `(subtask: i32) -> i32`
+- **Returns**: status code or BLOCKED (if async flag set)
+
+---
+
+## 5. Waitable Set Operations
+
+### 5.1 waitable-set.new
+
+```
+(canon waitable-set.new (core func $f))
+```
+
+- **Core signature**: `() -> i32`
+- **Returns**: waitable set handle.
+
+### 5.2 waitable.join
+
+```
+(canon waitable.join (core func $f))
+```
+
+- **Core signature**: `(waitable: i32, set: i32) -> ()`
+- **Parameters**:
+  - `waitable`: handle to a stream, future, or subtask
+  - `set`: waitable set handle (pass 0 to remove from current set)
+- **Semantics**: adds the waitable to the set. When the waitable becomes ready,
+  `waitable-set.wait` will return with that waitable's information.
+
+### 5.3 waitable-set.wait
+
+```
+(canon waitable-set.wait (core func $f))
+```
+
+- **Core signature**: `(set: i32, payload_ptr: i32) -> i32`
+- **Parameters**:
+  - `set`: waitable set handle
+  - `payload_ptr`: guest memory address (8 bytes, 4-byte aligned)
+- **Writes to payload_ptr**:
+  - `+0 (u32)`: waitable handle that became ready
+  - `+4 (u32)`: event-specific payload (ReturnCode or Status)
+- **Returns**: event code:
+  - `0` = EVENT_NONE
+  - `1` = EVENT_SUBTASK — payload is Status (see [§8.1](#81-status-encoding))
+  - `2` = EVENT_STREAM_READ — payload is ReturnCode
+  - `3` = EVENT_STREAM_WRITE — payload is ReturnCode
+  - `4` = EVENT_FUTURE_READ — payload is ReturnCode
+  - `5` = EVENT_FUTURE_WRITE — payload is ReturnCode
+  - `6` = EVENT_CANCELLED
+- **Semantics**: blocks until any waitable in the set is ready. This is the
+  fundamental blocking primitive for async coordination.
+
+### 5.4 waitable-set.poll
+
+Same as `waitable-set.wait` but **non-blocking**. Returns EVENT_NONE if nothing ready.
+
+### 5.5 waitable-set.drop
+
+```
+(canon waitable-set.drop (core func $f))
+```
+
+- **Core signature**: `(set: i32) -> ()`
+
+---
+
+## 6. Error Context Operations
+
+### 6.1 error-context.new
+
+```
+(canon error-context.new $options (core func $f))
+```
+
+- **Core signature**: `(debug_msg_ptr: i32, debug_msg_len: i32) -> i32`
+- **Returns**: error context handle
+- **Semantics**: creates an error context with a UTF-8 debug message from memory.
+
+### 6.2 error-context.debug-message
+
+```
+(canon error-context.debug-message $options (core func $f))
+```
+
+- **Core signature**: `(handle: i32, out_ptr: i32) -> ()`
+- **Semantics**: writes the debug message's (ptr, len) pair to `out_ptr`.
+  The runtime allocates via `realloc` and writes the string to memory.
+
+### 6.3 error-context.drop
+
+```
+(canon error-context.drop (core func $f))
+```
+
+- **Core signature**: `(handle: i32) -> ()`
+
+---
+
+## 7. Return Value Encoding
+
+All stream/future read/write operations return a 32-bit `ReturnCode`:
+
+```
+BLOCKED sentinel: 0xFFFF_FFFF (u32::MAX)
+  → operation did not complete; caller must wait via waitable set.
+
+Normal return: (count << 4) | status
+  → count: number of items processed (28-bit, max 2^28-1)
+  → status (4-bit):
+      0 = COMPLETED  — operation succeeded
+      1 = DROPPED    — the other end was closed/dropped
+      2 = CANCELLED  — operation was explicitly cancelled
+```
+
+**Decoding example**:
+```
+result = stream_read(rx, ptr, 100);
+if result == 0xFFFF_FFFF {
+    // BLOCKED — no data available, use waitable set
+} else {
+    status = result & 0xF;      // 0, 1, or 2
+    count  = result >> 4;       // number of items
+    if status == 0 {
+        // COMPLETED: read `count` items at ptr
+    } else if status == 1 {
+        // DROPPED: writer closed, `count` final items at ptr
+    } else {
+        // CANCELLED
+    }
+}
+```
+
+---
+
+## 8. Async Calling Convention
+
+### 8.1 Status Encoding
+
+When an async function is called via `canon lower async`, the return value encodes
+the subtask status:
+
+```
+Bits 0-3: status
+    0 = Starting     — async guest task is being set up
+    1 = Started      — async host task is in flight
+    2 = Returned     — sync completion (task finished immediately)
+    3 = StartCancelled
+    4 = ReturnCancelled
+
+Bits 4-31: subtask handle (28-bit)
+    Non-zero if status is Starting or Started (task still in flight).
+    Zero if status is Returned (task already completed).
+```
+
+**Decoding**:
+```
+packed = call_async_import(args...);
+status = packed & 0xF;
+handle = packed >> 4;
+
+if handle != 0 {
+    // Async: task in flight. Must wait for completion.
+    waitable_join(handle, waitable_set);
+    waitable_set_wait(waitable_set, payload_ptr);
+    subtask_drop(handle);
+} else {
+    // Sync: task completed immediately (status == Returned == 2).
+}
+```
+
+### 8.2 Event Codes
+
+Events returned by `waitable-set.wait`:
+
+| Code | Name               | Payload           |
+|------|--------------------|-------------------|
+| 0    | EVENT_NONE         | —                 |
+| 1    | EVENT_SUBTASK      | Status (§8.1)     |
+| 2    | EVENT_STREAM_READ  | ReturnCode (§7)   |
+| 3    | EVENT_STREAM_WRITE | ReturnCode (§7)   |
+| 4    | EVENT_FUTURE_READ  | ReturnCode (§7)   |
+| 5    | EVENT_FUTURE_WRITE | ReturnCode (§7)   |
+| 6    | EVENT_CANCELLED    | —                 |
+
+### 8.3 Async Export (canon lift async)
+
+When the host calls an async-lifted export:
+
+1. The host calls the core Wasm function (the "start" function).
+2. The core function runs until it calls `task.return` or exits.
+3. If `task.return` is called, the result is delivered to the host,
+   but the core function **continues executing** (post-return phase).
+4. The core function eventually returns (exits), completing the task.
+
+This two-phase model (pre-return + post-return) is essential for HTTP handlers
+that need to fulfill trailers futures after delivering the response.
+
+### 8.4 Async Import (canon lower async)
+
+When the guest calls an async-lowered import:
+
+1. The guest calls the core import function with arguments.
+2. The import returns a packed status (§8.1).
+3. If the handle is non-zero, the import hasn't completed yet.
+   The guest must wait via a waitable set.
+4. When the subtask completes (EVENT_SUBTASK with Returned status),
+   the result is available and the subtask handle must be dropped.
+
+### 8.5 Constants
+
+```
+MAX_FLAT_ASYNC_PARAMS = 4    (vs 16 for sync calls)
+MAX_FLAT_ASYNC_RESULTS = 4   (vs 16 for sync calls)
+```
+
+Async functions with more than 4 flat params/results use pointer-based
+argument passing through linear memory.
+
+---
+
+## 9. WASI P3 Interface Patterns
+
+### 9.1 CLI — stdout/stderr (write)
+
+```wit
+// wasi:cli/stdout@0.3.0-rc-2026-01-06
+interface stdout {
+    use types.{error-code};
+    write-via-stream: async func(data: stream<u8>) -> result<_, error-code>;
+}
+```
+
+**Pattern**: caller creates a stream, passes the **readable end** to `write-via-stream`,
+writes data to the **writable end**, then closes the writable end. The async function
+completes when all data is consumed.
+
+**Sequence**:
+```
+1. [rx, tx] = stream.new<u8>()
+2. subtask = call write-via-stream(rx)     ← pass readable end
+3. stream.write(tx, data_ptr, data_len)    ← write data
+4. stream.close-writable(tx)               ← signal EOF
+5. wait for subtask completion             ← blocks until host consumes all data
+6. subtask.drop(handle)
+```
+
+### 9.2 CLI — stdin (read)
+
+```wit
+// wasi:cli/stdin@0.3.0-rc-2026-01-06
+interface stdin {
+    use types.{error-code};
+    read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+}
+```
+
+**Pattern**: returns a stream of incoming bytes and a future for the completion result.
+The stream is **created by the host** — the guest reads from it.
+
+**Sequence**:
+```
+1. [stream_rx, done_future_rx] = call read-via-stream()
+2. loop:
+     result = stream.read(stream_rx, buf_ptr, buf_len)
+     if result == BLOCKED → wait on waitable set
+     if status == DROPPED → EOF, exit loop
+     if status == COMPLETED → process `count` bytes
+3. stream.close-readable(stream_rx)
+4. check done_future_rx for error status
+5. future.close-readable(done_future_rx)
+```
+
+### 9.3 Filesystem — read/write
+
+```wit
+// wasi:filesystem/types@0.3.0-rc-2026-01-06 (on descriptor resource)
+read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
+write-via-stream: async func(data: stream<u8>, offset: filesize) -> result<_, error-code>;
+append-via-stream: async func(data: stream<u8>) -> result<_, error-code>;
+read-directory: async func() -> tuple<stream<directory-entry>, future<result<_, error-code>>>;
+```
+
+Same patterns as CLI: reads return `tuple<stream, future>`, writes are `async func`
+taking a stream.
+
+### 9.4 HTTP — Request and Response
+
+```wit
+// wasi:http/types@0.3.0-rc-2026-01-06
+resource request {
+    new: static func(
+        headers: headers,
+        contents: option<stream<u8>>,
+        trailers: future<result<option<trailers>, error-code>>,
+        options: option<request-options>,
+    ) -> tuple<request, future<result<_, error-code>>>;
+
+    consume-body: static func(
+        this: request,
+        res: future<result<_, error-code>>,
+    ) -> tuple<stream<u8>, future<result<option<trailers>, error-code>>>;
+}
+
+resource response {
+    new: static func(
+        headers: headers,
+        contents: option<stream<u8>>,
+        trailers: future<result<option<trailers>, error-code>>,
+    ) -> tuple<response, future<result<_, error-code>>>;
+
+    consume-body: static func(
+        this: response,
+        res: future<result<_, error-code>>,
+    ) -> tuple<stream<u8>, future<result<option<trailers>, error-code>>>;
+}
+```
+
+```wit
+// wasi:http/handler@0.3.0-rc-2026-01-06
+interface handler {
+    handle: async func(request: request) -> result<response, error-code>;
+}
+
+// wasi:http/client@0.3.0-rc-2026-01-06
+interface client {
+    send: async func(request: request) -> result<response, error-code>;
+}
+```
+
+### 9.5 Common WIT Patterns Summary
+
+| Operation       | WIT Pattern                                                       | Who creates stream? |
+|-----------------|-------------------------------------------------------------------|---------------------|
+| **Write to**    | `async func(data: stream<T>) -> result<_, E>`                    | Guest (caller)      |
+| **Read from**   | `func() -> tuple<stream<T>, future<result<_, E>>>`               | Host (callee)       |
+| **HTTP new**    | `func(contents: option<stream<u8>>, trailers: future<...>) -> tuple<T, future<...>>` | Guest               |
+| **HTTP consume**| `func(this: T, res: future<...>) -> tuple<stream<u8>, future<...>>`| Host (extracts)    |
+
+---
+
+## 10. Stream/Future Lifecycle Patterns
+
+### 10.1 Producer-Writes-to-Consumer (stdout, filesystem write)
+
+```
+Guest (producer)                      Host (consumer)
+─────────────────                     ─────────────────
+[rx, tx] = stream.new()
+                                      ← rx passed to async import
+subtask = write-via-stream(rx)
+stream.write(tx, data, len)           → host reads from internal buffer
+stream.write(tx, more_data, len)      → host reads more
+stream.close-writable(tx)             → host sees EOF
+                                      → async import returns Ok/Err
+wait for subtask (EVENT_SUBTASK)
+subtask.drop(handle)
+```
+
+### 10.2 Consumer-Reads-from-Producer (stdin, filesystem read)
+
+```
+Guest (consumer)                      Host (producer)
+─────────────────                     ─────────────────
+[stream_rx, done_rx] = read-via-stream()
+                                      → host begins writing to stream
+result = stream.read(rx, buf, max)
+  if BLOCKED → join to waitable set
+            → wait → retry read
+  if COMPLETED → got data
+  if DROPPED → EOF
+stream.close-readable(rx)
+check done_rx for error
+future.close-readable(done_rx)
+```
+
+### 10.3 HTTP Response (Service Handler)
+
+```
+export async fn handle(request) -> Result<Response, ErrorCode>:
+
+1. Create trailers future pair:
+   [trailers_rx, trailers_tx] = future.new<Result<Option<Trailers>, ErrorCode>>()
+
+2. Optionally create body stream:
+   [body_rx, body_tx] = stream.new<u8>()
+
+3. Create response (passes ownership of rx handles to runtime):
+   [response, done_rx] = Response::new(headers, Some(body_rx), trailers_rx)
+
+4. task.return(Ok(response))
+   ← response headers sent to client
+
+5. POST-RETURN PHASE (function still alive):
+   stream.write(body_tx, body_data, len)
+   stream.close-writable(body_tx)
+   ← body sent to client
+
+6. Fulfill trailers:
+   future.write(trailers_tx, Ok(None))   // or Ok(Some(trailers))
+   future.close-writable(trailers_tx)
+
+7. Function returns (task complete)
+```
+
+### 10.4 HTTP Request Body Reading (Service Handler)
+
+```
+export async fn handle(request) -> Result<Response, ErrorCode>:
+
+1. Create error future for consume-body:
+   [err_rx, err_tx] = future.new<Result<(), ErrorCode>>()
+
+2. Extract body stream:
+   [body_stream, trailers_future] = Request::consume-body(request, err_rx)
+
+3. Read body:
+   loop:
+     result = stream.read(body_stream, buf, max)
+     if BLOCKED → wait
+     if DROPPED → done
+     if COMPLETED → process bytes
+
+4. Check trailers:
+   result = future.read(trailers_future, buf)
+   if BLOCKED → wait
+   → process trailers
+
+5. Signal success:
+   future.write(err_tx, Ok(()))
+   future.close-writable(err_tx)
+```
+
+---
+
+## 11. Pitfalls and Ordering Constraints
+
+### 11.1 Stream Write Order: Start Consumer First
+
+**Critical**: When writing to stdout/stderr via `write-via-stream`, the consumer
+(`write-via-stream`) must be started **before** writing to the stream.
+
+```
+✓ CORRECT:
+  subtask = write-via-stream(rx)   // start consumer first
+  stream.write(tx, data, len)      // then write
+
+✗ WRONG:
+  stream.write(tx, data, len)      // write to nobody → may block forever
+  subtask = write-via-stream(rx)   // too late
+```
+
+If data is written before the consumer exists, `stream.write` may return BLOCKED
+and there is nobody to drain the buffer.
+
+### 11.2 Must Close Writable End
+
+After writing all data to a stream, the **writable end must be closed**
+(`stream.close-writable`). Without this:
+
+- The consumer will never see EOF.
+- `write-via-stream` will never return.
+- The subtask will hang forever.
+
+### 11.3 Must Fulfill Trailers Future (HTTP)
+
+In HTTP handlers, the trailers future **must be fulfilled** after `task.return`:
+
+```
+✓ CORRECT:
+  task.return(Ok(response))
+  future.write(trailers_tx, Ok(None))
+
+✗ WRONG:
+  task.return(Ok(response))
+  // function returns without fulfilling trailers_tx
+  // → runtime gets cancelled future → protocol error
+```
+
+Even if there are no trailers, write `Ok(None)`.
+
+### 11.4 Close Body Stream Before Trailers
+
+HTTP protocol requires the body to complete before trailers. The body stream's
+writable end must be closed before the trailers future is fulfilled:
+
+```
+stream.close-writable(body_tx)        // body complete
+future.write(trailers_tx, Ok(None))   // then trailers
+```
+
+### 11.5 Handle BLOCKED Return Codes
+
+Stream/future read/write operations are **non-blocking**. A return of BLOCKED
+means the operation cannot proceed right now. The caller must:
+
+1. Join the handle to a waitable set.
+2. Call `waitable-set.wait` to block until ready.
+3. Retry the operation.
+
+Simply retrying in a busy loop without waiting wastes CPU and may never make progress.
+
+### 11.6 Memory Lifetime for stream.write / future.write
+
+The data at the memory pointer must remain valid until the operation completes.
+For non-blocking operations that return BLOCKED, the memory must remain valid
+until the operation is retried or cancelled.
+
+In practice for Wado: since `stream.write` in the current implementation always
+processes the entire buffer synchronously (wasmtime's current behavior), this is
+not yet an issue — but it may become one with truly async I/O.
+
+### 11.7 subtask.drop Requires Completion
+
+`subtask.drop` must only be called after the subtask reaches `Returned` status.
+Calling it on a running subtask will trap. Always wait for completion first:
+
+```
+waitable_set_wait(set, payload)   // blocks until EVENT_SUBTASK
+subtask_drop(handle)              // safe after completion
+```
+
+### 11.8 future.write Is One-Shot
+
+`future.write` can only be called once per future. A second call will trap.
+This is unlike streams, which support multiple writes.
+
+---
+
+## Appendix A: Canonical Built-in Opcode Reference
+
+From `vendor/wasm-tools/crates/wasm-encoder/src/component/canonicals.rs`:
+
+| Category        | Operation         | Wasm Encoder Method             |
+|-----------------|-------------------|---------------------------------|
+| **Stream**      | new               | `CanonicalFunctionSection::stream_new`    |
+|                 | read              | `...::stream_read`              |
+|                 | write             | `...::stream_write`             |
+|                 | cancel-read       | `...::stream_cancel_read`       |
+|                 | cancel-write      | `...::stream_cancel_write`      |
+|                 | close-readable    | `...::stream_close_readable`    |
+|                 | close-writable    | `...::stream_close_writable`    |
+| **Future**      | new               | `...::future_new`               |
+|                 | read              | `...::future_read`              |
+|                 | write             | `...::future_write`             |
+|                 | cancel-read       | `...::future_cancel_read`       |
+|                 | cancel-write      | `...::future_cancel_write`      |
+|                 | close-readable    | `...::future_close_readable`    |
+|                 | close-writable    | `...::future_close_writable`    |
+| **Task**        | return            | `...::task_return`              |
+|                 | cancel            | `...::task_cancel`              |
+| **Subtask**     | drop              | `...::subtask_drop`             |
+|                 | cancel            | `...::subtask_cancel`           |
+| **Waitable**    | set.new           | `...::waitable_set_new`         |
+|                 | set.wait          | `...::waitable_set_wait`        |
+|                 | set.poll          | `...::waitable_set_poll`        |
+|                 | set.drop          | `...::waitable_set_drop`        |
+|                 | join              | `...::waitable_join`            |
+| **Error Ctx**   | new               | `...::error_context_new`        |
+|                 | debug-message     | `...::error_context_debug_message` |
+|                 | drop              | `...::error_context_drop`       |
+
+## Appendix B: Flat Stream Variants
+
+For element types with a "flat" representation (no pointers, no handles — just
+plain scalars), wasmtime provides optimized `flat_stream.read` / `flat_stream.write`
+variants that include explicit `payload_size` and `payload_align` parameters.
+
+`stream<u8>` uses the flat variant since `u8` is a scalar type.
+
+## Appendix C: WASI P3 Worlds
+
+### wasi:cli/command
+
+```wit
+world command {
+    import environment;
+    import exit;
+    import types;           // error-code enum
+    import stdin;           // read-via-stream
+    import stdout;          // write-via-stream (async)
+    import stderr;          // write-via-stream (async)
+    import terminal-*;
+    import wasi:clocks/*;
+    import wasi:filesystem/*;
+    import wasi:sockets/*;
+    import wasi:random/*;
+
+    export run;             // async func() -> result
+}
+```
+
+### wasi:http/service
+
+```wit
+world service {
+    import wasi:cli/stdout;
+    import wasi:cli/stderr;
+    import wasi:cli/stdin;
+    import types;           // fields, request, response, error-code, etc.
+    import client;          // send: async func(request) -> result<response, error-code>
+    import wasi:clocks/*;
+    import wasi:random/*;
+
+    export handler;         // handle: async func(request) -> result<response, error-code>
+}
+```
+
+### wasi:http/middleware
+
+Same as service but also imports `handler` (the upstream handler to forward to).
+
+## Appendix D: File Locations in Vendor
+
+| What                        | Path                                                                        |
+|-----------------------------|-----------------------------------------------------------------------------|
+| WASI P3 CLI WIT             | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit`                       |
+| WASI P3 Filesystem WIT      | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit`                |
+| WASI P3 HTTP WIT            | `vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit`                 |
+| WASI P3 Clocks WIT          | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit`                    |
+| WASI P3 Sockets WIT         | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit`                   |
+| WASI P3 Random WIT          | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit`                    |
+| Canonical function sigs     | `vendor/wasmtime/crates/environ/src/component.rs`                           |
+| Stream/future runtime impl  | `vendor/wasmtime/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs` |
+| Canonical ABI encoder       | `vendor/wasm-tools/crates/wasm-encoder/src/component/canonicals.rs`         |
+| Async tests                 | `vendor/wasmtime/tests/all/component_model/async.rs`                        |

--- a/docs/research-wasm-cm.md
+++ b/docs/research-wasm-cm.md
@@ -33,6 +33,7 @@ wasmtime v41+.
 ### stream\<T\>
 
 A unidirectional, typed data channel between two ends:
+
 - **Readable end** (rx): the consumer reads data from this handle.
 - **Writable end** (tx): the producer writes data to this handle.
 
@@ -46,6 +47,7 @@ layout (size, alignment) of each item in memory.
 ### future\<T\>
 
 A one-shot async value:
+
 - **Readable end** (rx): the consumer waits for the value.
 - **Writable end** (tx): the producer fulfills the value exactly once.
 
@@ -381,6 +383,7 @@ Normal return: (count << 4) | status
 ```
 
 **Decoding example**:
+
 ```
 result = stream_read(rx, ptr, 100);
 if result == 0xFFFF_FFFF {
@@ -421,6 +424,7 @@ Bits 4-31: subtask handle (28-bit)
 ```
 
 **Decoding**:
+
 ```
 packed = call_async_import(args...);
 status = packed & 0xF;
@@ -440,15 +444,15 @@ if handle != 0 {
 
 Events returned by `waitable-set.wait`:
 
-| Code | Name               | Payload           |
-|------|--------------------|-------------------|
-| 0    | EVENT_NONE         | —                 |
-| 1    | EVENT_SUBTASK      | Status (§8.1)     |
-| 2    | EVENT_STREAM_READ  | ReturnCode (§7)   |
-| 3    | EVENT_STREAM_WRITE | ReturnCode (§7)   |
-| 4    | EVENT_FUTURE_READ  | ReturnCode (§7)   |
-| 5    | EVENT_FUTURE_WRITE | ReturnCode (§7)   |
-| 6    | EVENT_CANCELLED    | —                 |
+| Code | Name               | Payload         |
+| ---- | ------------------ | --------------- |
+| 0    | EVENT_NONE         | —               |
+| 1    | EVENT_SUBTASK      | Status (§8.1)   |
+| 2    | EVENT_STREAM_READ  | ReturnCode (§7) |
+| 3    | EVENT_STREAM_WRITE | ReturnCode (§7) |
+| 4    | EVENT_FUTURE_READ  | ReturnCode (§7) |
+| 5    | EVENT_FUTURE_WRITE | ReturnCode (§7) |
+| 6    | EVENT_CANCELLED    | —               |
 
 ### 8.3 Async Export (canon lift async)
 
@@ -503,6 +507,7 @@ writes data to the **writable end**, then closes the writable end. The async fun
 completes when all data is consumed.
 
 **Sequence**:
+
 ```
 1. [rx, tx] = stream.new<u8>()
 2. subtask = call write-via-stream(rx)     ← pass readable end
@@ -526,6 +531,7 @@ interface stdin {
 The stream is **created by the host** — the guest reads from it.
 
 **Sequence**:
+
 ```
 1. [stream_rx, done_future_rx] = call read-via-stream()
 2. loop:
@@ -597,12 +603,12 @@ interface client {
 
 ### 9.5 Common WIT Patterns Summary
 
-| Operation       | WIT Pattern                                                       | Who creates stream? |
-|-----------------|-------------------------------------------------------------------|---------------------|
-| **Write to**    | `async func(data: stream<T>) -> result<_, E>`                    | Guest (caller)      |
-| **Read from**   | `func() -> tuple<stream<T>, future<result<_, E>>>`               | Host (callee)       |
-| **HTTP new**    | `func(contents: option<stream<u8>>, trailers: future<...>) -> tuple<T, future<...>>` | Guest               |
-| **HTTP consume**| `func(this: T, res: future<...>) -> tuple<stream<u8>, future<...>>`| Host (extracts)    |
+| Operation        | WIT Pattern                                                                          | Who creates stream? |
+| ---------------- | ------------------------------------------------------------------------------------ | ------------------- |
+| **Write to**     | `async func(data: stream<T>) -> result<_, E>`                                        | Guest (caller)      |
+| **Read from**    | `func() -> tuple<stream<T>, future<result<_, E>>>`                                   | Host (callee)       |
+| **HTTP new**     | `func(contents: option<stream<u8>>, trailers: future<...>) -> tuple<T, future<...>>` | Guest               |
+| **HTTP consume** | `func(this: T, res: future<...>) -> tuple<stream<u8>, future<...>>`                  | Host (extracts)     |
 
 ---
 
@@ -801,20 +807,20 @@ in the resource method signatures.
 
 ### 12.1 ReturnCode → Wado Type Mapping
 
-| Operation | CM Return | Wado Mapping |
-|-----------|-----------|-------------|
-| `future.read` — COMPLETED | Value at ptr | `Option::Some(value)` |
-| `future.read` — DROPPED | No value | `Option::None` |
-| `future.read` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
-| `future.write` — COMPLETED | Value delivered | Returns normally |
-| `future.write` — DROPPED | Reader gone | Returns normally (no-op, value discarded) |
-| `future.write` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
-| `stream.read` — COMPLETED | `count` items | `Array<T>` with `count` elements |
-| `stream.read` — DROPPED | EOF, last items | Empty `Array<T>` (EOF signal) |
-| `stream.read` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
-| `stream.write` — COMPLETED | `count` items | Returns normally |
-| `stream.write` — DROPPED | Reader gone | Returns normally (no-op) |
-| `stream.write` — BLOCKED | (internal) | Synthesis waits via waitable-set, retries |
+| Operation                  | CM Return       | Wado Mapping                              |
+| -------------------------- | --------------- | ----------------------------------------- |
+| `future.read` — COMPLETED  | Value at ptr    | `Option::Some(value)`                     |
+| `future.read` — DROPPED    | No value        | `Option::None`                            |
+| `future.read` — BLOCKED    | (internal)      | Synthesis waits via waitable-set, retries |
+| `future.write` — COMPLETED | Value delivered | Returns normally                          |
+| `future.write` — DROPPED   | Reader gone     | Returns normally (no-op, value discarded) |
+| `future.write` — BLOCKED   | (internal)      | Synthesis waits via waitable-set, retries |
+| `stream.read` — COMPLETED  | `count` items   | `Array<T>` with `count` elements          |
+| `stream.read` — DROPPED    | EOF, last items | Empty `Array<T>` (EOF signal)             |
+| `stream.read` — BLOCKED    | (internal)      | Synthesis waits via waitable-set, retries |
+| `stream.write` — COMPLETED | `count` items   | Returns normally                          |
+| `stream.write` — DROPPED   | Reader gone     | Returns normally (no-op)                  |
+| `stream.write` — BLOCKED   | (internal)      | Synthesis waits via waitable-set, retries |
 
 ### 12.2 Future::read Returns Option<T>
 
@@ -850,36 +856,36 @@ boundaries. It is not used for stream/future operational errors.
 
 From `vendor/wasm-tools/crates/wasm-encoder/src/component/canonicals.rs`:
 
-| Category        | Operation         | Wasm Encoder Method             |
-|-----------------|-------------------|---------------------------------|
-| **Stream**      | new               | `CanonicalFunctionSection::stream_new`    |
-|                 | read              | `...::stream_read`              |
-|                 | write             | `...::stream_write`             |
-|                 | cancel-read       | `...::stream_cancel_read`       |
-|                 | cancel-write      | `...::stream_cancel_write`      |
-|                 | close-readable    | `...::stream_drop_readable`     |
-|                 | close-writable    | `...::stream_drop_writable`     |
-| **Future**      | new               | `...::future_new`               |
-|                 | read              | `...::future_read`              |
-|                 | write             | `...::future_write`             |
-|                 | cancel-read       | `...::future_cancel_read`       |
-|                 | cancel-write      | `...::future_cancel_write`      |
-|                 | close-readable    | `...::future_drop_readable`     |
-|                 | close-writable    | `...::future_drop_writable`     |
-| **Task**        | return            | `...::task_return`              |
-|                 | cancel            | `...::task_cancel`              |
-| **Subtask**     | drop              | `...::subtask_drop`             |
-|                 | cancel            | `...::subtask_cancel`           |
-| **Backpressure**| inc               | `...::backpressure_inc`         |
-|                 | dec               | `...::backpressure_dec`         |
-| **Waitable**    | set.new           | `...::waitable_set_new`         |
-|                 | set.wait          | `...::waitable_set_wait`        |
-|                 | set.poll          | `...::waitable_set_poll`        |
-|                 | set.drop          | `...::waitable_set_drop`        |
-|                 | join              | `...::waitable_join`            |
-| **Error Ctx**   | new               | `...::error_context_new`        |
-|                 | debug-message     | `...::error_context_debug_message` |
-|                 | drop              | `...::error_context_drop`       |
+| Category         | Operation      | Wasm Encoder Method                    |
+| ---------------- | -------------- | -------------------------------------- |
+| **Stream**       | new            | `CanonicalFunctionSection::stream_new` |
+|                  | read           | `...::stream_read`                     |
+|                  | write          | `...::stream_write`                    |
+|                  | cancel-read    | `...::stream_cancel_read`              |
+|                  | cancel-write   | `...::stream_cancel_write`             |
+|                  | close-readable | `...::stream_drop_readable`            |
+|                  | close-writable | `...::stream_drop_writable`            |
+| **Future**       | new            | `...::future_new`                      |
+|                  | read           | `...::future_read`                     |
+|                  | write          | `...::future_write`                    |
+|                  | cancel-read    | `...::future_cancel_read`              |
+|                  | cancel-write   | `...::future_cancel_write`             |
+|                  | close-readable | `...::future_drop_readable`            |
+|                  | close-writable | `...::future_drop_writable`            |
+| **Task**         | return         | `...::task_return`                     |
+|                  | cancel         | `...::task_cancel`                     |
+| **Subtask**      | drop           | `...::subtask_drop`                    |
+|                  | cancel         | `...::subtask_cancel`                  |
+| **Backpressure** | inc            | `...::backpressure_inc`                |
+|                  | dec            | `...::backpressure_dec`                |
+| **Waitable**     | set.new        | `...::waitable_set_new`                |
+|                  | set.wait       | `...::waitable_set_wait`               |
+|                  | set.poll       | `...::waitable_set_poll`               |
+|                  | set.drop       | `...::waitable_set_drop`               |
+|                  | join           | `...::waitable_join`                   |
+| **Error Ctx**    | new            | `...::error_context_new`               |
+|                  | debug-message  | `...::error_context_debug_message`     |
+|                  | drop           | `...::error_context_drop`              |
 
 ## Appendix B: Flat Stream Variants
 
@@ -933,15 +939,15 @@ Same as service but also imports `handler` (the upstream handler to forward to).
 
 ## Appendix D: File Locations in Vendor
 
-| What                        | Path                                                                        |
-|-----------------------------|-----------------------------------------------------------------------------|
-| WASI P3 CLI WIT             | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit`                       |
-| WASI P3 Filesystem WIT      | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit`                |
-| WASI P3 HTTP WIT            | `vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit`                 |
-| WASI P3 Clocks WIT          | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit`                    |
-| WASI P3 Sockets WIT         | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit`                   |
-| WASI P3 Random WIT          | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit`                    |
-| Canonical function sigs     | `vendor/wasmtime/crates/environ/src/component.rs`                           |
-| Stream/future runtime impl  | `vendor/wasmtime/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs` |
-| Canonical ABI encoder       | `vendor/wasm-tools/crates/wasm-encoder/src/component/canonicals.rs`         |
-| Async tests                 | `vendor/wasmtime/tests/all/component_model/async.rs`                        |
+| What                       | Path                                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------------- |
+| WASI P3 CLI WIT            | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit`                                     |
+| WASI P3 Filesystem WIT     | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit`                              |
+| WASI P3 HTTP WIT           | `vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit`                               |
+| WASI P3 Clocks WIT         | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit`                                  |
+| WASI P3 Sockets WIT        | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit`                                 |
+| WASI P3 Random WIT         | `vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit`                                  |
+| Canonical function sigs    | `vendor/wasmtime/crates/environ/src/component.rs`                                         |
+| Stream/future runtime impl | `vendor/wasmtime/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs` |
+| Canonical ABI encoder      | `vendor/wasm-tools/crates/wasm-encoder/src/component/canonicals.rs`                       |
+| Async tests                | `vendor/wasmtime/tests/all/component_model/async.rs`                                      |

--- a/docs/wep-2026-02-15-cm-adapter-synthesis.md
+++ b/docs/wep-2026-02-15-cm-adapter-synthesis.md
@@ -13,14 +13,19 @@ CM adapter synthesis replaces all of that with a single **type-driven recursive 
 ### Pipeline Position
 
 ```
-parse → desugar → modules → symbols → tir (resolve) → effect_check
-                                                            ↓
-                                                       cm_adapter_gen
-                                                            ↓
-                                       monomorphize → lower → optimize → wasm_plan → codegen
+load → analyze → resolve (TIR) → effect_check
+                                       ↓
+                                   synthesis (traits + inspect + cm_adapter)
+                                       ↓
+                    monomorphize → lower → optimize → wir_build → wir_optimize → codegen
 ```
 
-The phase runs after effect checking and before monomorphize, so adapter functions go through monomorphization, optimization, and codegen like user code.
+The CM adapter synthesis runs as part of the `synthesis` phase (alongside trait synthesis and
+inspect synthesis), after effect checking and before monomorphize. Adapter functions go through
+monomorphization, optimization, WIR translation, and codegen like user code.
+
+Note: `wasm_plan` (component planning) is now integrated into the `wir_build` phase as
+`wir_build::plan_project()`, not a standalone pipeline phase.
 
 ### Import Adapters
 
@@ -68,7 +73,7 @@ TirExprKind::CmRawCall {
 }
 ```
 
-Codegen resolves `local_name` to the imported function index. This node is also used for `task-return`, `future-write`, and other CM intrinsics in export adapters.
+Codegen resolves `local_name` to the imported function index. This node is also used for `task-return` and other CM intrinsics in export adapters. For stream/future/waitable-set CM operations, see [WEP: Redesign Wasm CM Builtins as Resource Canonical Attributes](wep-2026-03-01-cm-resource-canonical-attrs.md).
 
 ## Current State
 
@@ -266,12 +271,17 @@ Parameter count is validated, but parameter types and return type compatibility 
 ### Benefits
 
 - **Extensibility**: Any Canonical ABI type is supported by the recursive synthesizer — no per-type hand-coding.
-- **Optimization**: Adapter functions go through lower → optimize, so the optimizer can inline small adapters, eliminate dead branches, and propagate constants.
+- **Optimization**: Adapter functions go through lower → optimize → wir_optimize, so the optimizer can inline small adapters, eliminate dead branches, and propagate constants.
 - **Debuggability**: `wado dump --tir --unparse` and `wado dump --lower --unparse` show the full CM glue as Wado code.
 - **Simpler codegen**: Codegen no longer needs to know about CM lifting/lowering. It compiles adapter functions like any other function.
-- **WIR-ready**: When WIR migration begins, CM adapters are already ordinary TIR functions — no special CM translation needed in `tir_to_wir`.
+- **WIR-compatible**: CM adapters are ordinary TIR functions that translate to WIR without special handling in `wir_build`.
 
 ### Risks
 
 - **Canonical ABI correctness**: Layout computation must match the CM spec exactly. Mitigated by unit tests (37 in `cm_abi.rs`) and E2E tests against wasmtime.
 - **Performance**: Synthesized TIR may produce suboptimal Wasm compared to hand-written codegen. Mitigated by the optimizer and golden fixture comparison.
+
+## Related WEPs
+
+- [WEP: Redesign Wasm CM Builtins as Resource Canonical Attributes](wep-2026-03-01-cm-resource-canonical-attrs.md) — Moves stream/future/waitable-set canonical operations from `builtin.wado` to `#[canonical]` attributes on resource methods, complementing the import/export adapter synthesis here.
+- [WEP: WASI HTTP Integration](wep-2026-02-21-wasi-http.md) — HTTP handler patterns built on the export adapter synthesis and CM async primitives.

--- a/docs/wep-2026-02-21-wasi-http.md
+++ b/docs/wep-2026-02-21-wasi-http.md
@@ -55,7 +55,7 @@ Rules:
 - `return` is forbidden in `async fn` bodies.
 - The expression is type-checked against the declared return type of the enclosing `export async fn`.
 
-The compiler expands `task return` during the CM Adapter phase into a sequence that lowers the Wado value to flat CM ABI values and calls `builtin::task_return`. See [WEP: TIR-Level CM Adapter Synthesis](wep-2026-02-15-cm-adapter-synthesis.md) for implementation details.
+The compiler expands `task return` during the synthesis phase (CM adapter generation) into a sequence that lowers the Wado value to flat CM ABI values and calls `builtin::task_return`. See [WEP: TIR-Level CM Adapter Synthesis](wep-2026-02-15-cm-adapter-synthesis.md) for implementation details.
 
 ### 3. Trailers Future Pattern
 
@@ -240,7 +240,7 @@ HTTP test fixtures are in `wado-compiler/tests/fixtures/http-*.wado`. Each has a
 
 ### Compiler
 
-- The CM Adapter phase synthesizes a different adapter for `export async fn` vs `export fn`. The async adapter lifts parameters only; it does not wrap the return value. Instead, `task return` statements in the user function body are expanded inline into `task.return` calls. See [WEP: TIR-Level CM Adapter Synthesis](wep-2026-02-15-cm-adapter-synthesis.md).
+- The synthesis phase (CM adapter generation) synthesizes a different adapter for `export async fn` vs `export fn`. The async adapter lifts parameters only; it does not wrap the return value. Instead, `task return` statements in the user function body are expanded inline into `task.return` calls. See [WEP: TIR-Level CM Adapter Synthesis](wep-2026-02-15-cm-adapter-synthesis.md).
 - `return` in `async fn` is a compile error, detected during desugaring or type-checking.
 
 ### Runtime
@@ -253,6 +253,7 @@ HTTP test fixtures are in `wado-compiler/tests/fixtures/http-*.wado`. Each has a
 - WASI HTTP WIT: `vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit`
 - Wado HTTP types: `wado-compiler/lib/wasi/http.wado`
 - [WEP: TIR-Level CM Adapter Synthesis](wep-2026-02-15-cm-adapter-synthesis.md)
+- [WEP: Redesign Wasm CM Builtins as Resource Canonical Attributes](wep-2026-03-01-cm-resource-canonical-attrs.md)
 - [WEP: Target WASI P3 Only](wep-2026-01-11-wasi-p3-only.md)
 - WASI HTTP types: `wasi:http/types@0.3.0-rc-2026-01-06`
 - WASI HTTP handler: `wasi:http/handler@0.3.0-rc-2026-01-06`

--- a/docs/wep-2026-02-21-wasi-http.md
+++ b/docs/wep-2026-02-21-wasi-http.md
@@ -196,13 +196,12 @@ All types are imported from `"wasi:http"`.
 | ----------------------- | -------------------------------------- | -------------------------- |
 | `Client::send(request)` | `async -> Result<Response, ErrorCode>` | Send outbound HTTP request |
 
-### `FutureWritable<T>`
+### CM Async Primitives
 
-The writable end of a `Future<T>`, obtained from `Future::<T>::new()` which returns `[Future<T>, FutureWritable<T>]`.
-
-| Method               | Description                     |
-| -------------------- | ------------------------------- |
-| `tx.write(value: T)` | Resolve the future with a value |
+`Future<T>`, `FutureWritable<T>`, `Stream<T>`, and `StreamWritable<T>` are Component Model
+primitives used throughout the HTTP API. Their resource declarations, canonical attributes,
+and error handling semantics are defined in
+[WEP: Redesign Wasm CM Builtins as Resource Canonical Attributes](wep-2026-03-01-cm-resource-canonical-attrs.md).
 
 ## E2E Test Fixtures
 

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -574,3 +574,15 @@ __DATA__
 - No change to existing user-facing Stream/Future API
 - No change to Wasm output for existing programs
 - `task return` statement syntax unchanged
+
+## Related WEPs
+
+- [WEP: TIR-Level CM Adapter Synthesis](wep-2026-02-15-cm-adapter-synthesis.md) — The type-driven
+  synthesizer that generates CM ABI lowering/lifting code for import and export adapters.
+  The canonical method synthesis functions (`emit_stream_read`, etc.) proposed here complement
+  the import/export adapter synthesis: adapters handle the CM boundary crossing (flat ABI),
+  while canonical methods handle stream/future/waitable-set operations within a component.
+- [WEP: WASI HTTP Integration](wep-2026-02-21-wasi-http.md) — HTTP handler patterns that use
+  `Future<T>`, `FutureWritable<T>`, and `Stream<T>` defined here.
+- [Research: Wasm Component Model Async Primitives](../docs/research-wasm-cm.md) — Detailed
+  CM canonical API signatures and return value encoding.

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -136,10 +136,12 @@ a new CM concept — it is the same handle value that was joined, wrapped in a d
 Wado type for type safety.
 
 When `Subtask::join(set)` is called:
+
 1. The CM `waitable-join(subtask_handle, set_handle)` is invoked
 2. A `Waitable` wrapping `subtask_handle` is returned
 
 When `WaitableSet::wait()` returns a `WaitEvent`:
+
 1. The CM `waitable-set-wait(set, outptr)` writes `[handle, payload]` to linear memory
 2. The adapter loads them and constructs `WaitEvent { code, handle: Waitable(handle), payload }`
 
@@ -192,11 +194,11 @@ For futures, `count` is always 0 (single value). So the return is `0 | status` o
 
 `Future::read(&self) -> Option<T>`:
 
-| CM ReturnCode | Wado result | Meaning |
-|---------------|-------------|---------|
-| BLOCKED       | (internal)  | Wait via waitable-set, then retry |
-| COMPLETED     | `Option::Some(value)` | Writer fulfilled the future |
-| DROPPED       | `Option::None` | Writer dropped without fulfilling |
+| CM ReturnCode | Wado result           | Meaning                           |
+| ------------- | --------------------- | --------------------------------- |
+| BLOCKED       | (internal)            | Wait via waitable-set, then retry |
+| COMPLETED     | `Option::Some(value)` | Writer fulfilled the future       |
+| DROPPED       | `Option::None`        | Writer dropped without fulfilling |
 
 The synthesis handles BLOCKED internally (same pattern as `stream_read`), so the
 user never sees it. COMPLETED produces `Some(value)`, DROPPED produces `None`.
@@ -217,10 +219,10 @@ if let Some(value) = future.read() {
 
 `FutureWritable::write(&self, value: T)`:
 
-| CM ReturnCode | Wado behavior | Meaning |
-|---------------|---------------|---------|
-| BLOCKED       | (internal)    | Wait via waitable-set, then retry |
-| COMPLETED     | Returns normally | Value delivered to reader |
+| CM ReturnCode | Wado behavior            | Meaning                                 |
+| ------------- | ------------------------ | --------------------------------------- |
+| BLOCKED       | (internal)               | Wait via waitable-set, then retry       |
+| COMPLETED     | Returns normally         | Value delivered to reader               |
 | DROPPED       | Returns normally (no-op) | Reader already dropped; value discarded |
 
 DROPPED on write is silently ignored — the reader went away, but this is not an error
@@ -231,11 +233,11 @@ trailers where the reader may close before trailers are written.
 
 `Stream::read(&self, max: i32) -> Array<T>`:
 
-| CM ReturnCode | Wado result | Meaning |
-|---------------|-------------|---------|
-| BLOCKED       | (internal)  | Wait via waitable-set, then retry |
-| COMPLETED     | `Array` with `count` items | Data available |
-| DROPPED       | Empty `Array` | Writer closed (EOF) |
+| CM ReturnCode | Wado result                | Meaning                           |
+| ------------- | -------------------------- | --------------------------------- |
+| BLOCKED       | (internal)                 | Wait via waitable-set, then retry |
+| COMPLETED     | `Array` with `count` items | Data available                    |
+| DROPPED       | Empty `Array`              | Writer closed (EOF)               |
 
 For streams, DROPPED is "end of stream" — the empty array serves as the EOF signal.
 This is the existing behavior and remains unchanged.
@@ -244,11 +246,11 @@ This is the existing behavior and remains unchanged.
 
 `StreamWritable::write(&self, data: Array<T>)`:
 
-| CM ReturnCode | Wado behavior | Meaning |
-|---------------|---------------|---------|
-| BLOCKED       | (internal)    | Wait via waitable-set, then retry |
-| COMPLETED     | Returns normally | Data written |
-| DROPPED       | Returns normally (no-op) | Reader closed; data discarded |
+| CM ReturnCode | Wado behavior            | Meaning                           |
+| ------------- | ------------------------ | --------------------------------- |
+| BLOCKED       | (internal)               | Wait via waitable-set, then retry |
+| COMPLETED     | Returns normally         | Data written                      |
+| DROPPED       | Returns normally (no-op) | Reader closed; data discarded     |
 
 #### ErrorContext is Orthogonal
 
@@ -256,6 +258,7 @@ This is the existing behavior and remains unchanged.
 independent CM resource for carrying debug messages across component boundaries.
 
 Application-level errors are encoded in the payload type itself:
+
 - `Future<Result<Response, ErrorCode>>` — `ErrorCode` is in the Result, not in ReturnCode
 - `Stream<u8>` carrying HTTP body — errors go through a separate `Future<Result<...>>`
 
@@ -268,18 +271,21 @@ not application semantics.
 `Option<WaitEvent>`. The CM adapter synthesis handles linear memory details:
 
 For `wait`:
+
 1. Allocate 8 bytes via `realloc`
 2. Call `waitable-set-wait(set, addr)` → returns event code (i32)
 3. Load handle and payload: `i32_load(addr)`, `i32_load(addr+4)`
 4. Construct `WaitEvent { code, handle: Waitable(handle), payload }`
 
 For `poll`:
+
 1. Allocate 8 bytes via `realloc`
 2. Call `waitable-set-poll(set, addr)` → returns event code or sentinel
 3. If sentinel (no event): return `Option::None`
 4. Otherwise: load, construct `Option::Some(WaitEvent { ... })`
 
 For `Subtask::join`:
+
 1. Call `waitable-join(subtask_handle, set_handle)` (void return in CM)
 2. Return `Waitable(subtask_handle)` — wrap the joined handle as a token
 

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -86,7 +86,7 @@ pub resource Waitable;
 
 /// Result of `WaitableSet::wait` or `WaitableSet::poll`.
 pub struct WaitEvent {
-    pub code: i32,        // CM event code (stream-read=1, stream-write=2, etc.)
+    pub code: i32,        // CM event code (subtask=1, stream-read=2, stream-write=3, future-read=4, future-write=5, cancelled=6)
     pub handle: Waitable, // which waitable handle triggered the event
     pub payload: u32,     // event-specific data (e.g. count|status for streams)
 }
@@ -136,7 +136,7 @@ a new CM concept — it is the same handle value that was joined, wrapped in a d
 Wado type for type safety.
 
 When `Subtask::join(set)` is called:
-1. The CM `waitable-join(set_handle, subtask_handle)` is invoked
+1. The CM `waitable-join(subtask_handle, set_handle)` is invoked
 2. A `Waitable` wrapping `subtask_handle` is returned
 
 When `WaitableSet::wait()` returns a `WaitEvent`:
@@ -280,7 +280,7 @@ For `poll`:
 4. Otherwise: load, construct `Option::Some(WaitEvent { ... })`
 
 For `Subtask::join`:
-1. Call `waitable-join(set_handle, subtask_handle)` (void return in CM)
+1. Call `waitable-join(subtask_handle, set_handle)` (void return in CM)
 2. Return `Waitable(subtask_handle)` — wrap the joined handle as a token
 
 ### What Stays in builtin.wado

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -1,0 +1,266 @@
+# WEP: CM Resource Canonical Attributes
+
+## Context
+
+Component Model (CM) async primitives — `stream`, `future`, `waitable-set`, `subtask`,
+`error-context`, and `task.return` — are currently declared as bare functions in
+`builtin.wado` with `#[canonical("wasi", "...")]` attributes. The connection between
+these low-level builtins and the user-facing resource types (`Stream<T>`, `Future<T>`, etc.)
+is entirely hard-coded in Rust across multiple compiler phases:
+
+- `method_call.rs` matches type names to resolve `Stream::new()` → synthetic builtin call
+- `wir_build/translate.rs` has `try_translate_stream_method`, `try_translate_stream_writable_method`,
+  `try_translate_future_writable_method` — each 100+ lines of WIR generation
+- `optimize/dce.rs` matches `("Stream", "close")`, `("StreamWritable", "write")` etc.
+  to inject canonical builtin dependencies
+
+This design has several problems:
+
+1. **CM builtins pollute `builtin.wado`** — 14 CM functions mixed with ~60 Wasm instruction builtins
+2. **Invisible contract** — the resource method declarations in `types.wado` have no bodies
+   and nothing connects them to the canonical operations except hard-coded Rust
+3. **Hard to extend** — adding a new resource method (e.g., `Stream::cancel_read()`)
+   requires changes across 4+ Rust files
+4. **No type safety** — `builtin::stream_read(rx, ptr, len)` takes raw `i32` handles;
+   the type system doesn't enforce that `rx` is a Stream handle
+
+## Decision
+
+Move canonical operation declarations from `builtin.wado` to `#[canonical]` attributes
+on resource method declarations in `prelude/types.wado`. The compiler's CM adapter
+synthesis continues to generate the WIR glue code (memory allocation, BLOCKED handling,
+GC↔linear memory conversion), but is driven by these attributes instead of hard-coded
+type name matching.
+
+### Resource Declarations (types.wado)
+
+```wado
+pub resource Stream<T> {
+    #[canonical("stream-new")]
+    fn new() -> [Stream<T>, StreamWritable<T>];
+
+    #[canonical("stream-read")]
+    fn read(&self, max: i32) -> Array<T>;
+
+    #[canonical("stream-close-readable")]
+    fn close(&self);
+}
+
+pub resource StreamWritable<T> {
+    #[canonical("stream-write")]
+    fn write(&self, data: Array<T>);
+
+    #[canonical("stream-close-writable")]
+    fn close(&self);
+}
+
+pub resource Future<T> {
+    #[canonical("future-new")]
+    fn new() -> [Future<T>, FutureWritable<T>];
+
+    #[canonical("future-close-readable")]
+    fn close(&self);
+}
+
+pub resource FutureWritable<T> {
+    #[canonical("future-write")]
+    fn write(&self, value: T);
+
+    #[canonical("future-close-writable")]
+    fn close(&self);
+}
+
+pub resource WaitableSet {
+    #[canonical("waitable-set-new")]
+    fn new() -> WaitableSet;
+
+    #[canonical("waitable-set-wait")]
+    fn wait(&self, out_addr: i32) -> i32;
+
+    #[canonical("waitable-set-poll")]
+    fn poll(&self, out_addr: i32) -> i32;
+
+    #[canonical("waitable-set-drop")]
+    fn close(&self);
+}
+
+pub resource Subtask {
+    #[canonical("subtask-drop")]
+    fn close(&self);
+
+    #[canonical("waitable-join")]
+    fn join(&self, set: &WaitableSet);
+}
+```
+
+### What Stays in builtin.wado
+
+- All Wasm instruction builtins (array_*, i32_load, f64_sqrt, etc.)
+- `realloc` (`#[canonical("mem", "realloc")]`) — memory, not CM
+- Bundled libm functions (`#[canonical("bundled", "...")]`)
+- `call_indirect_stdout_write_via_stream` / `call_indirect_stderr_write_via_stream`
+  — ambient I/O, handled by separate codegen path
+- `inspect<T>` / `display<T>` — synthesis markers
+
+### What Gets Removed from builtin.wado
+
+All 14 CM canonical functions:
+- `stream_new`, `stream_read`, `stream_write`, `stream_drop_writable`, `stream_drop_readable`
+- `future_new`, `future_write`, `future_drop_writable`, `future_drop_readable`
+- `task_return`
+- `waitable_set_new`, `waitable_join`, `waitable_set_wait`
+- `subtask_drop`
+
+### What Gets Removed
+
+- `stream.wado` — thin wrappers around `builtin::*` functions, no longer needed
+
+### task.return
+
+`task return expr;` is a language statement, not a resource method. Its canonical operation
+`task-return` is emitted directly by the compiler when lowering the `task return` statement.
+It does not belong to any resource type.
+
+It will be declared as a standalone canonical function in `internal.wado`:
+
+```wado
+#[canonical("wasi", "task-return")]
+fn task_return(result: i32);
+```
+
+This keeps it out of `builtin.wado` (it's CM, not a Wasm instruction) while remaining
+accessible to the compiler's `task return` statement synthesis.
+
+## Compiler Changes
+
+### 1. Attribute Parsing (existing infrastructure)
+
+The `#[canonical("...")]` attribute syntax is already parsed. Resource method declarations
+are already function declarations in the AST. No parser changes needed.
+
+### 2. Resource Method Resolution (method_call.rs)
+
+Replace hard-coded type name matching with canonical attribute lookup:
+
+```rust
+// Before:
+ResolvedType::Stream(inner) if method == "new" && args.is_empty() => {
+    Some(("stream_create_pair", ...))
+}
+
+// After:
+if let Some(canonical_name) = resource_method.canonical_attr() {
+    // Dispatch to CM adapter synthesis based on canonical_name
+}
+```
+
+### 3. WIR Translation (wir_build/translate.rs)
+
+Replace `try_translate_stream_method` etc. with a unified `try_translate_canonical_method`:
+
+```rust
+fn try_translate_canonical_method(
+    &mut self,
+    receiver: &TirExpr,
+    method_info: &MethodInfo,
+    args: &[TirExpr],
+    result_type: TypeId,
+) -> Option<WirInstr> {
+    let canonical_name = method_info.canonical_name.as_ref()?;
+    match canonical_name.as_str() {
+        "stream-read" => Some(self.emit_stream_read(...)),
+        "stream-write" => Some(self.emit_stream_write(...)),
+        "stream-close-readable" | "stream-close-writable" => Some(self.emit_close(...)),
+        "stream-new" => Some(self.emit_stream_new(...)),
+        "future-new" => Some(self.emit_future_new(...)),
+        "future-write" => Some(self.emit_future_write(...)),
+        "future-close-readable" | "future-close-writable" => Some(self.emit_close(...)),
+        "waitable-set-new" => Some(self.emit_simple_canonical(...)),
+        "waitable-set-wait" => Some(self.emit_simple_canonical(...)),
+        "waitable-join" => Some(self.emit_simple_canonical(...)),
+        "subtask-drop" => Some(self.emit_simple_canonical(...)),
+        _ => None,
+    }
+}
+```
+
+The synthesis functions (`emit_stream_read`, `emit_stream_write`, etc.) remain unchanged
+in their WIR output. Only the dispatch mechanism changes.
+
+### 4. Canonical Intrinsic Registration
+
+Currently, canonical intrinsics are discovered by scanning TIR imports for
+`namespace == "wasi"`. With the new design, they are registered during WIR translation
+when a canonical method is encountered.
+
+The WIR build context will collect needed canonicals:
+
+```rust
+struct WirBuildContext {
+    needed_canonicals: IndexSet<String>,  // "stream-new", "stream-read", etc.
+    // ...
+}
+```
+
+When `try_translate_canonical_method` emits adapter code, it registers the canonical:
+
+```rust
+self.ctx.needed_canonicals.insert("stream-read".to_string());
+```
+
+The component plan then uses this set instead of filtering TIR imports.
+
+### 5. Dead Code Elimination (optimize/dce.rs)
+
+Replace hard-coded `("Stream", "close")` matching with canonical attribute lookup
+on the method info. The DCE phase already has access to method info — it just needs
+to check for the canonical attribute instead of matching on type/method name strings.
+
+### 6. MethodInfo Enhancement
+
+Add an optional `canonical_name` field to `MethodInfo`:
+
+```rust
+pub struct MethodInfo {
+    pub receiver_type: String,
+    pub method_name: String,
+    pub canonical_name: Option<String>,  // NEW: from #[canonical("...")] attribute
+}
+```
+
+This field is populated during type resolution when a resource method with a
+`#[canonical]` attribute is resolved.
+
+## Migration Path
+
+1. Add `canonical_name` field to `MethodInfo`
+2. Populate it from resource method `#[canonical]` attributes during resolution
+3. Add `try_translate_canonical_method` to WIR translation
+4. Route existing synthesis code through the new dispatch
+5. Update DCE to use canonical attributes
+6. Update component plan to collect from WIR context
+7. Remove CM functions from `builtin.wado`
+8. Remove `stream.wado`
+9. Add `WaitableSet` and `Subtask` resource types to `types.wado`
+10. Move `task_return` to `internal.wado` with `#[canonical]`
+
+## Consequences
+
+**Positive:**
+- CM operations are declared where they belong — on the resource types
+- Adding a new resource method requires only: (a) declaration in `types.wado`,
+  (b) one synthesis function in `translate.rs`
+- `builtin.wado` becomes clean: only Wasm instructions and libm
+- Resource method signatures document the user-facing API (typed handles, not raw i32)
+- `WaitableSet` and `Subtask` become first-class types, enabling advanced async patterns
+
+**Negative:**
+- The compiler still has hard-coded synthesis for each canonical operation
+  (this is inherent — each operation needs different adapter logic)
+- The `#[canonical]` attribute on resource methods is a Wado-specific extension
+  (but so was `#[canonical]` on builtins)
+
+**Neutral:**
+- No user-visible API change (Stream/Future methods remain the same)
+- No Wasm output change (same canonical intrinsics, same adapter code)
+- `task return` statement syntax unchanged

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -1,4 +1,4 @@
-# WEP: CM Resource Canonical Attributes
+# WEP: Redesign Wasm CM Builtins as Resource Canonical Attributes
 
 ## Context
 
@@ -6,31 +6,37 @@ Component Model (CM) async primitives — `stream`, `future`, `waitable-set`, `s
 `error-context`, and `task.return` — are currently declared as bare functions in
 `builtin.wado` with `#[canonical("wasi", "...")]` attributes. The connection between
 these low-level builtins and the user-facing resource types (`Stream<T>`, `Future<T>`, etc.)
-is entirely hard-coded in Rust across multiple compiler phases:
+is entirely hard-coded in Rust across five compiler phases:
 
-- `method_call.rs` matches type names to resolve `Stream::new()` → synthetic builtin call
-- `wir_build/translate.rs` has `try_translate_stream_method`, `try_translate_stream_writable_method`,
-  `try_translate_future_writable_method` — each 100+ lines of WIR generation
-- `optimize/dce.rs` matches `("Stream", "close")`, `("StreamWritable", "write")` etc.
-  to inject canonical builtin dependencies
+```
+method_call.rs   →  type name matching   →  synthetic "builtin::stream_create_pair" call
+translate.rs     →  try_translate_*       →  WIR inline synthesis (100+ lines each)
+dce.rs           →  ("Stream", "close")   →  canonical import dependency injection
+wasm_plan.rs     →  TirImport filtering   →  ComponentPlan.canonical_intrinsics
+component.rs     →  canonical name match  →  CM builder instruction
+```
 
-This design has several problems:
+Additionally, `stream.wado` provides thin wrappers (`stream_new()`, `waitable_set_new()`, etc.)
+around `builtin::*` functions, adding an unnecessary indirection layer.
 
-1. **CM builtins pollute `builtin.wado`** — 14 CM functions mixed with ~60 Wasm instruction builtins
-2. **Invisible contract** — the resource method declarations in `types.wado` have no bodies
-   and nothing connects them to the canonical operations except hard-coded Rust
-3. **Hard to extend** — adding a new resource method (e.g., `Stream::cancel_read()`)
-   requires changes across 4+ Rust files
-4. **No type safety** — `builtin::stream_read(rx, ptr, len)` takes raw `i32` handles;
-   the type system doesn't enforce that `rx` is a Stream handle
+### Problems
+
+1. **Scattered knowledge** — CM resource knowledge is hard-coded across 5 Rust files
+   with no single source of truth connecting resource methods to canonical operations
+2. **builtin.wado pollution** — 13 CM functions mixed with ~60 Wasm instruction builtins
+3. **Invisible contract** — resource declarations in `types.wado` have no bodies and
+   nothing links them to canonical operations except hard-coded Rust
+4. **Raw i32 handles** — `builtin::stream_read(rx, ptr, len)` bypasses the type system;
+   `WaitableSet` and `Subtask` exist only as raw i32 values
+5. **Missing operations** — `Future::read`, `WaitableSet`, `Subtask`, `ErrorContext`
+   are not user-facing types
 
 ## Decision
 
-Move canonical operation declarations from `builtin.wado` to `#[canonical]` attributes
-on resource method declarations in `prelude/types.wado`. The compiler's CM adapter
-synthesis continues to generate the WIR glue code (memory allocation, BLOCKED handling,
-GC↔linear memory conversion), but is driven by these attributes instead of hard-coded
-type name matching.
+Redesign the CM resource architecture from first principles. Resource method declarations
+in `types.wado` become the single source of truth via `#[canonical]` attributes. The compiler
+pipeline is restructured so that canonical intrinsic discovery flows from these attributes
+through the compilation phases, replacing all hard-coded type/method name matching.
 
 ### Resource Declarations (types.wado)
 
@@ -58,6 +64,9 @@ pub resource Future<T> {
     #[canonical("future-new")]
     fn new() -> [Future<T>, FutureWritable<T>];
 
+    #[canonical("future-read")]
+    fn read(&self) -> T;
+
     #[canonical("future-close-readable")]
     fn close(&self);
 }
@@ -75,10 +84,10 @@ pub resource WaitableSet {
     fn new() -> WaitableSet;
 
     #[canonical("waitable-set-wait")]
-    fn wait(&self, out_addr: i32) -> i32;
+    fn wait(&self) -> [i32, i32];
 
     #[canonical("waitable-set-poll")]
-    fn poll(&self, out_addr: i32) -> i32;
+    fn poll(&self) -> Option<[i32, i32]>;
 
     #[canonical("waitable-set-drop")]
     fn close(&self);
@@ -91,176 +100,331 @@ pub resource Subtask {
     #[canonical("waitable-join")]
     fn join(&self, set: &WaitableSet);
 }
+
+pub resource ErrorContext {
+    #[canonical("error-context-new")]
+    fn new(message: String) -> ErrorContext;
+
+    #[canonical("error-context-debug-message")]
+    fn debug_message(&self) -> String;
+
+    #[canonical("error-context-drop")]
+    fn close(&self);
+}
 ```
+
+### Naming: Future<T> as the Readable End
+
+`Future<T>` is the readable end (CM `future-read` handle). The CM spec names these
+`future-read` and `future-write`, so strictly speaking `Future<T>` should be
+`FutureReadable<T>`. We keep `Future<T>` because:
+
+- Most APIs receive futures (readable end); adding "Readable" is noise
+- Matches JS/Python convention where "future"/"promise" means the consumer side
+- `Stream<T>` has the same asymmetry (it's the readable end)
+
+This is documented here for clarity. A future redesign could introduce `Future<T>` as
+an effect or concept with `FutureReadable<T>` + `FutureWritable<T>` as the resource pair.
+
+### WaitableSet Wado-Level Types
+
+`WaitableSet::wait` and `WaitableSet::poll` use Wado-level types (`[i32, i32]` and
+`Option<[i32, i32]>`) instead of raw `out_addr: i32`. The CM adapter synthesis
+handles the linear memory buffer allocation and read-back:
+
+1. Allocate 8 bytes via `realloc`
+2. Call `waitable-set-wait(set, addr)` or `waitable-set-poll(set, addr)`
+3. Load `[i32_load(addr), i32_load(addr+4)]` into the return tuple
+4. Free the buffer
+
+This keeps the Wado API clean while the adapter handles CM-level details.
 
 ### What Stays in builtin.wado
 
-- All Wasm instruction builtins (array_*, i32_load, f64_sqrt, etc.)
-- `realloc` (`#[canonical("mem", "realloc")]`) — memory, not CM
+- All Wasm instruction builtins (`array_*`, `i32_load`, `f64_sqrt`, etc.)
+- `realloc` (`#[canonical("mem", "realloc")]`) — linear memory management, not CM
 - Bundled libm functions (`#[canonical("bundled", "...")]`)
 - `call_indirect_stdout_write_via_stream` / `call_indirect_stderr_write_via_stream`
   — ambient I/O, handled by separate codegen path
 - `inspect<T>` / `display<T>` — synthesis markers
+- `task_return` (`#[canonical("wasi", "task-return")]`) — language statement, not a
+  resource method
 
 ### What Gets Removed from builtin.wado
 
-All 14 CM canonical functions:
+13 CM canonical functions:
+
 - `stream_new`, `stream_read`, `stream_write`, `stream_drop_writable`, `stream_drop_readable`
 - `future_new`, `future_write`, `future_drop_writable`, `future_drop_readable`
-- `task_return`
 - `waitable_set_new`, `waitable_join`, `waitable_set_wait`
 - `subtask_drop`
 
-### What Gets Removed
+### What Gets Deleted
 
-- `stream.wado` — thin wrappers around `builtin::*` functions, no longer needed
+- `lib/core/stream.wado` — thin wrappers around `builtin::*`, replaced by resource methods
 
-### task.return
+## Architecture
 
-`task return expr;` is a language statement, not a resource method. Its canonical operation
-`task-return` is emitted directly by the compiler when lowering the `task return` statement.
-It does not belong to any resource type.
+### Current Pipeline (hard-coded)
 
-It will be declared as a standalone canonical function in `internal.wado`:
-
-```wado
-#[canonical("wasi", "task-return")]
-fn task_return(result: i32);
+```
+builtin.wado                     types.wado
+  #[canonical("wasi", "...")]      resource Stream<T> { fn read(...); }
+  fn stream_read(...)                  (no attributes, no bodies)
+         │                                      │
+         ▼                                      ▼
+  BuiltinRegistry                   method_call.rs
+  name → canonical_name              hard-coded: Stream → "stream_create_pair"
+         │                                      │
+         ▼                                      ▼
+  dce.rs                            translate.rs
+  hard-coded: ("Stream","read")       try_translate_stream_method(...)
+  → add stream_read + waitable_*     try_translate_stream_writable_method(...)
+  → populate TirImport list          try_translate_future_writable_method(...)
+         │                                      │
+         ▼                                      ▼
+  wasm_plan.rs                      WirInstr::Call { func_id }
+  filter namespace=="wasi"            via "builtin/stream_read" alias
+  → ComponentPlan.canonical_intrinsics
+         │
+         ▼
+  component.rs
+  match "stream-read" → builder.stream_read(...)
 ```
 
-This keeps it out of `builtin.wado` (it's CM, not a Wasm instruction) while remaining
-accessible to the compiler's `task return` statement synthesis.
+### New Pipeline (attribute-driven)
 
-## Compiler Changes
+```
+types.wado (single source of truth)
+  resource Stream<T> {
+      #[canonical("stream-read")]
+      fn read(&self, max: i32) -> Array<T>;
+  }
+         │
+         ▼
+  Resolver (method_lookup.rs)
+  resource method with #[canonical] attr
+  → MethodInfo { canonical_name: Some("stream-read") }
+         │
+         ▼
+  WIR Translation (translate.rs)
+  try_translate_canonical_method(method_info)
+  match canonical_name:
+    "stream-read" → emit_stream_read(...)
+                    ctx.register_canonical("stream-read")
+                    ctx.register_canonical("waitable-set-new")  // dependency
+                    ctx.register_canonical("waitable-join")
+                    ctx.register_canonical("waitable-set-wait")
+         │
+         ▼
+  WirContext.needed_canonicals: IndexSet<CanonicalImport>
+         │
+         ▼
+  ComponentPlan (wasm_plan.rs)
+  reads from WirContext, not from TirImport
+         │
+         ▼
+  Codegen (component.rs)
+  match "stream-read" → builder.stream_read(...)
+  (unchanged)
+```
 
-### 1. Attribute Parsing (existing infrastructure)
+### Key Architectural Changes
 
-The `#[canonical("...")]` attribute syntax is already parsed. Resource method declarations
-are already function declarations in the AST. No parser changes needed.
-
-### 2. Resource Method Resolution (method_call.rs)
-
-Replace hard-coded type name matching with canonical attribute lookup:
+#### 1. MethodInfo Carries Canonical Name
 
 ```rust
-// Before:
-ResolvedType::Stream(inner) if method == "new" && args.is_empty() => {
-    Some(("stream_create_pair", ...))
-}
-
-// After:
-if let Some(canonical_name) = resource_method.canonical_attr() {
-    // Dispatch to CM adapter synthesis based on canonical_name
+pub struct MethodInfo {
+    // ... existing fields ...
+    pub canonical_name: Option<String>,  // from #[canonical("...")] attribute
 }
 ```
 
-### 3. WIR Translation (wir_build/translate.rs)
+Populated by the resolver when resolving a resource method that has a `#[canonical]`
+attribute. This is the bridge between resource declarations and WIR synthesis.
 
-Replace `try_translate_stream_method` etc. with a unified `try_translate_canonical_method`:
+#### 2. Unified Canonical Method Dispatch
+
+Replace three separate interceptors with a single dispatch point:
 
 ```rust
-fn try_translate_canonical_method(
-    &mut self,
-    receiver: &TirExpr,
-    method_info: &MethodInfo,
-    args: &[TirExpr],
-    result_type: TypeId,
-) -> Option<WirInstr> {
-    let canonical_name = method_info.canonical_name.as_ref()?;
-    match canonical_name.as_str() {
-        "stream-read" => Some(self.emit_stream_read(...)),
-        "stream-write" => Some(self.emit_stream_write(...)),
-        "stream-close-readable" | "stream-close-writable" => Some(self.emit_close(...)),
-        "stream-new" => Some(self.emit_stream_new(...)),
-        "future-new" => Some(self.emit_future_new(...)),
-        "future-write" => Some(self.emit_future_write(...)),
-        "future-close-readable" | "future-close-writable" => Some(self.emit_close(...)),
-        "waitable-set-new" => Some(self.emit_simple_canonical(...)),
-        "waitable-set-wait" => Some(self.emit_simple_canonical(...)),
-        "waitable-join" => Some(self.emit_simple_canonical(...)),
-        "subtask-drop" => Some(self.emit_simple_canonical(...)),
+// Before: three separate functions, dispatched by receiver type
+if let Some(instr) = self.try_translate_future_writable_method(...) { ... }
+if let Some(instr) = self.try_translate_stream_method(...) { ... }
+if let Some(instr) = self.try_translate_stream_writable_method(...) { ... }
+
+// After: one function, dispatched by canonical attribute
+if let Some(instr) = self.try_translate_canonical_method(method_info, ...) { ... }
+```
+
+The dispatch is on `canonical_name`, not on receiver type:
+
+```rust
+fn try_translate_canonical_method(&mut self, ...) -> Option<WirInstr> {
+    let canonical = method_info.canonical_name.as_ref()?;
+    match canonical.as_str() {
+        "stream-new"             => self.emit_stream_new(...),
+        "stream-read"            => self.emit_stream_read(...),
+        "stream-write"           => self.emit_stream_write(...),
+        "stream-close-readable"  => self.emit_drop_handle("stream-close-readable", ...),
+        "stream-close-writable"  => self.emit_drop_handle("stream-close-writable", ...),
+        "future-new"             => self.emit_future_new(...),
+        "future-read"            => self.emit_future_read(...),
+        "future-write"           => self.emit_future_write(...),
+        "future-close-readable"  => self.emit_drop_handle("future-close-readable", ...),
+        "future-close-writable"  => self.emit_drop_handle("future-close-writable", ...),
+        "waitable-set-new"       => self.emit_waitable_set_new(...),
+        "waitable-set-wait"      => self.emit_waitable_set_wait(...),
+        "waitable-set-poll"      => self.emit_waitable_set_poll(...),
+        "waitable-set-drop"      => self.emit_drop_handle("waitable-set-drop", ...),
+        "waitable-join"          => self.emit_waitable_join(...),
+        "subtask-drop"           => self.emit_drop_handle("subtask-drop", ...),
+        "error-context-new"      => self.emit_error_context_new(...),
+        "error-context-debug-message" => self.emit_error_context_debug_message(...),
+        "error-context-drop"     => self.emit_drop_handle("error-context-drop", ...),
         _ => None,
     }
 }
 ```
 
-The synthesis functions (`emit_stream_read`, `emit_stream_write`, etc.) remain unchanged
-in their WIR output. Only the dispatch mechanism changes.
+Each `emit_*` function registers its own canonical dependencies, so the knowledge of
+"stream-read needs waitable-set-new + waitable-join + waitable-set-wait" lives in
+`emit_stream_read`, not in DCE.
 
-### 4. Canonical Intrinsic Registration
+#### 3. Canonical Import Registration Moves to WIR
 
-Currently, canonical intrinsics are discovered by scanning TIR imports for
-`namespace == "wasi"`. With the new design, they are registered during WIR translation
-when a canonical method is encountered.
-
-The WIR build context will collect needed canonicals:
+Currently canonical imports are collected by DCE (TIR phase) and stored in `TirImport`.
+In the new design, they are registered during WIR translation:
 
 ```rust
-struct WirBuildContext {
-    needed_canonicals: IndexSet<String>,  // "stream-new", "stream-read", etc.
+// WirBuildContext
+pub struct WirBuildContext {
+    needed_canonicals: IndexMap<String, CanonicalImport>,
     // ...
 }
-```
 
-When `try_translate_canonical_method` emits adapter code, it registers the canonical:
-
-```rust
-self.ctx.needed_canonicals.insert("stream-read".to_string());
-```
-
-The component plan then uses this set instead of filtering TIR imports.
-
-### 5. Dead Code Elimination (optimize/dce.rs)
-
-Replace hard-coded `("Stream", "close")` matching with canonical attribute lookup
-on the method info. The DCE phase already has access to method info — it just needs
-to check for the canonical attribute instead of matching on type/method name strings.
-
-### 6. MethodInfo Enhancement
-
-Add an optional `canonical_name` field to `MethodInfo`:
-
-```rust
-pub struct MethodInfo {
-    pub receiver_type: String,
-    pub method_name: String,
-    pub canonical_name: Option<String>,  // NEW: from #[canonical("...")] attribute
+pub struct CanonicalImport {
+    pub canonical_name: String,   // "stream-read"
+    pub params: Vec<WirType>,     // [I32, I32, I32]
+    pub returns: Vec<WirType>,    // [I32]
 }
 ```
 
-This field is populated during type resolution when a resource method with a
-`#[canonical]` attribute is resolved.
+Each synthesis function registers what it needs:
+
+```rust
+fn emit_stream_read(&mut self, ...) -> WirInstr {
+    let stream_read = self.ctx.ensure_canonical("stream-read", &[I32, I32, I32], &[I32]);
+    let ws_new = self.ctx.ensure_canonical("waitable-set-new", &[], &[I32]);
+    let w_join = self.ctx.ensure_canonical("waitable-join", &[I32, I32], &[]);
+    let ws_wait = self.ctx.ensure_canonical("waitable-set-wait", &[I32, I32], &[I32]);
+    // ... emit WIR using these func IDs ...
+}
+```
+
+`ensure_canonical` returns a `WirFuncId`, registering the import lazily if not
+already registered.
+
+#### 4. DCE Simplified
+
+DCE no longer needs CM-specific knowledge. It performs standard call-graph reachability
+analysis. The canonical import dependency injection (lines 202-252 in current `dce.rs`)
+is removed entirely — that responsibility now belongs to the WIR synthesis functions.
+
+DCE still handles:
+
+- Removing unreachable functions
+- Removing unused globals
+- Standard dead code elimination
+
+It does NOT handle:
+
+- ~~Matching `("Stream", "close")` → add `stream_drop_readable`~~
+- ~~Matching `("StreamWritable", "write")` → add `stream_write` + waitable_*~~
+- ~~Populating `TirImport` for canonical intrinsics~~
+
+#### 5. method_call.rs Simplified
+
+The special cases for `Stream::new()` and `Future::new()` that synthesize
+`"stream_create_pair"` / `"future_create_pair"` calls are removed. Instead,
+the resolver finds the `new` method on the resource declaration, sees its
+`#[canonical("stream-new")]` attribute, and passes it through as a normal
+method call with `canonical_name` set in `MethodInfo`.
+
+## Prelude Exports
+
+`prelude.wado` adds the new types:
+
+```wado
+pub use {
+    Option, Result,
+    Stream, StreamWritable,
+    Future, FutureWritable,
+    WaitableSet, Subtask, ErrorContext,
+} from "core:prelude/types.wado";
+```
+
+## E2E Tests
+
+WaitableSet and Subtask are user-facing, so e2e tests are required:
+
+```wado
+// tests/fixtures/waitable_set_basic.wado
+// Test that WaitableSet can be created and used directly
+export fn run() {
+    let ws = WaitableSet::new();
+    ws.close();
+    println("ok");
+}
+
+__DATA__
+{"stdout": "ok\n"}
+```
 
 ## Migration Path
 
 1. Add `canonical_name` field to `MethodInfo`
 2. Populate it from resource method `#[canonical]` attributes during resolution
-3. Add `try_translate_canonical_method` to WIR translation
-4. Route existing synthesis code through the new dispatch
-5. Update DCE to use canonical attributes
-6. Update component plan to collect from WIR context
-7. Remove CM functions from `builtin.wado`
-8. Remove `stream.wado`
-9. Add `WaitableSet` and `Subtask` resource types to `types.wado`
-10. Move `task_return` to `internal.wado` with `#[canonical]`
+3. Add `ensure_canonical` to `WirBuildContext` for lazy canonical import registration
+4. Add `try_translate_canonical_method` to WIR translation, dispatch by canonical name
+5. Move each existing `emit_*` function to register its own canonical dependencies
+6. Route existing `try_translate_stream_method` etc. through the new unified dispatch
+7. Remove CM-specific logic from DCE
+8. Update `wasm_plan.rs` to collect canonicals from WIR context
+9. Remove `method_call.rs` special cases for `Stream::new()` / `Future::new()`
+10. Add `#[canonical]` attributes to resource methods in `types.wado`
+11. Add `WaitableSet`, `Subtask`, `ErrorContext` resource declarations
+12. Add `Future::read` declaration
+13. Update `WaitableSet::wait`/`poll` to use Wado-level return types
+14. Remove 13 CM functions from `builtin.wado`
+15. Delete `stream.wado`
+16. Update prelude exports
+17. Add e2e tests for WaitableSet/Subtask
+18. Implement `emit_future_read`, `emit_waitable_set_wait`, `emit_waitable_set_poll`,
+    `emit_error_context_*` synthesis functions (or stub as compile errors)
 
 ## Consequences
 
 **Positive:**
-- CM operations are declared where they belong — on the resource types
-- Adding a new resource method requires only: (a) declaration in `types.wado`,
-  (b) one synthesis function in `translate.rs`
-- `builtin.wado` becomes clean: only Wasm instructions and libm
-- Resource method signatures document the user-facing API (typed handles, not raw i32)
-- `WaitableSet` and `Subtask` become first-class types, enabling advanced async patterns
+
+- Single source of truth: resource declarations in `types.wado` define both the
+  user-facing API and the canonical operation mapping
+- Adding a new resource method requires only: (a) declaration with `#[canonical]`
+  in `types.wado`, (b) one `emit_*` synthesis function in `translate.rs`
+- `builtin.wado` becomes clean: only Wasm instructions, libm, and `task_return`
+- WaitableSet, Subtask, ErrorContext become first-class typed resources
+- DCE is simpler and has no CM-specific knowledge
+- Type safety: handles are typed resources, not raw i32
 
 **Negative:**
-- The compiler still has hard-coded synthesis for each canonical operation
-  (this is inherent — each operation needs different adapter logic)
-- The `#[canonical]` attribute on resource methods is a Wado-specific extension
-  (but so was `#[canonical]` on builtins)
+
+- The compiler still has a hard-coded `match` on canonical names in `translate.rs`
+  (inherent — each operation needs different adapter logic)
+- New synthesis functions needed for previously unimplemented operations
+  (`future-read`, `waitable-set-wait` adapter, `waitable-set-poll`, `error-context-*`)
 
 **Neutral:**
-- No user-visible API change (Stream/Future methods remain the same)
-- No Wasm output change (same canonical intrinsics, same adapter code)
+
+- No change to existing user-facing Stream/Future API
+- No change to Wasm output for existing programs
 - `task return` statement syntax unchanged

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -79,15 +79,29 @@ pub resource FutureWritable<T> {
     fn close(&self);
 }
 
+/// Opaque token identifying a waitable handle within a WaitableSet.
+/// Obtained from `Subtask::join` (and future `Stream::join`, etc.).
+/// Compared by handle identity (==) to determine which waitable fired.
+pub resource Waitable;
+
+/// Result of `WaitableSet::wait` or `WaitableSet::poll`.
+pub struct WaitEvent {
+    pub code: i32,        // CM event code (stream-read=1, stream-write=2, etc.)
+    pub handle: Waitable, // which waitable handle triggered the event
+    pub payload: u32,     // event-specific data (e.g. count|status for streams)
+}
+
 pub resource WaitableSet {
     #[canonical("waitable-set-new")]
     fn new() -> WaitableSet;
 
+    /// Block until an event occurs. Returns the event details.
     #[canonical("waitable-set-wait")]
-    fn wait(&self) -> [i32, i32];
+    fn wait(&self) -> WaitEvent;
 
+    /// Non-blocking poll. Returns Some(event) if an event is ready, None otherwise.
     #[canonical("waitable-set-poll")]
-    fn poll(&self) -> Option<[i32, i32]>;
+    fn poll(&self) -> Option<WaitEvent>;
 
     #[canonical("waitable-set-drop")]
     fn close(&self);
@@ -97,8 +111,10 @@ pub resource Subtask {
     #[canonical("subtask-drop")]
     fn close(&self);
 
+    /// Join this subtask to a waitable set.
+    /// Returns a Waitable token that identifies this subtask in wait results.
     #[canonical("waitable-join")]
-    fn join(&self, set: &WaitableSet);
+    fn join(&self, set: &WaitableSet) -> Waitable;
 }
 
 pub resource ErrorContext {
@@ -113,6 +129,38 @@ pub resource ErrorContext {
 }
 ```
 
+### Waitable: Typed Handle Token
+
+`Waitable` is an opaque resource wrapping a CM handle (u32). It does not represent
+a new CM concept — it is the same handle value that was joined, wrapped in a distinct
+Wado type for type safety.
+
+When `Subtask::join(set)` is called:
+1. The CM `waitable-join(set_handle, subtask_handle)` is invoked
+2. A `Waitable` wrapping `subtask_handle` is returned
+
+When `WaitableSet::wait()` returns a `WaitEvent`:
+1. The CM `waitable-set-wait(set, outptr)` writes `[handle, payload]` to linear memory
+2. The adapter loads them and constructs `WaitEvent { code, handle: Waitable(handle), payload }`
+
+The user compares `event.handle` against tokens from `join`:
+
+```wado
+let ws = WaitableSet::new();
+let w1 = subtask1.join(&ws);
+let w2 = subtask2.join(&ws);
+
+let event = ws.wait();
+if event.handle == w1 {
+    // subtask1 fired
+} else if event.handle == w2 {
+    // subtask2 fired
+}
+```
+
+`Waitable` auto-derives `Eq` (compares underlying handle values). It intentionally
+does NOT expose the raw handle — users must go through `join` to obtain tokens.
+
 ### Naming: Future<T> as the Readable End
 
 `Future<T>` is the readable end (CM `future-read` handle). The CM spec names these
@@ -126,18 +174,26 @@ pub resource ErrorContext {
 This is documented here for clarity. A future redesign could introduce `Future<T>` as
 an effect or concept with `FutureReadable<T>` + `FutureWritable<T>` as the resource pair.
 
-### WaitableSet Wado-Level Types
+### WaitableSet Adapter Synthesis
 
-`WaitableSet::wait` and `WaitableSet::poll` use Wado-level types (`[i32, i32]` and
-`Option<[i32, i32]>`) instead of raw `out_addr: i32`. The CM adapter synthesis
-handles the linear memory buffer allocation and read-back:
+`WaitableSet::wait` returns `WaitEvent` and `WaitableSet::poll` returns
+`Option<WaitEvent>`. The CM adapter synthesis handles linear memory details:
 
+For `wait`:
 1. Allocate 8 bytes via `realloc`
-2. Call `waitable-set-wait(set, addr)` or `waitable-set-poll(set, addr)`
-3. Load `[i32_load(addr), i32_load(addr+4)]` into the return tuple
-4. Free the buffer
+2. Call `waitable-set-wait(set, addr)` → returns event code (i32)
+3. Load handle and payload: `i32_load(addr)`, `i32_load(addr+4)`
+4. Construct `WaitEvent { code, handle: Waitable(handle), payload }`
 
-This keeps the Wado API clean while the adapter handles CM-level details.
+For `poll`:
+1. Allocate 8 bytes via `realloc`
+2. Call `waitable-set-poll(set, addr)` → returns event code or sentinel
+3. If sentinel (no event): return `Option::None`
+4. Otherwise: load, construct `Option::Some(WaitEvent { ... })`
+
+For `Subtask::join`:
+1. Call `waitable-join(set_handle, subtask_handle)` (void return in CM)
+2. Return `Waitable(subtask_handle)` — wrap the joined handle as a token
 
 ### What Stays in builtin.wado
 
@@ -360,6 +416,7 @@ pub use {
     Option, Result,
     Stream, StreamWritable,
     Future, FutureWritable,
+    Waitable, WaitEvent,
     WaitableSet, Subtask, ErrorContext,
 } from "core:prelude/types.wado";
 ```
@@ -414,7 +471,8 @@ __DATA__
 - `builtin.wado` becomes clean: only Wasm instructions, libm, and `task_return`
 - WaitableSet, Subtask, ErrorContext become first-class typed resources
 - DCE is simpler and has no CM-specific knowledge
-- Type safety: handles are typed resources, not raw i32
+- Type safety: handles are typed resources, not raw i32; `Waitable` provides
+  typed wait event identification without exposing raw handle values
 
 **Negative:**
 

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -65,7 +65,7 @@ pub resource Future<T> {
     fn new() -> [Future<T>, FutureWritable<T>];
 
     #[canonical("future-read")]
-    fn read(&self) -> T;
+    fn read(&self) -> Option<T>;
 
     #[canonical("future-close-readable")]
     fn close(&self);
@@ -173,6 +173,94 @@ does NOT expose the raw handle — users must go through `join` to obtain tokens
 
 This is documented here for clarity. A future redesign could introduce `Future<T>` as
 an effect or concept with `FutureReadable<T>` + `FutureWritable<T>` as the resource pair.
+
+### Error Handling: ReturnCode Semantics
+
+All CM stream/future read/write operations return a 32-bit `ReturnCode`:
+
+```
+BLOCKED:  0xFFFF_FFFF — operation not ready, must wait via waitable set
+Normal:   (count << 4) | status
+  status 0 = COMPLETED — operation succeeded
+  status 1 = DROPPED   — the other end was closed/dropped
+  status 2 = CANCELLED — operation was explicitly cancelled
+```
+
+For futures, `count` is always 0 (single value). So the return is `0 | status` or BLOCKED.
+
+#### Future::read Error Handling
+
+`Future::read(&self) -> Option<T>`:
+
+| CM ReturnCode | Wado result | Meaning |
+|---------------|-------------|---------|
+| BLOCKED       | (internal)  | Wait via waitable-set, then retry |
+| COMPLETED     | `Option::Some(value)` | Writer fulfilled the future |
+| DROPPED       | `Option::None` | Writer dropped without fulfilling |
+
+The synthesis handles BLOCKED internally (same pattern as `stream_read`), so the
+user never sees it. COMPLETED produces `Some(value)`, DROPPED produces `None`.
+
+Returning `Option<T>` rather than bare `T` is essential because DROPPED is a normal
+condition — the writer may be cancelled or close without writing. Trapping would be
+too harsh for a recoverable situation. Users who need the value can handle the None:
+
+```wado
+if let Some(value) = future.read() {
+    // use value
+} else {
+    panic("future was not fulfilled");
+}
+```
+
+#### FutureWritable::write Error Handling
+
+`FutureWritable::write(&self, value: T)`:
+
+| CM ReturnCode | Wado behavior | Meaning |
+|---------------|---------------|---------|
+| BLOCKED       | (internal)    | Wait via waitable-set, then retry |
+| COMPLETED     | Returns normally | Value delivered to reader |
+| DROPPED       | Returns normally (no-op) | Reader already dropped; value discarded |
+
+DROPPED on write is silently ignored — the reader went away, but this is not an error
+for the writer. The value is simply discarded. This matches the pattern used in HTTP
+trailers where the reader may close before trailers are written.
+
+#### Stream::read Error Handling (Existing)
+
+`Stream::read(&self, max: i32) -> Array<T>`:
+
+| CM ReturnCode | Wado result | Meaning |
+|---------------|-------------|---------|
+| BLOCKED       | (internal)  | Wait via waitable-set, then retry |
+| COMPLETED     | `Array` with `count` items | Data available |
+| DROPPED       | Empty `Array` | Writer closed (EOF) |
+
+For streams, DROPPED is "end of stream" — the empty array serves as the EOF signal.
+This is the existing behavior and remains unchanged.
+
+#### StreamWritable::write Error Handling (Existing)
+
+`StreamWritable::write(&self, data: Array<T>)`:
+
+| CM ReturnCode | Wado behavior | Meaning |
+|---------------|---------------|---------|
+| BLOCKED       | (internal)    | Wait via waitable-set, then retry |
+| COMPLETED     | Returns normally | Data written |
+| DROPPED       | Returns normally (no-op) | Reader closed; data discarded |
+
+#### ErrorContext is Orthogonal
+
+`ErrorContext` is **not** used for stream/future operational errors. It is an
+independent CM resource for carrying debug messages across component boundaries.
+
+Application-level errors are encoded in the payload type itself:
+- `Future<Result<Response, ErrorCode>>` — `ErrorCode` is in the Result, not in ReturnCode
+- `Stream<u8>` carrying HTTP body — errors go through a separate `Future<Result<...>>`
+
+ReturnCode only indicates the **transfer status** (did the read/write succeed?),
+not application semantics.
 
 ### WaitableSet Adapter Synthesis
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the Wasm Component Model (CM) async primitives used by the Wado compiler, and proposes a major architectural redesign to make CM resource methods the single source of truth for canonical operations.

## Changes

### New Documentation

- **`docs/research-wasm-cm.md`** (953 lines)
  - Permanent reference for CM async primitives: `stream`, `future`, `error-context`, and async calling convention
  - Covers WASI P3 (0.3.0-rc-2026-01-06) and wasmtime v41+ implementation
  - Detailed operation reference (stream/future/task/subtask/waitable-set/error-context)
  - Return value encoding and async calling convention semantics
  - WASI P3 interface patterns (CLI, filesystem, HTTP)
  - Stream/future lifecycle patterns with sequence diagrams
  - Pitfalls and ordering constraints (critical for correctness)
  - Wado-level error handling mapping (ReturnCode → type system)
  - Canonical opcode reference appendix

### Proposed Architecture (WEP)

- **`docs/wep-2026-03-01-cm-resource-canonical-attrs.md`** (594 lines)
  - Redesign CM builtins as resource canonical attributes
  - Problem statement: CM knowledge scattered across 5 Rust files with no single source of truth
  - Solution: Resource method declarations in `types.wado` become authoritative via `#[canonical]` attributes
  - Introduces new user-facing types: `Waitable` (opaque handle token), `WaitEvent` (event result), `FutureWritable<T>`, `StreamWritable<T>`
  - Detailed error handling semantics: `Future::read() -> Option<T>`, `FutureWritable::write()` silent-drops on reader closure
  - Architecture changes: unified canonical method dispatch, canonical import registration moves to WIR phase
  - Removes 13 CM functions from `builtin.wado`, deletes `lib/core/stream.wado`

### Documentation Updates

- **`docs/wep-2026-02-15-cm-adapter-synthesis.md`** (minor)
  - Updated pipeline diagram to reflect current compilation phases (synthesis, wir_build, wir_optimize)

- **`docs/wep-2026-02-21-wasi-http.md`** (minor)
  - Updated reference to CM adapter synthesis documentation

## Notable Details

- **Waitable as typed handle token**: Wraps CM u32 handles in a distinct Wado type for type safety; obtained via `Subtask::join()` and compared in `WaitEvent` results
- **Future<T> naming**: Kept as readable end (not `FutureReadable<T>`) to match JS/Python convention and reduce noise
- **ReturnCode semantics**: BLOCKED (0xFFFFFFFF) triggers internal waitable-set synthesis; COMPLETED/DROPPED/CANCELLED encode status in low 4 bits, count in high 28 bits
- **Error handling asymmetry**: `Future::read()` returns `Option<T>` (DROPPED is normal), `FutureWritable::write()` silently ignores DROPPED (reader went away)
- **Dependency injection**: Each canonical operation registers its own dependencies (e.g., stream-read registers waitable-set-new, waitable-join, waitable-set-wait)

This documentation and proposal establish the foundation for refactoring the compiler's CM handling from hard-coded type/method matching to a declarative, attribute-driven architecture.

https://claude.ai/code/session_01M2KomLR3zNcBa3zEgRsgYM