### PR TITLE
Mark golden fixture files as generated in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+wado-compiler/tests/fixtures.golden* linguist-generated=true


### PR DESCRIPTION
## Summary
Added a `.gitattributes` configuration to mark golden fixture files as generated, which helps with repository management and code review workflows.

## Changes
- Added `.gitattributes` file with a rule to mark `wado-compiler/tests/fixtures.golden*` files as `linguist-generated=true`

## Details
This configuration tells Git and code hosting platforms (like GitHub) that golden fixture files are generated artifacts rather than hand-written source code. This helps:
- Exclude these files from language statistics
- Reduce noise in code reviews by collapsing diffs by default
- Clarify that these files should not be manually edited

https://claude.ai/code/session_01PznyWkyP5j6fw6wkKgTyrr