### PR TITLE
Optimize ref_elim to use two-pass algorithm for O(N) complexity

### DIFF
--- a/wado-compiler/src/optimize/ref_elim.rs
+++ b/wado-compiler/src/optimize/ref_elim.rs
@@ -1,7 +1,7 @@
 //! Reference elimination optimization for Wado TIR
 //!
-//! This module eliminates unnecessary reference bindings that are introduced
-//! during function inlining. After inlining, we often have patterns like:
+//! Eliminates unnecessary reference bindings introduced during function inlining.
+//! After inlining, we often have patterns like:
 //!
 //! ```text
 //! let self: &Array<T> = &arr;
@@ -14,494 +14,68 @@
 //! ... arr.repr ...
 //! ```
 //!
-//! The optimization works by:
-//! 1. Finding all `let ref_var: &T = &local_var` bindings
-//! 2. Checking if all uses of `ref_var` are field accesses
-//! 3. Replacing those field accesses with field accesses on the original variable
-//! 4. Removing the now-dead reference bindings
+//! The algorithm uses a two-pass approach that processes ALL ref bindings
+//! simultaneously, avoiding the O(K × N) cost of processing each binding
+//! separately (where K = number of bindings, N = body size).
+//!
+//! Pass 1 (analyze): Single traversal to collect all `let r = &v` bindings
+//!   and classify every use of each `r` as field-access-only or not.
+//! Pass 2 (transform): Single traversal to replace eliminable field accesses
+//!   and remove dead let statements.
 
 use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp, TypeTable,
 };
-use indexmap::IndexSet;
+use indexmap::IndexMap;
 
-/// Information about a reference binding that may be eliminable.
-/// Pattern: `let ref_var: &T = &local_var` or `let ref_var: &mut T = &mut local_var`
-#[derive(Debug)]
-struct RefBinding {
-    /// Local index of the reference variable (`ref_var`)
-    ref_local: u32,
-    /// Local index of the original variable (`local_var`)
+/// Per-binding analysis state, keyed by the ref local index.
+struct RefInfo {
+    /// Local index of the original variable (`local_var` in `let r = &local_var`)
     target_local: u32,
-    /// Name of the original variable (for reconstruction)
+    /// Name of the original variable
     target_name: String,
-    /// Whether this is a mutable reference
-    #[allow(dead_code)]
-    is_mut: bool,
+    /// True until a non-field-access use is found
+    eliminable: bool,
 }
 
-/// Analyze a Let statement to see if it binds a reference to a local variable.
-fn analyze_ref_binding(stmt: &TirStmt) -> Option<RefBinding> {
-    let TirStmtKind::Let {
-        local_index, value, ..
-    } = &stmt.kind
-    else {
-        return None;
-    };
-
-    // Check if value is &local or &mut local
-    let TirExprKind::Unary { op, expr } = &value.kind else {
-        return None;
-    };
-
-    let is_mut = match op {
-        TirUnaryOp::Ref => false,
-        TirUnaryOp::MutRef => true,
-        _ => return None,
-    };
-
-    // The inner expression must be a local variable
-    let TirExprKind::Local { index, name } = &expr.kind else {
-        return None;
-    };
-
-    Some(RefBinding {
-        ref_local: *local_index,
-        target_local: *index,
-        target_name: name.clone(),
-        is_mut,
-    })
-}
-
-/// Check if an expression is a use of the given local variable.
-fn is_local_use(expr: &TirExpr, local_index: u32) -> bool {
-    matches!(&expr.kind, TirExprKind::Local { index, .. } if *index == local_index)
-}
-
-/// Track all uses of a local variable in an expression.
-/// Returns (`is_only_field_access`, `uses_count`)
-/// If `is_only_field_access` is true, all uses are field accesses.
-fn track_local_uses_in_expr(expr: &TirExpr, local_index: u32) -> (bool, u32) {
-    match &expr.kind {
-        TirExprKind::Local { index, .. } if *index == local_index => {
-            // Direct use of the local (not through field access) - not eliminable
-            (false, 1)
-        }
-        TirExprKind::FieldAccess {
-            expr: inner,
-            ..
-        } => {
-            if is_local_use(inner, local_index) {
-                // Field access on the local - this is what we want to optimize
-                (true, 1)
-            } else {
-                // Field access on something else, recurse
-                track_local_uses_in_expr(inner, local_index)
-            }
-        }
-        // Recursively check nested expressions
-        TirExprKind::Binary { left, right, .. } => {
-            let (l_ok, l_count) = track_local_uses_in_expr(left, local_index);
-            let (r_ok, r_count) = track_local_uses_in_expr(right, local_index);
-            (l_ok && r_ok, l_count + r_count)
-        }
-        TirExprKind::Unary { expr: inner, .. } => track_local_uses_in_expr(inner, local_index),
-        TirExprKind::Cast { expr: inner, .. } => track_local_uses_in_expr(inner, local_index),
-        TirExprKind::Assign { target, value } => {
-            let (t_ok, t_count) = track_local_uses_in_expr(target, local_index);
-            let (v_ok, v_count) = track_local_uses_in_expr(value, local_index);
-            (t_ok && v_ok, t_count + v_count)
-        }
-        TirExprKind::Call { args, .. }
-        | TirExprKind::StaticCall { args, .. }
-
-        | TirExprKind::CmRawCall { args, .. } => {
-            let mut total = 0;
-            let mut all_ok = true;
-            for arg in args {
-                let (ok, count) = track_local_uses_in_expr(arg, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            (all_ok, total)
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            let (r_ok, r_count) = track_local_uses_in_expr(receiver, local_index);
-            let mut total = r_count;
-            let mut all_ok = r_ok;
-            for arg in args {
-                let (ok, count) = track_local_uses_in_expr(arg, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            (all_ok, total)
-        }
-        TirExprKind::IndirectCall { callee, args } => {
-            let (c_ok, c_count) = track_local_uses_in_expr(callee, local_index);
-            let mut total = c_count;
-            let mut all_ok = c_ok;
-            for arg in args {
-                let (ok, count) = track_local_uses_in_expr(arg, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            (all_ok, total)
-        }
-        TirExprKind::ClosureToCanonical { functor, .. } => {
-            track_local_uses_in_expr(functor, local_index)
-        }
-        TirExprKind::Index { expr: inner, index } => {
-            let (i_ok, i_count) = track_local_uses_in_expr(inner, local_index);
-            let (x_ok, x_count) = track_local_uses_in_expr(index, local_index);
-            (i_ok && x_ok, i_count + x_count)
-        }
-        TirExprKind::Block(block) => track_local_uses_in_block(block, local_index),
-        TirExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            let (c_ok, c_count) = track_local_uses_in_expr(condition, local_index);
-            let (t_ok, t_count) = track_local_uses_in_block(then_branch, local_index);
-            let (e_ok, e_count) = else_branch
-                .as_ref()
-                .map_or((true, 0), |eb| track_local_uses_in_block(eb, local_index));
-            (c_ok && t_ok && e_ok, c_count + t_count + e_count)
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            let mut total = 0;
-            let mut all_ok = true;
-            for field in fields {
-                let (ok, count) = track_local_uses_in_expr(&field.value, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            (all_ok, total)
-        }
-        TirExprKind::TupleLiteral { elements } => {
-            let mut total = 0;
-            let mut all_ok = true;
-            for elem in elements {
-                let (ok, count) = track_local_uses_in_expr(elem, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            (all_ok, total)
-        }
-        TirExprKind::VariantConstruct { payload, .. } => {
-            if let Some(payload_expr) = payload {
-                track_local_uses_in_expr(payload_expr, local_index)
-            } else {
-                (true, 0)
-            }
-        }
-        TirExprKind::LabeledBlock { block, .. } => track_local_uses_in_block(block, local_index),
-        TirExprKind::Closure { body, .. } => track_local_uses_in_expr(body, local_index),
-        TirExprKind::Match { expr: inner, arms } => {
-            let (i_ok, i_count) = track_local_uses_in_expr(inner, local_index);
-            let mut total = i_count;
-            let mut all_ok = i_ok;
-            for arm in arms {
-                if let Some(guard) = &arm.guard {
-                    let (ok, count) = track_local_uses_in_expr(guard, local_index);
-                    all_ok = all_ok && ok;
-                    total += count;
-                }
-                let (ok, count) = track_local_uses_in_expr(&arm.body, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            (all_ok, total)
-        }
-        TirExprKind::GlobalVarSet { value, .. } => track_local_uses_in_expr(value, local_index),
-        TirExprKind::VariantTag { expr }
-        | TirExprKind::VariantTest { expr, .. }
-        | TirExprKind::VariantPayload { expr, .. } => track_local_uses_in_expr(expr, local_index),
-        TirExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            let (s_ok, s_count) = track_local_uses_in_expr(scrutinee, local_index);
-            let mut total = s_count;
-            let mut all_ok = s_ok;
-            for arm in arms {
-                let (ok, count) = track_local_uses_in_block(arm, local_index);
-                all_ok = all_ok && ok;
-                total += count;
-            }
-            let (d_ok, d_count) = track_local_uses_in_block(default, local_index);
-            (all_ok && d_ok, total + d_count)
-        }
-        // Leaf nodes - no uses
-        TirExprKind::IntLiteral { .. }
-        | TirExprKind::FloatLiteral { .. }
-        | TirExprKind::BoolLiteral(_)
-        | TirExprKind::CharLiteral(_)
-        | TirExprKind::StringLiteral(_)
-        | TirExprKind::Null
-        | TirExprKind::Unit
-        | TirExprKind::Local { .. } // Different local
-        | TirExprKind::Global { .. }
-        | TirExprKind::GlobalVarGet { .. }
-        | TirExprKind::Capture { .. }
-        | TirExprKind::EnumConstruct { .. } => (true, 0),
-        TirExprKind::TemplateString { .. } => {
-            unreachable!("TemplateString should be expanded before this phase")
-        }
-    }
-}
-
-/// Track all uses of a local variable in a block.
-fn track_local_uses_in_block(block: &TirBlock, local_index: u32) -> (bool, u32) {
-    let mut total = 0;
-    let mut all_ok = true;
+/// Pass 1: Collect all ref bindings and analyze uses in a single traversal.
+///
+/// Walks the entire function body once, building an `IndexMap<u32, RefInfo>` for
+/// every `let r: &T = &v` binding found. Simultaneously, for every expression
+/// that uses a tracked local, checks whether the use is a field access. If any
+/// non-field-access use is found, marks the binding as non-eliminable.
+fn analyze_refs_in_block(block: &TirBlock, refs: &mut IndexMap<u32, RefInfo>) {
     for stmt in &block.stmts {
-        let (ok, count) = track_local_uses_in_stmt(stmt, local_index);
-        all_ok = all_ok && ok;
-        total += count;
+        // Check if this statement defines a new ref binding
+        if let TirStmtKind::Let {
+            local_index, value, ..
+        } = &stmt.kind
+            && let TirExprKind::Unary { op, expr } = &value.kind
+            && matches!(op, TirUnaryOp::Ref | TirUnaryOp::MutRef)
+            && let TirExprKind::Local { index, name } = &expr.kind
+        {
+            refs.insert(
+                *local_index,
+                RefInfo {
+                    target_local: *index,
+                    target_name: name.clone(),
+                    eliminable: true,
+                },
+            );
+        }
+        // Analyze uses within this statement
+        analyze_uses_in_stmt(stmt, refs);
     }
-    (all_ok, total)
 }
 
-/// Track all uses of a local variable in a statement.
-fn track_local_uses_in_stmt(stmt: &TirStmt, local_index: u32) -> (bool, u32) {
+fn analyze_uses_in_stmt(stmt: &TirStmt, refs: &mut IndexMap<u32, RefInfo>) {
     match &stmt.kind {
-        TirStmtKind::Let { value, .. } => track_local_uses_in_expr(value, local_index),
-        TirStmtKind::Expr(expr) => track_local_uses_in_expr(expr, local_index),
-        TirStmtKind::Return { value } => value
-            .as_ref()
-            .map_or((true, 0), |v| track_local_uses_in_expr(v, local_index)),
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            let (c_ok, c_count) = track_local_uses_in_expr(condition, local_index);
-            let (t_ok, t_count) = track_local_uses_in_block(then_block, local_index);
-            let (e_ok, e_count) = else_block
-                .as_ref()
-                .map_or((true, 0), |eb| track_local_uses_in_block(eb, local_index));
-            (c_ok && t_ok && e_ok, c_count + t_count + e_count)
-        }
-        TirStmtKind::Loop { body } => track_local_uses_in_block(body, local_index),
-        TirStmtKind::LabeledBlock { block, .. } => track_local_uses_in_block(block, local_index),
-        TirStmtKind::IfPattern {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            let (s_ok, s_count) = track_local_uses_in_expr(scrutinee, local_index);
-            let (t_ok, t_count) = track_local_uses_in_block(then_block, local_index);
-            let (e_ok, e_count) = else_block
-                .as_ref()
-                .map_or((true, 0), |eb| track_local_uses_in_block(eb, local_index));
-            (s_ok && t_ok && e_ok, s_count + t_count + e_count)
-        }
-        TirStmtKind::Break { value, .. } => value
-            .as_ref()
-            .map_or((true, 0), |v| track_local_uses_in_expr(v, local_index)),
-        TirStmtKind::Continue => (true, 0),
-        TirStmtKind::LetPattern { value, .. } => track_local_uses_in_expr(value, local_index),
-        TirStmtKind::TaskReturn { .. } => {
-            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
-        }
-    }
-}
-
-/// Replace field accesses on `ref_local` with field accesses on `target_local`.
-fn replace_ref_field_access_in_expr(
-    expr: &mut TirExpr,
-    ref_local: u32,
-    target_local: u32,
-    target_name: &str,
-) {
-    match &mut expr.kind {
-        TirExprKind::FieldAccess { expr: inner, .. } => {
-            if is_local_use(inner, ref_local) {
-                // Replace the inner local with the target local
-                **inner = TirExpr::new(
-                    TirExprKind::Local {
-                        index: target_local,
-                        name: target_name.to_string(),
-                    },
-                    inner.type_id, // Keep the type - codegen handles ref vs value
-                    inner.span,
-                );
-            } else {
-                replace_ref_field_access_in_expr(inner, ref_local, target_local, target_name);
-            }
-        }
-        TirExprKind::Binary { left, right, .. } => {
-            replace_ref_field_access_in_expr(left, ref_local, target_local, target_name);
-            replace_ref_field_access_in_expr(right, ref_local, target_local, target_name);
-        }
-        TirExprKind::Unary { expr: inner, .. } => {
-            replace_ref_field_access_in_expr(inner, ref_local, target_local, target_name);
-        }
-        TirExprKind::Cast { expr: inner, .. } => {
-            replace_ref_field_access_in_expr(inner, ref_local, target_local, target_name);
-        }
-        TirExprKind::Assign { target, value } => {
-            replace_ref_field_access_in_expr(target, ref_local, target_local, target_name);
-            replace_ref_field_access_in_expr(value, ref_local, target_local, target_name);
-        }
-        TirExprKind::Call { args, .. }
-        | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
-            for arg in args {
-                replace_ref_field_access_in_expr(arg, ref_local, target_local, target_name);
-            }
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            replace_ref_field_access_in_expr(receiver, ref_local, target_local, target_name);
-            for arg in args {
-                replace_ref_field_access_in_expr(arg, ref_local, target_local, target_name);
-            }
-        }
-        TirExprKind::IndirectCall { callee, args } => {
-            replace_ref_field_access_in_expr(callee, ref_local, target_local, target_name);
-            for arg in args {
-                replace_ref_field_access_in_expr(arg, ref_local, target_local, target_name);
-            }
-        }
-        TirExprKind::ClosureToCanonical { functor, .. } => {
-            replace_ref_field_access_in_expr(functor, ref_local, target_local, target_name);
-        }
-        TirExprKind::Index { expr: inner, index } => {
-            replace_ref_field_access_in_expr(inner, ref_local, target_local, target_name);
-            replace_ref_field_access_in_expr(index, ref_local, target_local, target_name);
-        }
-        TirExprKind::Block(block) => {
-            replace_ref_field_access_in_block(block, ref_local, target_local, target_name);
-        }
-        TirExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            replace_ref_field_access_in_expr(condition, ref_local, target_local, target_name);
-            replace_ref_field_access_in_block(then_branch, ref_local, target_local, target_name);
-            if let Some(eb) = else_branch {
-                replace_ref_field_access_in_block(eb, ref_local, target_local, target_name);
-            }
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            for field in fields {
-                replace_ref_field_access_in_expr(
-                    &mut field.value,
-                    ref_local,
-                    target_local,
-                    target_name,
-                );
-            }
-        }
-        TirExprKind::TupleLiteral { elements } => {
-            for elem in elements {
-                replace_ref_field_access_in_expr(elem, ref_local, target_local, target_name);
-            }
-        }
-        TirExprKind::VariantConstruct { payload, .. } => {
-            if let Some(payload_expr) = payload {
-                replace_ref_field_access_in_expr(
-                    payload_expr,
-                    ref_local,
-                    target_local,
-                    target_name,
-                );
-            }
-        }
-        TirExprKind::LabeledBlock { block, .. } => {
-            replace_ref_field_access_in_block(block, ref_local, target_local, target_name);
-        }
-        TirExprKind::Closure { body, .. } => {
-            replace_ref_field_access_in_expr(body, ref_local, target_local, target_name);
-        }
-        TirExprKind::Match { expr: inner, arms } => {
-            replace_ref_field_access_in_expr(inner, ref_local, target_local, target_name);
-            for arm in arms {
-                if let Some(guard) = &mut arm.guard {
-                    replace_ref_field_access_in_expr(guard, ref_local, target_local, target_name);
-                }
-                replace_ref_field_access_in_expr(
-                    &mut arm.body,
-                    ref_local,
-                    target_local,
-                    target_name,
-                );
-            }
-        }
-        TirExprKind::GlobalVarSet { value, .. } => {
-            replace_ref_field_access_in_expr(value, ref_local, target_local, target_name);
-        }
-        TirExprKind::VariantTag { expr }
-        | TirExprKind::VariantTest { expr, .. }
-        | TirExprKind::VariantPayload { expr, .. } => {
-            replace_ref_field_access_in_expr(expr, ref_local, target_local, target_name);
-        }
-        TirExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            replace_ref_field_access_in_expr(scrutinee, ref_local, target_local, target_name);
-            for arm in arms {
-                replace_ref_field_access_in_block(arm, ref_local, target_local, target_name);
-            }
-            replace_ref_field_access_in_block(default, ref_local, target_local, target_name);
-        }
-        // Leaf nodes - nothing to replace
-        TirExprKind::IntLiteral { .. }
-        | TirExprKind::FloatLiteral { .. }
-        | TirExprKind::BoolLiteral(_)
-        | TirExprKind::CharLiteral(_)
-        | TirExprKind::StringLiteral(_)
-        | TirExprKind::Null
-        | TirExprKind::Unit
-        | TirExprKind::Local { .. }
-        | TirExprKind::Global { .. }
-        | TirExprKind::GlobalVarGet { .. }
-        | TirExprKind::Capture { .. }
-        | TirExprKind::EnumConstruct { .. } => {}
-        TirExprKind::TemplateString { .. } => {
-            unreachable!("TemplateString should be expanded before this phase")
-        }
-    }
-}
-
-/// Replace field accesses in a block.
-fn replace_ref_field_access_in_block(
-    block: &mut TirBlock,
-    ref_local: u32,
-    target_local: u32,
-    target_name: &str,
-) {
-    for stmt in &mut block.stmts {
-        replace_ref_field_access_in_stmt(stmt, ref_local, target_local, target_name);
-    }
-}
-
-/// Replace field accesses in a statement.
-fn replace_ref_field_access_in_stmt(
-    stmt: &mut TirStmt,
-    ref_local: u32,
-    target_local: u32,
-    target_name: &str,
-) {
-    match &mut stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            replace_ref_field_access_in_expr(value, ref_local, target_local, target_name);
-        }
-        TirStmtKind::Expr(expr) => {
-            replace_ref_field_access_in_expr(expr, ref_local, target_local, target_name);
-        }
+        TirStmtKind::Let { value, .. } => analyze_uses_in_expr(value, refs),
+        TirStmtKind::Expr(expr) => analyze_uses_in_expr(expr, refs),
         TirStmtKind::Return { value } => {
             if let Some(v) = value {
-                replace_ref_field_access_in_expr(v, ref_local, target_local, target_name);
+                analyze_uses_in_expr(v, refs);
             }
         }
         TirStmtKind::If {
@@ -509,260 +83,140 @@ fn replace_ref_field_access_in_stmt(
             then_block,
             else_block,
         } => {
-            replace_ref_field_access_in_expr(condition, ref_local, target_local, target_name);
-            replace_ref_field_access_in_block(then_block, ref_local, target_local, target_name);
+            analyze_uses_in_expr(condition, refs);
+            analyze_refs_in_block(then_block, refs);
             if let Some(eb) = else_block {
-                replace_ref_field_access_in_block(eb, ref_local, target_local, target_name);
+                analyze_refs_in_block(eb, refs);
             }
         }
-        TirStmtKind::Loop { body } => {
-            replace_ref_field_access_in_block(body, ref_local, target_local, target_name);
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            replace_ref_field_access_in_block(block, ref_local, target_local, target_name);
-        }
+        TirStmtKind::Loop { body } => analyze_refs_in_block(body, refs),
+        TirStmtKind::LabeledBlock { block, .. } => analyze_refs_in_block(block, refs),
         TirStmtKind::IfPattern {
             scrutinee,
             then_block,
             else_block,
             ..
         } => {
-            replace_ref_field_access_in_expr(scrutinee, ref_local, target_local, target_name);
-            replace_ref_field_access_in_block(then_block, ref_local, target_local, target_name);
+            analyze_uses_in_expr(scrutinee, refs);
+            analyze_refs_in_block(then_block, refs);
             if let Some(eb) = else_block {
-                replace_ref_field_access_in_block(eb, ref_local, target_local, target_name);
+                analyze_refs_in_block(eb, refs);
             }
         }
         TirStmtKind::Break { value, .. } => {
             if let Some(v) = value {
-                replace_ref_field_access_in_expr(v, ref_local, target_local, target_name);
+                analyze_uses_in_expr(v, refs);
             }
         }
         TirStmtKind::Continue => {}
-        TirStmtKind::LetPattern { value, .. } => {
-            replace_ref_field_access_in_expr(value, ref_local, target_local, target_name);
-        }
-        TirStmtKind::TaskReturn { .. } => {
-            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
-        }
+        TirStmtKind::LetPattern { value, .. } => analyze_uses_in_expr(value, refs),
+        TirStmtKind::TaskReturn { .. } => {}
     }
 }
 
-/// Eliminate unnecessary reference bindings in a function.
-/// After inlining, we often have patterns like:
-///   let self: &Array<T> = &arr;
-///   ... self.repr ...
-/// This can be optimized to:
-///   ... arr.repr ...
-fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) -> bool {
-    let Some(body) = &mut func.body else {
-        return false;
-    };
-
-    // First pass: find all ref bindings
-    let mut ref_bindings: Vec<RefBinding> = Vec::new();
-    collect_ref_bindings(&body.stmts, &mut ref_bindings);
-
-    if ref_bindings.is_empty() {
-        return false;
-    }
-
-    // Second pass: for each ref binding, check if all uses are field accesses
-    let mut eliminable_bindings: Vec<RefBinding> = Vec::new();
-    for binding in ref_bindings {
-        let (all_field_access, _count) = track_local_uses_in_block(body, binding.ref_local);
-        if all_field_access {
-            eliminable_bindings.push(binding);
-        }
-    }
-
-    if eliminable_bindings.is_empty() {
-        return false;
-    }
-
-    // Third pass: replace field accesses and remove dead bindings
-    for binding in &eliminable_bindings {
-        replace_ref_field_access_in_block(
-            body,
-            binding.ref_local,
-            binding.target_local,
-            &binding.target_name,
-        );
-    }
-
-    // Fourth pass: remove the now-dead Let statements
-    // We need to handle nested blocks, so we do this recursively
-    let dead_locals: IndexSet<u32> = eliminable_bindings.iter().map(|b| b.ref_local).collect();
-    remove_dead_ref_bindings(&mut body.stmts, &dead_locals);
-    true
-}
-
-/// Collect ref bindings from statements (only at the top level of each block).
-fn collect_ref_bindings(stmts: &[TirStmt], bindings: &mut Vec<RefBinding>) {
-    for stmt in stmts {
-        if let Some(binding) = analyze_ref_binding(stmt) {
-            bindings.push(binding);
-        }
-        // Also check nested blocks
-        collect_ref_bindings_in_stmt(stmt, bindings);
-    }
-}
-
-/// Collect ref bindings from nested blocks within a statement.
-fn collect_ref_bindings_in_stmt(stmt: &TirStmt, bindings: &mut Vec<RefBinding>) {
-    match &stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            collect_ref_bindings_in_expr(value, bindings);
-        }
-        TirStmtKind::Expr(expr) => {
-            collect_ref_bindings_in_expr(expr, bindings);
-        }
-        TirStmtKind::Return { value } => {
-            if let Some(v) = value {
-                collect_ref_bindings_in_expr(v, bindings);
-            }
-        }
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            collect_ref_bindings_in_expr(condition, bindings);
-            collect_ref_bindings(&then_block.stmts, bindings);
-            if let Some(eb) = else_block {
-                collect_ref_bindings(&eb.stmts, bindings);
-            }
-        }
-        TirStmtKind::Loop { body } => {
-            collect_ref_bindings(&body.stmts, bindings);
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            collect_ref_bindings(&block.stmts, bindings);
-        }
-        TirStmtKind::IfPattern {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            collect_ref_bindings_in_expr(scrutinee, bindings);
-            collect_ref_bindings(&then_block.stmts, bindings);
-            if let Some(eb) = else_block {
-                collect_ref_bindings(&eb.stmts, bindings);
-            }
-        }
-        TirStmtKind::Break { value, .. } => {
-            if let Some(v) = value {
-                collect_ref_bindings_in_expr(v, bindings);
-            }
-        }
-        TirStmtKind::Continue => {}
-        TirStmtKind::LetPattern { value, .. } => {
-            collect_ref_bindings_in_expr(value, bindings);
-        }
-        TirStmtKind::TaskReturn { .. } => {
-            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
-        }
-    }
-}
-
-/// Collect ref bindings from nested blocks within an expression.
-fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) {
+fn analyze_uses_in_expr(expr: &TirExpr, refs: &mut IndexMap<u32, RefInfo>) {
     match &expr.kind {
-        TirExprKind::Block(block) => {
-            collect_ref_bindings(&block.stmts, bindings);
+        // Field access on a tracked ref local: this is the pattern we want to optimize.
+        // The use is acceptable (field-access-only), so we DON'T mark it as non-eliminable.
+        TirExprKind::FieldAccess { expr: inner, .. } => {
+            if let TirExprKind::Local { index, .. } = &inner.kind
+                && refs.contains_key(index)
+            {
+                // This is a field access on a tracked ref - acceptable use, skip.
+                return;
+            }
+            // Not a field access on tracked ref - recurse normally
+            analyze_uses_in_expr(inner, refs);
         }
-        TirExprKind::LabeledBlock { block, .. } => {
-            collect_ref_bindings(&block.stmts, bindings);
+        // Direct use of a tracked ref local (not through field access): non-eliminable
+        TirExprKind::Local { index, .. } => {
+            if let Some(info) = refs.get_mut(index) {
+                info.eliminable = false;
+            }
+        }
+        // Recursive cases
+        TirExprKind::Binary { left, right, .. } => {
+            analyze_uses_in_expr(left, refs);
+            analyze_uses_in_expr(right, refs);
+        }
+        TirExprKind::Unary { expr: inner, .. }
+        | TirExprKind::Cast { expr: inner, .. }
+        | TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. }
+        | TirExprKind::GlobalVarSet { value: inner, .. } => {
+            analyze_uses_in_expr(inner, refs);
+        }
+        TirExprKind::Assign { target, value } => {
+            analyze_uses_in_expr(target, refs);
+            analyze_uses_in_expr(value, refs);
+        }
+        TirExprKind::Call { args, .. }
+        | TirExprKind::StaticCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                analyze_uses_in_expr(arg, refs);
+            }
+        }
+        TirExprKind::MethodCall { receiver, args, .. } => {
+            analyze_uses_in_expr(receiver, refs);
+            for arg in args {
+                analyze_uses_in_expr(arg, refs);
+            }
+        }
+        TirExprKind::IndirectCall { callee, args } => {
+            analyze_uses_in_expr(callee, refs);
+            for arg in args {
+                analyze_uses_in_expr(arg, refs);
+            }
+        }
+        TirExprKind::ClosureToCanonical { functor, .. } => {
+            analyze_uses_in_expr(functor, refs);
+        }
+        TirExprKind::Index { expr: inner, index } => {
+            analyze_uses_in_expr(inner, refs);
+            analyze_uses_in_expr(index, refs);
+        }
+        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
+            analyze_refs_in_block(block, refs);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            collect_ref_bindings_in_expr(condition, bindings);
-            collect_ref_bindings(&then_branch.stmts, bindings);
+            analyze_uses_in_expr(condition, refs);
+            analyze_refs_in_block(then_branch, refs);
             if let Some(eb) = else_branch {
-                collect_ref_bindings(&eb.stmts, bindings);
+                analyze_refs_in_block(eb, refs);
             }
-        }
-        TirExprKind::Call { args, .. }
-        | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
-            for arg in args {
-                collect_ref_bindings_in_expr(arg, bindings);
-            }
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            collect_ref_bindings_in_expr(receiver, bindings);
-            for arg in args {
-                collect_ref_bindings_in_expr(arg, bindings);
-            }
-        }
-        TirExprKind::IndirectCall { callee, args } => {
-            collect_ref_bindings_in_expr(callee, bindings);
-            for arg in args {
-                collect_ref_bindings_in_expr(arg, bindings);
-            }
-        }
-        TirExprKind::ClosureToCanonical { functor, .. } => {
-            collect_ref_bindings_in_expr(functor, bindings);
-        }
-        TirExprKind::Binary { left, right, .. } => {
-            collect_ref_bindings_in_expr(left, bindings);
-            collect_ref_bindings_in_expr(right, bindings);
-        }
-        TirExprKind::Unary { expr: inner, .. } => {
-            collect_ref_bindings_in_expr(inner, bindings);
-        }
-        TirExprKind::Cast { expr: inner, .. } => {
-            collect_ref_bindings_in_expr(inner, bindings);
-        }
-        TirExprKind::Assign { target, value } => {
-            collect_ref_bindings_in_expr(target, bindings);
-            collect_ref_bindings_in_expr(value, bindings);
-        }
-        TirExprKind::FieldAccess { expr: inner, .. } => {
-            collect_ref_bindings_in_expr(inner, bindings);
-        }
-        TirExprKind::Index { expr: inner, index } => {
-            collect_ref_bindings_in_expr(inner, bindings);
-            collect_ref_bindings_in_expr(index, bindings);
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for field in fields {
-                collect_ref_bindings_in_expr(&field.value, bindings);
+                analyze_uses_in_expr(&field.value, refs);
             }
         }
         TirExprKind::TupleLiteral { elements } => {
             for elem in elements {
-                collect_ref_bindings_in_expr(elem, bindings);
+                analyze_uses_in_expr(elem, refs);
             }
         }
         TirExprKind::VariantConstruct { payload, .. } => {
             if let Some(payload_expr) = payload {
-                collect_ref_bindings_in_expr(payload_expr, bindings);
+                analyze_uses_in_expr(payload_expr, refs);
             }
         }
         TirExprKind::Closure { body, .. } => {
-            collect_ref_bindings_in_expr(body, bindings);
+            analyze_uses_in_expr(body, refs);
         }
         TirExprKind::Match { expr: inner, arms } => {
-            collect_ref_bindings_in_expr(inner, bindings);
+            analyze_uses_in_expr(inner, refs);
             for arm in arms {
                 if let Some(guard) = &arm.guard {
-                    collect_ref_bindings_in_expr(guard, bindings);
+                    analyze_uses_in_expr(guard, refs);
                 }
-                collect_ref_bindings_in_expr(&arm.body, bindings);
+                analyze_uses_in_expr(&arm.body, refs);
             }
-        }
-        TirExprKind::GlobalVarSet { value, .. } => {
-            collect_ref_bindings_in_expr(value, bindings);
-        }
-        TirExprKind::VariantTag { expr }
-        | TirExprKind::VariantTest { expr, .. }
-        | TirExprKind::VariantPayload { expr, .. } => {
-            collect_ref_bindings_in_expr(expr, bindings);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -770,11 +224,11 @@ fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) 
             default,
             ..
         } => {
-            collect_ref_bindings_in_expr(scrutinee, bindings);
+            analyze_uses_in_expr(scrutinee, refs);
             for arm in arms {
-                collect_ref_bindings(&arm.stmts, bindings);
+                analyze_refs_in_block(arm, refs);
             }
-            collect_ref_bindings(&default.stmts, bindings);
+            analyze_refs_in_block(default, refs);
         }
         // Leaf nodes
         TirExprKind::IntLiteral { .. }
@@ -784,7 +238,6 @@ fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) 
         | TirExprKind::StringLiteral(_)
         | TirExprKind::Null
         | TirExprKind::Unit
-        | TirExprKind::Local { .. }
         | TirExprKind::Global { .. }
         | TirExprKind::GlobalVarGet { .. }
         | TirExprKind::Capture { .. }
@@ -795,34 +248,32 @@ fn collect_ref_bindings_in_expr(expr: &TirExpr, bindings: &mut Vec<RefBinding>) 
     }
 }
 
-/// Remove Let statements for dead reference locals.
-fn remove_dead_ref_bindings(stmts: &mut Vec<TirStmt>, dead_locals: &IndexSet<u32>) {
-    stmts.retain(|stmt| {
+/// Pass 2: Replace field accesses and remove dead bindings in a single traversal.
+///
+/// For each eliminable binding `let r = &v`, replaces `r.field` with `v.field`
+/// and removes the dead `let r` statement.
+fn transform_block(block: &mut TirBlock, eliminable: &IndexMap<u32, RefInfo>) {
+    // Remove dead let statements for eliminable bindings
+    block.stmts.retain(|stmt| {
         if let TirStmtKind::Let { local_index, .. } = &stmt.kind {
-            !dead_locals.contains(local_index)
+            !eliminable.contains_key(local_index)
         } else {
             true
         }
     });
 
-    // Recursively process nested blocks
-    for stmt in stmts {
-        remove_dead_ref_bindings_in_stmt(stmt, dead_locals);
+    for stmt in &mut block.stmts {
+        transform_stmt(stmt, eliminable);
     }
 }
 
-/// Remove dead ref bindings from nested blocks in a statement.
-fn remove_dead_ref_bindings_in_stmt(stmt: &mut TirStmt, dead_locals: &IndexSet<u32>) {
+fn transform_stmt(stmt: &mut TirStmt, eliminable: &IndexMap<u32, RefInfo>) {
     match &mut stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            remove_dead_ref_bindings_in_expr(value, dead_locals);
-        }
-        TirStmtKind::Expr(expr) => {
-            remove_dead_ref_bindings_in_expr(expr, dead_locals);
-        }
+        TirStmtKind::Let { value, .. } => transform_expr(value, eliminable),
+        TirStmtKind::Expr(expr) => transform_expr(expr, eliminable),
         TirStmtKind::Return { value } => {
             if let Some(v) = value {
-                remove_dead_ref_bindings_in_expr(v, dead_locals);
+                transform_expr(v, eliminable);
             }
         }
         TirStmtKind::If {
@@ -830,142 +281,138 @@ fn remove_dead_ref_bindings_in_stmt(stmt: &mut TirStmt, dead_locals: &IndexSet<u
             then_block,
             else_block,
         } => {
-            remove_dead_ref_bindings_in_expr(condition, dead_locals);
-            remove_dead_ref_bindings(&mut then_block.stmts, dead_locals);
+            transform_expr(condition, eliminable);
+            transform_block(then_block, eliminable);
             if let Some(eb) = else_block {
-                remove_dead_ref_bindings(&mut eb.stmts, dead_locals);
+                transform_block(eb, eliminable);
             }
         }
-        TirStmtKind::Loop { body } => {
-            remove_dead_ref_bindings(&mut body.stmts, dead_locals);
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            remove_dead_ref_bindings(&mut block.stmts, dead_locals);
-        }
+        TirStmtKind::Loop { body } => transform_block(body, eliminable),
+        TirStmtKind::LabeledBlock { block, .. } => transform_block(block, eliminable),
         TirStmtKind::IfPattern {
             scrutinee,
             then_block,
             else_block,
             ..
         } => {
-            remove_dead_ref_bindings_in_expr(scrutinee, dead_locals);
-            remove_dead_ref_bindings(&mut then_block.stmts, dead_locals);
+            transform_expr(scrutinee, eliminable);
+            transform_block(then_block, eliminable);
             if let Some(eb) = else_block {
-                remove_dead_ref_bindings(&mut eb.stmts, dead_locals);
+                transform_block(eb, eliminable);
             }
         }
         TirStmtKind::Break { value, .. } => {
             if let Some(v) = value {
-                remove_dead_ref_bindings_in_expr(v, dead_locals);
+                transform_expr(v, eliminable);
             }
         }
         TirStmtKind::Continue => {}
-        TirStmtKind::LetPattern { value, .. } => {
-            remove_dead_ref_bindings_in_expr(value, dead_locals);
-        }
-        TirStmtKind::TaskReturn { .. } => {
-            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
-        }
+        TirStmtKind::LetPattern { value, .. } => transform_expr(value, eliminable),
+        TirStmtKind::TaskReturn { .. } => {}
     }
 }
 
-/// Remove dead ref bindings from nested blocks in an expression.
-fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u32>) {
+fn transform_expr(expr: &mut TirExpr, eliminable: &IndexMap<u32, RefInfo>) {
     match &mut expr.kind {
-        TirExprKind::Block(block) => {
-            remove_dead_ref_bindings(&mut block.stmts, dead_locals);
+        TirExprKind::FieldAccess { expr: inner, .. } => {
+            // Check if the inner expression is a local that should be replaced
+            if let TirExprKind::Local { index, .. } = &inner.kind
+                && let Some(info) = eliminable.get(index)
+            {
+                **inner = TirExpr::new(
+                    TirExprKind::Local {
+                        index: info.target_local,
+                        name: info.target_name.clone(),
+                    },
+                    inner.type_id,
+                    inner.span,
+                );
+                return;
+            }
+            transform_expr(inner, eliminable);
         }
-        TirExprKind::LabeledBlock { block, .. } => {
-            remove_dead_ref_bindings(&mut block.stmts, dead_locals);
+        TirExprKind::Binary { left, right, .. } => {
+            transform_expr(left, eliminable);
+            transform_expr(right, eliminable);
+        }
+        TirExprKind::Unary { expr: inner, .. }
+        | TirExprKind::Cast { expr: inner, .. }
+        | TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. }
+        | TirExprKind::GlobalVarSet { value: inner, .. } => {
+            transform_expr(inner, eliminable);
+        }
+        TirExprKind::Assign { target, value } => {
+            transform_expr(target, eliminable);
+            transform_expr(value, eliminable);
+        }
+        TirExprKind::Call { args, .. }
+        | TirExprKind::StaticCall { args, .. }
+        | TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                transform_expr(arg, eliminable);
+            }
+        }
+        TirExprKind::MethodCall { receiver, args, .. } => {
+            transform_expr(receiver, eliminable);
+            for arg in args {
+                transform_expr(arg, eliminable);
+            }
+        }
+        TirExprKind::IndirectCall { callee, args } => {
+            transform_expr(callee, eliminable);
+            for arg in args {
+                transform_expr(arg, eliminable);
+            }
+        }
+        TirExprKind::ClosureToCanonical { functor, .. } => {
+            transform_expr(functor, eliminable);
+        }
+        TirExprKind::Index { expr: inner, index } => {
+            transform_expr(inner, eliminable);
+            transform_expr(index, eliminable);
+        }
+        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
+            transform_block(block, eliminable);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            remove_dead_ref_bindings_in_expr(condition, dead_locals);
-            remove_dead_ref_bindings(&mut then_branch.stmts, dead_locals);
+            transform_expr(condition, eliminable);
+            transform_block(then_branch, eliminable);
             if let Some(eb) = else_branch {
-                remove_dead_ref_bindings(&mut eb.stmts, dead_locals);
+                transform_block(eb, eliminable);
             }
-        }
-        TirExprKind::Call { args, .. }
-        | TirExprKind::StaticCall { args, .. }
-        | TirExprKind::CmRawCall { args, .. } => {
-            for arg in args {
-                remove_dead_ref_bindings_in_expr(arg, dead_locals);
-            }
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            remove_dead_ref_bindings_in_expr(receiver, dead_locals);
-            for arg in args {
-                remove_dead_ref_bindings_in_expr(arg, dead_locals);
-            }
-        }
-        TirExprKind::IndirectCall { callee, args } => {
-            remove_dead_ref_bindings_in_expr(callee, dead_locals);
-            for arg in args {
-                remove_dead_ref_bindings_in_expr(arg, dead_locals);
-            }
-        }
-        TirExprKind::ClosureToCanonical { functor, .. } => {
-            remove_dead_ref_bindings_in_expr(functor, dead_locals);
-        }
-        TirExprKind::Binary { left, right, .. } => {
-            remove_dead_ref_bindings_in_expr(left, dead_locals);
-            remove_dead_ref_bindings_in_expr(right, dead_locals);
-        }
-        TirExprKind::Unary { expr: inner, .. } => {
-            remove_dead_ref_bindings_in_expr(inner, dead_locals);
-        }
-        TirExprKind::Cast { expr: inner, .. } => {
-            remove_dead_ref_bindings_in_expr(inner, dead_locals);
-        }
-        TirExprKind::Assign { target, value } => {
-            remove_dead_ref_bindings_in_expr(target, dead_locals);
-            remove_dead_ref_bindings_in_expr(value, dead_locals);
-        }
-        TirExprKind::FieldAccess { expr: inner, .. } => {
-            remove_dead_ref_bindings_in_expr(inner, dead_locals);
-        }
-        TirExprKind::Index { expr: inner, index } => {
-            remove_dead_ref_bindings_in_expr(inner, dead_locals);
-            remove_dead_ref_bindings_in_expr(index, dead_locals);
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for field in fields {
-                remove_dead_ref_bindings_in_expr(&mut field.value, dead_locals);
+                transform_expr(&mut field.value, eliminable);
             }
         }
         TirExprKind::TupleLiteral { elements } => {
             for elem in elements {
-                remove_dead_ref_bindings_in_expr(elem, dead_locals);
+                transform_expr(elem, eliminable);
             }
         }
         TirExprKind::VariantConstruct { payload, .. } => {
             if let Some(payload_expr) = payload {
-                remove_dead_ref_bindings_in_expr(payload_expr, dead_locals);
+                transform_expr(payload_expr, eliminable);
             }
         }
         TirExprKind::Closure { body, .. } => {
-            remove_dead_ref_bindings_in_expr(body, dead_locals);
+            transform_expr(body, eliminable);
         }
         TirExprKind::Match { expr: inner, arms } => {
-            remove_dead_ref_bindings_in_expr(inner, dead_locals);
+            transform_expr(inner, eliminable);
             for arm in arms {
                 if let Some(guard) = &mut arm.guard {
-                    remove_dead_ref_bindings_in_expr(guard, dead_locals);
+                    transform_expr(guard, eliminable);
                 }
-                remove_dead_ref_bindings_in_expr(&mut arm.body, dead_locals);
+                transform_expr(&mut arm.body, eliminable);
             }
-        }
-        TirExprKind::GlobalVarSet { value, .. } => {
-            remove_dead_ref_bindings_in_expr(value, dead_locals);
-        }
-        TirExprKind::VariantTag { expr }
-        | TirExprKind::VariantTest { expr, .. }
-        | TirExprKind::VariantPayload { expr, .. } => {
-            remove_dead_ref_bindings_in_expr(expr, dead_locals);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -973,11 +420,11 @@ fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u
             default,
             ..
         } => {
-            remove_dead_ref_bindings_in_expr(scrutinee, dead_locals);
+            transform_expr(scrutinee, eliminable);
             for arm in arms {
-                remove_dead_ref_bindings(&mut arm.stmts, dead_locals);
+                transform_block(arm, eliminable);
             }
-            remove_dead_ref_bindings(&mut default.stmts, dead_locals);
+            transform_block(default, eliminable);
         }
         // Leaf nodes
         TirExprKind::IntLiteral { .. }
@@ -998,11 +445,34 @@ fn remove_dead_ref_bindings_in_expr(expr: &mut TirExpr, dead_locals: &IndexSet<u
     }
 }
 
+/// Eliminate unnecessary reference bindings in a single function.
+fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) -> bool {
+    let Some(body) = &mut func.body else {
+        return false;
+    };
+
+    // Pass 1: Collect all ref bindings and analyze uses in a single traversal.
+    let mut refs: IndexMap<u32, RefInfo> = IndexMap::new();
+    analyze_refs_in_block(body, &mut refs);
+
+    // Filter to only eliminable bindings
+    let eliminable: IndexMap<u32, RefInfo> = refs
+        .into_iter()
+        .filter(|(_, info)| info.eliminable)
+        .collect();
+
+    if eliminable.is_empty() {
+        return false;
+    }
+
+    // Pass 2: Replace field accesses and remove dead bindings in a single traversal.
+    transform_block(body, &eliminable);
+    true
+}
+
 /// Eliminate unnecessary reference bindings in all functions.
 ///
-/// This is the main entry point for reference elimination optimization.
-/// It iterates through all modules and functions, eliminating reference
-/// bindings that are only used for field access.
+/// Main entry point for reference elimination optimization.
 pub fn eliminate_unnecessary_refs(project: &mut Project) -> bool {
     let mut changed = false;
     for module in project.tir_modules.values_mut() {


### PR DESCRIPTION
## Summary
Refactored the reference elimination optimization to use a two-pass algorithm that processes all ref bindings simultaneously in a single traversal each, reducing time complexity from O(K × N) to O(N) where K = number of bindings and N = body size.

## Key Changes

- **Replaced multi-pass approach with two-pass algorithm:**
  - Pass 1 (analyze): Single traversal to collect all `let r = &v` bindings and classify every use of each `r` as field-access-only or not
  - Pass 2 (transform): Single traversal to replace eliminable field accesses and remove dead let statements

- **Simplified data structures:**
  - Replaced `Vec<RefBinding>` with `IndexMap<u32, RefInfo>` to track all bindings simultaneously
  - Removed separate `RefBinding` struct in favor of inline pattern matching during analysis
  - Eliminated `IndexSet<u32>` for dead locals tracking

- **Consolidated traversal logic:**
  - Merged `collect_ref_bindings`, `collect_ref_bindings_in_stmt`, and `collect_ref_bindings_in_expr` into single `analyze_refs_in_block` function
  - Merged `track_local_uses_*` functions into `analyze_uses_in_expr` that directly updates binding eliminability
  - Merged `replace_ref_field_access_*` and `remove_dead_ref_bindings_*` functions into `transform_expr` and `transform_block`

- **Improved algorithm efficiency:**
  - Eliminated the O(K × N) cost of processing each binding separately
  - Field access detection now happens during use analysis rather than in separate tracking pass
  - Dead binding removal integrated into transformation pass

## Implementation Details

The new algorithm uses a unified `IndexMap<u32, RefInfo>` that tracks:
- The target local variable being referenced
- The target variable's name for reconstruction
- An `eliminable` flag that starts as `true` and is set to `false` upon finding any non-field-access use

During Pass 1, when a field access on a tracked ref is encountered, the use is accepted without marking the binding as non-eliminable. Any other use of the ref local immediately marks it as non-eliminable.

During Pass 2, only bindings that remain `eliminable` are processed for field access replacement and let statement removal.

https://claude.ai/code/session_01SK1B3Wd5N3BtkiqU9zAnip