### PR TITLE
Implement precision-aware float formatting for Display trait

### DIFF
--- a/wado-compiler/lib/core/prelude/primitives.wado
+++ b/wado-compiler/lib/core/prelude/primitives.wado
@@ -582,6 +582,10 @@ impl f32 {
     pub const NAN: f32 = 0.0 / 0.0;
 
     fn fmt_into(&self, f: &mut Formatter) {
+        if f.precision >= 0 {
+            self.fmt_fixed(f.precision, f);
+            return;
+        }
         let [is_special, is_neg, kind] = check_special(*self as f64);
         if is_special {
             let mark = f.mark();
@@ -764,6 +768,10 @@ impl f64 {
     pub const NAN: f64 = 0.0 / 0.0;
 
     fn fmt_into(&self, f: &mut Formatter) {
+        if f.precision >= 0 {
+            self.fmt_fixed(f.precision, f);
+            return;
+        }
         let value = *self;
         let [is_special, is_neg, kind] = check_special(value);
         if is_special {

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -17,9 +17,8 @@ use indexmap::IndexMap;
 
 use crate::name::{LocalMethodName, ModuleSource};
 use crate::tir::{
-    FunctionRef, PrimitiveType, ResolvedType, TemplateFormatSpec, TirBlock, TirExpr, TirExprKind,
-    TirModule, TirStmt, TirStmtKind, TirStructField, TirTemplatePart, TirUnaryOp, TypeId,
-    TypeTable,
+    FunctionRef, ResolvedType, TemplateFormatSpec, TirBlock, TirExpr, TirExprKind, TirModule,
+    TirStmt, TirStmtKind, TirStructField, TirTemplatePart, TirUnaryOp, TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -562,21 +561,6 @@ fn build_template_block(
                     span,
                 );
 
-                // Check for float-with-precision fast path (using inner type)
-                let float_fixed_impl = if trait_name == "Display"
-                    && format_spec
-                        .as_ref()
-                        .is_some_and(|fs| fs.precision.is_some())
-                {
-                    match tt.borrow().get(inner_type).clone() {
-                        ResolvedType::Primitive(PrimitiveType::F64) => Some("f64"),
-                        ResolvedType::Primitive(PrimitiveType::F32) => Some("f32"),
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-
                 if is_inspect {
                     // Closure with alternate mode (#:?): emit source text if available,
                     // otherwise fall back to signature via inspect trait call
@@ -603,48 +587,6 @@ fn build_template_block(
                             inspect_trait_call(resolved.type_id, resolved, fmt_mut_ref, tt, span);
                         stmts.extend(call_stmts);
                     }
-                } else if let Some(impl_type_name) = float_fixed_impl {
-                    let precision_value = format_spec.as_ref().unwrap().precision.unwrap();
-                    let precision_expr = TirExpr::new(
-                        TirExprKind::IntLiteral {
-                            value: precision_value as u64,
-                            repr: precision_value.to_string(),
-                        },
-                        TypeTable::I32,
-                        span,
-                    );
-                    let inner_val = deref_to_inner(resolved, inner_type, span);
-                    let ref_inner_type = tt.borrow_mut().make_ref(inner_type);
-                    let ref_val = TirExpr::new(
-                        TirExprKind::Unary {
-                            op: TirUnaryOp::Ref,
-                            expr: Box::new(inner_val),
-                        },
-                        ref_inner_type,
-                        span,
-                    );
-                    let method_info = LocalMethodName::new(
-                        impl_type_name.to_string(),
-                        None,
-                        "fmt_fixed".to_string(),
-                    );
-                    let mangled = method_info.to_mangled_name();
-                    let fmt_call = TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(ref_val),
-                            func: FunctionRef::External {
-                                module_source: ModuleSource::primitives(),
-                                name: mangled,
-                                monomorph_info: None,
-                                method_info: Some(method_info),
-                            },
-                            type_args: vec![],
-                            args: vec![precision_expr, fmt_mut_ref],
-                        },
-                        TypeTable::UNIT,
-                        span,
-                    );
-                    stmts.push(TirStmt::new(TirStmtKind::Expr(fmt_call), span));
                 } else {
                     // Always call Display::fmt (or other format trait).
                     // Every type has a Display impl — either user-defined or

--- a/wado-compiler/tests/fixtures.golden.wir/match_variant_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/match_variant_basic.wir.wado
@@ -126,6 +126,8 @@ type "functype/unpack64" = fn(f64) -> ref null UnpackResult;
 
 type "functype/unrounded_round" = fn(u64) -> u64;
 
+type "functype/unrounded_div" = fn(u64, u64) -> u64;
+
 type "functype/pow10_coarse" = fn(i32) -> ref null PmHiLo;
 
 type "functype/pow10_fine" = fn(i32) -> u64;
@@ -133,6 +135,8 @@ type "functype/pow10_fine" = fn(i32) -> u64;
 type "functype/mul_pow10" = fn(i32) -> ref null PmHiLo;
 
 type "functype/uscale" = fn(u64, u64, u64, i32) -> u64;
+
+type "functype/fixed_width_for_prec" = fn(f64, i32) -> ref null FormatResult;
 
 type "functype/short" = fn(f64) -> ref null FormatResult;
 
@@ -146,6 +150,8 @@ type "functype/write_decimal" = fn(ref null String, u64, i32, i32);
 
 type "functype/write_exp" = fn(ref null String, u64, i32, i32, bool);
 
+type "functype/write_decimal_prec" = fn(ref null String, u64, i32, i32, i32);
+
 type "functype/check_special" = fn(f64) -> ref null "tuple/[bool, bool, SpecialKind]";
 
 type "functype/__initialize_module" = fn();
@@ -155,6 +161,8 @@ type "functype/Array<u64>::append" = fn(ref null Array<u64>, u64);
 type "functype/Array<u64>^IndexValue::index_value" = fn(ref null Array<u64>, i32) -> u64;
 
 type "functype/f64::fmt_into" = fn(ref null "core:internal/Box<f64>", ref null Formatter);
+
+type "functype/f64::fmt_fixed" = fn(ref null "core:internal/Box<f64>", i32, ref null Formatter);
 
 type "functype/String::grow" = fn(ref null String, i32);
 
@@ -171,6 +179,8 @@ type "functype/unpack64" = fn(f64) -> [u64, i32];
 type "functype/pow10_coarse" = fn(i32) -> [u64, u64];
 
 type "functype/mul_pow10" = fn(i32) -> [u64, u64];
+
+type "functype/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];
 
 type "functype/short" = fn(f64) -> [u64, i32];
 
@@ -236,7 +246,7 @@ fn run() with Stdout {
     };
     "core:cli/println"(__tmpl: block -> ref null String {
         __local_6 = String { repr: ref.as_non_null(builtin::array_new<u8>(29)), used: 0 };
-        String::append(__local_6, String { repr: ref.as_non_null(array.new_data<u8>[12](0, 13)), used: 13 });
+        String::append(__local_6, String { repr: ref.as_non_null(array.new_data<u8>[14](0, 13)), used: 13 });
         __local_7 = __inline_Formatter__new_2: block -> ref null Formatter {
             __local_11 = __local_6;
             break __inline_Formatter__new_2: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_11) };
@@ -260,7 +270,7 @@ fn run() with Stdout {
     };
     "core:cli/println"(__tmpl: block -> ref null String {
         __local_8 = String { repr: ref.as_non_null(builtin::array_new<u8>(28)), used: 0 };
-        String::append(__local_8, String { repr: ref.as_non_null(array.new_data<u8>[13](0, 12)), used: 12 });
+        String::append(__local_8, String { repr: ref.as_non_null(array.new_data<u8>[15](0, 12)), used: 12 });
         __local_9 = __inline_Formatter__new_5: block -> ref null Formatter {
             __local_15 = __local_8;
             break __inline_Formatter__new_5: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_15) };
@@ -441,6 +451,14 @@ fn unpack64(f) {
 
 fn unrounded_round(u) {
     return ((u + 1_i64) + ((u >>u 2_i64) & 1_i64)) >>u 2_i64;
+}
+
+fn unrounded_div(u, d) {
+    let q: u64;
+    let r: u64;
+    q = u /u d;
+    r = u %u d;
+    return (q | (u & 1_i64)) | builtin::i64_extend_i32_u(r != 0_i64);
 }
 
 fn pow10_coarse(i) {
@@ -761,6 +779,76 @@ fn uscale(x, pm_hi, pm_lo, s) {
     return (hi >>u builtin::i64_extend_i32_s(s)) | sticky;
 }
 
+fn fixed_width_for_prec(f, precision) {
+    let unpack: ref null UnpackResult;
+    let m: u64;
+    let e: i32;
+    let log10_e63: i32;
+    let p1: i32;
+    let lp1: i32;
+    let pm1: ref null PmHiLo;
+    let s1: i32;
+    let u1: u64;
+    let d1_floor: u64;
+    let decimal_pos: i32;
+    let total_digits: i32;
+    let n: i32;
+    let p: i32;
+    let lp: i32;
+    let pm: ref null PmHiLo;
+    let s: i32;
+    let u: u64;
+    let d: u64;
+    let __local_21: i32;
+    let __local_22: i32;
+    let __local_23: i32;
+    let __local_24: u64;
+    let __local_25: i32;
+    let __local_26: i32;
+    let __local_27: i32;
+    let __sroa_unpack_mantissa: u64;
+    let __sroa_unpack_exponent: i32;
+    multivalue_bind [__sroa_unpack_mantissa, __sroa_unpack_exponent] = unpack64(f);
+    m = __sroa_unpack_mantissa;
+    e = __sroa_unpack_exponent;
+    log10_e63 = __inline_log10_pow2_0: block -> i32 {
+        __local_21 = e + 63;
+        break __inline_log10_pow2_0: (__local_21 * 78913) >> 18;
+    };
+    p1 = 0 - log10_e63;
+    lp1 = (p1 * 108853) >> 15;
+    let __sroa_pm1_hi: u64;
+    let __sroa_pm1_lo: u64;
+    multivalue_bind [__sroa_pm1_hi, __sroa_pm1_lo] = mul_pow10(p1);
+    s1 = 0 - ((e + lp1) + 3);
+    u1 = uscale(m, __sroa_pm1_hi, __sroa_pm1_lo, s1);
+    d1_floor = (u1 + 0_i64) >>u 2_i64;
+    decimal_pos = if d1_floor >=u 10_i64 -> i32 {
+        2 - p1;
+    } else {
+        1 - p1;
+    };
+    total_digits = decimal_pos + precision;
+    n = if total_digits > 18 -> i32 {
+        18;
+    } else {
+        select i32(total_digits < 1, 1, total_digits);
+    };
+    p = (n - 1) - log10_e63;
+    lp = (p * 108853) >> 15;
+    let __sroa_pm_hi: u64;
+    let __sroa_pm_lo: u64;
+    multivalue_bind [__sroa_pm_hi, __sroa_pm_lo] = mul_pow10(p);
+    s = 0 - ((e + lp) + 3);
+    u = uscale(m, __sroa_pm_hi, __sroa_pm_lo, s);
+    d = unrounded_round(u);
+    if d >=u Array<u64>^IndexValue::index_value(POW10, n) {
+        d = unrounded_round(unrounded_div(u, 10_i64));
+        return d; (0 - p) + 1;
+    };
+    return d; 0 - p;
+}
+
 fn short(f) {
     let __local_1: i32;
     let unpack: ref null UnpackResult;
@@ -1005,17 +1093,17 @@ fn write_digits_at(buf, offset, val, nd) {
     v = val;
     idx = (offset + nd) - 1;
     _licm_repr = buf.repr;
-    b91: block {
-        l92: loop {
+    b94: block {
+        l95: loop {
             if (idx >= offset) == 0 {
-                break b91;
+                break b94;
             };
             __local_7 = idx;
             __local_8 = 48 + (builtin::i32_wrap_i64(v %u 10_i64) & 255);
             builtin::array_set_u8(_licm_repr, __local_7, __local_8);
             v = v /u 10_i64;
             idx = idx - 1;
-            continue l92;
+            continue l95;
         };
     };
 }
@@ -1162,6 +1250,140 @@ fn write_exp(buf, d, p, nd, upper) {
     };
 }
 
+fn write_decimal_prec(buf, d, p, nd, precision) {
+    let decimal_pos: i32;
+    let leading_zeros: i32;
+    let remaining_prec: i32;
+    let digits_to_output: i32;
+    let trailing_9: i32;
+    let trim_d_10: u64;
+    let skip_11: i32;
+    let digit_offset: i32;
+    let start_13: i32;
+    let after_decimal: i32;
+    let output_nd: i32;
+    let trim_d_16: u64;
+    let skip_17: i32;
+    let total: i32;
+    let start_19: i32;
+    let raw_20: ref null array<u8>;
+    let trailing_21: i32;
+    let start_22: i32;
+    let raw_23: ref null array<u8>;
+    let __local_24: ref null String;
+    let __local_25: i32;
+    let __local_26: ref null String;
+    let __local_27: i32;
+    let __local_28: ref null String;
+    let __local_29: ref null String;
+    let __local_30: i32;
+    let __local_31: ref null String;
+    let __local_32: i32;
+    let __local_33: ref null String;
+    let __local_34: ref null String;
+    let __local_35: i32;
+    let __local_36: ref null String;
+    let __local_37: i32;
+    let __local_38: ref null String;
+    let __local_39: i32;
+    let __local_40: ref null String;
+    let __local_41: ref null String;
+    let __local_42: i32;
+    let __local_43: ref null String;
+    let __local_44: ref null String;
+    let __local_45: i32;
+    let __local_46: u8;
+    let __local_47: ref null String;
+    let __local_48: ref null String;
+    let __local_49: i32;
+    let __local_50: ref null String;
+    let __local_51: ref null String;
+    let __local_52: i32;
+    let __local_53: u8;
+    let __local_54: ref null String;
+    let __local_55: i32;
+    if precision < 0 {
+        write_decimal(buf, d, p, nd);
+        return;
+    };
+    decimal_pos = nd + p;
+    if decimal_pos <= 0 {
+        leading_zeros = 0 - decimal_pos;
+        String::append_char(buf, 48);
+        String::append_char(buf, 46);
+        if precision <= leading_zeros {
+            String::append_byte_filled(buf, 48, precision);
+            return;
+        };
+        String::append_byte_filled(buf, 48, leading_zeros);
+        remaining_prec = precision - leading_zeros;
+        digits_to_output = select i32(remaining_prec < nd, remaining_prec, nd);
+        trailing_9 = (precision - leading_zeros) - digits_to_output;
+        trim_d_10 = d;
+        skip_11 = nd - digits_to_output;
+        b108: block {
+            l109: loop {
+                if (skip_11 > 0) == 0 {
+                    break b108;
+                };
+                trim_d_10 = trim_d_10 /u 10_i64;
+                skip_11 = skip_11 - 1;
+                continue l109;
+            };
+        };
+        digit_offset = buf.used;
+        String::append_byte_filled(buf, 48, digits_to_output);
+        write_digits_at(buf, digit_offset, trim_d_10, digits_to_output);
+        String::append_byte_filled(buf, 48, trailing_9);
+    } else if decimal_pos >= nd {
+        start_13 = buf.used;
+        String::append_byte_filled(buf, 48, nd);
+        write_digits_at(buf, start_13, d, nd);
+        __local_37 = decimal_pos - nd;
+        String::append_byte_filled(buf, 48, __local_37);
+        if precision > 0 {
+            String::append_char(buf, 46);
+            String::append_byte_filled(buf, 48, precision);
+        };
+    } else {
+        after_decimal = nd - decimal_pos;
+        if precision <= after_decimal {
+            output_nd = decimal_pos + precision;
+            trim_d_16 = d;
+            skip_17 = nd - output_nd;
+            b114: block {
+                l115: loop {
+                    if (skip_17 > 0) == 0 {
+                        break b114;
+                    };
+                    trim_d_16 = trim_d_16 /u 10_i64;
+                    skip_17 = skip_17 - 1;
+                    continue l115;
+                };
+            };
+            total = output_nd + 1;
+            start_19 = buf.used;
+            String::append_byte_filled(buf, 48, total);
+            write_digits_at(buf, start_19, trim_d_16, output_nd);
+            raw_20 = buf.repr;
+            builtin::array_copy<u8>(raw_20, (start_19 + decimal_pos) + 1, raw_20, start_19 + decimal_pos, output_nd - decimal_pos);
+            __local_45 = start_19 + decimal_pos;
+            builtin::array_set_u8(buf.repr, __local_45, 46);
+            return;
+        };
+        trailing_21 = precision - after_decimal;
+        start_22 = buf.used;
+        __local_49 = nd + 1;
+        String::append_byte_filled(buf, 48, __local_49);
+        write_digits_at(buf, start_22, d, nd);
+        raw_23 = buf.repr;
+        builtin::array_copy<u8>(raw_23, (start_22 + decimal_pos) + 1, raw_23, start_22 + decimal_pos, nd - decimal_pos);
+        __local_52 = start_22 + decimal_pos;
+        builtin::array_set_u8(buf.repr, __local_52, 46);
+        String::append_byte_filled(buf, 48, trailing_21);
+    };
+}
+
 fn check_special(f) {
     let bits: i64;
     let is_neg: bool;
@@ -1259,7 +1481,7 @@ fn Array<u64>::append(self, value) {
 
 fn Array<u64>^IndexValue::index_value(self, index) {
     if index >= self.used {
-        "core:internal/panic"(String { repr: ref.as_non_null(array.new_data<u8>[4](0, 19)), used: 19 });
+        "core:internal/panic"(String { repr: ref.as_non_null(array.new_data<u8>[5](0, 19)), used: 19 });
         unreachable;
     };
     return builtin::array_get<u64>(self.repr, index);
@@ -1283,6 +1505,10 @@ fn f64::fmt_into(self, f) {
     let __local_16: ref null String;
     let __local_17: ref null Formatter;
     let __local_18: ref null String;
+    if f.precision >= 0 {
+        f64::fmt_fixed(self, f.precision, f);
+        return;
+    };
     value = self.value;
     let __sroa___pattern_temp_0_0: bool;
     let __sroa___pattern_temp_0_1: bool;
@@ -1302,15 +1528,15 @@ fn f64::fmt_into(self, f) {
             String::append_char(f.buf, 78);
         } else if kind == 2 {
             String::append(f.buf, if is_neg -> ref null String {
-                String { repr: ref.as_non_null(array.new_data<u8>[6](0, 4)), used: 4 };
+                String { repr: ref.as_non_null(array.new_data<u8>[7](0, 4)), used: 4 };
             } else {
-                String { repr: ref.as_non_null(array.new_data<u8>[7](0, 3)), used: 3 };
+                String { repr: ref.as_non_null(array.new_data<u8>[8](0, 3)), used: 3 };
             });
         } else {
             String::append(f.buf, if is_neg -> ref null String {
-                String { repr: ref.as_non_null(array.new_data<u8>[8](0, 4)), used: 4 };
+                String { repr: ref.as_non_null(array.new_data<u8>[9](0, 4)), used: 4 };
             } else {
-                String { repr: ref.as_non_null(array.new_data<u8>[9](0, 3)), used: 3 };
+                String { repr: ref.as_non_null(array.new_data<u8>[10](0, 3)), used: 3 };
             });
         };
         Formatter::apply_padding(f, mark_6);
@@ -1351,6 +1577,85 @@ fn f64::fmt_into(self, f) {
         write_decimal(f.buf, d, p, nd);
     };
     Formatter::apply_padding(f, mark_13);
+}
+
+fn f64::fmt_fixed(self, precision, f) {
+    let value: f64;
+    let is_special: bool;
+    let is_neg: bool;
+    let kind: enum:SpecialKind;
+    let mark_7: i32;
+    let buf: ref null String;
+    let abs_f: f64;
+    let result: ref null FormatResult;
+    let d: u64;
+    let p: i32;
+    let nd: i32;
+    let mark_14: i32;
+    let __pattern_temp_0: ref null "tuple/[bool, bool, SpecialKind]";
+    let __local_16: ref null Formatter;
+    let __local_17: ref null String;
+    let __local_18: ref null Formatter;
+    let __local_19: ref null String;
+    value = self.value;
+    let __sroa___pattern_temp_0_0: bool;
+    let __sroa___pattern_temp_0_1: bool;
+    let __sroa___pattern_temp_0_2: i32;
+    multivalue_bind [__sroa___pattern_temp_0_0, __sroa___pattern_temp_0_1, __sroa___pattern_temp_0_2] = check_special(value);
+    is_special = __sroa___pattern_temp_0_0;
+    is_neg = __sroa___pattern_temp_0_1;
+    kind = __sroa___pattern_temp_0_2;
+    if is_special {
+        mark_7 = __inline_String__len_1: block -> i32 {
+            __local_17 = f.buf;
+            break __inline_String__len_1: __local_17.used;
+        };
+        if kind == 3 {
+            String::append_char(f.buf, 78);
+            String::append_char(f.buf, 97);
+            String::append_char(f.buf, 78);
+        } else if kind == 2 {
+            String::append(f.buf, if is_neg -> ref null String {
+                String { repr: ref.as_non_null(array.new_data<u8>[7](0, 4)), used: 4 };
+            } else {
+                String { repr: ref.as_non_null(array.new_data<u8>[8](0, 3)), used: 3 };
+            });
+        } else {
+            buf = f.buf;
+            if is_neg {
+                String::append_char(buf, 45);
+            };
+            String::append_char(buf, 48);
+            if precision > 0 {
+                String::append_char(buf, 46);
+                String::append_byte_filled(buf, 48, precision);
+            };
+        };
+        Formatter::apply_padding(f, mark_7);
+        return;
+    };
+    abs_f = if is_neg -> f64 {
+        builtin::f64_neg(value);
+    } else {
+        value;
+    };
+    let __sroa_result_digits: u64;
+    let __sroa_result_exponent: i32;
+    multivalue_bind [__sroa_result_digits, __sroa_result_exponent] = fixed_width_for_prec(abs_f, precision);
+    d = __sroa_result_digits;
+    p = __sroa_result_exponent;
+    nd = digits(d);
+    mark_14 = __inline_String__len_3: block -> i32 {
+        __local_19 = f.buf;
+        break __inline_String__len_3: __local_19.used;
+    };
+    if is_neg {
+        String::append_char(f.buf, 45);
+    } else if f.sign_plus {
+        String::append_char(f.buf, 43);
+    };
+    write_decimal_prec(f.buf, d, p, nd, precision);
+    Formatter::apply_padding(f, mark_14);
 }
 
 fn String::grow(self, min_capacity) {
@@ -1493,10 +1798,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b132: block {
-            l133: loop {
+        b157: block {
+            l158: loop {
                 if (i_8 >= 0) == 0 {
-                    break b132;
+                    break b157;
                 };
                 __local_14 = (start_pos + left_pad) + i_8;
                 __local_15 = __inline_String__get_byte_2: block -> u8 {
@@ -1505,7 +1810,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, __local_14, __local_15);
                 i_8 = i_8 - 1;
-                continue l133;
+                continue l158;
             };
         };
         __for_1: block {
@@ -1513,14 +1818,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l136: loop {
+                l161: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     __local_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, __local_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l136;
+                    continue l161;
                 };
             };
         };
@@ -1530,10 +1835,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b138: block {
-            l139: loop {
+        b163: block {
+            l164: loop {
                 if (i_10 >= 0) == 0 {
-                    break b138;
+                    break b163;
                 };
                 __local_22 = (start_pos + padding) + i_10;
                 __local_23 = __inline_String__get_byte_5: block -> u8 {
@@ -1542,7 +1847,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, __local_22, __local_23);
                 i_10 = i_10 - 1;
-                continue l139;
+                continue l164;
             };
         };
         __for_2: block {
@@ -1550,14 +1855,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l142: loop {
+                l167: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     __local_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, __local_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l142;
+                    continue l167;
                 };
             };
         };

--- a/wado-compiler/tests/fixtures.golden.wir/newtype_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden.wir/newtype_basic.wir.wado
@@ -116,6 +116,8 @@ type "functype/unpack64" = fn(f64) -> ref null UnpackResult;
 
 type "functype/unrounded_round" = fn(u64) -> u64;
 
+type "functype/unrounded_div" = fn(u64, u64) -> u64;
+
 type "functype/pow10_coarse" = fn(i32) -> ref null PmHiLo;
 
 type "functype/pow10_fine" = fn(i32) -> u64;
@@ -123,6 +125,8 @@ type "functype/pow10_fine" = fn(i32) -> u64;
 type "functype/mul_pow10" = fn(i32) -> ref null PmHiLo;
 
 type "functype/uscale" = fn(u64, u64, u64, i32) -> u64;
+
+type "functype/fixed_width_for_prec" = fn(f64, i32) -> ref null FormatResult;
 
 type "functype/short" = fn(f64) -> ref null FormatResult;
 
@@ -136,6 +140,8 @@ type "functype/write_decimal" = fn(ref null String, u64, i32, i32);
 
 type "functype/write_exp" = fn(ref null String, u64, i32, i32, bool);
 
+type "functype/write_decimal_prec" = fn(ref null String, u64, i32, i32, i32);
+
 type "functype/check_special" = fn(f64) -> ref null "tuple/[bool, bool, SpecialKind]";
 
 type "functype/__initialize_module" = fn();
@@ -145,6 +151,8 @@ type "functype/Array<u64>::append" = fn(ref null Array<u64>, u64);
 type "functype/Array<u64>^IndexValue::index_value" = fn(ref null Array<u64>, i32) -> u64;
 
 type "functype/f64::fmt_into" = fn(ref null "core:internal/Box<f64>", ref null Formatter);
+
+type "functype/f64::fmt_fixed" = fn(ref null "core:internal/Box<f64>", i32, ref null Formatter);
 
 type "functype/String::grow" = fn(ref null String, i32);
 
@@ -161,6 +169,8 @@ type "functype/unpack64" = fn(f64) -> [u64, i32];
 type "functype/pow10_coarse" = fn(i32) -> [u64, u64];
 
 type "functype/mul_pow10" = fn(i32) -> [u64, u64];
+
+type "functype/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];
 
 type "functype/short" = fn(f64) -> [u64, i32];
 
@@ -243,7 +253,7 @@ fn run() with Stdout {
     };
     "core:cli/println"(__tmpl: block -> ref null String {
         __local_7 = String { repr: ref.as_non_null(builtin::array_new<u8>(31)), used: 0 };
-        String::append(__local_7, String { repr: ref.as_non_null(array.new_data<u8>[12](0, 15)), used: 15 });
+        String::append(__local_7, String { repr: ref.as_non_null(array.new_data<u8>[14](0, 15)), used: 15 });
         __local_8 = __inline_Formatter__new_2: block -> ref null Formatter {
             __local_16 = __local_7;
             break __inline_Formatter__new_2: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_16) };
@@ -252,7 +262,7 @@ fn run() with Stdout {
         __local_18 = __local_8;
         __local_21 = "core:internal/Box<f64>" { value: __local_17.value };
         f64::fmt_into(__local_21, __local_18);
-        __local_24 = String { repr: ref.as_non_null(array.new_data<u8>[16](0, 10)), used: 10 };
+        __local_24 = String { repr: ref.as_non_null(array.new_data<u8>[18](0, 10)), used: 10 };
         String::append(__local_18.buf, __local_24);
         break __tmpl: __local_7;
     });
@@ -276,7 +286,7 @@ fn run() with Stdout {
     from_raw = 100;
     "core:cli/println"(__tmpl: block -> ref null String {
         __local_11 = String { repr: ref.as_non_null(builtin::array_new<u8>(26)), used: 0 };
-        String::append(__local_11, String { repr: ref.as_non_null(array.new_data<u8>[14](0, 10)), used: 10 });
+        String::append(__local_11, String { repr: ref.as_non_null(array.new_data<u8>[16](0, 10)), used: 10 });
         __local_12 = __inline_Formatter__new_11: block -> ref null Formatter {
             __local_30 = __local_11;
             break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_30) };
@@ -285,14 +295,14 @@ fn run() with Stdout {
         __local_32 = __local_12;
         __local_35 = "core:internal/Box<f64>" { value: __local_31.value };
         f64::fmt_into(__local_35, __local_32);
-        __local_38 = String { repr: ref.as_non_null(array.new_data<u8>[16](0, 10)), used: 10 };
+        __local_38 = String { repr: ref.as_non_null(array.new_data<u8>[18](0, 10)), used: 10 };
         String::append(__local_32.buf, __local_38);
         break __tmpl: __local_11;
     });
     km_from_m = 1000 / 1000;
     "core:cli/println"(__tmpl: block -> ref null String {
         __local_13 = String { repr: ref.as_non_null(builtin::array_new<u8>(27)), used: 0 };
-        String::append(__local_13, String { repr: ref.as_non_null(array.new_data<u8>[15](0, 11)), used: 11 });
+        String::append(__local_13, String { repr: ref.as_non_null(array.new_data<u8>[17](0, 11)), used: 11 });
         __local_14 = __inline_Formatter__new_17: block -> ref null Formatter {
             __local_40 = __local_13;
             break __inline_Formatter__new_17: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_40) };
@@ -301,7 +311,7 @@ fn run() with Stdout {
         __local_42 = __local_14;
         __local_45 = "core:internal/Box<f64>" { value: __local_41.value };
         f64::fmt_into(__local_45, __local_42);
-        __local_48 = String { repr: ref.as_non_null(array.new_data<u8>[17](0, 14)), used: 14 };
+        __local_48 = String { repr: ref.as_non_null(array.new_data<u8>[19](0, 14)), used: 14 };
         String::append(__local_42.buf, __local_48);
         break __tmpl: __local_13;
     });
@@ -476,6 +486,14 @@ fn unpack64(f) {
 
 fn unrounded_round(u) {
     return ((u + 1_i64) + ((u >>u 2_i64) & 1_i64)) >>u 2_i64;
+}
+
+fn unrounded_div(u, d) {
+    let q: u64;
+    let r: u64;
+    q = u /u d;
+    r = u %u d;
+    return (q | (u & 1_i64)) | builtin::i64_extend_i32_u(r != 0_i64);
 }
 
 fn pow10_coarse(i) {
@@ -796,6 +814,76 @@ fn uscale(x, pm_hi, pm_lo, s) {
     return (hi >>u builtin::i64_extend_i32_s(s)) | sticky;
 }
 
+fn fixed_width_for_prec(f, precision) {
+    let unpack: ref null UnpackResult;
+    let m: u64;
+    let e: i32;
+    let log10_e63: i32;
+    let p1: i32;
+    let lp1: i32;
+    let pm1: ref null PmHiLo;
+    let s1: i32;
+    let u1: u64;
+    let d1_floor: u64;
+    let decimal_pos: i32;
+    let total_digits: i32;
+    let n: i32;
+    let p: i32;
+    let lp: i32;
+    let pm: ref null PmHiLo;
+    let s: i32;
+    let u: u64;
+    let d: u64;
+    let __local_21: i32;
+    let __local_22: i32;
+    let __local_23: i32;
+    let __local_24: u64;
+    let __local_25: i32;
+    let __local_26: i32;
+    let __local_27: i32;
+    let __sroa_unpack_mantissa: u64;
+    let __sroa_unpack_exponent: i32;
+    multivalue_bind [__sroa_unpack_mantissa, __sroa_unpack_exponent] = unpack64(f);
+    m = __sroa_unpack_mantissa;
+    e = __sroa_unpack_exponent;
+    log10_e63 = __inline_log10_pow2_0: block -> i32 {
+        __local_21 = e + 63;
+        break __inline_log10_pow2_0: (__local_21 * 78913) >> 18;
+    };
+    p1 = 0 - log10_e63;
+    lp1 = (p1 * 108853) >> 15;
+    let __sroa_pm1_hi: u64;
+    let __sroa_pm1_lo: u64;
+    multivalue_bind [__sroa_pm1_hi, __sroa_pm1_lo] = mul_pow10(p1);
+    s1 = 0 - ((e + lp1) + 3);
+    u1 = uscale(m, __sroa_pm1_hi, __sroa_pm1_lo, s1);
+    d1_floor = (u1 + 0_i64) >>u 2_i64;
+    decimal_pos = if d1_floor >=u 10_i64 -> i32 {
+        2 - p1;
+    } else {
+        1 - p1;
+    };
+    total_digits = decimal_pos + precision;
+    n = if total_digits > 18 -> i32 {
+        18;
+    } else {
+        select i32(total_digits < 1, 1, total_digits);
+    };
+    p = (n - 1) - log10_e63;
+    lp = (p * 108853) >> 15;
+    let __sroa_pm_hi: u64;
+    let __sroa_pm_lo: u64;
+    multivalue_bind [__sroa_pm_hi, __sroa_pm_lo] = mul_pow10(p);
+    s = 0 - ((e + lp) + 3);
+    u = uscale(m, __sroa_pm_hi, __sroa_pm_lo, s);
+    d = unrounded_round(u);
+    if d >=u Array<u64>^IndexValue::index_value(POW10, n) {
+        d = unrounded_round(unrounded_div(u, 10_i64));
+        return d; (0 - p) + 1;
+    };
+    return d; 0 - p;
+}
+
 fn short(f) {
     let __local_1: i32;
     let unpack: ref null UnpackResult;
@@ -1040,17 +1128,17 @@ fn write_digits_at(buf, offset, val, nd) {
     v = val;
     idx = (offset + nd) - 1;
     _licm_repr = buf.repr;
-    b87: block {
-        l88: loop {
+    b90: block {
+        l91: loop {
             if (idx >= offset) == 0 {
-                break b87;
+                break b90;
             };
             __local_7 = idx;
             __local_8 = 48 + (builtin::i32_wrap_i64(v %u 10_i64) & 255);
             builtin::array_set_u8(_licm_repr, __local_7, __local_8);
             v = v /u 10_i64;
             idx = idx - 1;
-            continue l88;
+            continue l91;
         };
     };
 }
@@ -1197,6 +1285,140 @@ fn write_exp(buf, d, p, nd, upper) {
     };
 }
 
+fn write_decimal_prec(buf, d, p, nd, precision) {
+    let decimal_pos: i32;
+    let leading_zeros: i32;
+    let remaining_prec: i32;
+    let digits_to_output: i32;
+    let trailing_9: i32;
+    let trim_d_10: u64;
+    let skip_11: i32;
+    let digit_offset: i32;
+    let start_13: i32;
+    let after_decimal: i32;
+    let output_nd: i32;
+    let trim_d_16: u64;
+    let skip_17: i32;
+    let total: i32;
+    let start_19: i32;
+    let raw_20: ref null array<u8>;
+    let trailing_21: i32;
+    let start_22: i32;
+    let raw_23: ref null array<u8>;
+    let __local_24: ref null String;
+    let __local_25: i32;
+    let __local_26: ref null String;
+    let __local_27: i32;
+    let __local_28: ref null String;
+    let __local_29: ref null String;
+    let __local_30: i32;
+    let __local_31: ref null String;
+    let __local_32: i32;
+    let __local_33: ref null String;
+    let __local_34: ref null String;
+    let __local_35: i32;
+    let __local_36: ref null String;
+    let __local_37: i32;
+    let __local_38: ref null String;
+    let __local_39: i32;
+    let __local_40: ref null String;
+    let __local_41: ref null String;
+    let __local_42: i32;
+    let __local_43: ref null String;
+    let __local_44: ref null String;
+    let __local_45: i32;
+    let __local_46: u8;
+    let __local_47: ref null String;
+    let __local_48: ref null String;
+    let __local_49: i32;
+    let __local_50: ref null String;
+    let __local_51: ref null String;
+    let __local_52: i32;
+    let __local_53: u8;
+    let __local_54: ref null String;
+    let __local_55: i32;
+    if precision < 0 {
+        write_decimal(buf, d, p, nd);
+        return;
+    };
+    decimal_pos = nd + p;
+    if decimal_pos <= 0 {
+        leading_zeros = 0 - decimal_pos;
+        String::append_char(buf, 48);
+        String::append_char(buf, 46);
+        if precision <= leading_zeros {
+            String::append_byte_filled(buf, 48, precision);
+            return;
+        };
+        String::append_byte_filled(buf, 48, leading_zeros);
+        remaining_prec = precision - leading_zeros;
+        digits_to_output = select i32(remaining_prec < nd, remaining_prec, nd);
+        trailing_9 = (precision - leading_zeros) - digits_to_output;
+        trim_d_10 = d;
+        skip_11 = nd - digits_to_output;
+        b104: block {
+            l105: loop {
+                if (skip_11 > 0) == 0 {
+                    break b104;
+                };
+                trim_d_10 = trim_d_10 /u 10_i64;
+                skip_11 = skip_11 - 1;
+                continue l105;
+            };
+        };
+        digit_offset = buf.used;
+        String::append_byte_filled(buf, 48, digits_to_output);
+        write_digits_at(buf, digit_offset, trim_d_10, digits_to_output);
+        String::append_byte_filled(buf, 48, trailing_9);
+    } else if decimal_pos >= nd {
+        start_13 = buf.used;
+        String::append_byte_filled(buf, 48, nd);
+        write_digits_at(buf, start_13, d, nd);
+        __local_37 = decimal_pos - nd;
+        String::append_byte_filled(buf, 48, __local_37);
+        if precision > 0 {
+            String::append_char(buf, 46);
+            String::append_byte_filled(buf, 48, precision);
+        };
+    } else {
+        after_decimal = nd - decimal_pos;
+        if precision <= after_decimal {
+            output_nd = decimal_pos + precision;
+            trim_d_16 = d;
+            skip_17 = nd - output_nd;
+            b110: block {
+                l111: loop {
+                    if (skip_17 > 0) == 0 {
+                        break b110;
+                    };
+                    trim_d_16 = trim_d_16 /u 10_i64;
+                    skip_17 = skip_17 - 1;
+                    continue l111;
+                };
+            };
+            total = output_nd + 1;
+            start_19 = buf.used;
+            String::append_byte_filled(buf, 48, total);
+            write_digits_at(buf, start_19, trim_d_16, output_nd);
+            raw_20 = buf.repr;
+            builtin::array_copy<u8>(raw_20, (start_19 + decimal_pos) + 1, raw_20, start_19 + decimal_pos, output_nd - decimal_pos);
+            __local_45 = start_19 + decimal_pos;
+            builtin::array_set_u8(buf.repr, __local_45, 46);
+            return;
+        };
+        trailing_21 = precision - after_decimal;
+        start_22 = buf.used;
+        __local_49 = nd + 1;
+        String::append_byte_filled(buf, 48, __local_49);
+        write_digits_at(buf, start_22, d, nd);
+        raw_23 = buf.repr;
+        builtin::array_copy<u8>(raw_23, (start_22 + decimal_pos) + 1, raw_23, start_22 + decimal_pos, nd - decimal_pos);
+        __local_52 = start_22 + decimal_pos;
+        builtin::array_set_u8(buf.repr, __local_52, 46);
+        String::append_byte_filled(buf, 48, trailing_21);
+    };
+}
+
 fn check_special(f) {
     let bits: i64;
     let is_neg: bool;
@@ -1294,7 +1516,7 @@ fn Array<u64>::append(self, value) {
 
 fn Array<u64>^IndexValue::index_value(self, index) {
     if index >= self.used {
-        "core:internal/panic"(String { repr: ref.as_non_null(array.new_data<u8>[4](0, 19)), used: 19 });
+        "core:internal/panic"(String { repr: ref.as_non_null(array.new_data<u8>[5](0, 19)), used: 19 });
         unreachable;
     };
     return builtin::array_get<u64>(self.repr, index);
@@ -1318,6 +1540,10 @@ fn f64::fmt_into(self, f) {
     let __local_16: ref null String;
     let __local_17: ref null Formatter;
     let __local_18: ref null String;
+    if f.precision >= 0 {
+        f64::fmt_fixed(self, f.precision, f);
+        return;
+    };
     value = self.value;
     let __sroa___pattern_temp_0_0: bool;
     let __sroa___pattern_temp_0_1: bool;
@@ -1337,15 +1563,15 @@ fn f64::fmt_into(self, f) {
             String::append_char(f.buf, 78);
         } else if kind == 2 {
             String::append(f.buf, if is_neg -> ref null String {
-                String { repr: ref.as_non_null(array.new_data<u8>[6](0, 4)), used: 4 };
+                String { repr: ref.as_non_null(array.new_data<u8>[7](0, 4)), used: 4 };
             } else {
-                String { repr: ref.as_non_null(array.new_data<u8>[7](0, 3)), used: 3 };
+                String { repr: ref.as_non_null(array.new_data<u8>[8](0, 3)), used: 3 };
             });
         } else {
             String::append(f.buf, if is_neg -> ref null String {
-                String { repr: ref.as_non_null(array.new_data<u8>[8](0, 4)), used: 4 };
+                String { repr: ref.as_non_null(array.new_data<u8>[9](0, 4)), used: 4 };
             } else {
-                String { repr: ref.as_non_null(array.new_data<u8>[9](0, 3)), used: 3 };
+                String { repr: ref.as_non_null(array.new_data<u8>[10](0, 3)), used: 3 };
             });
         };
         Formatter::apply_padding(f, mark_6);
@@ -1386,6 +1612,85 @@ fn f64::fmt_into(self, f) {
         write_decimal(f.buf, d, p, nd);
     };
     Formatter::apply_padding(f, mark_13);
+}
+
+fn f64::fmt_fixed(self, precision, f) {
+    let value: f64;
+    let is_special: bool;
+    let is_neg: bool;
+    let kind: enum:SpecialKind;
+    let mark_7: i32;
+    let buf: ref null String;
+    let abs_f: f64;
+    let result: ref null FormatResult;
+    let d: u64;
+    let p: i32;
+    let nd: i32;
+    let mark_14: i32;
+    let __pattern_temp_0: ref null "tuple/[bool, bool, SpecialKind]";
+    let __local_16: ref null Formatter;
+    let __local_17: ref null String;
+    let __local_18: ref null Formatter;
+    let __local_19: ref null String;
+    value = self.value;
+    let __sroa___pattern_temp_0_0: bool;
+    let __sroa___pattern_temp_0_1: bool;
+    let __sroa___pattern_temp_0_2: i32;
+    multivalue_bind [__sroa___pattern_temp_0_0, __sroa___pattern_temp_0_1, __sroa___pattern_temp_0_2] = check_special(value);
+    is_special = __sroa___pattern_temp_0_0;
+    is_neg = __sroa___pattern_temp_0_1;
+    kind = __sroa___pattern_temp_0_2;
+    if is_special {
+        mark_7 = __inline_String__len_1: block -> i32 {
+            __local_17 = f.buf;
+            break __inline_String__len_1: __local_17.used;
+        };
+        if kind == 3 {
+            String::append_char(f.buf, 78);
+            String::append_char(f.buf, 97);
+            String::append_char(f.buf, 78);
+        } else if kind == 2 {
+            String::append(f.buf, if is_neg -> ref null String {
+                String { repr: ref.as_non_null(array.new_data<u8>[7](0, 4)), used: 4 };
+            } else {
+                String { repr: ref.as_non_null(array.new_data<u8>[8](0, 3)), used: 3 };
+            });
+        } else {
+            buf = f.buf;
+            if is_neg {
+                String::append_char(buf, 45);
+            };
+            String::append_char(buf, 48);
+            if precision > 0 {
+                String::append_char(buf, 46);
+                String::append_byte_filled(buf, 48, precision);
+            };
+        };
+        Formatter::apply_padding(f, mark_7);
+        return;
+    };
+    abs_f = if is_neg -> f64 {
+        builtin::f64_neg(value);
+    } else {
+        value;
+    };
+    let __sroa_result_digits: u64;
+    let __sroa_result_exponent: i32;
+    multivalue_bind [__sroa_result_digits, __sroa_result_exponent] = fixed_width_for_prec(abs_f, precision);
+    d = __sroa_result_digits;
+    p = __sroa_result_exponent;
+    nd = digits(d);
+    mark_14 = __inline_String__len_3: block -> i32 {
+        __local_19 = f.buf;
+        break __inline_String__len_3: __local_19.used;
+    };
+    if is_neg {
+        String::append_char(f.buf, 45);
+    } else if f.sign_plus {
+        String::append_char(f.buf, 43);
+    };
+    write_decimal_prec(f.buf, d, p, nd, precision);
+    Formatter::apply_padding(f, mark_14);
 }
 
 fn String::grow(self, min_capacity) {
@@ -1528,10 +1833,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b128: block {
-            l129: loop {
+        b153: block {
+            l154: loop {
                 if (i_8 >= 0) == 0 {
-                    break b128;
+                    break b153;
                 };
                 __local_14 = (start_pos + left_pad) + i_8;
                 __local_15 = __inline_String__get_byte_2: block -> u8 {
@@ -1540,7 +1845,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, __local_14, __local_15);
                 i_8 = i_8 - 1;
-                continue l129;
+                continue l154;
             };
         };
         __for_1: block {
@@ -1548,14 +1853,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l132: loop {
+                l157: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     __local_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, __local_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l132;
+                    continue l157;
                 };
             };
         };
@@ -1565,10 +1870,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b134: block {
-            l135: loop {
+        b159: block {
+            l160: loop {
                 if (i_10 >= 0) == 0 {
-                    break b134;
+                    break b159;
                 };
                 __local_22 = (start_pos + padding) + i_10;
                 __local_23 = __inline_String__get_byte_5: block -> u8 {
@@ -1577,7 +1882,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, __local_22, __local_23);
                 i_10 = i_10 - 1;
-                continue l135;
+                continue l160;
             };
         };
         __for_2: block {
@@ -1585,14 +1890,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l138: loop {
+                l163: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     __local_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, __local_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l138;
+                    continue l163;
                 };
             };
         };

--- a/wado-compiler/tests/fixtures.golden/array_new_data_f64.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_f64.lowered.wado
@@ -706,13 +706,25 @@ export fn run() with Stdout {
         };
         __r.String::append(" sum=");
         __f = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: sum }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: sum };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         __r.String::append(" first=");
         __f = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: a."Array<f64>^IndexValue::index_value"(0) }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: a."Array<f64>^IndexValue::index_value"(0) };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         __r.String::append(" last=");
         __f = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: a."Array<f64>^IndexValue::index_value"(127) }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: a."Array<f64>^IndexValue::index_value"(127) };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
 }

--- a/wado-compiler/tests/fixtures.golden/display_fts_precision.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_fts_precision.lowered.wado
@@ -27,700 +27,1100 @@ export fn run() with Stdout {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("a_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("a_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("b_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("b_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 0.001234567 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("c_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("c_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 3.14159265358979 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("d_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("d_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 99.999999 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 99.999999 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("e_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("e_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 0.9999995 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.9999995 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("f_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("f_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 0.5 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.5 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("g_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("g_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: 0.000009876 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.000009876 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("h_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("h_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: -0.582307589706 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.582307589706 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("i_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("i_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: -3.14159265358979 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -3.14159265358979 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_1: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 1, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_2: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 2, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_3: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 3, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_4: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 4, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_5: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 5, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_6: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 6, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_7: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 7, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(7, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_8: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 8, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(8, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(21), used: 0 };
         __r.String::append("j_9: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 9, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(9, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println(__tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(22), used: 0 };
         __r.String::append("j_10: ");
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 0, precision: 10, buf: &mut __r };
-        Box<f64> { value: -0.001234567 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.001234567 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     });
     core::cli::println("all done");

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers_float.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers_float.lowered.wado
@@ -264,7 +264,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 1, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(1, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.1");
     if !__cond {
@@ -275,9 +279,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_52: {
+            let mut __f: Formatter = __inline_Formatter__new_53: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_52: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_53: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 16 };
@@ -291,7 +295,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.14");
     if !__cond {
@@ -302,9 +310,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_57: {
+            let mut __f: Formatter = __inline_Formatter__new_59: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_57: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_59: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 17 };
@@ -318,7 +326,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 3, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(3, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.142");
     if !__cond {
@@ -329,9 +341,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_62: {
+            let mut __f: Formatter = __inline_Formatter__new_65: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_62: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_65: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 18 };
@@ -345,7 +357,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.1416");
     if !__cond {
@@ -356,9 +372,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_67: {
+            let mut __f: Formatter = __inline_Formatter__new_71: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_67: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_71: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 19 };
@@ -372,7 +388,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 5, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(5, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.14159");
     if !__cond {
@@ -383,9 +403,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_72: {
+            let mut __f: Formatter = __inline_Formatter__new_77: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_72: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_77: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 20 };
@@ -399,7 +419,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 6, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(6, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.141590");
     if !__cond {
@@ -410,9 +434,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_77: {
+            let mut __f: Formatter = __inline_Formatter__new_83: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_77: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_83: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 21 };
@@ -426,7 +450,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
-        Box<f64> { value: -2.71828 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -2.71828 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"-2.72");
     if !__cond {
@@ -437,9 +465,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_82: {
+            let mut __f: Formatter = __inline_Formatter__new_89: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_82: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_89: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 24 };
@@ -453,7 +481,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 4, buf: &mut __r };
-        Box<f64> { value: -2.71828 }.f64::fmt_fixed(4, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -2.71828 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"-2.7183");
     if !__cond {
@@ -464,9 +496,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_87: {
+            let mut __f: Formatter = __inline_Formatter__new_95: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_87: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_95: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 25 };
@@ -480,7 +512,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
-        Box<f64> { value: 0.0 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 0.0 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"0.00");
     if !__cond {
@@ -491,9 +527,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_92: {
+            let mut __f: Formatter = __inline_Formatter__new_101: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_92: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_101: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 28 };
@@ -507,7 +543,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
-        Box<f64> { value: 100.0 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 100.0 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"100.00");
     if !__cond {
@@ -518,9 +558,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_97: {
+            let mut __f: Formatter = __inline_Formatter__new_107: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_97: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_107: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 31 };
@@ -533,9 +573,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_101: {
+        let mut __f: Formatter = __inline_Formatter__new_111: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_101: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_111: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 3.14159 };
@@ -552,9 +592,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_104: {
+            let mut __f: Formatter = __inline_Formatter__new_114: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_104: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_114: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 33 };
@@ -567,9 +607,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_108: {
+        let mut __f: Formatter = __inline_Formatter__new_118: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_108: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_118: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: -2.71828 };
@@ -586,9 +626,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_111: {
+            let mut __f: Formatter = __inline_Formatter__new_121: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_111: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_121: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 34 };
@@ -601,9 +641,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_115: {
+        let mut __f: Formatter = __inline_Formatter__new_125: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_115: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_125: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 0.0 };
@@ -620,9 +660,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_118: {
+            let mut __f: Formatter = __inline_Formatter__new_128: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_118: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_128: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 35 };
@@ -635,9 +675,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_122: {
+        let mut __f: Formatter = __inline_Formatter__new_132: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_122: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_132: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 1.0 };
@@ -654,9 +694,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_125: {
+            let mut __f: Formatter = __inline_Formatter__new_135: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_125: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_135: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 36 };
@@ -669,9 +709,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_129: {
+        let mut __f: Formatter = __inline_Formatter__new_139: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_129: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_139: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 100.0 };
@@ -688,9 +728,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_132: {
+            let mut __f: Formatter = __inline_Formatter__new_142: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_132: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_142: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 37 };
@@ -703,9 +743,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_136: {
+        let mut __f: Formatter = __inline_Formatter__new_146: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_136: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_146: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 1.23e15 };
@@ -722,9 +762,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_139: {
+            let mut __f: Formatter = __inline_Formatter__new_149: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_139: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_149: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 41 };
@@ -737,9 +777,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_143: {
+        let mut __f: Formatter = __inline_Formatter__new_153: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_143: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_153: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 1.5e-10 };
@@ -756,9 +796,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_146: {
+            let mut __f: Formatter = __inline_Formatter__new_156: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_146: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_156: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 45 };
@@ -771,9 +811,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_150: {
+        let mut __f: Formatter = __inline_Formatter__new_160: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_150: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_160: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 3.14159 };
@@ -790,9 +830,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_153: {
+            let mut __f: Formatter = __inline_Formatter__new_163: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_153: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_163: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 47 };
@@ -805,9 +845,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_157: {
+        let mut __f: Formatter = __inline_Formatter__new_167: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_157: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_167: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: -2.71828 };
@@ -824,9 +864,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_160: {
+            let mut __f: Formatter = __inline_Formatter__new_170: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_160: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_170: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 48 };
@@ -839,9 +879,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_164: {
+        let mut __f: Formatter = __inline_Formatter__new_174: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_164: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_174: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 0.0 };
@@ -858,9 +898,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_167: {
+            let mut __f: Formatter = __inline_Formatter__new_177: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_167: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_177: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 49 };
@@ -873,9 +913,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_171: {
+        let mut __f: Formatter = __inline_Formatter__new_181: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_171: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_181: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 1.23e15 };
@@ -892,9 +932,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_174: {
+            let mut __f: Formatter = __inline_Formatter__new_184: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_174: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_184: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 50 };
@@ -907,9 +947,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_178: {
+        let mut __f: Formatter = __inline_Formatter__new_188: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_178: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_188: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 1.5e-10 };
@@ -926,9 +966,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_181: {
+            let mut __f: Formatter = __inline_Formatter__new_191: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_181: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_191: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 51 };
@@ -957,9 +997,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_187: {
+            let mut __f: Formatter = __inline_Formatter__new_197: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_187: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_197: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 53 };
@@ -988,9 +1028,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_193: {
+            let mut __f: Formatter = __inline_Formatter__new_203: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_193: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_203: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 54 };
@@ -1019,9 +1059,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_199: {
+            let mut __f: Formatter = __inline_Formatter__new_209: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_199: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_209: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 55 };
@@ -1050,9 +1090,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_205: {
+            let mut __f: Formatter = __inline_Formatter__new_215: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_205: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_215: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 57 };
@@ -1081,9 +1121,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_211: {
+            let mut __f: Formatter = __inline_Formatter__new_221: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_211: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_221: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 58 };
@@ -1112,9 +1152,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_217: {
+            let mut __f: Formatter = __inline_Formatter__new_227: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_217: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_227: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 60 };
@@ -1143,9 +1183,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_223: {
+            let mut __f: Formatter = __inline_Formatter__new_233: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_223: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_233: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 62 };
@@ -1174,9 +1214,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_229: {
+            let mut __f: Formatter = __inline_Formatter__new_239: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_229: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_239: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 63 };
@@ -1205,9 +1245,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_235: {
+            let mut __f: Formatter = __inline_Formatter__new_245: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_235: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_245: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 65 };
@@ -1236,9 +1276,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_241: {
+            let mut __f: Formatter = __inline_Formatter__new_251: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_241: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_251: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 67 };
@@ -1251,9 +1291,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_245: {
+        let mut __f: Formatter = __inline_Formatter__new_255: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_245: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_255: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f64> = Box<f64> { value: 123456.789 };
@@ -1270,9 +1310,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_248: {
+            let mut __f: Formatter = __inline_Formatter__new_258: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_248: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_258: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 70 };
@@ -1301,9 +1341,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_254: {
+            let mut __f: Formatter = __inline_Formatter__new_264: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_254: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_264: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 71 };
@@ -1332,9 +1372,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_260: {
+            let mut __f: Formatter = __inline_Formatter__new_270: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_260: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_270: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 72 };
@@ -1348,7 +1388,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"      3.14");
     if !__cond {
@@ -1359,9 +1403,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_265: {
+            let mut __f: Formatter = __inline_Formatter__new_276: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_265: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_276: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 75 };
@@ -1375,7 +1419,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.14      ");
     if !__cond {
@@ -1386,9 +1434,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_270: {
+            let mut __f: Formatter = __inline_Formatter__new_282: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_270: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_282: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 77 };
@@ -1402,7 +1450,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"   3.14   ");
     if !__cond {
@@ -1413,9 +1465,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_275: {
+            let mut __f: Formatter = __inline_Formatter__new_288: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_275: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_288: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 79 };
@@ -1429,7 +1481,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: '*', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"******3.14");
     if !__cond {
@@ -1440,9 +1496,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_280: {
+            let mut __f: Formatter = __inline_Formatter__new_294: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_280: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_294: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 81 };
@@ -1456,7 +1512,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: '*', align: Alignment::Left, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.14******");
     if !__cond {
@@ -1467,9 +1527,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_285: {
+            let mut __f: Formatter = __inline_Formatter__new_300: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_285: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_300: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 82 };
@@ -1483,7 +1543,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: '*', align: Alignment::Center, sign_plus: false, alternate: false, zero_pad: false, width: 10, precision: 2, buf: &mut __r };
-        Box<f64> { value: 3.14159 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 3.14159 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"***3.14***");
     if !__cond {
@@ -1494,9 +1558,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_290: {
+            let mut __f: Formatter = __inline_Formatter__new_306: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_290: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_306: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 83 };
@@ -1525,9 +1589,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_296: {
+            let mut __f: Formatter = __inline_Formatter__new_312: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_296: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_312: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 86 };
@@ -1556,9 +1620,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_302: {
+            let mut __f: Formatter = __inline_Formatter__new_318: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_302: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_318: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 87 };
@@ -1587,9 +1651,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_308: {
+            let mut __f: Formatter = __inline_Formatter__new_324: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_308: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_324: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 90 };
@@ -1618,9 +1682,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_314: {
+            let mut __f: Formatter = __inline_Formatter__new_330: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_314: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_330: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 91 };
@@ -1649,9 +1713,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_320: {
+            let mut __f: Formatter = __inline_Formatter__new_336: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_320: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_336: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 94 };
@@ -1680,9 +1744,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_326: {
+            let mut __f: Formatter = __inline_Formatter__new_342: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_326: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_342: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 95 };
@@ -1700,8 +1764,7 @@ export fn run() with Stdout {
         {
             let self: Box<f32> = Box<f32> { value: f };
             let f: &mut Formatter = &mut __f;
-            let v64: f64 = self.value as f64;
-            Box<f64> { value: v64 }.f64::fmt_fixed(2, f);
+            self.f32::fmt_into(f);
         };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.14");
@@ -1713,9 +1776,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_332: {
+            let mut __f: Formatter = __inline_Formatter__new_348: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_332: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_348: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 98 };
@@ -1732,8 +1795,7 @@ export fn run() with Stdout {
         {
             let self: Box<f32> = Box<f32> { value: f };
             let f: &mut Formatter = &mut __f;
-            let v64: f64 = self.value as f64;
-            Box<f64> { value: v64 }.f64::fmt_fixed(4, f);
+            self.f32::fmt_into(f);
         };
         break __tmpl: __r;
     }."String^Eq::eq"(&"3.1400");
@@ -1745,9 +1807,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_338: {
+            let mut __f: Formatter = __inline_Formatter__new_354: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_338: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_354: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 99 };
@@ -1765,8 +1827,7 @@ export fn run() with Stdout {
         {
             let self: Box<f32> = Box<f32> { value: f2 };
             let f: &mut Formatter = &mut __f;
-            let v64: f64 = self.value as f64;
-            Box<f64> { value: v64 }.f64::fmt_fixed(1, f);
+            self.f32::fmt_into(f);
         };
         break __tmpl: __r;
     }."String^Eq::eq"(&"2.5");
@@ -1778,9 +1839,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_344: {
+            let mut __f: Formatter = __inline_Formatter__new_360: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_344: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_360: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 102 };
@@ -1797,8 +1858,7 @@ export fn run() with Stdout {
         {
             let self: Box<f32> = Box<f32> { value: f2 };
             let f: &mut Formatter = &mut __f;
-            let v64: f64 = self.value as f64;
-            Box<f64> { value: v64 }.f64::fmt_fixed(3, f);
+            self.f32::fmt_into(f);
         };
         break __tmpl: __r;
     }."String^Eq::eq"(&"2.500");
@@ -1810,9 +1870,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_350: {
+            let mut __f: Formatter = __inline_Formatter__new_366: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_350: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_366: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 103 };
@@ -1845,9 +1905,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_357: {
+            let mut __f: Formatter = __inline_Formatter__new_373: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_357: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_373: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 104 };
@@ -1880,9 +1940,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_364: {
+            let mut __f: Formatter = __inline_Formatter__new_380: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_364: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_380: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 105 };
@@ -1895,9 +1955,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_368: {
+        let mut __f: Formatter = __inline_Formatter__new_384: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_368: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_384: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f32> = Box<f32> { value: f2 };
@@ -1918,9 +1978,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_372: {
+            let mut __f: Formatter = __inline_Formatter__new_388: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_372: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_388: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 106 };
@@ -1938,8 +1998,7 @@ export fn run() with Stdout {
         {
             let self: Box<f32> = Box<f32> { value: fz };
             let f: &mut Formatter = &mut __f;
-            let v64: f64 = self.value as f64;
-            Box<f64> { value: v64 }.f64::fmt_fixed(2, f);
+            self.f32::fmt_into(f);
         };
         break __tmpl: __r;
     }."String^Eq::eq"(&"0.00");
@@ -1951,9 +2010,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_378: {
+            let mut __f: Formatter = __inline_Formatter__new_394: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_378: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_394: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 110 };
@@ -1966,9 +2025,9 @@ export fn run() with Stdout {
     }
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
-        let mut __f: Formatter = __inline_Formatter__new_382: {
+        let mut __f: Formatter = __inline_Formatter__new_398: {
             let buf: &mut String = &mut __r;
-            break __inline_Formatter__new_382: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+            break __inline_Formatter__new_398: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
         };
         {
             let self: Box<f32> = Box<f32> { value: fz };
@@ -1989,9 +2048,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_386: {
+            let mut __f: Formatter = __inline_Formatter__new_402: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_386: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_402: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 111 };
@@ -2020,9 +2079,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_392: {
+            let mut __f: Formatter = __inline_Formatter__new_408: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_392: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_408: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 114 };
@@ -2051,9 +2110,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_398: {
+            let mut __f: Formatter = __inline_Formatter__new_414: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_398: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_414: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 115 };
@@ -2067,7 +2126,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 2, buf: &mut __r };
-        Box<f64> { value: -0.0 }.f64::fmt_fixed(2, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: -0.0 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"-0.00");
     if !__cond {
@@ -2078,9 +2141,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_403: {
+            let mut __f: Formatter = __inline_Formatter__new_420: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_403: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_420: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 118 };
@@ -2094,7 +2157,11 @@ export fn run() with Stdout {
     let __cond: bool = __tmpl: {
         let mut __r: String = String { repr: "core::prelude/string.wado::array_new<u8>"(16), used: 0 };
         let mut __f: Formatter = Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: 10, buf: &mut __r };
-        Box<f64> { value: 1.0 }.f64::fmt_fixed(10, &mut __f);
+        {
+            let self: Box<f64> = Box<f64> { value: 1.0 };
+            let f: &mut Formatter = &mut __f;
+            self.f64::fmt_into(f);
+        };
         break __tmpl: __r;
     }."String^Eq::eq"(&"1.0000000000");
     if !__cond {
@@ -2105,9 +2172,9 @@ export fn run() with Stdout {
             __r.String::append(" at ");
             __r.String::append("wado-compiler/tests/fixtures/display_template_specifiers_float.wado");
             __r.String::append(":");
-            let mut __f: Formatter = __inline_Formatter__new_408: {
+            let mut __f: Formatter = __inline_Formatter__new_426: {
                 let buf: &mut String = &mut __r;
-                break __inline_Formatter__new_408: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
+                break __inline_Formatter__new_426: Formatter { fill: ' ', align: Alignment::Right, sign_plus: false, alternate: false, zero_pad: false, width: -1, precision: -1, buf: buf };
             };
             {
                 let self: Box<i32> = Box<i32> { value: 121 };


### PR DESCRIPTION
## Summary
This PR implements precision-aware float formatting for the Display trait, allowing floats to be formatted with a specified number of decimal places. The changes refactor how float formatting is handled in template expressions and add a new `fmt_fixed` method to complement the existing `fmt_into` method.

## Key Changes

- **Modified float formatting in templates**: Changed from directly calling `fmt_fixed(precision, formatter)` to using a new wrapper approach that calls `fmt_into(formatter)` after setting up the formatter with the desired precision. This simplifies the method dispatch and makes precision handling more consistent.

- **Added `fmt_fixed` method**: Introduced a new `f64::fmt_fixed(precision, formatter)` method that handles fixed-point formatting with a specific precision. This method is now called internally by `fmt_into` when a precision is set on the formatter.

- **Updated `fmt_into` implementation**: Modified the `fmt_into` method in `f32` and `f64` implementations to check if a precision is set on the formatter (`f.precision >= 0`). If so, it delegates to `fmt_fixed` with that precision value.

- **Added helper functions**: Introduced `unrounded_div` and `fixed_width_for_prec` functions to support precision-aware decimal formatting calculations.

- **Added `write_decimal_prec` function**: New function to handle writing decimal numbers with a specific precision, including proper handling of leading zeros, decimal positioning, and trailing digits.

## Implementation Details

The refactoring changes the template code generation pattern from:
```wado
Box<f64> { value: 0.582307589706 }.f64::fmt_fixed(1, &mut __f);
```

To:
```wado
{
    let self: Box<f64> = Box<f64> { value: 0.582307589706 };
    let f: &mut Formatter = &mut __f;
    self.f64::fmt_into(f);
};
```

This approach allows the formatter's precision field to control the formatting behavior, making the code more maintainable and reducing duplication in the template synthesis logic.

https://claude.ai/code/session_01W69KhYz1qu7PGhzBYHs5T5