### PR TITLE
Add Range Object design (WEP-2026-03-03)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,7 @@ WEPs combine language specification and implementation strategy in a single docu
 - [Documentation Generation (`wado doc`)](./docs/wep-2026-02-28-doc-command.md)
 - [Compile-Time File Inclusion (`#include_str`)](./docs/wep-2026-03-02-include-str.md)
 - [Gale — Grammar Adaptive LL Engine](./docs/wep-2026-03-02-gale.md)
+- [Range Object](./docs/wep-2026-03-03-range-object.md)
 
 ### Structure
 

--- a/docs/wep-2026-01-11-operator-precedence.md
+++ b/docs/wep-2026-01-11-operator-precedence.md
@@ -258,7 +258,7 @@ From highest to lowest precedence:
 | 11    | `==`, `<`, `>`, `<=`, `>=` (left-assoc with rules), `!=` (no chain) | **Restricted** | Comparison                  |
 | 12    | `&&`                                                                | Left-to-right  | Logical AND                 |
 | 13    | `\|\|`                                                              | Left-to-right  | Logical OR                  |
-| 14    | `..`, `..=`                                                         | N/A            | Range operators             |
+| 14    | `..<`, `..=`                                                        | N/A            | Range operators             |
 | 15    | `=`, `+=`, `-=`, etc.                                               | Right-to-left  | Assignment                  |
 
 **Key differences from Rust**:

--- a/docs/wep-2026-01-18-operator-overloading.md
+++ b/docs/wep-2026-01-18-operator-overloading.md
@@ -474,9 +474,9 @@ let result = a && b;  // ❌ Cannot overload
 
 **Note**: Compound assignment operators (`+=`, `-=`, etc.) ARE overloadable via traits like `AddAssign` (see section above).
 
-#### Range Operators: `..`, `..=`
+#### Range Operators: `..<`, `..=`
 
-**Reason**: These construct `Range` and `RangeInclusive` types, not user-overloadable.
+**Reason**: These construct `RangeExclusive` and `RangeInclusive` types, not user-overloadable.
 
 #### Member Access: `.`, `::`
 

--- a/docs/wep-2026-01-20-indexing-traits.md
+++ b/docs/wep-2026-01-20-indexing-traits.md
@@ -116,7 +116,7 @@ The compiler desugars `[]` syntax based on which traits are implemented:
 | ------------------ | --------------------------------------------- |
 | `Array<i32>`       | Returns `i32` by value - cannot return `&i32` |
 | Computed sequences | Fibonacci where `fib[n]` computes on demand   |
-| Range objects      | `range[i]` computes i-th value, no storage    |
+| `RangeExclusive`   | `range[i]` computes i-th value, no storage    |
 | Packed bit arrays  | `bits[i]` returns extracted bool              |
 
 #### IndexValue + IndexAssign (Primitive Arrays)

--- a/docs/wep-2026-01-24-iterator-traits.md
+++ b/docs/wep-2026-01-24-iterator-traits.md
@@ -63,7 +63,7 @@ Understanding the difference between `Iterator` and `IntoIterator`:
 
 | Trait            | Question it answers                    | Example types                    |
 | ---------------- | -------------------------------------- | -------------------------------- |
-| **Iterator**     | "Can I call `next()` on this?"         | `ArrayIter<T>`, `Range`, `Chars` |
+| **Iterator**     | "Can I call `next()` on this?"         | `ArrayIter<T>`, `RangeExclusive<T>`, `Chars` |
 | **IntoIterator** | "Can I convert this into an iterator?" | `Array<T>`, `String`, `Stack<T>` |
 
 A collection (like `Array<T>`) is **not** an iterator itself—it doesn't have iteration state. Instead, it implements `IntoIterator` to create a separate iterator object that tracks the current position:
@@ -83,12 +83,12 @@ iter.next();  // Some(3) - advances internal index from 2 to 3
 iter.next();  // None - exhausted
 ```
 
-Some types (like `Range`) are both a collection and their own iterator:
+Some types (like `RangeExclusive`) are both a collection and their own iterator:
 
 ```wado
-// Range implements BOTH IntoIterator and Iterator
-let r = range(1, 4);
-// r.into_iter() returns self (Range is its own iterator)
+// RangeExclusive implements BOTH IntoIterator and Iterator
+let r = 1..<4;
+// r.into_iter() returns self (RangeExclusive is its own iterator)
 // r.next() works directly
 ```
 
@@ -435,37 +435,38 @@ impl IntoIterator for [T, T, T] {
 
 ### 10. Range Iterator
 
+See [WEP: Range Object](./wep-2026-03-03-range-object.md) for the full design.
+
 ```wado
 /// Half-open range [start, end)
-pub struct Range {
-    start: i32,
-    end: i32,
+pub struct RangeExclusive<T> {
+    pub start: T,
+    pub end: T,
 }
 
-/// Creates a range from start (inclusive) to end (exclusive)
-pub fn range(start: i32, end: i32) -> Range {
-    return Range { start, end };
-}
+impl Iterator for RangeExclusive<T: Step + Ord> {
+    type Item = T;
 
-impl Iterator for Range {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<i32> {
+    fn next(&mut self) -> Option<T> {
         if self.start >= self.end {
             return null;
         }
         let current = self.start;
-        self.start += 1;
-        return Option::<i32>::Some(current);
+        if let Some(next) = current.next_step() {
+            self.start = next;
+        } else {
+            self.start = self.end;
+        }
+        return Option::<T>::Some(current);
     }
 }
 
-impl IntoIterator for Range {
-    type Item = i32;
-    type Iter = Range;  // Range is its own iterator
+impl IntoIterator for RangeExclusive<T: Step + Ord> {
+    type Item = T;
+    type Iter = RangeExclusive<T>;
 
-    fn into_iter(self) -> Range {
-        return self;
+    fn into_iter(&self) -> RangeExclusive<T> {
+        return *self;
     }
 }
 ```
@@ -474,12 +475,12 @@ Usage:
 
 ```wado
 // Iterate from 0 to 9
-for let i of range(0, 10) {
+for let i of 0..<10 {
     println(`{i}`);
 }
 
 // With combinators
-let sum = range(1, 101).fold(0, |acc, x| acc + x);  // 5050
+let sum = (1..<101).fold(0, |acc: i32, x: i32| acc + x);  // 5050
 ```
 
 ### 11. String Iterator
@@ -738,12 +739,12 @@ fn run() with Stdout {
 ```wado
 fn run() with Stdout {
     // Sum of 1 to 100
-    let sum = range(1, 101).fold(0, |acc, x| acc + x);
+    let sum = (1..<101).fold(0, |acc: i32, x: i32| acc + x);
     println(`Sum 1-100: {sum}`);  // 5050
 
     // Generate squares
-    let squares: Array<i32> = range(1, 6)
-        .map(|x| x * x)
+    let squares: Array<i32> = (1..<6)
+        .map(|x: i32| x * x)
         .collect();
     // [1, 4, 9, 16, 25]
 }

--- a/docs/wep-2026-01-24-iterator-traits.md
+++ b/docs/wep-2026-01-24-iterator-traits.md
@@ -61,10 +61,10 @@ Rust requires three iteration methods (`iter()`, `iter_mut()`, `into_iter()`) be
 
 Understanding the difference between `Iterator` and `IntoIterator`:
 
-| Trait            | Question it answers                    | Example types                    |
-| ---------------- | -------------------------------------- | -------------------------------- |
+| Trait            | Question it answers                    | Example types                                |
+| ---------------- | -------------------------------------- | -------------------------------------------- |
 | **Iterator**     | "Can I call `next()` on this?"         | `ArrayIter<T>`, `RangeExclusive<T>`, `Chars` |
-| **IntoIterator** | "Can I convert this into an iterator?" | `Array<T>`, `String`, `Stack<T>` |
+| **IntoIterator** | "Can I convert this into an iterator?" | `Array<T>`, `String`, `Stack<T>`             |
 
 A collection (like `Array<T>`) is **not** an iterator itself—it doesn't have iteration state. Instead, it implements `IntoIterator` to create a separate iterator object that tracks the current position:
 

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -130,7 +130,7 @@ pub struct RangeInclusive<T> {
 
 **Why `RangeExclusive` / `RangeInclusive`**: The operators `..<` (exclusive) and `..=` (inclusive) are symmetric and self-documenting. The type names mirror this: both explicitly state the boundary rule. Unlike Rust's `Range` / `RangeInclusive` or Swift's `Range` / `ClosedRange`, Wado avoids an asymmetric "default" name.
 
-**Why two types, not six**: Wado targets pragmatic simplicity. The primary use cases (iteration and slicing) are served by `RangeExclusive` and `RangeInclusive`. Partial ranges (`a..`, `..b`, `..`) add complexity for marginal benefit — Wado already has `arr.slice(start, end)` and `arr.len()` for these cases. If partial ranges prove necessary, they can be added later without breaking changes.
+**Why two types, not six**: Wado targets pragmatic simplicity. The primary use cases (iteration, slicing, and pattern matching) are served by `RangeExclusive` and `RangeInclusive`. Partial ranges (`a..`, `..b`, `..`) add complexity for marginal benefit — Wado already has `arr.slice(start, end)` and `arr.len()` for these cases. If partial ranges prove necessary, they can be added later without breaking changes.
 
 **Why generic**: Unlike Zig's `usize`-only limitation, generic ranges allow natural expressions like `for let c of 'a'..='z'` and `if (0.0..<1.0).contains(x)`. The type parameter is inferred from the operands.
 
@@ -241,7 +241,7 @@ impl Iterator for RangeInclusive<T: Step + Ord> {
 }
 ```
 
-**`RangeInclusive` and T::MAX**: `RangeInclusive` must correctly handle the case where `end == T::MAX` (e.g., `0u8..=255`). The private `exhausted` field solves this: when `start == end`, the last element is yielded and `exhausted` is set to `true`. On the next call, `next()` returns `null` immediately — no overflow. This is the same approach used by Rust (`RangeInclusive`) and Swift (`ClosedRange.Iterator`). The `exhausted` field is private so it does not appear in the constructor syntax — the `..=` operator always initializes it to `false`.
+**`RangeInclusive` and T::MAX**: `RangeInclusive` must correctly handle the case where `end == T::MAX` (e.g., `0u8..=255`). The private `exhausted` field solves this: when `start == end`, the last element is yielded and `exhausted` is set to `true`. On the next call, `next()` returns `null` immediately — no overflow. This is the same approach used by Rust and Swift. The `exhausted` field is private so it does not appear in the constructor syntax — the `..=` operator always initializes it to `false`.
 
 #### IntoIterator
 
@@ -379,6 +379,93 @@ impl IndexValue<RangeInclusive<i32>> for Array<T> {
 }
 ```
 
+### Pattern Matching with Ranges
+
+Range patterns allow matching a value against a range in `match` arms, `if let`, and `matches`:
+
+```wado
+// Grade classification
+let grade = match score {
+    0..<60 => "F",
+    60..<70 => "D",
+    70..<80 => "C",
+    80..<90 => "B",
+    90..=100 => "A",
+    _ => "invalid",
+};
+
+// Character classification
+let kind = match c {
+    'a'..='z' => "lowercase",
+    'A'..='Z' => "uppercase",
+    '0'..='9' => "digit",
+    _ => "other",
+};
+
+// With matches operator
+if code matches { 0..<128 } {
+    println("ASCII");
+}
+
+// Can mix range patterns with other patterns
+let label = match value {
+    0 => "zero",
+    1..<10 => "small",
+    10..=100 => "medium",
+    _ => "large",
+};
+```
+
+#### Syntax
+
+Both `..<` and `..=` are allowed as pattern forms:
+
+- `a..<b` matches if `a <= scrutinee < b`
+- `a..=b` matches if `a <= scrutinee <= b`
+
+The bounds `a` and `b` must be compile-time constant expressions: integer literals, character literals, unary negation of literals (`-1`), or associated constants (`i32::MAX`).
+
+```wado
+// Negative ranges
+let sign = match n {
+    i32::MIN..<0 => "negative",
+    0 => "zero",
+    1..=i32::MAX => "positive",
+};
+
+// Empty range pattern is a compile error
+// 5..<5 => ...     // error: empty range pattern
+// 10..=5 => ...    // error: empty range pattern
+```
+
+#### Exhaustiveness
+
+Range patterns participate in exhaustiveness checking. The compiler tracks which values are covered:
+
+```wado
+// Exhaustive — no wildcard needed
+let bit: u8 = get_bit();
+let name = match bit {
+    0 => "zero",
+    1..=255 => "nonzero",
+};
+```
+
+When the compiler cannot prove exhaustiveness (large integer ranges, complex combinations), a wildcard `_` arm is required.
+
+#### Overlap Detection
+
+Overlapping range patterns are a compile error:
+
+```wado
+// Compile error: overlapping patterns
+let x = match n {
+    0..=10 => "a",
+    5..=15 => "b",   // error: range 5..=10 overlaps with previous arm
+    _ => "c",
+};
+```
+
 ### Display and Inspect
 
 ```wado
@@ -460,51 +547,6 @@ for let mut i = 9; i >= 0; i -= 1 {
 
 A general `.rev()` iterator combinator can be added later to the `Iterator` trait.
 
-#### No pattern matching with ranges
-
-Range patterns in `match` arms (e.g., `0..=9 => "digit"`) require parser and pattern matching infrastructure changes that are orthogonal to the range object design. This can be addressed in a separate WEP.
-
-### Wasm GC Representation
-
-`RangeExclusive<T>` and `RangeInclusive<T>` are struct types. For primitive `T`, the compiler monomorphizes them to simple Wasm GC structs:
-
-```wat
-;; RangeExclusive<i32>
-(type $RangeExclusive_i32 (struct (field $start i32) (field $end i32)))
-
-;; RangeInclusive<i32> (exhausted is a private field, always present)
-(type $RangeInclusive_i32 (struct (field $start i32) (field $end i32) (field $exhausted i32)))
-```
-
-The `exhausted` field is always present in `RangeInclusive` as a private struct field. The `..=` operator initializes it to `0` (false).
-
-## Implementation Strategy
-
-### Phase 1: Lexer and Parser
-
-1. Add `DotDotLt` (`..<`) and `DotDotEq` (`..=`) tokens to the lexer
-2. Add `RangeExclusive` and `RangeInclusive` expression AST nodes
-3. Parse range expressions at precedence level 14 (non-associative)
-4. Update the operator precedence WEP to reflect `..<` and `..=` (replacing `..` and `..=`)
-
-### Phase 2: Type Checking
-
-1. Define `RangeExclusive<T>` and `RangeInclusive<T>` as built-in generic structs in `core:prelude`
-2. Infer `T` from the operands (both must have the same type after literal coercion)
-3. Add `Step` trait and implement for integer types and `char`
-
-### Phase 3: Iterator Integration
-
-1. Implement `Iterator` for `RangeExclusive<T: Step + Ord>` and `RangeInclusive<T: Step + Ord>`
-2. Implement `IntoIterator` for both types
-3. Verify for-of desugaring works with range expressions
-
-### Phase 4: Methods and Traits
-
-1. Implement `contains`, `is_empty` methods
-2. Implement `Display`, `Inspect`, and `Eq` traits
-3. Implement `IndexValue<RangeExclusive<i32>>` and `IndexValue<RangeInclusive<i32>>` for `Array<T>`
-
 ## Consequences
 
 ### Positive
@@ -513,10 +555,11 @@ The `exhausted` field is always present in `RangeInclusive` as a private struct 
 2. **Works with existing iterator system**: Ranges plug directly into `for-of`, `map`, `filter`, `fold`, etc.
 3. **Type-safe membership testing**: `(0.0..<1.0).contains(&x)` works for any `Ord` type
 4. **Array slicing sugar**: `arr[1..<5]` is more natural than `arr.slice(1, 5)`
-5. **Minimal type count**: Two types cover the vast majority of use cases
-6. **Explicit syntax**: Both `..<` and `..=` are self-documenting — no ambiguous "bare" `..`
-7. **Generic**: Works with all integer types, `char`, and `Ord` types for membership testing
-8. **Frees `..` for rest syntax**: `..` remains exclusively for struct rest patterns and destructuring, avoiding ambiguity
+5. **Range patterns in match**: `0..<10 => ...` and `'a'..='z' => ...` replace verbose guard chains
+6. **Symmetric naming**: `RangeExclusive` / `RangeInclusive` mirrors the operator symmetry of `..<` / `..=`
+7. **Explicit syntax**: Both `..<` and `..=` are self-documenting — no ambiguous "bare" `..`
+8. **Generic**: Works with all integer types, `char`, and `Ord` types for membership testing
+9. **Frees `..` for rest syntax**: `..` remains exclusively for struct rest patterns and destructuring, avoiding ambiguity
 
 ### Negative
 
@@ -526,11 +569,9 @@ The `exhausted` field is always present in `RangeInclusive` as a private struct 
    - **Mitigation**: Can be added later as an iterator combinator
 3. **No reverse iteration**: Requires C-style `for` or future `.rev()` combinator
    - **Mitigation**: Can be added later to the `Iterator` trait
-4. **No range patterns in match**: Requires separate design work
-   - **Mitigation**: Addressed in a future WEP
-5. **`RangeInclusive` has extra `exhausted` field**: Adds one i32 of overhead per instance
+4. **`RangeInclusive` has extra `exhausted` field**: Adds one i32 of overhead per instance
    - **Mitigation**: Private field, not visible in constructor syntax; same approach as Rust and Swift
-6. **New `Step` trait**: Adds one more trait to the prelude
+5. **New `Step` trait**: Adds one more trait to the prelude
    - **Mitigation**: Small, focused trait with obvious purpose
 
 ## References

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -124,6 +124,7 @@ pub struct Range<T> {
 pub struct RangeInclusive<T> {
     pub start: T,
     pub end: T,
+    exhausted: bool,  // private: tracks whether the iterator has yielded `end`
 }
 ```
 
@@ -217,34 +218,28 @@ impl Iterator for RangeInclusive<T: Step + Ord> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
+        if self.exhausted {
+            return null;
+        }
         if self.start > self.end {
             return null;
         }
         let current = self.start;
         if self.start == self.end {
-            // Last element — advance start past end to mark as exhausted
-            if let Some(next) = current.next_step() {
-                self.start = next;
-            } else {
-                // At T::MAX — use a sentinel state
-                // We set start > end by retreating end if possible,
-                // or by relying on the start > end check above next time
-                // Implementation detail: compiler can use an exhausted flag internally
-                self.start = self.end;
-                // Mark that we already yielded this element
-                // (handled via an internal exhausted flag in the compiler)
-            }
+            self.exhausted = true;
             return Option::<T>::Some(current);
         }
         if let Some(next) = current.next_step() {
             self.start = next;
+        } else {
+            self.exhausted = true;
         }
         return Option::<T>::Some(current);
     }
 }
 ```
 
-**`RangeInclusive` and T::MAX**: Following Rust's lead, `RangeInclusive` must correctly handle the case where `end == T::MAX` (e.g., `0u8..=255`). The compiler adds an internal `exhausted: bool` flag to `RangeInclusive` that is not visible in the struct definition but tracked in codegen. This is a pragmatic compromise — exposing the flag would leak implementation details; hiding it keeps the API clean.
+**`RangeInclusive` and T::MAX**: `RangeInclusive` must correctly handle the case where `end == T::MAX` (e.g., `0u8..=255`). The private `exhausted` field solves this: when `start == end`, the last element is yielded and `exhausted` is set to `true`. On the next call, `next()` returns `null` immediately — no overflow. This is the same approach used by Rust (`RangeInclusive`) and Swift (`ClosedRange.Iterator`). The `exhausted` field is private so it does not appear in the constructor syntax — the `..=` operator always initializes it to `false`.
 
 #### IntoIterator
 
@@ -479,7 +474,7 @@ Range patterns in `match` arms (e.g., `0..=9 => "digit"`) require parser and pat
 (type $RangeInclusive_i32 (struct (field $start i32) (field $end i32) (field $exhausted i32)))
 ```
 
-For iteration, the `exhausted` flag is only present in `RangeInclusive` and only when it is used as an iterator (monomorphization can elide it when only `contains` is used).
+The `exhausted` field is always present in `RangeInclusive` as a private struct field. The `..=` operator initializes it to `0` (false).
 
 ## Implementation Strategy
 
@@ -531,8 +526,8 @@ For iteration, the `exhausted` flag is only present in `RangeInclusive` and only
    - **Mitigation**: Can be added later to the `Iterator` trait
 4. **No range patterns in match**: Requires separate design work
    - **Mitigation**: Addressed in a future WEP
-5. **`RangeInclusive` hidden `exhausted` flag**: Implementation detail leaks into codegen
-   - **Mitigation**: Not visible to users; only affects compiler internals
+5. **`RangeInclusive` has extra `exhausted` field**: Adds one i32 of overhead per instance
+   - **Mitigation**: Private field, not visible in constructor syntax; same approach as Rust and Swift
 6. **New `Step` trait**: Adds one more trait to the prelude
    - **Mitigation**: Small, focused trait with obvious purpose
 

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -1,0 +1,542 @@
+# WEP: Range Object
+
+## Context
+
+Wado needs a range object to support common patterns like counted iteration, membership testing, and array slicing. Currently, counted loops require C-style `for` syntax:
+
+```wado
+for let mut i = 0; i < 10; i += 1 {
+    println(`{i}`);
+}
+```
+
+A range object would enable the more idiomatic:
+
+```wado
+for let i of 0..10 {
+    println(`{i}`);
+}
+```
+
+The operator precedence WEP already reserves `..` and `..=` at level 14 (between logical OR and assignment). The iterator traits WEP sketches a non-generic `Range` struct for `i32` only. This WEP defines the full design.
+
+### Language Survey
+
+#### Rust
+
+Rust has the most comprehensive range system with six distinct types:
+
+| Type | Syntax | Interval | Iterable |
+|------|--------|----------|----------|
+| `Range<Idx>` | `a..b` | [a, b) | Yes (when `Idx: Step`) |
+| `RangeInclusive<Idx>` | `a..=b` | [a, b] | Yes (when `Idx: Step`) |
+| `RangeFrom<Idx>` | `a..` | [a, +inf) | Yes (infinite) |
+| `RangeTo<Idx>` | `..b` | (-inf, b) | No |
+| `RangeToInclusive<Idx>` | `..=b` | (-inf, b] | No |
+| `RangeFull` | `..` | (-inf, +inf) | No |
+
+Key design elements:
+- All types are generic structs in `std::ops`
+- The `Step` trait (unstable) enables integer/char iteration
+- `RangeBounds` trait unifies all range types for generic code accepting any range
+- `RangeInclusive` has an internal `exhausted` flag to handle `T::MAX` correctly
+- Ranges are used for iteration, slicing, membership testing (`contains`), and pattern matching
+- `Range` is not `Copy` because it implements `Iterator` (mutable state)
+- No negative step — use `.rev()` for reverse iteration
+- Zero-cost: compiles to the same code as a C-style loop
+
+**Trade-offs**: Six types add complexity. The `Step` trait is unstable after years. `RangeInclusive`'s `exhausted` flag adds overhead. Not having negative step requires `.rev()`.
+
+#### Swift
+
+Swift has five range types with different operators:
+
+| Type | Syntax | Interval |
+|------|--------|----------|
+| `Range<Bound>` | `a..<b` | [a, b) |
+| `ClosedRange<Bound>` | `a...b` | [a, b] |
+| `PartialRangeFrom<Bound>` | `a...` | [a, +inf) |
+| `PartialRangeThrough<Bound>` | `...b` | (-inf, b] |
+| `PartialRangeUpTo<Bound>` | `..<b` | (-inf, b) |
+
+Key design elements:
+- All require `Bound: Comparable` — any comparable type can form a range
+- Only iterable when `Bound: Strideable & Comparable` (integers, not floats by default)
+- `stride(from:to:by:)` and `stride(from:through:by:)` provide stepping
+- Used for for-in loops, subscript slicing, switch/case, and `contains`
+- Separate `RangeExpression` protocol unifies all range types
+
+**Trade-offs**: Two operators (`..<` and `...`) are visually similar — easy to confuse. Five types, like Rust, add complexity. `stride` is a separate concept from ranges.
+
+#### Go
+
+Go takes a fundamentally different approach — `range` is a keyword, not a type:
+
+- `for i := range 10` (Go 1.22+) iterates 0..9
+- `for i, v := range slice` iterates over collections
+- `for k, v := range funcIterator` (Go 1.23+) supports user-defined iterators via push-style callbacks
+- No `Range` type — ranges are purely syntactic
+- No lazy ranges or combinators in the standard library
+
+**Trade-offs**: Maximum simplicity. No range objects to store, pass, or compose. But no way to express ranges as values, no slicing with ranges, no generic range abstraction.
+
+#### Zig
+
+Zig treats ranges as syntax, not types:
+
+- `for (0..n)` iterates in `for` loops (exclusive end, `usize` only)
+- `arr[a..b]` for slicing (produces fat-pointer slices)
+- `'a'...'z'` in `switch` for inclusive range matching (three dots)
+- Multi-sequence `for` with strict same-length requirement
+- No first-class `Range` type — community workarounds use custom structs
+
+**Trade-offs**: Simple and zero-cost. But `usize`-only for loop counters, no generic ranges, and ranges cannot be passed as values.
+
+### Summary
+
+| | Rust | Swift | Go | Zig |
+|---|---|---|---|---|
+| Range as type | Yes (6 types) | Yes (5 types) | No (keyword) | No (syntax) |
+| Half-open syntax | `a..b` | `a..<b` | N/A | `a..b` |
+| Inclusive syntax | `a..=b` | `a...b` | N/A | `a...b` (switch only) |
+| Generic | Yes | Yes | N/A | No (usize only) |
+| Iterable | Via Step trait | Via Strideable | Built-in | Built-in |
+| Slicing | Yes | Yes | No | Yes |
+| Contains | Yes | Yes | No | No |
+| Pattern matching | Yes (inclusive only) | Yes (switch/case) | No | Yes (switch) |
+| Custom step | `.step_by(n)` | `stride(from:to:by:)` | N/A | No |
+| Reverse iteration | `.rev()` | `.reversed()` | N/A | No |
+
+## Decision
+
+### Range Types
+
+Wado defines two range types as generic structs in `core:prelude`:
+
+```wado
+/// Half-open range [start, end)
+pub struct Range<T> {
+    pub start: T,
+    pub end: T,
+}
+
+/// Inclusive range [start, end]
+pub struct RangeInclusive<T> {
+    pub start: T,
+    pub end: T,
+}
+```
+
+**Why two types, not six**: Wado targets pragmatic simplicity. The primary use cases (iteration and slicing) are served by `Range` and `RangeInclusive`. Partial ranges (`a..`, `..b`, `..`) add complexity for marginal benefit — Wado already has `arr.slice(start, end)` and `arr.len()` for these cases. If partial ranges prove necessary, they can be added later without breaking changes.
+
+**Why generic**: Unlike Zig's `usize`-only limitation, generic ranges allow natural expressions like `for let c of 'a'..='z'` and `if (0.0..1.0).contains(x)`. The type parameter is inferred from the operands.
+
+### Syntax
+
+```wado
+// Half-open range [start, end)
+0..10             // Range<i32>
+0 as i64..100     // Range<i64>
+
+// Inclusive range [start, end]
+0..=10            // RangeInclusive<i32>
+'a'..='z'         // RangeInclusive<char>
+
+// With expressions (parentheses needed due to low precedence)
+0..arr.len()      // Range<i32>
+(x + 1)..(y - 1) // Range<i32>
+```
+
+Range operators `..` and `..=` sit at precedence level 14 (between logical OR and assignment), following the existing operator precedence WEP. They are non-associative — `a..b..c` is a compile error.
+
+**Why `..` and `..=` (Rust-style), not `..<` and `...` (Swift-style)**:
+- `..` is more concise and widely recognized (Rust, Zig, Kotlin, Ruby)
+- `...` conflicts with potential future variadic syntax and is visually similar to `..` — easy to misread
+- `..<` is unique to Swift and unfamiliar to most developers
+- The existing operator precedence WEP already specifies `..` and `..=`
+
+### Iteration
+
+Ranges implement `Iterator` and `IntoIterator` for integer and char types via bounded impl blocks.
+
+#### Step Trait
+
+A new `Step` trait defines how to advance a value by one:
+
+```wado
+/// Types that can be incremented by one step (for range iteration).
+pub trait Step {
+    /// Advance the value by one step. Returns null if overflow would occur.
+    fn next_step(&self) -> Option<Self>;
+}
+```
+
+Built-in implementations for all integer types and `char`:
+
+```wado
+impl Step for i32 {
+    fn next_step(&self) -> Option<i32> {
+        if *self == i32::MAX { return null; }
+        return Option::Some(*self + 1);
+    }
+}
+
+// Similarly for i8, i16, i64, u8, u16, u32, u64, i128, u128
+
+impl Step for char {
+    fn next_step(&self) -> Option<char> {
+        let code = *self as u32 + 1;
+        return char::from_u32(code);
+    }
+}
+```
+
+#### Iterator Implementations
+
+```wado
+impl Iterator for Range<T: Step + Ord> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.start >= self.end {
+            return null;
+        }
+        let current = self.start;
+        if let Some(next) = current.next_step() {
+            self.start = next;
+        } else {
+            // Overflow — make the range empty so iteration stops
+            self.start = self.end;
+        }
+        return Option::<T>::Some(current);
+    }
+}
+
+impl Iterator for RangeInclusive<T: Step + Ord> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.start > self.end {
+            return null;
+        }
+        let current = self.start;
+        if self.start == self.end {
+            // Last element — advance start past end to mark as exhausted
+            if let Some(next) = current.next_step() {
+                self.start = next;
+            } else {
+                // At T::MAX — use a sentinel state
+                // We set start > end by retreating end if possible,
+                // or by relying on the start > end check above next time
+                // Implementation detail: compiler can use an exhausted flag internally
+                self.start = self.end;
+                // Mark that we already yielded this element
+                // (handled via an internal exhausted flag in the compiler)
+            }
+            return Option::<T>::Some(current);
+        }
+        if let Some(next) = current.next_step() {
+            self.start = next;
+        }
+        return Option::<T>::Some(current);
+    }
+}
+```
+
+**`RangeInclusive` and T::MAX**: Following Rust's lead, `RangeInclusive` must correctly handle the case where `end == T::MAX` (e.g., `0u8..=255`). The compiler adds an internal `exhausted: bool` flag to `RangeInclusive` that is not visible in the struct definition but tracked in codegen. This is a pragmatic compromise — exposing the flag would leak implementation details; hiding it keeps the API clean.
+
+#### IntoIterator
+
+Both range types are their own iterators (Range itself implements Iterator), so IntoIterator returns self:
+
+```wado
+impl IntoIterator for Range<T: Step + Ord> {
+    type Item = T;
+    type Iter = Range<T>;
+
+    fn into_iter(&self) -> Range<T> {
+        return *self;  // Copy (value semantics)
+    }
+}
+
+impl IntoIterator for RangeInclusive<T: Step + Ord> {
+    type Item = T;
+    type Iter = RangeInclusive<T>;
+
+    fn into_iter(&self) -> RangeInclusive<T> {
+        return *self;
+    }
+}
+```
+
+Since ranges have value semantics, copying a range into the iterator is safe and cheap.
+
+### Usage: For-Of Loops
+
+```wado
+// Count from 0 to 9
+for let i of 0..10 {
+    println(`{i}`);
+}
+
+// Count from 1 to 10 (inclusive)
+for let i of 1..=10 {
+    println(`{i}`);
+}
+
+// Character range
+for let c of 'a'..='z' {
+    print(`{c}`);
+}
+// Output: abcdefghijklmnopqrstuvwxyz
+
+// With iterator combinators
+let sum = (1..=100).fold(0, |acc: i32, x: i32| acc + x);  // 5050
+
+let evens = (0..20).filter(|x: i32| x % 2 == 0).collect();
+// [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+```
+
+### Membership Testing
+
+All ranges support `contains` for any `Ord` type, including non-iterable types like floats:
+
+```wado
+impl Range<T: Ord> {
+    /// Returns true if the value is within [start, end).
+    pub fn contains(&self, value: &T) -> bool {
+        return *value >= self.start && *value < self.end;
+    }
+
+    /// Returns true if the range contains no elements.
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+}
+
+impl RangeInclusive<T: Ord> {
+    /// Returns true if the value is within [start, end].
+    pub fn contains(&self, value: &T) -> bool {
+        return *value >= self.start && *value <= self.end;
+    }
+
+    /// Returns true if the range contains no elements.
+    pub fn is_empty(&self) -> bool {
+        return self.start > self.end;
+    }
+}
+```
+
+```wado
+// Float membership testing (not iterable, but contains works)
+let unit_range = 0.0..1.0;
+if unit_range.contains(&x) {
+    println("x is in [0, 1)");
+}
+
+// Integer membership testing
+if (0..256).contains(&code) {
+    println("valid byte");
+}
+
+// Comparison chaining is often clearer for simple cases:
+if 0 <= x && x < 256 {
+    // equivalent to (0..256).contains(&x)
+}
+// Or with Wado's comparison chaining:
+if 0 <= x < 256 {
+    // same
+}
+```
+
+### Array Slicing
+
+Ranges can be used as array index types to produce slices:
+
+```wado
+let arr: Array<i32> = [10, 20, 30, 40, 50];
+
+// Range slicing (produces ArraySlice<T>)
+let slice = arr[1..4];    // ArraySlice<i32> containing [20, 30, 40]
+let slice = arr[2..=4];   // ArraySlice<i32> containing [30, 40, 50]
+```
+
+This is implemented via `IndexValue` trait:
+
+```wado
+impl IndexValue<Range<i32>> for Array<T> {
+    type Output = ArraySlice<T>;
+
+    fn index_value(&self, range: Range<i32>) -> ArraySlice<T> {
+        return self.slice(range.start, range.end);
+    }
+}
+
+impl IndexValue<RangeInclusive<i32>> for Array<T> {
+    type Output = ArraySlice<T>;
+
+    fn index_value(&self, range: RangeInclusive<i32>) -> ArraySlice<T> {
+        return self.slice(range.start, range.end + 1);
+    }
+}
+```
+
+### Display and Inspect
+
+```wado
+impl Display for Range<T: Display> {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write(`{self.start}..{self.end}`);
+    }
+}
+
+impl Display for RangeInclusive<T: Display> {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write(`{self.start}..={self.end}`);
+    }
+}
+```
+
+```wado
+let r = 0..10;
+println(`{r}`);   // "0..10"
+
+let r = 1..=5;
+println(`{r}`);   // "1..=5"
+```
+
+### Eq for Ranges
+
+```wado
+impl Eq for Range<T: Eq> {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+impl Eq for RangeInclusive<T: Eq> {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+```
+
+### What Is NOT Included (and Why)
+
+#### No partial ranges (`a..`, `..b`, `..`)
+
+Partial ranges add three more types for limited benefit. The primary use case is slicing sugar:
+
+```wado
+// These are NOT supported:
+arr[2..]     // use arr.slice(2, arr.len()) instead
+arr[..3]     // use arr.slice(0, 3) instead
+arr[..]      // use arr directly (already value semantics)
+```
+
+If demand arises, partial ranges can be added as separate types without breaking existing code.
+
+#### No `step_by` method
+
+Custom step sizes add complexity. Use C-style `for` for non-unit steps:
+
+```wado
+// Instead of (0..100).step_by(2)
+for let mut i = 0; i < 100; i += 2 {
+    // every other number
+}
+```
+
+A `step_by` combinator can be added later as a method on iterators (not range-specific).
+
+#### No reverse iteration method
+
+Reverse ranges can use C-style `for`:
+
+```wado
+// Instead of (0..10).rev()
+for let mut i = 9; i >= 0; i -= 1 {
+    println(`{i}`);
+}
+```
+
+A general `.rev()` iterator combinator can be added later to the `Iterator` trait.
+
+#### No pattern matching with ranges
+
+Range patterns in `match` arms (e.g., `0..=9 => "digit"`) require parser and pattern matching infrastructure changes that are orthogonal to the range object design. This can be addressed in a separate WEP.
+
+### Wasm GC Representation
+
+`Range<T>` and `RangeInclusive<T>` are struct types. For primitive `T`, the compiler monomorphizes them to simple Wasm GC structs:
+
+```wat
+;; Range<i32>
+(type $Range_i32 (struct (field $start i32) (field $end i32)))
+
+;; RangeInclusive<i32> (with exhausted flag for Iterator)
+(type $RangeInclusive_i32 (struct (field $start i32) (field $end i32) (field $exhausted i32)))
+```
+
+For iteration, the `exhausted` flag is only present in `RangeInclusive` and only when it is used as an iterator (monomorphization can elide it when only `contains` is used).
+
+## Implementation Strategy
+
+### Phase 1: Lexer and Parser
+
+1. Add `DotDot` (`..`) and `DotDotEq` (`..=`) tokens to the lexer
+2. Add `Range` and `RangeInclusive` expression AST nodes
+3. Parse range expressions at precedence level 14 (non-associative)
+
+### Phase 2: Type Checking
+
+1. Define `Range<T>` and `RangeInclusive<T>` as built-in generic structs in `core:prelude`
+2. Infer `T` from the operands (both must have the same type after literal coercion)
+3. Add `Step` trait and implement for integer types and `char`
+
+### Phase 3: Iterator Integration
+
+1. Implement `Iterator` for `Range<T: Step + Ord>` and `RangeInclusive<T: Step + Ord>`
+2. Implement `IntoIterator` for both types
+3. Verify for-of desugaring works with range expressions
+
+### Phase 4: Methods and Traits
+
+1. Implement `contains`, `is_empty` methods
+2. Implement `Display`, `Inspect`, and `Eq` traits
+3. Implement `IndexValue<Range<i32>>` and `IndexValue<RangeInclusive<i32>>` for `Array<T>`
+
+## Consequences
+
+### Positive
+
+1. **Idiomatic counted loops**: `for let i of 0..10` is clearer and more concise than C-style `for`
+2. **Works with existing iterator system**: Ranges plug directly into `for-of`, `map`, `filter`, `fold`, etc.
+3. **Type-safe membership testing**: `(0.0..1.0).contains(&x)` works for any `Ord` type
+4. **Array slicing sugar**: `arr[1..5]` is more natural than `arr.slice(1, 5)`
+5. **Minimal type count**: Two types cover the vast majority of use cases
+6. **Familiar syntax**: `..` and `..=` are familiar from Rust and other languages
+7. **Generic**: Works with all integer types, `char`, and `Ord` types for membership testing
+
+### Negative
+
+1. **No partial ranges**: Users must write `arr.slice(2, arr.len())` instead of `arr[2..]`
+   - **Mitigation**: Can be added later without breaking changes
+2. **No step_by**: Custom step sizes require C-style `for` loops
+   - **Mitigation**: Can be added later as an iterator combinator
+3. **No reverse iteration**: Requires C-style `for` or future `.rev()` combinator
+   - **Mitigation**: Can be added later to the `Iterator` trait
+4. **No range patterns in match**: Requires separate design work
+   - **Mitigation**: Addressed in a future WEP
+5. **`RangeInclusive` hidden `exhausted` flag**: Implementation detail leaks into codegen
+   - **Mitigation**: Not visible to users; only affects compiler internals
+6. **New `Step` trait**: Adds one more trait to the prelude
+   - **Mitigation**: Small, focused trait with obvious purpose
+
+## References
+
+- [WEP: Operator Precedence and Associativity](./wep-2026-01-11-operator-precedence.md) — defines `..` and `..=` at level 14
+- [WEP: Iterator Traits Design](./wep-2026-01-24-iterator-traits.md) — iterator system that ranges integrate with
+- [WEP: Indexing Traits Design](./wep-2026-01-20-indexing-traits.md) — `IndexValue` trait for range-based slicing
+- [Rust `std::ops::Range` documentation](https://doc.rust-lang.org/std/ops/struct.Range.html)
+- [Swift `Range` documentation](https://developer.apple.com/documentation/swift/range)

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -13,12 +13,12 @@ for let mut i = 0; i < 10; i += 1 {
 A range object would enable the more idiomatic:
 
 ```wado
-for let i of 0..10 {
+for let i of 0..<10 {
     println(`{i}`);
 }
 ```
 
-The operator precedence WEP already reserves `..` and `..=` at level 14 (between logical OR and assignment). The iterator traits WEP sketches a non-generic `Range` struct for `i32` only. This WEP defines the full design.
+The operator precedence WEP reserves `..` and `..=` at level 14; this WEP revises the syntax to `..<` (half-open) and `..=` (inclusive) for clarity. The iterator traits WEP sketches a non-generic `Range` struct for `i32` only. This WEP defines the full design.
 
 ### Language Survey
 
@@ -129,31 +129,32 @@ pub struct RangeInclusive<T> {
 
 **Why two types, not six**: Wado targets pragmatic simplicity. The primary use cases (iteration and slicing) are served by `Range` and `RangeInclusive`. Partial ranges (`a..`, `..b`, `..`) add complexity for marginal benefit — Wado already has `arr.slice(start, end)` and `arr.len()` for these cases. If partial ranges prove necessary, they can be added later without breaking changes.
 
-**Why generic**: Unlike Zig's `usize`-only limitation, generic ranges allow natural expressions like `for let c of 'a'..='z'` and `if (0.0..1.0).contains(x)`. The type parameter is inferred from the operands.
+**Why generic**: Unlike Zig's `usize`-only limitation, generic ranges allow natural expressions like `for let c of 'a'..='z'` and `if (0.0..<1.0).contains(x)`. The type parameter is inferred from the operands.
 
 ### Syntax
 
 ```wado
 // Half-open range [start, end)
-0..10             // Range<i32>
-0 as i64..100     // Range<i64>
+0..<10             // Range<i32>
+0 as i64..<100     // Range<i64>
 
 // Inclusive range [start, end]
 0..=10            // RangeInclusive<i32>
 'a'..='z'         // RangeInclusive<char>
 
-// With expressions (parentheses needed due to low precedence)
-0..arr.len()      // Range<i32>
-(x + 1)..(y - 1) // Range<i32>
+// With expressions
+0..<arr.len()      // Range<i32>
+(x + 1)..<(y - 1) // Range<i32>
 ```
 
-Range operators `..` and `..=` sit at precedence level 14 (between logical OR and assignment), following the existing operator precedence WEP. They are non-associative — `a..b..c` is a compile error.
+Range operators `..<` and `..=` sit at precedence level 14 (between logical OR and assignment). They are non-associative — `a..<b..<c` is a compile error.
 
-**Why `..` and `..=` (Rust-style), not `..<` and `...` (Swift-style)**:
-- `..` is more concise and widely recognized (Rust, Zig, Kotlin, Ruby)
-- `...` conflicts with potential future variadic syntax and is visually similar to `..` — easy to misread
-- `..<` is unique to Swift and unfamiliar to most developers
-- The existing operator precedence WEP already specifies `..` and `..=`
+**Why `..<` and `..=`**:
+- **Both operators are explicit about the bound**: `..<` clearly reads as "less than" (exclusive end), `..=` clearly reads as "equals" (inclusive end). There is no ambiguous "bare" `..` operator — both sides state the boundary rule.
+- **Reduces off-by-one bugs**: With `..` and `..=`, forgetting `=` silently gives a different range. With `..<` and `..=`, there is no "default" form to accidentally misuse.
+- **Frees `..` for other syntax**: Wado already uses `..` for struct rest patterns (`let { name, .. } = p`). Keeping `..` out of range syntax avoids ambiguity.
+- **Familiar components**: `..<` is from Swift; `..=` is from Rust. The combination takes the clearest element from each.
+- `...` (Swift/Zig inclusive) is avoided because it conflicts with potential variadic syntax and is visually similar to `..`.
 
 ### Iteration
 
@@ -275,7 +276,7 @@ Since ranges have value semantics, copying a range into the iterator is safe and
 
 ```wado
 // Count from 0 to 9
-for let i of 0..10 {
+for let i of 0..<10 {
     println(`{i}`);
 }
 
@@ -293,7 +294,7 @@ for let c of 'a'..='z' {
 // With iterator combinators
 let sum = (1..=100).fold(0, |acc: i32, x: i32| acc + x);  // 5050
 
-let evens = (0..20).filter(|x: i32| x % 2 == 0).collect();
+let evens = (0..<20).filter(|x: i32| x % 2 == 0).collect();
 // [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
 ```
 
@@ -329,19 +330,19 @@ impl RangeInclusive<T: Ord> {
 
 ```wado
 // Float membership testing (not iterable, but contains works)
-let unit_range = 0.0..1.0;
+let unit_range = 0.0..<1.0;
 if unit_range.contains(&x) {
     println("x is in [0, 1)");
 }
 
 // Integer membership testing
-if (0..256).contains(&code) {
+if (0..<256).contains(&code) {
     println("valid byte");
 }
 
 // Comparison chaining is often clearer for simple cases:
 if 0 <= x && x < 256 {
-    // equivalent to (0..256).contains(&x)
+    // equivalent to (0..<256).contains(&x)
 }
 // Or with Wado's comparison chaining:
 if 0 <= x < 256 {
@@ -357,7 +358,7 @@ Ranges can be used as array index types to produce slices:
 let arr: Array<i32> = [10, 20, 30, 40, 50];
 
 // Range slicing (produces ArraySlice<T>)
-let slice = arr[1..4];    // ArraySlice<i32> containing [20, 30, 40]
+let slice = arr[1..<4];    // ArraySlice<i32> containing [20, 30, 40]
 let slice = arr[2..=4];   // ArraySlice<i32> containing [30, 40, 50]
 ```
 
@@ -386,7 +387,7 @@ impl IndexValue<RangeInclusive<i32>> for Array<T> {
 ```wado
 impl Display for Range<T: Display> {
     fn fmt(&self, f: &mut Formatter) {
-        f.write(`{self.start}..{self.end}`);
+        f.write(`{self.start}..<{self.end}`);
     }
 }
 
@@ -398,8 +399,8 @@ impl Display for RangeInclusive<T: Display> {
 ```
 
 ```wado
-let r = 0..10;
-println(`{r}`);   // "0..10"
+let r = 0..<10;
+println(`{r}`);   // "0..<10"
 
 let r = 1..=5;
 println(`{r}`);   // "1..=5"
@@ -423,15 +424,15 @@ impl Eq for RangeInclusive<T: Eq> {
 
 ### What Is NOT Included (and Why)
 
-#### No partial ranges (`a..`, `..b`, `..`)
+#### No partial ranges (`a..<`, `..<b`, `..`)
 
 Partial ranges add three more types for limited benefit. The primary use case is slicing sugar:
 
 ```wado
 // These are NOT supported:
-arr[2..]     // use arr.slice(2, arr.len()) instead
-arr[..3]     // use arr.slice(0, 3) instead
-arr[..]      // use arr directly (already value semantics)
+arr[2..<]     // use arr.slice(2, arr.len()) instead
+arr[..<3]     // use arr.slice(0, 3) instead
+arr[..]       // use arr directly (already value semantics)
 ```
 
 If demand arises, partial ranges can be added as separate types without breaking existing code.
@@ -441,7 +442,7 @@ If demand arises, partial ranges can be added as separate types without breaking
 Custom step sizes add complexity. Use C-style `for` for non-unit steps:
 
 ```wado
-// Instead of (0..100).step_by(2)
+// Instead of (0..<100).step_by(2)
 for let mut i = 0; i < 100; i += 2 {
     // every other number
 }
@@ -454,7 +455,7 @@ A `step_by` combinator can be added later as a method on iterators (not range-sp
 Reverse ranges can use C-style `for`:
 
 ```wado
-// Instead of (0..10).rev()
+// Instead of (0..<10).rev()
 for let mut i = 9; i >= 0; i -= 1 {
     println(`{i}`);
 }
@@ -484,9 +485,10 @@ For iteration, the `exhausted` flag is only present in `RangeInclusive` and only
 
 ### Phase 1: Lexer and Parser
 
-1. Add `DotDot` (`..`) and `DotDotEq` (`..=`) tokens to the lexer
+1. Add `DotDotLt` (`..<`) and `DotDotEq` (`..=`) tokens to the lexer
 2. Add `Range` and `RangeInclusive` expression AST nodes
 3. Parse range expressions at precedence level 14 (non-associative)
+4. Update the operator precedence WEP to reflect `..<` and `..=` (replacing `..` and `..=`)
 
 ### Phase 2: Type Checking
 
@@ -510,17 +512,18 @@ For iteration, the `exhausted` flag is only present in `RangeInclusive` and only
 
 ### Positive
 
-1. **Idiomatic counted loops**: `for let i of 0..10` is clearer and more concise than C-style `for`
+1. **Idiomatic counted loops**: `for let i of 0..<10` is clearer and more concise than C-style `for`
 2. **Works with existing iterator system**: Ranges plug directly into `for-of`, `map`, `filter`, `fold`, etc.
-3. **Type-safe membership testing**: `(0.0..1.0).contains(&x)` works for any `Ord` type
-4. **Array slicing sugar**: `arr[1..5]` is more natural than `arr.slice(1, 5)`
+3. **Type-safe membership testing**: `(0.0..<1.0).contains(&x)` works for any `Ord` type
+4. **Array slicing sugar**: `arr[1..<5]` is more natural than `arr.slice(1, 5)`
 5. **Minimal type count**: Two types cover the vast majority of use cases
-6. **Familiar syntax**: `..` and `..=` are familiar from Rust and other languages
+6. **Explicit syntax**: Both `..<` and `..=` are self-documenting — no ambiguous "bare" `..`
 7. **Generic**: Works with all integer types, `char`, and `Ord` types for membership testing
+8. **Frees `..` for rest syntax**: `..` remains exclusively for struct rest patterns and destructuring, avoiding ambiguity
 
 ### Negative
 
-1. **No partial ranges**: Users must write `arr.slice(2, arr.len())` instead of `arr[2..]`
+1. **No partial ranges**: Users must write `arr.slice(2, arr.len())` instead of `arr[2..<]`
    - **Mitigation**: Can be added later without breaking changes
 2. **No step_by**: Custom step sizes require C-style `for` loops
    - **Mitigation**: Can be added later as an iterator combinator
@@ -535,7 +538,7 @@ For iteration, the `exhausted` flag is only present in `RangeInclusive` and only
 
 ## References
 
-- [WEP: Operator Precedence and Associativity](./wep-2026-01-11-operator-precedence.md) — defines `..` and `..=` at level 14
+- [WEP: Operator Precedence and Associativity](./wep-2026-01-11-operator-precedence.md) — precedence level 14 (this WEP revises `..` to `..<`)
 - [WEP: Iterator Traits Design](./wep-2026-01-24-iterator-traits.md) — iterator system that ranges integrate with
 - [WEP: Indexing Traits Design](./wep-2026-01-20-indexing-traits.md) — `IndexValue` trait for range-based slicing
 - [Rust `std::ops::Range` documentation](https://doc.rust-lang.org/std/ops/struct.Range.html)

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -18,7 +18,7 @@ for let i of 0..<10 {
 }
 ```
 
-The operator precedence WEP reserves `..` and `..=` at level 14; this WEP revises the syntax to `..<` (half-open) and `..=` (inclusive) for clarity. The iterator traits WEP sketches a non-generic `Range` struct for `i32` only. This WEP defines the full design.
+The operator precedence WEP reserves `..` and `..=` at level 14; this WEP revises the syntax to `..<` (half-open) and `..=` (inclusive) for clarity. The iterator traits WEP sketches a non-generic `RangeExclusive` struct for `i32` only. This WEP defines the full design.
 
 ### Language Survey
 
@@ -115,7 +115,7 @@ Wado defines two range types as generic structs in `core:prelude`:
 
 ```wado
 /// Half-open range [start, end)
-pub struct Range<T> {
+pub struct RangeExclusive<T> {
     pub start: T,
     pub end: T,
 }
@@ -128,7 +128,9 @@ pub struct RangeInclusive<T> {
 }
 ```
 
-**Why two types, not six**: Wado targets pragmatic simplicity. The primary use cases (iteration and slicing) are served by `Range` and `RangeInclusive`. Partial ranges (`a..`, `..b`, `..`) add complexity for marginal benefit — Wado already has `arr.slice(start, end)` and `arr.len()` for these cases. If partial ranges prove necessary, they can be added later without breaking changes.
+**Why `RangeExclusive` / `RangeInclusive`**: The operators `..<` (exclusive) and `..=` (inclusive) are symmetric and self-documenting. The type names mirror this: both explicitly state the boundary rule. Unlike Rust's `Range` / `RangeInclusive` or Swift's `Range` / `ClosedRange`, Wado avoids an asymmetric "default" name.
+
+**Why two types, not six**: Wado targets pragmatic simplicity. The primary use cases (iteration and slicing) are served by `RangeExclusive` and `RangeInclusive`. Partial ranges (`a..`, `..b`, `..`) add complexity for marginal benefit — Wado already has `arr.slice(start, end)` and `arr.len()` for these cases. If partial ranges prove necessary, they can be added later without breaking changes.
 
 **Why generic**: Unlike Zig's `usize`-only limitation, generic ranges allow natural expressions like `for let c of 'a'..='z'` and `if (0.0..<1.0).contains(x)`. The type parameter is inferred from the operands.
 
@@ -136,16 +138,16 @@ pub struct RangeInclusive<T> {
 
 ```wado
 // Half-open range [start, end)
-0..<10             // Range<i32>
-0 as i64..<100     // Range<i64>
+0..<10             // RangeExclusive<i32>
+0 as i64..<100     // RangeExclusive<i64>
 
 // Inclusive range [start, end]
 0..=10            // RangeInclusive<i32>
 'a'..='z'         // RangeInclusive<char>
 
 // With expressions
-0..<arr.len()      // Range<i32>
-(x + 1)..<(y - 1) // Range<i32>
+0..<arr.len()      // RangeExclusive<i32>
+(x + 1)..<(y - 1) // RangeExclusive<i32>
 ```
 
 Range operators `..<` and `..=` sit at precedence level 14 (between logical OR and assignment). They are non-associative — `a..<b..<c` is a compile error.
@@ -196,7 +198,7 @@ impl Step for char {
 #### Iterator Implementations
 
 ```wado
-impl Iterator for Range<T: Step + Ord> {
+impl Iterator for RangeExclusive<T: Step + Ord> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
@@ -243,14 +245,14 @@ impl Iterator for RangeInclusive<T: Step + Ord> {
 
 #### IntoIterator
 
-Both range types are their own iterators (Range itself implements Iterator), so IntoIterator returns self:
+Both range types are their own iterators (the range struct itself implements Iterator), so IntoIterator returns self:
 
 ```wado
-impl IntoIterator for Range<T: Step + Ord> {
+impl IntoIterator for RangeExclusive<T: Step + Ord> {
     type Item = T;
-    type Iter = Range<T>;
+    type Iter = RangeExclusive<T>;
 
-    fn into_iter(&self) -> Range<T> {
+    fn into_iter(&self) -> RangeExclusive<T> {
         return *self;  // Copy (value semantics)
     }
 }
@@ -298,7 +300,7 @@ let evens = (0..<20).filter(|x: i32| x % 2 == 0).collect();
 All ranges support `contains` for any `Ord` type, including non-iterable types like floats:
 
 ```wado
-impl Range<T: Ord> {
+impl RangeExclusive<T: Ord> {
     /// Returns true if the value is within [start, end).
     pub fn contains(&self, value: &T) -> bool {
         return *value >= self.start && *value < self.end;
@@ -360,10 +362,10 @@ let slice = arr[2..=4];   // ArraySlice<i32> containing [30, 40, 50]
 This is implemented via `IndexValue` trait:
 
 ```wado
-impl IndexValue<Range<i32>> for Array<T> {
+impl IndexValue<RangeExclusive<i32>> for Array<T> {
     type Output = ArraySlice<T>;
 
-    fn index_value(&self, range: Range<i32>) -> ArraySlice<T> {
+    fn index_value(&self, range: RangeExclusive<i32>) -> ArraySlice<T> {
         return self.slice(range.start, range.end);
     }
 }
@@ -380,7 +382,7 @@ impl IndexValue<RangeInclusive<i32>> for Array<T> {
 ### Display and Inspect
 
 ```wado
-impl Display for Range<T: Display> {
+impl Display for RangeExclusive<T: Display> {
     fn fmt(&self, f: &mut Formatter) {
         f.write(`{self.start}..<{self.end}`);
     }
@@ -404,7 +406,7 @@ println(`{r}`);   // "1..=5"
 ### Eq for Ranges
 
 ```wado
-impl Eq for Range<T: Eq> {
+impl Eq for RangeExclusive<T: Eq> {
     fn eq(&self, other: &Self) -> bool {
         return self.start == other.start && self.end == other.end;
     }
@@ -464,13 +466,13 @@ Range patterns in `match` arms (e.g., `0..=9 => "digit"`) require parser and pat
 
 ### Wasm GC Representation
 
-`Range<T>` and `RangeInclusive<T>` are struct types. For primitive `T`, the compiler monomorphizes them to simple Wasm GC structs:
+`RangeExclusive<T>` and `RangeInclusive<T>` are struct types. For primitive `T`, the compiler monomorphizes them to simple Wasm GC structs:
 
 ```wat
-;; Range<i32>
-(type $Range_i32 (struct (field $start i32) (field $end i32)))
+;; RangeExclusive<i32>
+(type $RangeExclusive_i32 (struct (field $start i32) (field $end i32)))
 
-;; RangeInclusive<i32> (with exhausted flag for Iterator)
+;; RangeInclusive<i32> (exhausted is a private field, always present)
 (type $RangeInclusive_i32 (struct (field $start i32) (field $end i32) (field $exhausted i32)))
 ```
 
@@ -481,19 +483,19 @@ The `exhausted` field is always present in `RangeInclusive` as a private struct 
 ### Phase 1: Lexer and Parser
 
 1. Add `DotDotLt` (`..<`) and `DotDotEq` (`..=`) tokens to the lexer
-2. Add `Range` and `RangeInclusive` expression AST nodes
+2. Add `RangeExclusive` and `RangeInclusive` expression AST nodes
 3. Parse range expressions at precedence level 14 (non-associative)
 4. Update the operator precedence WEP to reflect `..<` and `..=` (replacing `..` and `..=`)
 
 ### Phase 2: Type Checking
 
-1. Define `Range<T>` and `RangeInclusive<T>` as built-in generic structs in `core:prelude`
+1. Define `RangeExclusive<T>` and `RangeInclusive<T>` as built-in generic structs in `core:prelude`
 2. Infer `T` from the operands (both must have the same type after literal coercion)
 3. Add `Step` trait and implement for integer types and `char`
 
 ### Phase 3: Iterator Integration
 
-1. Implement `Iterator` for `Range<T: Step + Ord>` and `RangeInclusive<T: Step + Ord>`
+1. Implement `Iterator` for `RangeExclusive<T: Step + Ord>` and `RangeInclusive<T: Step + Ord>`
 2. Implement `IntoIterator` for both types
 3. Verify for-of desugaring works with range expressions
 
@@ -501,7 +503,7 @@ The `exhausted` field is always present in `RangeInclusive` as a private struct 
 
 1. Implement `contains`, `is_empty` methods
 2. Implement `Display`, `Inspect`, and `Eq` traits
-3. Implement `IndexValue<Range<i32>>` and `IndexValue<RangeInclusive<i32>>` for `Array<T>`
+3. Implement `IndexValue<RangeExclusive<i32>>` and `IndexValue<RangeInclusive<i32>>` for `Array<T>`
 
 ## Consequences
 

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -26,16 +26,17 @@ The operator precedence WEP reserves `..` and `..=` at level 14; this WEP revise
 
 Rust has the most comprehensive range system with six distinct types:
 
-| Type | Syntax | Interval | Iterable |
-|------|--------|----------|----------|
-| `Range<Idx>` | `a..b` | [a, b) | Yes (when `Idx: Step`) |
-| `RangeInclusive<Idx>` | `a..=b` | [a, b] | Yes (when `Idx: Step`) |
-| `RangeFrom<Idx>` | `a..` | [a, +inf) | Yes (infinite) |
-| `RangeTo<Idx>` | `..b` | (-inf, b) | No |
-| `RangeToInclusive<Idx>` | `..=b` | (-inf, b] | No |
-| `RangeFull` | `..` | (-inf, +inf) | No |
+| Type                    | Syntax  | Interval     | Iterable               |
+| ----------------------- | ------- | ------------ | ---------------------- |
+| `Range<Idx>`            | `a..b`  | [a, b)       | Yes (when `Idx: Step`) |
+| `RangeInclusive<Idx>`   | `a..=b` | [a, b]       | Yes (when `Idx: Step`) |
+| `RangeFrom<Idx>`        | `a..`   | [a, +inf)    | Yes (infinite)         |
+| `RangeTo<Idx>`          | `..b`   | (-inf, b)    | No                     |
+| `RangeToInclusive<Idx>` | `..=b`  | (-inf, b]    | No                     |
+| `RangeFull`             | `..`    | (-inf, +inf) | No                     |
 
 Key design elements:
+
 - All types are generic structs in `std::ops`
 - The `Step` trait (unstable) enables integer/char iteration
 - `RangeBounds` trait unifies all range types for generic code accepting any range
@@ -51,15 +52,16 @@ Key design elements:
 
 Swift has five range types with different operators:
 
-| Type | Syntax | Interval |
-|------|--------|----------|
-| `Range<Bound>` | `a..<b` | [a, b) |
-| `ClosedRange<Bound>` | `a...b` | [a, b] |
-| `PartialRangeFrom<Bound>` | `a...` | [a, +inf) |
-| `PartialRangeThrough<Bound>` | `...b` | (-inf, b] |
-| `PartialRangeUpTo<Bound>` | `..<b` | (-inf, b) |
+| Type                         | Syntax  | Interval  |
+| ---------------------------- | ------- | --------- |
+| `Range<Bound>`               | `a..<b` | [a, b)    |
+| `ClosedRange<Bound>`         | `a...b` | [a, b]    |
+| `PartialRangeFrom<Bound>`    | `a...`  | [a, +inf) |
+| `PartialRangeThrough<Bound>` | `...b`  | (-inf, b] |
+| `PartialRangeUpTo<Bound>`    | `..<b`  | (-inf, b) |
 
 Key design elements:
+
 - All require `Bound: Comparable` — any comparable type can form a range
 - Only iterable when `Bound: Strideable & Comparable` (integers, not floats by default)
 - `stride(from:to:by:)` and `stride(from:through:by:)` provide stepping
@@ -94,18 +96,18 @@ Zig treats ranges as syntax, not types:
 
 ### Summary
 
-| | Rust | Swift | Go | Zig |
-|---|---|---|---|---|
-| Range as type | Yes (6 types) | Yes (5 types) | No (keyword) | No (syntax) |
-| Half-open syntax | `a..b` | `a..<b` | N/A | `a..b` |
-| Inclusive syntax | `a..=b` | `a...b` | N/A | `a...b` (switch only) |
-| Generic | Yes | Yes | N/A | No (usize only) |
-| Iterable | Via Step trait | Via Strideable | Built-in | Built-in |
-| Slicing | Yes | Yes | No | Yes |
-| Contains | Yes | Yes | No | No |
-| Pattern matching | Yes (inclusive only) | Yes (switch/case) | No | Yes (switch) |
-| Custom step | `.step_by(n)` | `stride(from:to:by:)` | N/A | No |
-| Reverse iteration | `.rev()` | `.reversed()` | N/A | No |
+|                   | Rust                 | Swift                 | Go           | Zig                   |
+| ----------------- | -------------------- | --------------------- | ------------ | --------------------- |
+| Range as type     | Yes (6 types)        | Yes (5 types)         | No (keyword) | No (syntax)           |
+| Half-open syntax  | `a..b`               | `a..<b`               | N/A          | `a..b`                |
+| Inclusive syntax  | `a..=b`              | `a...b`               | N/A          | `a...b` (switch only) |
+| Generic           | Yes                  | Yes                   | N/A          | No (usize only)       |
+| Iterable          | Via Step trait       | Via Strideable        | Built-in     | Built-in              |
+| Slicing           | Yes                  | Yes                   | No           | Yes                   |
+| Contains          | Yes                  | Yes                   | No           | No                    |
+| Pattern matching  | Yes (inclusive only) | Yes (switch/case)     | No           | Yes (switch)          |
+| Custom step       | `.step_by(n)`        | `stride(from:to:by:)` | N/A          | No                    |
+| Reverse iteration | `.rev()`             | `.reversed()`         | N/A          | No                    |
 
 ## Decision
 
@@ -153,6 +155,7 @@ pub struct RangeInclusive<T> {
 Range operators `..<` and `..=` sit at precedence level 14 (between logical OR and assignment). They are non-associative — `a..<b..<c` is a compile error.
 
 **Why `..<` and `..=`**:
+
 - **Both operators are explicit about the bound**: `..<` clearly reads as "less than" (exclusive end), `..=` clearly reads as "equals" (inclusive end). There is no ambiguous "bare" `..` operator — both sides state the boundary rule.
 - **Reduces off-by-one bugs**: With `..` and `..=`, forgetting `=` silently gives a different range. With `..<` and `..=`, there is no "default" form to accidentally misuse.
 - **Frees `..` for other syntax**: Wado already uses `..` for struct rest patterns (`let { name, .. } = p`). Keeping `..` out of range syntax avoids ambiguity.

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -547,6 +547,47 @@ for let mut i = 9; i >= 0; i -= 1 {
 
 A general `.rev()` iterator combinator can be added later to the `Iterator` trait.
 
+### Wasm GC Representation
+
+`RangeExclusive<T>` and `RangeInclusive<T>` are struct types. For primitive `T`, the compiler monomorphizes them to simple Wasm GC structs:
+
+```wat
+;; RangeExclusive<i32>
+(type $RangeExclusive_i32 (struct (field $start i32) (field $end i32)))
+
+;; RangeInclusive<i32> (with exhausted flag for Iterator)
+(type $RangeInclusive_i32 (struct (field $start i32) (field $end i32) (field $exhausted i32)))
+```
+
+For iteration, the `exhausted` flag is only present in `RangeInclusive` and only when it is used as an iterator (monomorphization can elide it when only `contains` is used).
+
+## Implementation Strategy
+
+### Phase 1: Lexer and Parser
+
+1. Add `DotDotLt` (`..<`) and `DotDotEq` (`..=`) tokens to the lexer
+2. Add `RangeExclusive` and `RangeInclusive` expression AST nodes
+3. Parse range expressions at precedence level 14 (non-associative)
+4. Update the operator precedence WEP to reflect `..<` and `..=` (replacing `..` and `..=`)
+
+### Phase 2: Type Checking
+
+1. Define `RangeExclusive<T>` and `RangeInclusive<T>` as built-in generic structs in `core:prelude`
+2. Infer `T` from the operands (both must have the same type after literal coercion)
+3. Add `Step` trait and implement for integer types and `char`
+
+### Phase 3: Iterator Integration
+
+1. Implement `Iterator` for `RangeExclusive<T: Step + Ord>` and `RangeInclusive<T: Step + Ord>`
+2. Implement `IntoIterator` for both types
+3. Verify for-of desugaring works with range expressions
+
+### Phase 4: Methods and Traits
+
+1. Implement `contains`, `is_empty` methods
+2. Implement `Display`, `Inspect`, and `Eq` traits
+3. Implement `IndexValue<RangeExclusive<i32>>` and `IndexValue<RangeInclusive<i32>>` for `Array<T>`
+
 ## Consequences
 
 ### Positive

--- a/docs/wep-2026-03-03-range-object.md
+++ b/docs/wep-2026-03-03-range-object.md
@@ -381,7 +381,7 @@ impl IndexValue<RangeInclusive<i32>> for Array<T> {
 
 ### Pattern Matching with Ranges
 
-Range patterns allow matching a value against a range in `match` arms, `if let`, and `matches`:
+Range patterns allow matching a value against a range in `match` arms and `matches` expressions:
 
 ```wado
 // Grade classification
@@ -423,7 +423,7 @@ Both `..<` and `..=` are allowed as pattern forms:
 - `a..<b` matches if `a <= scrutinee < b`
 - `a..=b` matches if `a <= scrutinee <= b`
 
-The bounds `a` and `b` must be compile-time constant expressions: integer literals, character literals, unary negation of literals (`-1`), or associated constants (`i32::MAX`).
+Range patterns are restricted to integer and `char` types (not floats — NaN breaks comparison semantics and exhaustiveness is undecidable). The bounds `a` and `b` must be compile-time constant expressions: integer literals, character literals, unary negation of literals (`-1`), or associated constants (`i32::MAX`).
 
 ```wado
 // Negative ranges


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive design for range objects in Wado, enabling idiomatic iteration patterns, membership testing, array slicing, and pattern matching. The design defines two generic range types (`RangeExclusive<T>` and `RangeInclusive<T>`) with operators `..<` and `..=` respectively.

## Key Changes

- **New WEP document** (`wep-2026-03-03-range-object.md`): Complete specification for range objects including:
  - Two generic range types: `RangeExclusive<T>` (half-open `[start, end)`) and `RangeInclusive<T>` (inclusive `[start, end]`)
  - Syntax using `..<` and `..=` operators at precedence level 14
  - `Step` trait for enabling iteration on integer and char types
  - Iterator implementations with proper handling of boundary cases (e.g., `T::MAX` in inclusive ranges)
  - Support for membership testing via `contains()` method
  - Array slicing via `IndexValue` trait integration
  - Range patterns in `match` expressions with exhaustiveness and overlap checking
  - Comprehensive language survey comparing Rust, Swift, Go, and Zig approaches
  - Implementation strategy in four phases

- **Updated Iterator Traits WEP** (`wep-2026-01-24-iterator-traits.md`):
  - Changed example from `Range` to `RangeExclusive<T>` in trait comparison table
  - Updated range iterator section to reference the new Range Object WEP
  - Updated code examples to use `..<` syntax instead of `range()` function

- **Updated Operator Precedence WEP** (`wep-2026-01-11-operator-precedence.md`):
  - Revised precedence level 14 to use `..<` (exclusive) and `..=` (inclusive) instead of `..` and `..=`

- **Updated Operator Overloading WEP** (`wep-2026-01-18-operator-overloading.md`):
  - Updated range operator section to reflect `..<` and `..=` syntax

- **Updated Indexing Traits WEP** (`wep-2026-01-20-indexing-traits.md`):
  - Added reference to Range Object WEP for range-based slicing

- **Updated AGENTS.md**: Added reference to the new Range Object WEP in the WEP index

## Notable Design Decisions

- **Two types, not six**: Unlike Rust (6 types) or Swift (5 types), Wado provides only `RangeExclusive` and `RangeInclusive` for pragmatic simplicity, with partial ranges deferred to future work
- **Symmetric naming**: Type names (`RangeExclusive`/`RangeInclusive`) mirror operator symmetry (`..<`/`..=`), avoiding ambiguous "default" forms
- **Explicit operators**: Both `..<` and `..=` clearly state boundary rules, reducing off-by-one bugs
- **Generic ranges**: Support all integer types and `char`, plus `Ord` types for membership testing (including floats)
- **Exhausted flag**: `RangeInclusive` uses a private `exhausted` field to correctly handle `T::MAX` cases
- **Value semantics**: Ranges are `Copy` types that serve as their own iterators

https://claude.ai/code/session_01LKhoSjdAUQK18EQonRbL5b