### PR TITLE
Run benchmarks at multiple optimization levels (-O1, -O2, -O3)

### DIFF
--- a/.github/scripts/run_wado_benchmarks.ts
+++ b/.github/scripts/run_wado_benchmarks.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 // Run Wado-only runtime benchmarks and output JSON for github-action-benchmark.
+// Each benchmark is run at -O1, -O2, and -O3 optimization levels.
 import { execFileSync } from 'node:child_process';
 
 const WADO = './target/release/wado';
 
 type BenchResult = { name: string; unit: string; value: number };
 
-function runBench(src: string): string {
-  return execFileSync(WADO, ['run', '-O2', src], { encoding: 'utf8' });
+function runBench(src: string, optLevel: string): string {
+  return execFileSync(WADO, ['run', optLevel, src], { encoding: 'utf8' });
 }
 
 function parseMs(output: string, pattern: RegExp = /Elapsed: (\d+) ms/): number {
@@ -16,22 +17,32 @@ function parseMs(output: string, pattern: RegExp = /Elapsed: (\d+) ms/): number 
   return parseInt(m[1], 10);
 }
 
+const OPT_LEVELS = ['-O1', '-O2', '-O3'] as const;
+
+function optLabel(opt: string): string {
+  return opt.replace('-', '');
+}
+
 const benchmarks: BenchResult[] = [];
 
-let output = runBench('benchmark/count_prime/count_prime.wado');
-benchmarks.push({ name: 'count_prime', unit: 'ms', value: parseMs(output) });
+for (const opt of OPT_LEVELS) {
+  const label = optLabel(opt);
 
-output = runBench('benchmark/mandelbrot/mandelbrot.wado');
-benchmarks.push({ name: 'mandelbrot', unit: 'ms', value: parseMs(output) });
+  let output = runBench('benchmark/count_prime/count_prime.wado', opt);
+  benchmarks.push({ name: `count_prime (${label})`, unit: 'ms', value: parseMs(output) });
 
-output = runBench('benchmark/sieve/sieve.wado');
-benchmarks.push({ name: 'sieve', unit: 'ms', value: parseMs(output) });
+  output = runBench('benchmark/mandelbrot/mandelbrot.wado', opt);
+  benchmarks.push({ name: `mandelbrot (${label})`, unit: 'ms', value: parseMs(output) });
 
-output = runBench('benchmark/fts/fts.wado');
-benchmarks.push({ name: 'fts', unit: 'ms', value: parseMs(output) });
+  output = runBench('benchmark/sieve/sieve.wado', opt);
+  benchmarks.push({ name: `sieve (${label})`, unit: 'ms', value: parseMs(output) });
 
-output = runBench('benchmark/zlib/zlib_bench.wado');
-benchmarks.push({ name: 'zlib/compress', unit: 'ms', value: parseMs(output, /Compress: (\d+) ms/) });
-benchmarks.push({ name: 'zlib/decompress', unit: 'ms', value: parseMs(output, /Decompress: (\d+) ms/) });
+  output = runBench('benchmark/fts/fts.wado', opt);
+  benchmarks.push({ name: `fts (${label})`, unit: 'ms', value: parseMs(output) });
+
+  output = runBench('benchmark/zlib/zlib_bench.wado', opt);
+  benchmarks.push({ name: `zlib/compress (${label})`, unit: 'ms', value: parseMs(output, /Compress: (\d+) ms/) });
+  benchmarks.push({ name: `zlib/decompress (${label})`, unit: 'ms', value: parseMs(output, /Decompress: (\d+) ms/) });
+}
 
 process.stdout.write(JSON.stringify(benchmarks, null, 2) + '\n');

--- a/.github/scripts/run_wado_benchmarks.ts
+++ b/.github/scripts/run_wado_benchmarks.ts
@@ -19,14 +19,10 @@ function parseMs(output: string, pattern: RegExp = /Elapsed: (\d+) ms/): number 
 
 const OPT_LEVELS = ['-O1', '-O2', '-O3'] as const;
 
-function optLabel(opt: string): string {
-  return opt.replace('-', '');
-}
-
 const benchmarks: BenchResult[] = [];
 
 for (const opt of OPT_LEVELS) {
-  const label = optLabel(opt);
+  const label = opt;
 
   let output = runBench('benchmark/count_prime/count_prime.wado', opt);
   benchmarks.push({ name: `count_prime (${label})`, unit: 'ms', value: parseMs(output) });


### PR DESCRIPTION
## Summary
Updated the benchmark runner to execute all benchmarks at three different optimization levels (-O1, -O2, -O3) instead of only at -O2, providing more comprehensive performance data across the optimization spectrum.

## Changes
- Modified `runBench()` function to accept an `optLevel` parameter, allowing dynamic optimization level specification
- Added `OPT_LEVELS` constant defining the three optimization levels to test
- Wrapped all benchmark executions in a loop that iterates through each optimization level
- Updated benchmark result names to include the optimization level in parentheses (e.g., `count_prime (-O1)`, `count_prime (-O2)`, etc.)
- Added clarifying comment at the top of the file documenting the multi-level optimization approach

## Implementation Details
- Each of the 5 benchmarks (count_prime, mandelbrot, sieve, fts, zlib) is now run 3 times, once per optimization level
- The zlib benchmark continues to report both compress and decompress metrics, now with optimization level suffixes
- Total benchmark results increase from 7 to 21 entries in the output JSON

https://claude.ai/code/session_01MEFagPNDJwqNfup5yUXBXu