### PR TITLE
Add JSON NSD (Non-Self-Describing) serialization format

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1371,6 +1371,15 @@ let json = to_string::<User>(&User { name: "Alice", age: 30 });
 let parsed = from_string::<User>(`\{"name":"Alice","age":30\}`);
 // Ok(User { name: "Alice", age: 30 })
 
+// core:json_nsd - Non-self-describing JSON (compact)
+use { to_string, from_string } from "core:json_nsd";
+
+let nsd = to_string::<User>(&User { name: "Alice", age: 30 });
+// Ok("[\"Alice\",30]")  — struct as positional array, no field names
+
+let parsed_nsd = from_string::<User>(`["Alice",30]`);
+// Ok(User { name: "Alice", age: 30 })
+
 // core:base64 - Base64 encoding/decoding
 use { encode, decode } from "core:base64";
 let data: Array<u8> = [72, 101, 108, 108, 111];

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2705,6 +2705,22 @@ let user = from_string::<User>(json);  // Result<User, DeserializeError>
 
 JSON serialization returns `Err` for `NaN` and `Infinity` float values. JSON deserialization returns `Err` for malformed input, missing required fields, type mismatches, and trailing data.
 
+### JSON NSD Module (`core:json_nsd`)
+
+Non-self-describing JSON format. Structs are encoded as positional arrays (field names omitted), unit variants as discriminant integers, and payload variants as `[disc, payload]`.
+
+```wado
+use { to_string, from_string } from "core:json_nsd";
+
+// Struct as positional array
+let json = to_string::<User>(&user);   // Result: Ok("[\"Alice\",30]")
+
+// Deserialize from positional array
+let user = from_string::<User>(`["Alice",30]`);  // Result<User, DeserializeError>
+```
+
+The same `Serialize` and `Deserialize` trait impls work with both `core:json` and `core:json_nsd`.
+
 ## Module System
 
 Wado uses an ESM-like import syntax with `use {...} from "module"`. This aligns with JavaScript/TypeScript conventions, as JavaScript is a primary host environment for Wado.

--- a/wado-compiler/lib/core/json.wado
+++ b/wado-compiler/lib/core/json.wado
@@ -27,14 +27,14 @@ use {
     DeserializeErrorKind,
 } from "core:serde";
 
-fn hex_digit(v: i32) -> char {
+pub fn hex_digit(v: i32) -> char {
     if v < 10 {
         return ('0' as i32 + v) as u8 as char;
     }
     return ('a' as i32 + v - 10) as u8 as char;
 }
 
-fn utf8_sequence_length(leading_byte: i32) -> i32 {
+pub fn utf8_sequence_length(leading_byte: i32) -> i32 {
     if leading_byte < 0x80 {
         return 1;
     }
@@ -327,23 +327,23 @@ impl Serializer for JsonSerializer {
 }
 
 pub struct JsonDeserializer {
-    input: String,
-    pos: i32,
+    pub input: String,
+    pub pos: i32,
 }
 
 impl JsonDeserializer {
-    fn peek(&self) -> i32 {
+    pub fn peek(&self) -> i32 {
         if self.pos >= self.input.len() {
             return -1;
         }
         return self.input.get_byte(self.pos) as i32;
     }
 
-    fn advance(&mut self) {
+    pub fn advance(&mut self) {
         self.pos += 1;
     }
 
-    fn skip_whitespace(&mut self) {
+    pub fn skip_whitespace(&mut self) {
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
             if b == ' ' as i32 || b == '\t' as i32 || b == '\n' as i32 || b == '\r' as i32 {
@@ -354,7 +354,7 @@ impl JsonDeserializer {
         }
     }
 
-    fn expect_char(&mut self, c: i32) -> Result<(), DeserializeError> {
+    pub fn expect_char(&mut self, c: i32) -> Result<(), DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
             return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
@@ -370,7 +370,7 @@ impl JsonDeserializer {
         return Result::<(), DeserializeError>::Ok(());
     }
 
-    fn expect_literal(&mut self, lit: &String) -> Result<(), DeserializeError> {
+    pub fn expect_literal(&mut self, lit: &String) -> Result<(), DeserializeError> {
         let start = self.pos;
         for let b of lit.bytes() {
             if self.pos >= self.input.len() {
@@ -387,7 +387,7 @@ impl JsonDeserializer {
         return Result::<(), DeserializeError>::Ok(());
     }
 
-    fn read_json_string(&mut self) -> Result<String, DeserializeError> {
+    pub fn read_json_string(&mut self) -> Result<String, DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
             return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
@@ -518,7 +518,7 @@ impl JsonDeserializer {
         ));
     }
 
-    fn read_number_raw(&mut self) -> Result<String, DeserializeError> {
+    pub fn read_number_raw(&mut self) -> Result<String, DeserializeError> {
         self.skip_whitespace();
         let start = self.pos;
         if self.pos >= self.input.len() {
@@ -583,7 +583,7 @@ impl JsonDeserializer {
         return Result::<String, DeserializeError>::Ok(raw);
     }
 
-    fn has_exp_or_dot(&self, raw: &String) -> bool {
+    pub fn has_exp_or_dot(&self, raw: &String) -> bool {
         for let mut i = 0; i < raw.len(); i += 1 {
             let b = raw.get_byte(i) as i32;
             if b == '.' as i32 || b == 'e' as i32 || b == 'E' as i32 {
@@ -593,7 +593,7 @@ impl JsonDeserializer {
         return false;
     }
 
-    fn parse_i32_from(&self, raw: &String, start: i64) -> Result<i32, DeserializeError> {
+    pub fn parse_i32_from(&self, raw: &String, start: i64) -> Result<i32, DeserializeError> {
         let has_exp = self.has_exp_or_dot(raw);
         if has_exp {
             // Parse via f64 for scientific notation (e.g. 1e2 → 100)
@@ -644,7 +644,7 @@ impl JsonDeserializer {
         return Result::<i32, DeserializeError>::Ok(result);
     }
 
-    fn parse_i64_from(&self, raw: &String, start: i64) -> Result<i64, DeserializeError> {
+    pub fn parse_i64_from(&self, raw: &String, start: i64) -> Result<i64, DeserializeError> {
         let has_exp = self.has_exp_or_dot(raw);
         if has_exp {
             let parsed = f64::parse(*raw);
@@ -687,6 +687,39 @@ impl JsonDeserializer {
             result = -result;
         }
         return Result::<i64, DeserializeError>::Ok(result);
+    }
+
+    pub fn parse_u64_from(&self, raw: &String, start: i64) -> Result<u64, DeserializeError> {
+        if raw.len() > 0 && raw.get_byte(0) as i32 == '-' as i32 {
+            return Result::<u64, DeserializeError>::Err(DeserializeError::overflow("negative value for u64", start));
+        }
+        let has_exp = self.has_exp_or_dot(raw);
+        if has_exp {
+            let parsed = f64::parse(*raw);
+            if let Some(v) = parsed {
+                if v < 0.0 {
+                    return Result::<u64, DeserializeError>::Err(DeserializeError::overflow("negative value for u64", start));
+                }
+                if v != f64::floor(v) {
+                    return Result::<u64, DeserializeError>::Err(DeserializeError::unexpected_type("expected integer, got float", start));
+                }
+                return Result::<u64, DeserializeError>::Ok(v as u64);
+            }
+            return Result::<u64, DeserializeError>::Err(DeserializeError::invalid_value("invalid number", start));
+        }
+        let mut idx = 0;
+        let len = raw.len();
+        let mut result: u64 = 0 as u64;
+        while idx < len {
+            let b = raw.get_byte(idx) as i32;
+            if b < '0' as i32 || b > '9' as i32 {
+                return Result::<u64, DeserializeError>::Err(DeserializeError::invalid_value("invalid digit", start));
+            }
+            let digit = (b - '0' as i32) as u64;
+            result = result * 10 as u64 + digit;
+            idx += 1;
+        }
+        return Result::<u64, DeserializeError>::Ok(result);
     }
 
     /// Skips the next JSON value without allocating.
@@ -1051,39 +1084,6 @@ impl Deserializer for JsonDeserializer {
             return Result::<u64, DeserializeError>::Err(e);
         }
         unreachable();
-    }
-
-    fn parse_u64_from(&self, raw: &String, start: i64) -> Result<u64, DeserializeError> {
-        if raw.len() > 0 && raw.get_byte(0) as i32 == '-' as i32 {
-            return Result::<u64, DeserializeError>::Err(DeserializeError::overflow("negative value for u64", start));
-        }
-        let has_exp = self.has_exp_or_dot(raw);
-        if has_exp {
-            let parsed = f64::parse(*raw);
-            if let Some(v) = parsed {
-                if v < 0.0 {
-                    return Result::<u64, DeserializeError>::Err(DeserializeError::overflow("negative value for u64", start));
-                }
-                if v != f64::floor(v) {
-                    return Result::<u64, DeserializeError>::Err(DeserializeError::unexpected_type("expected integer, got float", start));
-                }
-                return Result::<u64, DeserializeError>::Ok(v as u64);
-            }
-            return Result::<u64, DeserializeError>::Err(DeserializeError::invalid_value("invalid number", start));
-        }
-        let mut idx = 0;
-        let len = raw.len();
-        let mut result: u64 = 0 as u64;
-        while idx < len {
-            let b = raw.get_byte(idx) as i32;
-            if b < '0' as i32 || b > '9' as i32 {
-                return Result::<u64, DeserializeError>::Err(DeserializeError::invalid_value("invalid digit", start));
-            }
-            let digit = (b - '0' as i32) as u64;
-            result = result * 10 as u64 + digit;
-            idx += 1;
-        }
-        return Result::<u64, DeserializeError>::Ok(result);
     }
 
     fn deserialize_i128(&mut self) -> Result<i128, DeserializeError> {

--- a/wado-compiler/lib/core/json_nsd.wado
+++ b/wado-compiler/lib/core/json_nsd.wado
@@ -1,0 +1,621 @@
+//! JSON NSD (Non-Self-Describing) serialization and deserialization.
+//!
+//! Structs are encoded as positional arrays (field names omitted).
+//! Unit variants (enums) are encoded as integer discriminants.
+//! Payload variants are encoded as `[disc, payload]`.
+//!
+//! Usage:
+//!   use { to_string, from_string } from "core:json_nsd";
+//!
+//!   struct Point { x: i32, y: i32 }
+//!   impl Serialize for Point;
+//!   impl Deserialize for Point;
+//!
+//!   let json = to_string::<Point>(&Point { x: 1, y: 2 });  // "[1,2]"
+//!   let val = from_string::<Point>("[1,2]");                 // Ok(Point { x: 1, y: 2 })
+
+use {
+    Serialize,
+    Deserialize,
+    Serializer,
+    Deserializer,
+    SerializeSeq,
+    SerializeMap,
+    SerializeStruct,
+    SerializeVariant,
+    DeserializeSeq,
+    DeserializeMap,
+    DeserializeStruct,
+    DeserializeVariant,
+    SerializeError,
+    SerializeErrorKind,
+    DeserializeError,
+    DeserializeErrorKind,
+} from "core:serde";
+
+use {
+    write_escaped_string,
+    JsonDeserializer,
+} from "core:json";
+
+struct NsdSeqSerializer {
+    buf: String,
+    count: i32,
+}
+
+struct NsdMapSerializer {
+    buf: String,
+    count: i32,
+    need_value: bool,
+}
+
+struct NsdStructSerializer {
+    buf: String,
+    count: i32,
+}
+
+struct NsdVariantSerializer {
+    buf: String,
+}
+
+pub struct NsdSerializer {
+    buf: String,
+}
+
+impl SerializeSeq for NsdSeqSerializer {
+    fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError> {
+        if self.count > 0 {
+            self.buf.append(",");
+        }
+        let mut ser = NsdSerializer { buf: self.buf };
+        let r = value.serialize::<NsdSerializer>(&mut ser);
+        self.buf = ser.buf;
+        self.count += 1;
+        return r;
+    }
+
+    fn end(&mut self) -> Result<(), SerializeError> {
+        self.buf.append("]");
+        return Result::<(), SerializeError>::Ok(());
+    }
+}
+
+impl SerializeMap for NsdMapSerializer {
+    fn key<T: Serialize>(&mut self, key: &T) -> Result<(), SerializeError> {
+        if self.count > 0 {
+            self.buf.append(",");
+        }
+        let mut ser = NsdSerializer { buf: self.buf };
+        let r = key.serialize::<NsdSerializer>(&mut ser);
+        self.buf = ser.buf;
+        self.buf.append(":");
+        self.need_value = true;
+        return r;
+    }
+
+    fn value<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError> {
+        let mut ser = NsdSerializer { buf: self.buf };
+        let r = value.serialize::<NsdSerializer>(&mut ser);
+        self.buf = ser.buf;
+        self.count += 1;
+        self.need_value = false;
+        return r;
+    }
+
+    fn end(&mut self) -> Result<(), SerializeError> {
+        self.buf.append("}");
+        return Result::<(), SerializeError>::Ok(());
+    }
+}
+
+impl SerializeStruct for NsdStructSerializer {
+    fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError> {
+        if self.count > 0 {
+            self.buf.append(",");
+        }
+        // NSD: omit field name, write value only
+        let mut ser = NsdSerializer { buf: self.buf };
+        let r = value.serialize::<NsdSerializer>(&mut ser);
+        self.buf = ser.buf;
+        self.count += 1;
+        return r;
+    }
+
+    fn end(&mut self) -> Result<(), SerializeError> {
+        self.buf.append("]");
+        return Result::<(), SerializeError>::Ok(());
+    }
+}
+
+impl SerializeVariant for NsdVariantSerializer {
+    fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError> {
+        self.buf.append(",");
+        let mut ser = NsdSerializer { buf: self.buf };
+        let r = value.serialize::<NsdSerializer>(&mut ser);
+        self.buf = ser.buf;
+        return r;
+    }
+
+    fn end(&mut self) -> Result<(), SerializeError> {
+        self.buf.append("]");
+        return Result::<(), SerializeError>::Ok(());
+    }
+}
+
+impl Serializer for NsdSerializer {
+    type SeqSerializer = NsdSeqSerializer;
+    type MapSerializer = NsdMapSerializer;
+    type StructSerializer = NsdStructSerializer;
+    type VariantSerializer = NsdVariantSerializer;
+
+    fn serialize_i32(&mut self, v: i32) -> Result<(), SerializeError> {
+        self.buf.append(`{v}`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_i64(&mut self, v: i64) -> Result<(), SerializeError> {
+        if v > 9007199254740991 as i64 || v < -9007199254740991 as i64 {
+            self.buf.append(`"{v}"`);
+        } else {
+            self.buf.append(`{v}`);
+        }
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_u32(&mut self, v: u32) -> Result<(), SerializeError> {
+        self.buf.append(`{v}`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_u64(&mut self, v: u64) -> Result<(), SerializeError> {
+        if v > 9007199254740991 as u64 {
+            self.buf.append(`"{v}"`);
+        } else {
+            self.buf.append(`{v}`);
+        }
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_i128(&mut self, v: i128) -> Result<(), SerializeError> {
+        self.buf.append(`"{v}"`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_u128(&mut self, v: u128) -> Result<(), SerializeError> {
+        self.buf.append(`"{v}"`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_f32(&mut self, v: f32) -> Result<(), SerializeError> {
+        if v.is_nan() {
+            return Result::<(), SerializeError>::Err(SerializeError {
+                kind: SerializeErrorKind::UnsupportedValue,
+                message: "NaN is not allowed in JSON",
+            });
+        }
+        if !v.is_finite() {
+            return Result::<(), SerializeError>::Err(SerializeError {
+                kind: SerializeErrorKind::UnsupportedValue,
+                message: "Infinity is not allowed in JSON",
+            });
+        }
+        self.buf.append(`{v as f64}`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_f64(&mut self, v: f64) -> Result<(), SerializeError> {
+        if v.is_nan() {
+            return Result::<(), SerializeError>::Err(SerializeError {
+                kind: SerializeErrorKind::UnsupportedValue,
+                message: "NaN is not allowed in JSON",
+            });
+        }
+        if !v.is_finite() {
+            return Result::<(), SerializeError>::Err(SerializeError {
+                kind: SerializeErrorKind::UnsupportedValue,
+                message: "Infinity is not allowed in JSON",
+            });
+        }
+        self.buf.append(`{v}`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_bool(&mut self, v: bool) -> Result<(), SerializeError> {
+        if v {
+            self.buf.append("true");
+        } else {
+            self.buf.append("false");
+        }
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_char(&mut self, v: char) -> Result<(), SerializeError> {
+        let s = `{v}`;
+        write_escaped_string(&mut self.buf, &s);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError> {
+        write_escaped_string(&mut self.buf, v);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn serialize_null(&mut self) -> Result<(), SerializeError> {
+        self.buf.append("null");
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn begin_seq(&mut self, len: i32) -> Result<NsdSeqSerializer, SerializeError> {
+        self.buf.append("[");
+        return Result::<NsdSeqSerializer, SerializeError>::Ok(NsdSeqSerializer {
+            buf: self.buf,
+            count: 0,
+        });
+    }
+
+    fn begin_map(&mut self, len: i32) -> Result<NsdMapSerializer, SerializeError> {
+        self.buf.append("{");
+        return Result::<NsdMapSerializer, SerializeError>::Ok(NsdMapSerializer {
+            buf: self.buf,
+            count: 0,
+            need_value: false,
+        });
+    }
+
+    fn begin_struct(&mut self, name: &String, fields: i32) -> Result<NsdStructSerializer, SerializeError> {
+        // NSD: struct as array
+        self.buf.append("[");
+        return Result::<NsdStructSerializer, SerializeError>::Ok(NsdStructSerializer {
+            buf: self.buf,
+            count: 0,
+        });
+    }
+
+    fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerializeError> {
+        // NSD: discriminant integer
+        self.buf.append(`{disc}`);
+        return Result::<(), SerializeError>::Ok(());
+    }
+
+    fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<NsdVariantSerializer, SerializeError> {
+        // NSD: [disc, payload]
+        self.buf.append(`[{disc}`);
+        return Result::<NsdVariantSerializer, SerializeError>::Ok(NsdVariantSerializer {
+            buf: self.buf,
+        });
+    }
+}
+
+struct NsdSeqAccess {
+    de: JsonDeserializer,
+    first: bool,
+}
+
+struct NsdMapAccess {
+    de: JsonDeserializer,
+    first: bool,
+}
+
+struct NsdStructAccess {
+    de: JsonDeserializer,
+    index: i32,
+    num_fields: i32,
+    first: bool,
+}
+
+struct NsdVariantAccess {
+    de: JsonDeserializer,
+    disc: i32,
+    is_unit: bool,
+}
+
+impl DeserializeSeq for NsdSeqAccess {
+    fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError> {
+        self.de.skip_whitespace();
+        if self.de.pos >= self.de.input.len() {
+            return Result::<Option<T>, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+        }
+        if self.de.input.get_byte(self.de.pos) as i32 == ']' as i32 {
+            return Result::<Option<T>, DeserializeError>::Ok(null);
+        }
+        if !self.first {
+            let r = self.de.expect_char(',' as i32);
+            if let Err(e) = r {
+                return Result::<Option<T>, DeserializeError>::Err(e);
+            }
+        }
+        self.first = false;
+        let elem = T::deserialize::<NsdDeserializer>(&mut NsdDeserializer { de: self.de });
+        if let Ok(v) = elem {
+            return Result::<Option<T>, DeserializeError>::Ok(Option::<T>::Some(v));
+        }
+        if let Err(e) = elem {
+            return Result::<Option<T>, DeserializeError>::Err(e);
+        }
+        unreachable();
+    }
+
+    fn end(&mut self) -> Result<(), DeserializeError> {
+        return self.de.expect_char(']' as i32);
+    }
+}
+
+impl DeserializeMap for NsdMapAccess {
+    fn next_key_string(&mut self) -> Result<Option<String>, DeserializeError> {
+        self.de.skip_whitespace();
+        if self.de.pos >= self.de.input.len() {
+            return Result::<Option<String>, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+        }
+        if self.de.input.get_byte(self.de.pos) as i32 == '}' as i32 {
+            return Result::<Option<String>, DeserializeError>::Ok(null);
+        }
+        if !self.first {
+            let r = self.de.expect_char(',' as i32);
+            if let Err(e) = r {
+                return Result::<Option<String>, DeserializeError>::Err(e);
+            }
+        }
+        self.first = false;
+        let key_r = self.de.read_json_string();
+        if let Ok(key) = key_r {
+            let r = self.de.expect_char(':' as i32);
+            if let Err(e) = r {
+                return Result::<Option<String>, DeserializeError>::Err(e);
+            }
+            return Result::<Option<String>, DeserializeError>::Ok(Option::<String>::Some(key));
+        }
+        if let Err(e) = key_r {
+            return Result::<Option<String>, DeserializeError>::Err(e);
+        }
+        unreachable();
+    }
+
+    fn next_value<V: Deserialize>(&mut self) -> Result<V, DeserializeError> {
+        return V::deserialize::<NsdDeserializer>(&mut NsdDeserializer { de: self.de });
+    }
+
+    fn end(&mut self) -> Result<(), DeserializeError> {
+        return self.de.expect_char('}' as i32);
+    }
+}
+
+impl DeserializeStruct for NsdStructAccess {
+    fn next_field(&mut self) -> Result<Option<i32>, DeserializeError> {
+        self.de.skip_whitespace();
+        if self.de.pos >= self.de.input.len() {
+            return Result::<Option<i32>, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+        }
+        if self.de.input.get_byte(self.de.pos) as i32 == ']' as i32 {
+            return Result::<Option<i32>, DeserializeError>::Ok(null);
+        }
+        if !self.first {
+            let r = self.de.expect_char(',' as i32);
+            if let Err(e) = r {
+                return Result::<Option<i32>, DeserializeError>::Err(e);
+            }
+        }
+        self.first = false;
+        // NSD: return sequential field index
+        let idx = self.index;
+        self.index += 1;
+        return Result::<Option<i32>, DeserializeError>::Ok(Option::<i32>::Some(idx));
+    }
+
+    fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError> {
+        return T::deserialize::<NsdDeserializer>(&mut NsdDeserializer { de: self.de });
+    }
+
+    fn skip(&mut self) -> Result<(), DeserializeError> {
+        return self.de.skip_value();
+    }
+
+    fn end(&mut self) -> Result<(), DeserializeError> {
+        return self.de.expect_char(']' as i32);
+    }
+}
+
+impl DeserializeVariant for NsdVariantAccess {
+    fn variant_name(&mut self) -> Result<String, DeserializeError> {
+        return Result::<String, DeserializeError>::Err(DeserializeError {
+            kind: DeserializeErrorKind::Custom,
+            message: "NSD does not encode variant names",
+            offset: -1 as i64,
+        });
+    }
+
+    fn disc(&mut self) -> Result<i32, DeserializeError> {
+        return Result::<i32, DeserializeError>::Ok(self.disc);
+    }
+
+    fn payload<T: Deserialize>(&mut self) -> Result<T, DeserializeError> {
+        return T::deserialize::<NsdDeserializer>(&mut NsdDeserializer { de: self.de });
+    }
+
+    fn is_unit(&mut self) -> Result<bool, DeserializeError> {
+        return Result::<bool, DeserializeError>::Ok(self.is_unit);
+    }
+
+    fn end(&mut self) -> Result<(), DeserializeError> {
+        if !self.is_unit {
+            return self.de.expect_char(']' as i32);
+        }
+        return Result::<(), DeserializeError>::Ok(());
+    }
+}
+
+pub struct NsdDeserializer {
+    de: JsonDeserializer,
+}
+
+impl Deserializer for NsdDeserializer {
+    type SeqAccess = NsdSeqAccess;
+    type MapAccess = NsdMapAccess;
+    type StructAccess = NsdStructAccess;
+    type VariantAccess = NsdVariantAccess;
+
+    fn deserialize_i32(&mut self) -> Result<i32, DeserializeError> {
+        return self.de.deserialize_i32();
+    }
+
+    fn deserialize_i64(&mut self) -> Result<i64, DeserializeError> {
+        return self.de.deserialize_i64();
+    }
+
+    fn deserialize_u32(&mut self) -> Result<u32, DeserializeError> {
+        return self.de.deserialize_u32();
+    }
+
+    fn deserialize_u64(&mut self) -> Result<u64, DeserializeError> {
+        return self.de.deserialize_u64();
+    }
+
+    fn deserialize_i128(&mut self) -> Result<i128, DeserializeError> {
+        return self.de.deserialize_i128();
+    }
+
+    fn deserialize_u128(&mut self) -> Result<u128, DeserializeError> {
+        return self.de.deserialize_u128();
+    }
+
+    fn deserialize_f32(&mut self) -> Result<f32, DeserializeError> {
+        return self.de.deserialize_f32();
+    }
+
+    fn deserialize_f64(&mut self) -> Result<f64, DeserializeError> {
+        return self.de.deserialize_f64();
+    }
+
+    fn deserialize_bool(&mut self) -> Result<bool, DeserializeError> {
+        return self.de.deserialize_bool();
+    }
+
+    fn deserialize_char(&mut self) -> Result<char, DeserializeError> {
+        return self.de.deserialize_char();
+    }
+
+    fn deserialize_string(&mut self) -> Result<String, DeserializeError> {
+        return self.de.deserialize_string();
+    }
+
+    fn is_null(&mut self) -> Result<bool, DeserializeError> {
+        return self.de.is_null();
+    }
+
+    fn begin_seq(&mut self) -> Result<NsdSeqAccess, DeserializeError> {
+        let r = self.de.expect_char('[' as i32);
+        if let Err(e) = r {
+            return Result::<NsdSeqAccess, DeserializeError>::Err(e);
+        }
+        return Result::<NsdSeqAccess, DeserializeError>::Ok(NsdSeqAccess {
+            de: self.de,
+            first: true,
+        });
+    }
+
+    fn begin_map(&mut self) -> Result<NsdMapAccess, DeserializeError> {
+        let r = self.de.expect_char('{' as i32);
+        if let Err(e) = r {
+            return Result::<NsdMapAccess, DeserializeError>::Err(e);
+        }
+        return Result::<NsdMapAccess, DeserializeError>::Ok(NsdMapAccess {
+            de: self.de,
+            first: true,
+        });
+    }
+
+    fn begin_struct(&mut self, name: &String, num_fields: i32, lookup: fn(&String) -> Option<i32>) -> Result<NsdStructAccess, DeserializeError> {
+        // NSD: struct encoded as array
+        let r = self.de.expect_char('[' as i32);
+        if let Err(e) = r {
+            return Result::<NsdStructAccess, DeserializeError>::Err(e);
+        }
+        return Result::<NsdStructAccess, DeserializeError>::Ok(NsdStructAccess {
+            de: self.de,
+            index: 0,
+            num_fields,
+            first: true,
+        });
+    }
+
+    fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<NsdVariantAccess, DeserializeError> {
+        self.de.skip_whitespace();
+        if self.de.pos >= self.de.input.len() {
+            return Result::<NsdVariantAccess, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+        }
+        let b = self.de.input.get_byte(self.de.pos) as i32;
+        if b == '[' as i32 {
+            // Payload variant: [disc, payload]
+            self.de.pos += 1;
+            let start = self.de.pos as i64;
+            let raw_r = self.de.read_number_raw();
+            if let Ok(raw) = raw_r {
+                let disc_r = self.de.parse_i32_from(&raw, start);
+                if let Ok(disc) = disc_r {
+                    let comma_r = self.de.expect_char(',' as i32);
+                    if let Err(e) = comma_r {
+                        return Result::<NsdVariantAccess, DeserializeError>::Err(e);
+                    }
+                    return Result::<NsdVariantAccess, DeserializeError>::Ok(NsdVariantAccess {
+                        de: self.de,
+                        disc,
+                        is_unit: false,
+                    });
+                }
+                if let Err(e) = disc_r {
+                    return Result::<NsdVariantAccess, DeserializeError>::Err(e);
+                }
+            }
+            if let Err(e) = raw_r {
+                return Result::<NsdVariantAccess, DeserializeError>::Err(e);
+            }
+            unreachable();
+        }
+        // Unit variant: bare integer discriminant
+        let start = self.de.pos as i64;
+        let raw_r = self.de.read_number_raw();
+        if let Ok(raw) = raw_r {
+            let disc_r = self.de.parse_i32_from(&raw, start);
+            if let Ok(disc) = disc_r {
+                return Result::<NsdVariantAccess, DeserializeError>::Ok(NsdVariantAccess {
+                    de: self.de,
+                    disc,
+                    is_unit: true,
+                });
+            }
+            if let Err(e) = disc_r {
+                return Result::<NsdVariantAccess, DeserializeError>::Err(e);
+            }
+        }
+        if let Err(e) = raw_r {
+            return Result::<NsdVariantAccess, DeserializeError>::Err(e);
+        }
+        unreachable();
+    }
+}
+
+/// Serializes a value to a JSON NSD string.
+pub fn to_string<T: Serialize>(value: &T) -> Result<String, SerializeError> {
+    let mut ser = NsdSerializer { buf: "" };
+    let r = value.serialize::<NsdSerializer>(&mut ser);
+    if let Err(e) = r {
+        return Result::<String, SerializeError>::Err(e);
+    }
+    return Result::<String, SerializeError>::Ok(ser.buf);
+}
+
+/// Deserializes a value from a JSON NSD string.
+pub fn from_string<T: Deserialize>(input: String) -> Result<T, DeserializeError> {
+    let mut nsd = NsdDeserializer { de: JsonDeserializer { input, pos: 0 } };
+    let r = T::deserialize::<NsdDeserializer>(&mut nsd);
+    if let Ok(v) = r {
+        nsd.de.skip_whitespace();
+        if nsd.de.pos < nsd.de.input.len() {
+            return Result::<T, DeserializeError>::Err(DeserializeError::trailing(nsd.de.pos as i64));
+        }
+        return Result::<T, DeserializeError>::Ok(v);
+    }
+    if let Err(e) = r {
+        return Result::<T, DeserializeError>::Err(e);
+    }
+    unreachable();
+}

--- a/wado-compiler/lib/core/json_nsd_test.wado
+++ b/wado-compiler/lib/core/json_nsd_test.wado
@@ -1,0 +1,364 @@
+use {
+    Serialize,
+    Deserialize,
+    DeserializeError,
+    DeserializeErrorKind,
+} from "core:serde";
+
+use { to_string, from_string } from "core:json_nsd";
+
+// --- Primitive serialization (same as JSON) ---
+
+test "serialize i32" {
+    let n = 42;
+    let r = to_string::<i32>(&n);
+    assert r matches { Ok(s) && s == "42" };
+}
+
+test "serialize negative i32" {
+    let n = -123;
+    let r = to_string::<i32>(&n);
+    assert r matches { Ok(s) && s == "-123" };
+}
+
+test "serialize i64" {
+    let n = 1000000000000 as i64;
+    let r = to_string::<i64>(&n);
+    assert r matches { Ok(s) && s == "1000000000000" };
+}
+
+test "serialize u32" {
+    let n = 255 as u32;
+    let r = to_string::<u32>(&n);
+    assert r matches { Ok(s) && s == "255" };
+}
+
+test "serialize f64" {
+    let n = 3.14;
+    let r = to_string::<f64>(&n);
+    assert r matches { Ok(s) && s == "3.14" };
+}
+
+test "serialize bool" {
+    let v = true;
+    let r = to_string::<bool>(&v);
+    assert r matches { Ok(s) && s == "true" };
+}
+
+test "serialize string" {
+    let v = "hello";
+    let r = to_string::<String>(&v);
+    assert r matches { Ok(s) && s == `"hello"` };
+}
+
+test "serialize string with escapes" {
+    let v = "line1\nline2";
+    let r = to_string::<String>(&v);
+    assert r matches { Ok(s) && s == `"line1\\nline2"` };
+}
+
+test "serialize null" {
+    let v: Option<i32> = null;
+    let r = to_string::<Option<i32>>(&v);
+    assert r matches { Ok(s) && s == "null" };
+}
+
+// --- Struct serialization (NSD: positional array) ---
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+impl Serialize for Point;
+impl Deserialize for Point;
+
+test "serialize struct as array" {
+    let p = Point { x: 10, y: 20 };
+    let r = to_string::<Point>(&p);
+    assert r matches { Ok(s) && s == "[10,20]" };
+}
+
+struct Person {
+    name: String,
+    age: i32,
+    active: bool,
+}
+
+impl Serialize for Person;
+impl Deserialize for Person;
+
+test "serialize struct with mixed types" {
+    let p = Person { name: "Alice", age: 30, active: true };
+    let r = to_string::<Person>(&p);
+    assert r matches { Ok(s) && s == `["Alice",30,true]` };
+}
+
+// --- Nested struct serialization ---
+
+struct Line {
+    start: Point,
+    end: Point,
+}
+
+impl Serialize for Line;
+impl Deserialize for Line;
+
+test "serialize nested struct" {
+    let l = Line { start: Point { x: 1, y: 2 }, end: Point { x: 3, y: 4 } };
+    let r = to_string::<Line>(&l);
+    assert r matches { Ok(s) && s == "[[1,2],[3,4]]" };
+}
+
+// --- Enum (unit variant) serialization ---
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+impl Serialize for Color;
+impl Deserialize for Color;
+
+test "serialize unit variant as discriminant" {
+    let c = Color::Red;
+    let r = to_string::<Color>(&c);
+    assert r matches { Ok(s) && s == "0" };
+}
+
+test "serialize unit variant Green" {
+    let c = Color::Green;
+    let r = to_string::<Color>(&c);
+    assert r matches { Ok(s) && s == "1" };
+}
+
+test "serialize unit variant Blue" {
+    let c = Color::Blue;
+    let r = to_string::<Color>(&c);
+    assert r matches { Ok(s) && s == "2" };
+}
+
+// --- Variant (with payload) serialization ---
+
+variant Shape {
+    Circle(f64),
+    Rectangle([f64, f64]),
+    Point,
+}
+
+impl Serialize for Shape;
+impl Deserialize for Shape;
+
+test "serialize payload variant" {
+    let s = Shape::Circle(5.0);
+    let r = to_string::<Shape>(&s);
+    assert r matches { Ok(v) && v == "[0,5.0]" };
+}
+
+test "serialize tuple-payload variant" {
+    let s = Shape::Rectangle([10.0, 20.0]);
+    let r = to_string::<Shape>(&s);
+    assert r matches { Ok(v) && v == "[1,[10.0,20.0]]" };
+}
+
+test "serialize unit variant in variant type" {
+    let s = Shape::Point;
+    let r = to_string::<Shape>(&s);
+    assert r matches { Ok(v) && v == "2" };
+}
+
+// --- Option serialization ---
+
+test "serialize Option Some" {
+    let v = Option::<i32>::Some(42);
+    let r = to_string::<Option<i32>>(&v);
+    assert r matches { Ok(s) && s == "42" };
+}
+
+test "serialize Option None" {
+    let v: Option<i32> = null;
+    let r = to_string::<Option<i32>>(&v);
+    assert r matches { Ok(s) && s == "null" };
+}
+
+// --- Array serialization ---
+
+test "serialize Array" {
+    let v: Array<i32> = [1, 2, 3];
+    let r = to_string::<Array<i32>>(&v);
+    assert r matches { Ok(s) && s == "[1,2,3]" };
+}
+
+test "serialize Array of structs" {
+    let v: Array<Point> = [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
+    let r = to_string::<Array<Point>>(&v);
+    assert r matches { Ok(s) && s == "[[1,2],[3,4]]" };
+}
+
+// --- Primitive deserialization (same as JSON) ---
+
+test "deserialize i32" {
+    let r = from_string::<i32>("42");
+    assert r matches { Ok(v) && v == 42 };
+}
+
+test "deserialize f64" {
+    let r = from_string::<f64>("3.14");
+    assert r matches { Ok(v) && v == 3.14 };
+}
+
+test "deserialize bool" {
+    let r = from_string::<bool>("true");
+    assert r matches { Ok(v) && v == true };
+}
+
+test "deserialize string" {
+    let r = from_string::<String>(`"hello"`);
+    assert r matches { Ok(v) && v == "hello" };
+}
+
+// --- Struct deserialization (NSD: from positional array) ---
+
+test "deserialize struct from array" {
+    let r = from_string::<Point>("[10,20]");
+    if let Ok(p) = r {
+        assert p.x == 10;
+        assert p.y == 20;
+    } else {
+        panic("expected Ok");
+    }
+}
+
+test "deserialize struct with mixed types" {
+    let r = from_string::<Person>(`["Alice",30,true]`);
+    if let Ok(p) = r {
+        assert p.name == "Alice";
+        assert p.age == 30;
+        assert p.active == true;
+    } else {
+        panic("expected Ok");
+    }
+}
+
+test "deserialize nested struct" {
+    let r = from_string::<Line>("[[1,2],[3,4]]");
+    if let Ok(l) = r {
+        assert l.start.x == 1;
+        assert l.start.y == 2;
+        assert l.end.x == 3;
+        assert l.end.y == 4;
+    } else {
+        panic("expected Ok");
+    }
+}
+
+// --- Enum deserialization ---
+
+test "deserialize unit variant Red" {
+    let r = from_string::<Color>("0");
+    if let Ok(c) = r {
+        assert c == Color::Red;
+    } else {
+        panic("expected Ok");
+    }
+}
+
+test "deserialize unit variant Blue" {
+    let r = from_string::<Color>("2");
+    if let Ok(c) = r {
+        assert c == Color::Blue;
+    } else {
+        panic("expected Ok");
+    }
+}
+
+// --- Variant deserialization ---
+
+test "deserialize payload variant" {
+    let r = from_string::<Shape>("[0,5.0]");
+    if let Ok(s) = r {
+        if let Circle(radius) = s {
+            assert radius == 5.0;
+        } else {
+            panic("expected Circle");
+        }
+    } else {
+        panic("expected Ok");
+    }
+}
+
+test "deserialize unit variant in variant type" {
+    let r = from_string::<Shape>("2");
+    if let Ok(s) = r {
+        assert s matches { Point };
+    } else {
+        panic("expected Ok");
+    }
+}
+
+// --- Round-trip tests ---
+
+test "round-trip struct" {
+    let orig = Point { x: 42, y: -7 };
+    let json_r = to_string::<Point>(&orig);
+    if let Ok(json) = json_r {
+        let parsed_r = from_string::<Point>(json);
+        if let Ok(parsed) = parsed_r {
+            assert parsed.x == 42;
+            assert parsed.y == -7;
+        } else {
+            panic("round-trip parse failed");
+        }
+    } else {
+        panic("round-trip serialize failed");
+    }
+}
+
+test "round-trip nested struct" {
+    let orig = Line {
+        start: Point { x: 1, y: 2 },
+        end: Point { x: 3, y: 4 },
+    };
+    let json_r = to_string::<Line>(&orig);
+    if let Ok(json) = json_r {
+        let parsed_r = from_string::<Line>(json);
+        if let Ok(parsed) = parsed_r {
+            assert parsed.start.x == 1;
+            assert parsed.start.y == 2;
+            assert parsed.end.x == 3;
+            assert parsed.end.y == 4;
+        } else {
+            panic("round-trip parse failed");
+        }
+    } else {
+        panic("round-trip serialize failed");
+    }
+}
+
+test "round-trip enum" {
+    let orig = Color::Green;
+    let json_r = to_string::<Color>(&orig);
+    if let Ok(json) = json_r {
+        let parsed_r = from_string::<Color>(json);
+        if let Ok(parsed) = parsed_r {
+            assert parsed == Color::Green;
+        } else {
+            panic("round-trip parse failed");
+        }
+    } else {
+        panic("round-trip serialize failed");
+    }
+}
+
+// --- Error cases ---
+
+test "deserialize struct wrong type" {
+    let r: Result<Point, DeserializeError> = from_string::<Point>("42");
+    assert r matches { Err(_) };
+}
+
+test "deserialize trailing data" {
+    let r: Result<i32, DeserializeError> = from_string::<i32>("42 extra");
+    assert r matches { Err(e) && e.kind == DeserializeErrorKind::TrailingData };
+}

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -37,6 +37,7 @@ pub const CORE_ZLIB: &str = include_str!("../lib/core/zlib.wado");
 pub const CORE_BASE64: &str = include_str!("../lib/core/base64.wado");
 pub const CORE_SERDE: &str = include_str!("../lib/core/serde.wado");
 pub const CORE_JSON: &str = include_str!("../lib/core/json.wado");
+pub const CORE_JSON_NSD: &str = include_str!("../lib/core/json_nsd.wado");
 pub const WASI_CLI: &str = include_str!("../lib/wasi/cli.wado");
 pub const WASI_FILESYSTEM: &str = include_str!("../lib/wasi/filesystem.wado");
 pub const WASI_CLOCKS: &str = include_str!("../lib/wasi/clocks.wado");
@@ -71,6 +72,7 @@ pub fn get_stdlib_module(import_path: &str) -> Option<&'static str> {
         "core:base64" => Some(CORE_BASE64),
         "core:serde" => Some(CORE_SERDE),
         "core:json" => Some(CORE_JSON),
+        "core:json_nsd" => Some(CORE_JSON_NSD),
 
         // WASI library
         "wasi:cli" => Some(WASI_CLI),

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -1447,10 +1447,17 @@ fn generate_enum_deserialize(
 
     drop(tt);
 
+    let result_i32_err = {
+        let mut tt = module.type_table.borrow_mut();
+        tt.make_result(TypeTable::I32, deser_error_type)
+    };
+
     let mut local_types = vec![mut_ref_d];
     let mut next_local: u32 = 1;
     let va_result_local = alloc_local(&mut next_local, &mut local_types, result_va_err);
     let va_local = alloc_local(&mut next_local, &mut local_types, variant_access_type);
+    let disc_result_local = alloc_local(&mut next_local, &mut local_types, result_i32_err);
+    let disc_local = alloc_local(&mut next_local, &mut local_types, TypeTable::I32);
     let name_result_local = alloc_local(&mut next_local, &mut local_types, result_string_err);
     let name_local = alloc_local(&mut next_local, &mut local_types, string_type);
 
@@ -1486,6 +1493,91 @@ fn generate_enum_deserialize(
     // if let Ok(mut va) = __va_r { ... }
     let mut then_stmts = Vec::new();
 
+    // --- disc-based path (tried first) ---
+    // let __disc_r = va.disc()
+    let disc_call = type_param_method_call(
+        local_ref(va_local, "va", mut_ref_va),
+        "D::VariantAccess",
+        "DeserializeVariant",
+        "disc",
+        serde_module.clone(),
+        vec![],
+        vec![],
+        vec![],
+        result_i32_err,
+        span,
+    );
+    then_stmts.push(let_mut_stmt(
+        "__disc_r",
+        disc_result_local,
+        result_i32_err,
+        disc_call,
+    ));
+
+    // Build disc-based matching: if __disc == 0 { ... } if __disc == 1 { ... } ...
+    let mut disc_then_stmts = Vec::new();
+    for (case_name, case_index) in &cases {
+        let condition = TirExpr::new(
+            TirExprKind::Binary {
+                op: crate::tir::TirBinaryOp::Eq,
+                left: Box::new(local_ref(disc_local, "__disc", TypeTable::I32)),
+                right: Box::new(i32_const(*case_index as i32)),
+            },
+            TypeTable::BOOL,
+            span,
+        );
+
+        let end_call = type_param_method_call(
+            local_ref(va_local, "va", mut_ref_va),
+            "D::VariantAccess",
+            "DeserializeVariant",
+            "end",
+            serde_module.clone(),
+            vec![],
+            vec![],
+            vec![],
+            result_unit_err,
+            span,
+        );
+
+        let enum_construct = TirExpr::new(
+            TirExprKind::EnumConstruct {
+                enum_type,
+                case_index: *case_index,
+                case_name: case_name.clone(),
+            },
+            enum_type,
+            span,
+        );
+
+        let if_body = block(vec![
+            expr_stmt(end_call),
+            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span))),
+        ]);
+        disc_then_stmts.push(if_stmt(condition, if_body, None));
+    }
+
+    // Unknown disc error
+    let disc_unknown_err = deserialize_error_literal(
+        deser_error_type,
+        deser_error_kind_type,
+        "UnknownVariant",
+        2,
+        "unknown variant discriminant",
+        string_type,
+        span,
+    );
+    disc_then_stmts.push(return_stmt(Some(variant_err(
+        disc_unknown_err,
+        result_enum_err,
+        span,
+    ))));
+
+    // if let Ok(__disc) = __disc_r { disc_matching } else { name fallback }
+
+    // --- name-based fallback (existing logic) ---
+    let mut name_fallback_stmts = Vec::new();
+
     // let __name_r = va.variant_name()
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
@@ -1499,14 +1591,13 @@ fn generate_enum_deserialize(
         result_string_err,
         span,
     );
-    then_stmts.push(let_mut_stmt(
+    name_fallback_stmts.push(let_mut_stmt(
         "__name_r",
         name_result_local,
         result_string_err,
         name_call,
     ));
 
-    // if let Ok(name) = __name_r { ... match on name ... }
     let mut name_then_stmts = Vec::new();
 
     // For each case: if name == "CaseName" { ... end(); return Ok(EnumConstruct) }
@@ -1542,7 +1633,6 @@ fn generate_enum_deserialize(
             span,
         );
 
-        // va.end()
         let end_call = type_param_method_call(
             local_ref(va_local, "va", mut_ref_va),
             "D::VariantAccess",
@@ -1589,8 +1679,7 @@ fn generate_enum_deserialize(
         span,
     ))));
 
-    // Wire up: if let Ok(__name) = __name_r { name_then_stmts } else { propagate err }
-    then_stmts.push(if_let_ok(
+    name_fallback_stmts.push(if_let_ok(
         local_ref(name_result_local, "__name_r", result_string_err),
         result_string_err,
         string_type,
@@ -1605,6 +1694,18 @@ fn generate_enum_deserialize(
             result_enum_err,
             span,
         ),
+        span,
+    ));
+
+    // Wire up disc path with name fallback in else
+    then_stmts.push(if_let_ok(
+        local_ref(disc_result_local, "__disc_r", result_i32_err),
+        result_i32_err,
+        TypeTable::I32,
+        disc_local,
+        "__disc",
+        block(disc_then_stmts),
+        block(name_fallback_stmts),
         span,
     ));
 
@@ -1978,12 +2079,16 @@ fn generate_variant_deserialize(
         .map(|(_, _, payload)| tt.type_name(*payload))
         .collect();
 
+    let result_i32_err = tt.make_result(TypeTable::I32, deser_error_type);
+
     drop(tt);
 
     let mut local_types = vec![mut_ref_d];
     let mut next_local: u32 = 1;
     let va_result_local = alloc_local(&mut next_local, &mut local_types, result_va_err);
     let va_local = alloc_local(&mut next_local, &mut local_types, variant_access_type);
+    let disc_result_local = alloc_local(&mut next_local, &mut local_types, result_i32_err);
+    let disc_local = alloc_local(&mut next_local, &mut local_types, TypeTable::I32);
     let name_result_local = alloc_local(&mut next_local, &mut local_types, result_string_err);
     let name_local = alloc_local(&mut next_local, &mut local_types, string_type);
 
@@ -2018,7 +2123,168 @@ fn generate_variant_deserialize(
 
     let mut then_stmts = Vec::new();
 
-    // let __name_r = va.variant_name()
+    // --- disc-based path (tried first) ---
+    let disc_call = type_param_method_call(
+        local_ref(va_local, "va", mut_ref_va),
+        "D::VariantAccess",
+        "DeserializeVariant",
+        "disc",
+        serde_module.clone(),
+        vec![],
+        vec![],
+        vec![],
+        result_i32_err,
+        span,
+    );
+    then_stmts.push(let_mut_stmt(
+        "__disc_r",
+        disc_result_local,
+        result_i32_err,
+        disc_call,
+    ));
+
+    let mut disc_then_stmts = Vec::new();
+    for (i, (case_name, case_index, payload_type)) in cases.iter().enumerate() {
+        let is_unit = *payload_type == TypeTable::UNIT;
+
+        let condition = TirExpr::new(
+            TirExprKind::Binary {
+                op: crate::tir::TirBinaryOp::Eq,
+                left: Box::new(local_ref(disc_local, "__disc", TypeTable::I32)),
+                right: Box::new(i32_const(*case_index as i32)),
+            },
+            TypeTable::BOOL,
+            span,
+        );
+
+        if is_unit {
+            let end_call = type_param_method_call(
+                local_ref(va_local, "va", mut_ref_va),
+                "D::VariantAccess",
+                "DeserializeVariant",
+                "end",
+                serde_module.clone(),
+                vec![],
+                vec![],
+                vec![],
+                result_unit_err,
+                span,
+            );
+
+            let construct = TirExpr::new(
+                TirExprKind::VariantConstruct {
+                    variant_type,
+                    case_index: *case_index,
+                    case_name: case_name.clone(),
+                    payload: None,
+                },
+                variant_type,
+                span,
+            );
+
+            let if_body = block(vec![
+                expr_stmt(end_call),
+                return_stmt(Some(variant_ok(construct, result_variant_err, span))),
+            ]);
+            disc_then_stmts.push(if_stmt(condition, if_body, None));
+        } else {
+            let payload_local = alloc_local(&mut next_local, &mut local_types, *payload_type);
+            let p_result_local =
+                alloc_local(&mut next_local, &mut local_types, payload_result_types[i]);
+
+            let payload_call = type_param_method_call(
+                local_ref(va_local, "va", mut_ref_va),
+                "D::VariantAccess",
+                "DeserializeVariant",
+                "payload",
+                serde_module.clone(),
+                vec![payload_type_names[i].clone()],
+                vec![*payload_type],
+                vec![],
+                payload_result_types[i],
+                span,
+            );
+
+            let end_call = type_param_method_call(
+                local_ref(va_local, "va", mut_ref_va),
+                "D::VariantAccess",
+                "DeserializeVariant",
+                "end",
+                serde_module.clone(),
+                vec![],
+                vec![],
+                vec![],
+                result_unit_err,
+                span,
+            );
+
+            let construct = TirExpr::new(
+                TirExprKind::VariantConstruct {
+                    variant_type,
+                    case_index: *case_index,
+                    case_name: case_name.clone(),
+                    payload: Some(Box::new(local_ref(
+                        payload_local,
+                        "__payload",
+                        *payload_type,
+                    ))),
+                },
+                variant_type,
+                span,
+            );
+
+            let ok_block = block(vec![
+                expr_stmt(end_call),
+                return_stmt(Some(variant_ok(construct, result_variant_err, span))),
+            ]);
+
+            let if_body = block(vec![
+                let_mut_stmt(
+                    "__p_r",
+                    p_result_local,
+                    payload_result_types[i],
+                    payload_call,
+                ),
+                if_let_ok(
+                    local_ref(p_result_local, "__p_r", payload_result_types[i]),
+                    payload_result_types[i],
+                    *payload_type,
+                    payload_local,
+                    "__payload",
+                    ok_block,
+                    propagate_err_block(
+                        p_result_local,
+                        "__p_r",
+                        payload_result_types[i],
+                        deser_error_type,
+                        result_variant_err,
+                        span,
+                    ),
+                    span,
+                ),
+            ]);
+            disc_then_stmts.push(if_stmt(condition, if_body, None));
+        }
+    }
+
+    let disc_unknown_err = deserialize_error_literal(
+        deser_error_type,
+        deser_error_kind_type,
+        "UnknownVariant",
+        2,
+        "unknown variant discriminant",
+        string_type,
+        span,
+    );
+    disc_then_stmts.push(return_stmt(Some(variant_err(
+        disc_unknown_err,
+        result_variant_err,
+        span,
+    ))));
+
+    // --- name-based fallback ---
+    let mut name_fallback_stmts = Vec::new();
+
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         "D::VariantAccess",
@@ -2031,7 +2297,7 @@ fn generate_variant_deserialize(
         result_string_err,
         span,
     );
-    then_stmts.push(let_mut_stmt(
+    name_fallback_stmts.push(let_mut_stmt(
         "__name_r",
         name_result_local,
         result_string_err,
@@ -2075,7 +2341,6 @@ fn generate_variant_deserialize(
         );
 
         if is_unit {
-            // va.end(); return Ok(Variant::CaseName)
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
@@ -2106,7 +2371,6 @@ fn generate_variant_deserialize(
             ]);
             name_then_stmts.push(if_stmt(condition, if_body, None));
         } else {
-            // let __p_r = va.payload::<PayloadType>()
             let payload_local = alloc_local(&mut next_local, &mut local_types, *payload_type);
             let p_result_local =
                 alloc_local(&mut next_local, &mut local_types, payload_result_types[i]);
@@ -2202,8 +2466,7 @@ fn generate_variant_deserialize(
         span,
     ))));
 
-    // Wire up
-    then_stmts.push(if_let_ok(
+    name_fallback_stmts.push(if_let_ok(
         local_ref(name_result_local, "__name_r", result_string_err),
         result_string_err,
         string_type,
@@ -2218,6 +2481,18 @@ fn generate_variant_deserialize(
             result_variant_err,
             span,
         ),
+        span,
+    ));
+
+    // Wire up disc path with name fallback
+    then_stmts.push(if_let_ok(
+        local_ref(disc_result_local, "__disc_r", result_i32_err),
+        result_i32_err,
+        TypeTable::I32,
+        disc_local,
+        "__disc",
+        block(disc_then_stmts),
+        block(name_fallback_stmts),
         span,
     ));
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.lowered.wado
@@ -1034,11 +1034,10 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
     let __pattern_temp_0: Result<JsonVariantAccess, DeserializeError> = __va_r;
     if __variant_test(__pattern_temp_0, case=0, name=Ok) {
         let va: JsonVariantAccess = __variant_payload(__pattern_temp_0, case=0);
-        let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
-        let __pattern_temp_1: Result<String, DeserializeError> = __name_r;
-        if __variant_test(__pattern_temp_1, case=0, name=Ok) {
-            let __name: String = __variant_payload(__pattern_temp_1, case=0);
-            if __name."String^Eq::eq"(&"Red") {
+        let mut __disc_r: Result<i32, DeserializeError> = Result<i32, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::Custom, message: "JSON does not encode discriminants", offset: -1 });
+        if __variant_test(__disc_r, case=0, name=Ok) {
+            let __disc: i32 = __variant_payload(__disc_r, case=0);
+            if (__disc == 0) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_0: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_0: va.de.JsonDeserializer::expect_char(125);
@@ -1047,7 +1046,7 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Color, DeserializeError>::Ok(Color::Red);
             }
-            if __name."String^Eq::eq"(&"Green") {
+            if (__disc == 1) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_1: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_1: va.de.JsonDeserializer::expect_char(125);
@@ -1056,7 +1055,7 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Color, DeserializeError>::Ok(Color::Green);
             }
-            if __name."String^Eq::eq"(&"Blue") {
+            if (__disc == 2) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_2: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_2: va.de.JsonDeserializer::expect_char(125);
@@ -1065,9 +1064,43 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Color, DeserializeError>::Ok(Color::Blue);
             }
-            return Result<Color, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            return Result<Color, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant discriminant", offset: -1 });
         } else {
-            return Result<Color, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
+            let __pattern_temp_2: Result<String, DeserializeError> = __name_r;
+            if __variant_test(__pattern_temp_2, case=0, name=Ok) {
+                let __name: String = __variant_payload(__pattern_temp_2, case=0);
+                if __name."String^Eq::eq"(&"Red") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_3: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_3: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_3: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Color, DeserializeError>::Ok(Color::Red);
+                }
+                if __name."String^Eq::eq"(&"Green") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_4: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_4: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_4: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Color, DeserializeError>::Ok(Color::Green);
+                }
+                if __name."String^Eq::eq"(&"Blue") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_5: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_5: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_5: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Color, DeserializeError>::Ok(Color::Blue);
+                }
+                return Result<Color, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            } else {
+                return Result<Color, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            }
         }
     } else {
         return Result<Color, DeserializeError>::Err(__variant_payload(__va_r, case=1));

--- a/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.lowered.wado
@@ -3279,11 +3279,10 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
     let __pattern_temp_0: Result<JsonVariantAccess, DeserializeError> = __va_r;
     if __variant_test(__pattern_temp_0, case=0, name=Ok) {
         let va: JsonVariantAccess = __variant_payload(__pattern_temp_0, case=0);
-        let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
-        let __pattern_temp_1: Result<String, DeserializeError> = __name_r;
-        if __variant_test(__pattern_temp_1, case=0, name=Ok) {
-            let __name: String = __variant_payload(__pattern_temp_1, case=0);
-            if __name."String^Eq::eq"(&"Circle") {
+        let mut __disc_r: Result<i32, DeserializeError> = Result<i32, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::Custom, message: "JSON does not encode discriminants", offset: -1 });
+        if __variant_test(__disc_r, case=0, name=Ok) {
+            let __disc: i32 = __variant_payload(__disc_r, case=0);
+            if (__disc == 0) {
                 let mut __p_r: Result<f64, DeserializeError> = __inline_f64_Deserialize__deserialize_JsonDeserializer__2: {
                     let d: &mut JsonDeserializer = &mut va.de;
                     break __inline_f64_Deserialize__deserialize_JsonDeserializer__2: d."JsonDeserializer^Deserializer::deserialize_f64"();
@@ -3302,7 +3301,7 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                     return Result<Shape, DeserializeError>::Err(__variant_payload(__p_r, case=1));
                 }
             }
-            if __name."String^Eq::eq"(&"Rectangle") {
+            if (__disc == 1) {
                 let mut __p_r: Result<Inner, DeserializeError> = "Inner^Deserialize::deserialize<JsonDeserializer>"(&mut va.de);
                 let __pattern_temp_3: Result<Inner, DeserializeError> = __p_r;
                 if __variant_test(__pattern_temp_3, case=0, name=Ok) {
@@ -3318,7 +3317,7 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                     return Result<Shape, DeserializeError>::Err(__variant_payload(__p_r, case=1));
                 }
             }
-            if __name."String^Eq::eq"(&"Point") {
+            if (__disc == 2) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_2: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_2: va.de.JsonDeserializer::expect_char(125);
@@ -3327,9 +3326,60 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Shape, DeserializeError>::Ok(Shape::Point);
             }
-            return Result<Shape, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            return Result<Shape, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant discriminant", offset: -1 });
         } else {
-            return Result<Shape, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
+            let __pattern_temp_4: Result<String, DeserializeError> = __name_r;
+            if __variant_test(__pattern_temp_4, case=0, name=Ok) {
+                let __name: String = __variant_payload(__pattern_temp_4, case=0);
+                if __name."String^Eq::eq"(&"Circle") {
+                    let mut __p_r: Result<f64, DeserializeError> = __inline_f64_Deserialize__deserialize_JsonDeserializer__6: {
+                        let d: &mut JsonDeserializer = &mut va.de;
+                        break __inline_f64_Deserialize__deserialize_JsonDeserializer__6: d."JsonDeserializer^Deserializer::deserialize_f64"();
+                    };
+                    let __pattern_temp_5: Result<f64, DeserializeError> = __p_r;
+                    if __variant_test(__pattern_temp_5, case=0, name=Ok) {
+                        let __payload: f64 = __variant_payload(__pattern_temp_5, case=0);
+                        __inline_JsonVariantAccess_DeserializeVariant__end_3: {
+                            if va.is_object {
+                                break __inline_JsonVariantAccess_DeserializeVariant__end_3: va.de.JsonDeserializer::expect_char(125);
+                            }
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_3: Result<(), DeserializeError>::Ok(());
+                        };
+                        return Result<Shape, DeserializeError>::Ok(Shape::Circle(__payload));
+                    } else {
+                        return Result<Shape, DeserializeError>::Err(__variant_payload(__p_r, case=1));
+                    }
+                }
+                if __name."String^Eq::eq"(&"Rectangle") {
+                    let mut __p_r: Result<Inner, DeserializeError> = "Inner^Deserialize::deserialize<JsonDeserializer>"(&mut va.de);
+                    let __pattern_temp_6: Result<Inner, DeserializeError> = __p_r;
+                    if __variant_test(__pattern_temp_6, case=0, name=Ok) {
+                        let __payload: Inner = __variant_payload(__pattern_temp_6, case=0);
+                        __inline_JsonVariantAccess_DeserializeVariant__end_4: {
+                            if va.is_object {
+                                break __inline_JsonVariantAccess_DeserializeVariant__end_4: va.de.JsonDeserializer::expect_char(125);
+                            }
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_4: Result<(), DeserializeError>::Ok(());
+                        };
+                        return Result<Shape, DeserializeError>::Ok(Shape::Rectangle(__payload));
+                    } else {
+                        return Result<Shape, DeserializeError>::Err(__variant_payload(__p_r, case=1));
+                    }
+                }
+                if __name."String^Eq::eq"(&"Point") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_5: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_5: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_5: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Shape, DeserializeError>::Ok(Shape::Point);
+                }
+                return Result<Shape, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            } else {
+                return Result<Shape, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            }
         }
     } else {
         return Result<Shape, DeserializeError>::Err(__variant_payload(__va_r, case=1));
@@ -3565,11 +3615,10 @@ pub fn "Direction^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeseri
     let __pattern_temp_0: Result<JsonVariantAccess, DeserializeError> = __va_r;
     if __variant_test(__pattern_temp_0, case=0, name=Ok) {
         let va: JsonVariantAccess = __variant_payload(__pattern_temp_0, case=0);
-        let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
-        let __pattern_temp_1: Result<String, DeserializeError> = __name_r;
-        if __variant_test(__pattern_temp_1, case=0, name=Ok) {
-            let __name: String = __variant_payload(__pattern_temp_1, case=0);
-            if __name."String^Eq::eq"(&"North") {
+        let mut __disc_r: Result<i32, DeserializeError> = Result<i32, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::Custom, message: "JSON does not encode discriminants", offset: -1 });
+        if __variant_test(__disc_r, case=0, name=Ok) {
+            let __disc: i32 = __variant_payload(__disc_r, case=0);
+            if (__disc == 0) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_0: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_0: va.de.JsonDeserializer::expect_char(125);
@@ -3578,7 +3627,7 @@ pub fn "Direction^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeseri
                 };
                 return Result<Direction, DeserializeError>::Ok(Direction::North);
             }
-            if __name."String^Eq::eq"(&"South") {
+            if (__disc == 1) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_1: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_1: va.de.JsonDeserializer::expect_char(125);
@@ -3587,7 +3636,7 @@ pub fn "Direction^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeseri
                 };
                 return Result<Direction, DeserializeError>::Ok(Direction::South);
             }
-            if __name."String^Eq::eq"(&"East") {
+            if (__disc == 2) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_2: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_2: va.de.JsonDeserializer::expect_char(125);
@@ -3596,7 +3645,7 @@ pub fn "Direction^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeseri
                 };
                 return Result<Direction, DeserializeError>::Ok(Direction::East);
             }
-            if __name."String^Eq::eq"(&"West") {
+            if (__disc == 3) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_3: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_3: va.de.JsonDeserializer::expect_char(125);
@@ -3605,9 +3654,52 @@ pub fn "Direction^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeseri
                 };
                 return Result<Direction, DeserializeError>::Ok(Direction::West);
             }
-            return Result<Direction, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            return Result<Direction, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant discriminant", offset: -1 });
         } else {
-            return Result<Direction, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
+            let __pattern_temp_2: Result<String, DeserializeError> = __name_r;
+            if __variant_test(__pattern_temp_2, case=0, name=Ok) {
+                let __name: String = __variant_payload(__pattern_temp_2, case=0);
+                if __name."String^Eq::eq"(&"North") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_4: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_4: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_4: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Direction, DeserializeError>::Ok(Direction::North);
+                }
+                if __name."String^Eq::eq"(&"South") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_5: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_5: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_5: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Direction, DeserializeError>::Ok(Direction::South);
+                }
+                if __name."String^Eq::eq"(&"East") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_6: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_6: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_6: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Direction, DeserializeError>::Ok(Direction::East);
+                }
+                if __name."String^Eq::eq"(&"West") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_7: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_7: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_7: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Direction, DeserializeError>::Ok(Direction::West);
+                }
+                return Result<Direction, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            } else {
+                return Result<Direction, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            }
         }
     } else {
         return Result<Direction, DeserializeError>::Err(__variant_payload(__va_r, case=1));

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.lowered.wado
@@ -281,11 +281,10 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
     let __pattern_temp_0: Result<JsonVariantAccess, DeserializeError> = __va_r;
     if __variant_test(__pattern_temp_0, case=0, name=Ok) {
         let va: JsonVariantAccess = __variant_payload(__pattern_temp_0, case=0);
-        let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
-        let __pattern_temp_1: Result<String, DeserializeError> = __name_r;
-        if __variant_test(__pattern_temp_1, case=0, name=Ok) {
-            let __name: String = __variant_payload(__pattern_temp_1, case=0);
-            if __name."String^Eq::eq"(&"Red") {
+        let mut __disc_r: Result<i32, DeserializeError> = Result<i32, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::Custom, message: "JSON does not encode discriminants", offset: -1 });
+        if __variant_test(__disc_r, case=0, name=Ok) {
+            let __disc: i32 = __variant_payload(__disc_r, case=0);
+            if (__disc == 0) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_0: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_0: va.de.JsonDeserializer::expect_char(125);
@@ -294,7 +293,7 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Color, DeserializeError>::Ok(Color::Red);
             }
-            if __name."String^Eq::eq"(&"Green") {
+            if (__disc == 1) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_1: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_1: va.de.JsonDeserializer::expect_char(125);
@@ -303,7 +302,7 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Color, DeserializeError>::Ok(Color::Green);
             }
-            if __name."String^Eq::eq"(&"Blue") {
+            if (__disc == 2) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_2: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_2: va.de.JsonDeserializer::expect_char(125);
@@ -312,9 +311,43 @@ pub fn "Color^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Color, DeserializeError>::Ok(Color::Blue);
             }
-            return Result<Color, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            return Result<Color, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant discriminant", offset: -1 });
         } else {
-            return Result<Color, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
+            let __pattern_temp_2: Result<String, DeserializeError> = __name_r;
+            if __variant_test(__pattern_temp_2, case=0, name=Ok) {
+                let __name: String = __variant_payload(__pattern_temp_2, case=0);
+                if __name."String^Eq::eq"(&"Red") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_3: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_3: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_3: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Color, DeserializeError>::Ok(Color::Red);
+                }
+                if __name."String^Eq::eq"(&"Green") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_4: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_4: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_4: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Color, DeserializeError>::Ok(Color::Green);
+                }
+                if __name."String^Eq::eq"(&"Blue") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_5: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_5: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_5: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Color, DeserializeError>::Ok(Color::Blue);
+                }
+                return Result<Color, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            } else {
+                return Result<Color, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            }
         }
     } else {
         return Result<Color, DeserializeError>::Err(__variant_payload(__va_r, case=1));

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.lowered.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.lowered.wado
@@ -232,11 +232,10 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
     let __pattern_temp_0: Result<JsonVariantAccess, DeserializeError> = __va_r;
     if __variant_test(__pattern_temp_0, case=0, name=Ok) {
         let va: JsonVariantAccess = __variant_payload(__pattern_temp_0, case=0);
-        let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
-        let __pattern_temp_1: Result<String, DeserializeError> = __name_r;
-        if __variant_test(__pattern_temp_1, case=0, name=Ok) {
-            let __name: String = __variant_payload(__pattern_temp_1, case=0);
-            if __name."String^Eq::eq"(&"Circle") {
+        let mut __disc_r: Result<i32, DeserializeError> = Result<i32, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::Custom, message: "JSON does not encode discriminants", offset: -1 });
+        if __variant_test(__disc_r, case=0, name=Ok) {
+            let __disc: i32 = __variant_payload(__disc_r, case=0);
+            if (__disc == 0) {
                 let mut __p_r: Result<f64, DeserializeError> = __inline_f64_Deserialize__deserialize_JsonDeserializer__2: {
                     let d: &mut JsonDeserializer = &mut va.de;
                     break __inline_f64_Deserialize__deserialize_JsonDeserializer__2: d."JsonDeserializer^Deserializer::deserialize_f64"();
@@ -255,7 +254,7 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                     return Result<Shape, DeserializeError>::Err(__variant_payload(__p_r, case=1));
                 }
             }
-            if __name."String^Eq::eq"(&"Point") {
+            if (__disc == 1) {
                 __inline_JsonVariantAccess_DeserializeVariant__end_1: {
                     if va.is_object {
                         break __inline_JsonVariantAccess_DeserializeVariant__end_1: va.de.JsonDeserializer::expect_char(125);
@@ -264,9 +263,44 @@ pub fn "Shape^Deserialize::deserialize<JsonDeserializer>"(d: &mut JsonDeserializ
                 };
                 return Result<Shape, DeserializeError>::Ok(Shape::Point);
             }
-            return Result<Shape, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            return Result<Shape, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant discriminant", offset: -1 });
         } else {
-            return Result<Shape, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            let mut __name_r: Result<String, DeserializeError> = Result<String, DeserializeError>::Ok(va.variant);
+            let __pattern_temp_3: Result<String, DeserializeError> = __name_r;
+            if __variant_test(__pattern_temp_3, case=0, name=Ok) {
+                let __name: String = __variant_payload(__pattern_temp_3, case=0);
+                if __name."String^Eq::eq"(&"Circle") {
+                    let mut __p_r: Result<f64, DeserializeError> = __inline_f64_Deserialize__deserialize_JsonDeserializer__5: {
+                        let d: &mut JsonDeserializer = &mut va.de;
+                        break __inline_f64_Deserialize__deserialize_JsonDeserializer__5: d."JsonDeserializer^Deserializer::deserialize_f64"();
+                    };
+                    let __pattern_temp_4: Result<f64, DeserializeError> = __p_r;
+                    if __variant_test(__pattern_temp_4, case=0, name=Ok) {
+                        let __payload: f64 = __variant_payload(__pattern_temp_4, case=0);
+                        __inline_JsonVariantAccess_DeserializeVariant__end_2: {
+                            if va.is_object {
+                                break __inline_JsonVariantAccess_DeserializeVariant__end_2: va.de.JsonDeserializer::expect_char(125);
+                            }
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_2: Result<(), DeserializeError>::Ok(());
+                        };
+                        return Result<Shape, DeserializeError>::Ok(Shape::Circle(__payload));
+                    } else {
+                        return Result<Shape, DeserializeError>::Err(__variant_payload(__p_r, case=1));
+                    }
+                }
+                if __name."String^Eq::eq"(&"Point") {
+                    __inline_JsonVariantAccess_DeserializeVariant__end_3: {
+                        if va.is_object {
+                            break __inline_JsonVariantAccess_DeserializeVariant__end_3: va.de.JsonDeserializer::expect_char(125);
+                        }
+                        break __inline_JsonVariantAccess_DeserializeVariant__end_3: Result<(), DeserializeError>::Ok(());
+                    };
+                    return Result<Shape, DeserializeError>::Ok(Shape::Point);
+                }
+                return Result<Shape, DeserializeError>::Err(DeserializeError { kind: DeserializeErrorKind::UnknownVariant, message: "unknown variant", offset: -1 });
+            } else {
+                return Result<Shape, DeserializeError>::Err(__variant_payload(__name_r, case=1));
+            }
         }
     } else {
         return Result<Shape, DeserializeError>::Err(__variant_payload(__va_r, case=1));


### PR DESCRIPTION
## Summary

This PR introduces a new `core:json_nsd` module that provides a compact, non-self-describing JSON serialization format. In NSD format, structs are encoded as positional arrays (omitting field names), unit variants as integer discriminants, and payload variants as `[discriminant, payload]` arrays.

## Key Changes

- **New `core:json_nsd` module** (`lib/core/json_nsd.wado`):
  - Implements `NsdSerializer` and `NsdDeserializer` for compact JSON encoding
  - Structs serialized as positional arrays: `Point { x: 1, y: 2 }` → `[1,2]`
  - Unit enum variants serialized as discriminant integers: `Color::Red` → `0`
  - Payload variants serialized as `[disc, payload]`: `Shape::Circle(5.0)` → `[0,5.0]`
  - Comprehensive test suite (`json_nsd_test.wado`) with 40+ tests covering primitives, structs, enums, variants, arrays, and round-trip serialization

- **Enhanced enum/variant deserialization** (`src/synthesis/serde_synth.rs`):
  - Modified `generate_enum_deserialize()` and `generate_variant_deserialize()` to try discriminant-based matching first
  - Falls back to name-based matching if discriminant path fails (for JSON compatibility)
  - Enables efficient deserialization for formats that encode discriminants

- **Exposed internal JSON utilities** (`lib/core/json.wado`):
  - Made `JsonDeserializer` fields (`input`, `pos`) and methods (`peek`, `advance`, `skip_whitespace`, `expect_char`, `expect_literal`, `read_json_string`, `read_number_raw`) public
  - Exposed helper functions `hex_digit()` and `utf8_sequence_length()` for use by NSD module

- **Updated documentation**:
  - Added `core:json_nsd` section to `docs/spec.md` with format specification
  - Added usage examples to `docs/cheatsheet.md`
  - Updated `src/stdlib.rs` to include the new module

## Implementation Details

- NSD format is more compact than standard JSON by eliminating field names and using integer discriminants instead of variant names
- The deserialization strategy prioritizes discriminant-based matching (O(1) lookup) before falling back to name-based matching for backward compatibility
- Large integers (i64/u64 beyond JavaScript's safe integer range, i128/u128) are encoded as quoted strings to preserve precision
- NaN and Infinity values are rejected during serialization, consistent with JSON spec

https://claude.ai/code/session_01Pe2j4F5JRXTEqZa4zV7ZNV