### PR TITLE
Remove BuiltinArray special handling from method resolution

### DIFF
--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1163,8 +1163,8 @@ pub enum TypeNameInfo {
         param_count: usize,
         return_type: String,
     },
-    /// Array<T> with element type name
-    Array(String),
+    /// `builtin::array<T>` (raw Wasm GC array, NOT the user-facing `Array<T>` struct)
+    BuiltinArray(String),
     /// Stream<T> with inner type name
     Stream(String),
     /// `StreamWritable`<T> with inner type name
@@ -1198,7 +1198,7 @@ pub fn format_type_name(info: TypeNameInfo) -> String {
             param_count,
             return_type,
         } => mangle_fn_type(param_count, &return_type),
-        TypeNameInfo::Array(elem) => mangle_array_type(&elem),
+        TypeNameInfo::BuiltinArray(elem) => mangle_builtin_array_type(&elem),
         TypeNameInfo::Stream(inner) => mangle_generic_name("Stream", &[inner]),
         TypeNameInfo::StreamWritable(inner) => mangle_generic_name("StreamWritable", &[inner]),
         TypeNameInfo::Future(inner) => mangle_generic_name("Future", &[inner]),
@@ -1258,12 +1258,12 @@ pub fn mangle_option_type(inner_type: &str) -> String {
     format!("Option<{inner_type}>")
 }
 
-/// Build an Array type name from element type name.
+/// Build a `builtin::array` type name from element type name.
 ///
 /// Examples:
-/// - `mangle_array_type("i32")` → `"Array<i32>"`
-pub fn mangle_array_type(elem_type: &str) -> String {
-    format!("Array<{elem_type}>")
+/// - `mangle_builtin_array_type("i32")` → `"builtin::array<i32>"`
+pub fn mangle_builtin_array_type(elem_type: &str) -> String {
+    format!("builtin::array<{elem_type}>")
 }
 
 /// Build a local method name from struct name and method name.

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -789,29 +789,6 @@ fn analyze_expr(
                         ));
                         analysis.callees.insert(callee_id);
                     }
-                    ResolvedType::BuiltinArray(elem_type) => {
-                        // Array<T> method call (e.g., arr.len(), arr.append())
-                        let elem_name = type_table.mangle_type_name(elem_type);
-                        // Include trait name for trait methods (e.g., Array<i32>^Index::index)
-                        let (mangled_func_name, base_name) = if let Some(ref trait_n) = trait_name {
-                            let array_name = mangle_generic_name("Array", &[elem_name]);
-                            let mangled =
-                                mangle_local_trait_method(&array_name, trait_n, &method_name);
-                            let base = mangle_local_trait_method("Array", trait_n, &method_name);
-                            (mangled, base)
-                        } else {
-                            let mangled =
-                                mangle_method_generic("Array", &[elem_name], &method_name);
-                            let base = mangle_local_method("Array", &method_name);
-                            (mangled, base)
-                        };
-                        let callee_id = FunctionId::Free(FreeFunctionName::with_monomorph_info(
-                            current_module.clone(),
-                            mangled_func_name,
-                            base_name,
-                        ));
-                        analysis.callees.insert(callee_id);
-                    }
                     ResolvedType::Enum {
                         name,
                         module_source,

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -338,9 +338,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
                 ResolvedType::BuiltinArray(elem) => {
                     let elem_name = self.type_table.borrow().mangle_type_name(elem);
-                    let _mangled = format!("Array<{elem_name}>");
+                    let mangled = format!("Array<{elem_name}>");
                     (
-                        "Array".to_string(),
+                        mangled,
                         "Array".to_string(),
                         vec![elem_name],
                         Some(vec![elem]),

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -60,8 +60,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 self.type_table.borrow().mangle_type_name(base_type_id),
                 ModuleSource::primitives(),
             ),
-            // BuiltinArray is Array - impl blocks are in core:prelude/array.wado
-            ResolvedType::BuiltinArray(_) => ("Array".to_string(), ModuleSource::array()),
             // Enum types - use enum name and its defining module
             ResolvedType::Enum {
                 name,
@@ -94,8 +92,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 ResolvedType::GenericInstance { type_args, .. } if !type_args.is_empty() => {
                     Some(type_args)
                 }
-                // BuiltinArray(elem) is Array<elem>, so type args = [elem]
-                ResolvedType::BuiltinArray(elem) => Some(vec![elem]),
                 _ => None,
             };
 
@@ -262,11 +258,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     impl_offset = receiver_type_args.len() as u32;
                     subst_ctx = subst_ctx.with_impl_args(&receiver_type_args);
                 }
-                // BuiltinArray(elem) is Array<elem>, so type args = [elem]
-                ResolvedType::BuiltinArray(elem) => {
-                    impl_offset = 1;
-                    subst_ctx = subst_ctx.with_impl_args(&[elem]);
-                }
                 // Stream<T> has one type param T
                 ResolvedType::Stream(inner) => {
                     impl_offset = 1;
@@ -290,8 +281,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 ResolvedType::GenericInstance { type_args, .. } if !type_args.is_empty() => {
                     impl_offset = type_args.len() as u32;
                 }
-                ResolvedType::BuiltinArray(_)
-                | ResolvedType::Stream(_)
+                ResolvedType::Stream(_)
                 | ResolvedType::StreamWritable(_)
                 | ResolvedType::FutureWritable(_) => {
                     impl_offset = 1;
@@ -334,16 +324,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         name.clone(),
                         type_arg_names,
                         Some(type_args.clone()),
-                    )
-                }
-                ResolvedType::BuiltinArray(elem) => {
-                    let elem_name = self.type_table.borrow().mangle_type_name(elem);
-                    let mangled = format!("Array<{elem_name}>");
-                    (
-                        mangled,
-                        "Array".to_string(),
-                        vec![elem_name],
-                        Some(vec![elem]),
                     )
                 }
                 // Stream<T>: base name is "Stream", one type arg

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -1861,7 +1861,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     Some(type_args.clone())
                 },
             ),
-            ResolvedType::BuiltinArray(elem) => ("Array".to_string(), Some(vec![*elem])),
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
                 // For references, check if the inner type implements the trait
                 return self.type_implements_trait(*inner, trait_name);

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -1011,7 +1011,6 @@ fn inspect_impl_module(type_id: TypeId, tt: &Rc<RefCell<TypeTable>>) -> ModuleSo
     match tt.borrow().get(type_id).clone() {
         ResolvedType::Primitive(_) => ModuleSource::primitives(),
         ResolvedType::Struct { ref name, .. } if name == "String" => ModuleSource::format(),
-        ResolvedType::BuiltinArray(_) => ModuleSource::format(),
         ResolvedType::Struct {
             ref module_source, ..
         }
@@ -1034,7 +1033,7 @@ fn inspect_impl_module(type_id: TypeId, tt: &Rc<RefCell<TypeTable>>) -> ModuleSo
 /// Build a `LocalMethodName` for a concrete (post-mono) type.
 ///
 /// Extracts the base name from the resolved type and applies type args
-/// for parameterized types like `GenericInstance`, `BuiltinArray`, etc.
+/// for parameterized types like `GenericInstance`, etc.
 fn method_name_for_type(
     type_id: TypeId,
     trait_name: &str,
@@ -1052,15 +1051,6 @@ fn method_name_for_type(
             );
             info.is_type_param_receiver = true;
             info
-        }
-        ResolvedType::BuiltinArray(elem) => {
-            let elem_name = tt_ref.mangle_type_name(elem);
-            LocalMethodName::new(
-                "Array".to_string(),
-                Some(trait_name.to_string()),
-                method_name.to_string(),
-            )
-            .with_struct_type_args(&[elem_name])
         }
         ResolvedType::GenericInstance {
             name, type_args, ..

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -2071,9 +2071,11 @@ fn decompose_type_for_method_name(
 ) -> (String, bool, Vec<String>) {
     match resolved {
         ResolvedType::TypeParam { name, .. } => (name.clone(), true, vec![]),
-        ResolvedType::BuiltinArray(elem) => {
-            ("builtin::array".to_string(), false, vec![tt.mangle_type_name(*elem)])
-        }
+        ResolvedType::BuiltinArray(elem) => (
+            "builtin::array".to_string(),
+            false,
+            vec![tt.mangle_type_name(*elem)],
+        ),
         ResolvedType::GenericInstance {
             name, type_args, ..
         } => {

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -2072,7 +2072,7 @@ fn decompose_type_for_method_name(
     match resolved {
         ResolvedType::TypeParam { name, .. } => (name.clone(), true, vec![]),
         ResolvedType::BuiltinArray(elem) => {
-            ("Array".to_string(), false, vec![tt.mangle_type_name(*elem)])
+            ("builtin::array".to_string(), false, vec![tt.mangle_type_name(*elem)])
         }
         ResolvedType::GenericInstance {
             name, type_args, ..
@@ -2135,7 +2135,6 @@ fn inspect_impl_module(type_id: TypeId, tt: &TypeTable, default: &ModuleSource) 
     match tt.get(type_id).clone() {
         ResolvedType::Primitive(_) => ModuleSource::primitives(),
         ResolvedType::Struct { ref name, .. } if name == "String" => ModuleSource::format(),
-        ResolvedType::BuiltinArray(_) => ModuleSource::format(),
         ResolvedType::Struct {
             ref module_source, ..
         }

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -212,9 +212,6 @@ fn generate_inspect_impls(module: &mut TirModule) {
         .collect();
 
     for (name, type_params, fields, has_hidden, sspan) in &generic_struct_infos {
-        if name == "Array" {
-            continue;
-        }
         let key = MethodName::format_local(name, Some("Inspect"), "inspect");
         if existing.contains(&key) {
             continue;

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1079,7 +1079,7 @@ impl TypeTable {
                 param_count: params.len(),
                 return_type: self.mangle_type_name(*return_type),
             },
-            ResolvedType::BuiltinArray(elem) => TypeNameInfo::Array(self.mangle_type_name(*elem)),
+            ResolvedType::BuiltinArray(elem) => TypeNameInfo::BuiltinArray(self.mangle_type_name(*elem)),
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
                 // For references, use the inner type's name (strip reference)
                 TypeNameInfo::Ref(self.mangle_type_name(*inner))

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1079,7 +1079,9 @@ impl TypeTable {
                 param_count: params.len(),
                 return_type: self.mangle_type_name(*return_type),
             },
-            ResolvedType::BuiltinArray(elem) => TypeNameInfo::BuiltinArray(self.mangle_type_name(*elem)),
+            ResolvedType::BuiltinArray(elem) => {
+                TypeNameInfo::BuiltinArray(self.mangle_type_name(*elem))
+            }
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
                 // For references, use the inner type's name (strip reference)
                 TypeNameInfo::Ref(self.mangle_type_name(*inner))


### PR DESCRIPTION
## Summary
This PR removes special-case handling for `BuiltinArray` (the raw Wasm GC array type) from method resolution and related code generation. The `BuiltinArray` type is now treated as a low-level implementation detail rather than a user-facing type that supports method calls.

## Key Changes

- **Method Resolution**: Removed `BuiltinArray` cases from `method_call.rs` that mapped it to the user-facing `Array` type with module source `ModuleSource::array()`. Method lookups for `BuiltinArray` will no longer resolve to `Array` implementations.

- **Dead Code Elimination**: Removed `BuiltinArray` handling from DCE analysis in `dce.rs` that was tracking callees for array methods.

- **Type Naming**: Updated `name.rs` to clarify that `BuiltinArray` represents the raw `builtin::array<T>` type (not the user-facing `Array<T>` struct):
  - Renamed `TypeNameInfo::Array` to `TypeNameInfo::BuiltinArray`
  - Updated `mangle_array_type()` to `mangle_builtin_array_type()` with output format `builtin::array<T>`

- **Trait Implementation**: Removed `BuiltinArray` special cases from trait synthesis in `traits.rs` and `template.rs`, including removal of the skip logic for `Array` in `generate_inspect_impls()`.

- **Trait Lookup**: Removed `BuiltinArray` from trait implementation checks in `method_lookup.rs`.

## Implementation Details

The changes clarify the architectural distinction between:
- `BuiltinArray`: Low-level Wasm GC array type used internally
- `Array<T>`: User-facing generic struct with method implementations

By removing the special mapping that treated `BuiltinArray` as `Array`, the compiler now requires explicit use of the `Array` type for method calls, improving type system clarity.

https://claude.ai/code/session_013t3U5Zsfg3axn69QSaL6DD