### PR TITLE
Add combined runtime benchmark visualization page

### DIFF
--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+    <style>
+      html {
+        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+        -webkit-font-smoothing: antialiased;
+        background-color: #fff;
+        font-size: 16px;
+      }
+      body {
+        color: #4a4a4a;
+        margin: 8px;
+        font-size: 1em;
+        font-weight: 400;
+      }
+      header {
+        margin-bottom: 8px;
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: #3273dc;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      a:hover {
+        color: #000;
+      }
+      button {
+        color: #fff;
+        background-color: #3298dc;
+        border-color: transparent;
+        cursor: pointer;
+        text-align: center;
+      }
+      button:hover {
+        background-color: #2793da;
+      }
+      .spacer {
+        flex: auto;
+      }
+      .small {
+        font-size: 0.75rem;
+      }
+      footer {
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+      }
+      .benchmark-set {
+        margin: 8px 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .benchmark-title {
+        font-size: 2rem;
+        font-weight: 600;
+        word-break: break-word;
+        text-align: center;
+      }
+      .benchmark-graphs {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        width: 100%;
+      }
+      .benchmark-chart {
+        max-width: 1000px;
+      }
+    </style>
+    <title>Runtime Benchmarks (Combined)</title>
+  </head>
+
+  <body>
+    <header id="header">
+      <div class="header-item">
+        <strong>Last Update:</strong>
+        <span id="last-update"></span>
+      </div>
+      <div class="header-item">
+        <strong>Repository:</strong>
+        <a id="repository-link" rel="noopener"></a>
+      </div>
+    </header>
+    <main id="main"></main>
+    <footer>
+      <button id="dl-button">Download data as JSON</button>
+      <div class="spacer"></div>
+      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+    <script src="data.js"></script>
+    <script>
+      'use strict';
+      (function() {
+        const OPT_COLORS = {
+          '-O1': '#3273dc',
+          '-O2': '#23d160',
+          '-O3': '#ff3860',
+        };
+        const FALLBACK_COLOR = '#ffdd57';
+
+        const OPT_PATTERN = / \((-O\d)\)$/;
+
+        function init() {
+          const data = window.BENCHMARK_DATA;
+
+          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
+          const repoLink = document.getElementById('repository-link');
+          repoLink.href = data.repoUrl;
+          repoLink.textContent = data.repoUrl;
+
+          document.getElementById('dl-button').onclick = () => {
+            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
+            const a = document.createElement('a');
+            a.href = dataUrl;
+            a.download = 'benchmark_data.json';
+            a.click();
+          };
+
+          // Collect all bench results per benchmark name
+          const benchesByName = new Map();
+          for (const entries of Object.values(data.entries)) {
+            for (const entry of entries) {
+              const {commit, date, tool, benches} = entry;
+              for (const bench of benches) {
+                const result = { commit, date, tool, bench };
+                if (!benchesByName.has(bench.name)) {
+                  benchesByName.set(bench.name, []);
+                }
+                benchesByName.get(bench.name).push(result);
+              }
+            }
+          }
+
+          // Group by base name (strip optimization level suffix)
+          const groups = new Map();
+          for (const [name, results] of benchesByName) {
+            const match = name.match(OPT_PATTERN);
+            if (match) {
+              const baseName = name.replace(OPT_PATTERN, '');
+              const optLevel = match[1];
+              if (!groups.has(baseName)) {
+                groups.set(baseName, new Map());
+              }
+              groups.get(baseName).set(optLevel, results);
+            }
+            // Skip entries without optimization level suffix (legacy data)
+          }
+
+          return groups;
+        }
+
+        function renderCombinedGraph(parent, baseName, optLevelMap) {
+          const canvas = document.createElement('canvas');
+          canvas.className = 'benchmark-chart';
+          parent.appendChild(canvas);
+
+          // Find all unique commit IDs across all optimization levels, preserving order
+          const commitIds = [];
+          const commitSet = new Set();
+          const commitMeta = new Map();
+          for (const results of optLevelMap.values()) {
+            for (const r of results) {
+              const id = r.commit.id;
+              if (!commitSet.has(id)) {
+                commitSet.add(id);
+                commitIds.push(id);
+                commitMeta.set(id, r);
+              }
+            }
+          }
+
+          // Sort optimization levels
+          const sortedOpts = [...optLevelMap.keys()].sort();
+
+          // Build datasets: one line per optimization level
+          const datasets = sortedOpts.map(opt => {
+            const results = optLevelMap.get(opt);
+            const valueByCommit = new Map();
+            for (const r of results) {
+              valueByCommit.set(r.commit.id, r.bench.value);
+            }
+            const color = OPT_COLORS[opt] || FALLBACK_COLOR;
+            return {
+              label: opt,
+              data: commitIds.map(id => valueByCommit.has(id) ? valueByCommit.get(id) : null),
+              borderColor: color,
+              backgroundColor: color + '40',
+              fill: false,
+              spanGaps: true,
+            };
+          });
+
+          const unit = (() => {
+            for (const results of optLevelMap.values()) {
+              if (results.length > 0) return results[0].bench.unit;
+            }
+            return '';
+          })();
+
+          new Chart(canvas, {
+            type: 'line',
+            data: {
+              labels: commitIds.map(id => id.slice(0, 7)),
+              datasets,
+            },
+            options: {
+              title: {
+                display: true,
+                text: baseName,
+                fontSize: 18,
+              },
+              scales: {
+                xAxes: [{
+                  scaleLabel: { display: true, labelString: 'commit' },
+                }],
+                yAxes: [{
+                  scaleLabel: { display: true, labelString: unit },
+                  ticks: { beginAtZero: true },
+                }],
+              },
+              tooltips: {
+                mode: 'index',
+                intersect: false,
+                callbacks: {
+                  afterTitle: items => {
+                    const {index} = items[0];
+                    const id = commitIds[index];
+                    const meta = commitMeta.get(id);
+                    if (!meta) return '';
+                    return '\n' + meta.commit.message + '\n\n' + meta.commit.timestamp + ' by @' + meta.commit.committer.username + '\n';
+                  },
+                  label: item => {
+                    if (item.value === null || item.value === undefined) return null;
+                    return item.dataset.label + ': ' + item.value + ' ' + unit;
+                  },
+                },
+              },
+              onClick: (_mouseEvent, activeElems) => {
+                if (activeElems.length === 0) return;
+                const index = activeElems[0]._index;
+                const id = commitIds[index];
+                const meta = commitMeta.get(id);
+                if (meta) window.open(meta.commit.url, '_blank');
+              },
+            },
+          });
+        }
+
+        function render(groups) {
+          const main = document.getElementById('main');
+          for (const [baseName, optLevelMap] of groups) {
+            const setElem = document.createElement('div');
+            setElem.className = 'benchmark-set';
+            main.appendChild(setElem);
+
+            const graphsElem = document.createElement('div');
+            graphsElem.className = 'benchmark-graphs';
+            setElem.appendChild(graphsElem);
+
+            renderCombinedGraph(graphsElem, baseName, optLevelMap);
+          }
+        }
+
+        render(init());
+      })();
+    </script>
+  </body>
+</html>

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,6 +69,20 @@ jobs:
           benchmark-data-dir-path: benchmarks/wasm-size
           skip-fetch-gh-pages: true
 
+      - name: Deploy combined benchmark pages
+        if: github.event_name == 'push'
+        run: |
+          git worktree add /tmp/gh-pages gh-pages
+          cp .github/pages/runtime-index.html /tmp/gh-pages/benchmarks/runtime/index.html
+          cd /tmp/gh-pages
+          git add benchmarks/runtime/index.html
+          git diff --cached --quiet || {
+            git commit -m "Deploy combined benchmark graphs"
+            git push origin gh-pages
+          }
+          cd -
+          git worktree remove /tmp/gh-pages
+
       # ── PRs: compare against baseline, comment + fail on regression ───────
 
       - name: Compare runtime benchmarks


### PR DESCRIPTION
## Summary
This PR adds a new combined benchmark visualization page that displays runtime benchmarks across different optimization levels (-O1, -O2, -O3) on a single graph for easier comparison.

## Key Changes
- **New HTML page** (`.github/pages/runtime-index.html`): A standalone benchmark visualization page that:
  - Groups benchmarks by base name, stripping optimization level suffixes
  - Displays multiple optimization levels as separate lines on a single chart
  - Uses color coding for different optimization levels (-O1: blue, -O2: green, -O3: red)
  - Includes interactive features: hover tooltips with commit details and click-to-navigate to commit URLs
  - Provides a download button to export benchmark data as JSON
  - Displays repository information and last update timestamp

- **Updated workflow** (`.github/workflows/benchmark.yml`): Added a new deployment step that:
  - Copies the combined benchmark index page to the gh-pages branch
  - Commits and pushes changes only when there are modifications
  - Runs on push events to keep the visualization up-to-date

## Implementation Details
- The visualization uses Chart.js for rendering line charts
- Benchmarks are grouped by stripping the ` (-O\d)` suffix from benchmark names
- Commits are displayed in chronological order with short SHA-7 identifiers
- Missing data points are handled gracefully with `spanGaps: true` to maintain line continuity
- The page is responsive and includes proper styling for readability

https://claude.ai/code/session_01D2ehqQsVLss5rJBzDiRSYR