### PR TITLE
Fix benchmark workflow: set git user identity for deploy step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,6 +75,8 @@ jobs:
           git worktree add /tmp/gh-pages gh-pages
           cp .github/pages/runtime-index.html /tmp/gh-pages/benchmarks/runtime/index.html
           cd /tmp/gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add benchmarks/runtime/index.html
           git diff --cached --quiet || {
             git commit -m "Deploy combined benchmark graphs"


### PR DESCRIPTION
The Deploy combined benchmark pages step fails with exit code 128 because git commit requires user.name and user.email to be configured. The benchmark-action handles this internally, but the raw git commands in the deploy step do not.

https://claude.ai/code/session_01Wypq9K9DFce7zjFjG79hWW