### PR TITLE
Enable Rust warnings as errors and fix compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,20 +20,22 @@ on-task-started:
 		echo "Development environment ready."; \
 	fi
 
+RUSTFLAGS ?= -D warnings
+
 .PHONY: build
 build: wado-compiler/lib/builtins/wado-bundled-libm.wat
-	cargo check
-	cargo check -p wado-compiler --target wasm32-unknown-unknown
-	cargo check -p wado-manifest --target wasm32-unknown-unknown
+	RUSTFLAGS="$(RUSTFLAGS)" cargo check
+	RUSTFLAGS="$(RUSTFLAGS)" cargo check -p wado-compiler --target wasm32-unknown-unknown
+	RUSTFLAGS="$(RUSTFLAGS)" cargo check -p wado-manifest --target wasm32-unknown-unknown
 
 .PHONY: hello
 hello:
-	cargo run -p wado-cli -- compile -O2 -o example/hello.wat  example/hello.wado
-	cargo run -p wado-cli -- compile -O2 -o example/hello.wasm example/hello.wado
+	RUSTFLAGS="$(RUSTFLAGS)" cargo run -p wado-cli -- compile -O2 -o example/hello.wat  example/hello.wado
+	RUSTFLAGS="$(RUSTFLAGS)" cargo run -p wado-cli -- compile -O2 -o example/hello.wasm example/hello.wado
 
 .PHONY: hello-run
 hello-run:
-	cargo run -p wado-cli -- run example/hello.wado
+	RUSTFLAGS="$(RUSTFLAGS)" cargo run -p wado-cli -- run example/hello.wado
 
 .PHONY: hello-run-wasmtime
 hello-run-wasmtime: hello
@@ -41,7 +43,7 @@ hello-run-wasmtime: hello
 
 .PHONY: test
 test:
-	RUST_TEST_THREADS=12 cargo test
+	RUSTFLAGS="$(RUSTFLAGS)" RUST_TEST_THREADS=12 cargo test
 
 .PHONY: test-wado
 test-wado:
@@ -88,7 +90,7 @@ update-golden-format-fixtures:
 
 .PHONY: clippy
 clippy:
-	cargo clippy --all --all-features
+	RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --all --all-features -- -D warnings
 
 .PHONY: clippy-fix
 clippy-fix:

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -1035,8 +1035,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             type_table.make_enum(named.name.clone(), info.module_source.clone())
                         } else if let Some(info) = variant_cases.get(&named.name) {
                             type_table.make_variant(named.name.clone(), info.module_source.clone())
-                        } else if flags_cases.contains_key(&named.name) {
-                            TypeTable::UNKNOWN
                         } else {
                             TypeTable::UNKNOWN
                         }

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1166,6 +1166,9 @@ impl TirExpr {
 
 /// Reference to a function, either resolved to TIR or external
 #[derive(Debug, Clone)]
+// The External variant is intentionally large because boxing it would add pervasive
+// heap allocation overhead at 97+ call sites throughout the compiler.
+#[allow(clippy::large_enum_variant)]
 pub enum FunctionRef {
     /// Reference to a resolved TIR function
     Resolved {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -2994,7 +2994,7 @@ impl FunctionTranslator<'_, '_> {
         let mut seq = vec![declare_ptr, alloc_ptr];
         for i in 0..(BUF_SIZE / 8) {
             seq.push(WirInstr::I64Store {
-                offset: u64::from((i * 8) as u32),
+                offset: u64::from((i * 8).cast_unsigned()),
                 align: 3,
                 addr: Box::new(WirInstr::LocalGet {
                     name: ptr_name.clone(),

--- a/wado-compiler/src/wir_optimize.rs
+++ b/wado-compiler/src/wir_optimize.rs
@@ -2628,7 +2628,7 @@ fn elide_dead_single_field_struct_locals(module: &mut WirModule) {
 }
 
 /// One pass: collect candidates, validate, rewrite. Returns `true` if anything changed.
-fn elide_struct_locals_one_pass(body: &mut Vec<WirInstr>) -> bool {
+fn elide_struct_locals_one_pass(body: &mut [WirInstr]) -> bool {
     // Step 1: collect LocalSet(name, StructNew { [inner] }) at any depth.
     let mut all_defs: IndexMap<String, WirInstr> = IndexMap::new();
     for instr in body.iter() {
@@ -4388,7 +4388,7 @@ fn is_wir_constant(instr: &WirInstr) -> bool {
 
 /// Process a body (list of instructions), forwarding known constants.
 /// Returns true if any changes were made.
-fn forward_fields_in_body(body: &mut Vec<WirInstr>, known: &mut FieldKnowledge<'_>) -> bool {
+fn forward_fields_in_body(body: &mut [WirInstr], known: &mut FieldKnowledge<'_>) -> bool {
     let mut changed = false;
     let mut i = 0;
     while i < body.len() {

--- a/wado-compiler/src/wir_unparse.rs
+++ b/wado-compiler/src/wir_unparse.rs
@@ -85,8 +85,8 @@ impl<'a> WirUnparser<'a> {
             return None;
         };
         let segment = self.data.get(data_index as usize)?;
-        let off = *off as usize;
-        let length = *length as usize;
+        let off = (*off).cast_unsigned() as usize;
+        let length = (*length).cast_unsigned() as usize;
 
         // Look up the element type from the array type definition
         let elem_type = {


### PR DESCRIPTION
This PR enables treating Rust warnings as errors (`-D warnings`) across the build system and fixes the resulting compiler warnings.

## Summary
The changes enforce stricter Rust compiler standards by configuring `RUSTFLAGS` to deny all warnings, then addressing the warnings that were revealed.

## Key Changes

- **Build system**: Added `RUSTFLAGS ?= -D warnings` to the Makefile and applied it to all `cargo` invocations (`check`, `run`, `test`, `clippy`)
- **Type safety improvements**: Changed function parameters from `&mut Vec<T>` to `&mut [T]` in two optimization functions to use slice types instead of vector references, which is more idiomatic Rust
- **Cast safety**: Fixed signed-to-unsigned integer casts by using explicit `.cast_unsigned()` method calls instead of implicit casts, improving type safety
- **Clippy lint suppression**: Added `#[allow(clippy::large_enum_variant)]` to `FunctionRef` enum with a comment explaining why the External variant is intentionally large (to avoid heap allocation overhead at 97+ call sites)
- **Dead code removal**: Removed an unreachable conditional branch checking `flags_cases` that was never used

## Implementation Details

The changes maintain backward compatibility while improving code quality. The Makefile changes use a makefile variable with a default value, allowing overrides if needed. The type safety improvements in `wir_optimize.rs` and `wir_unparse.rs` follow Rust best practices by preferring slice types and explicit casts over implicit conversions.

https://claude.ai/code/session_014UW9d9vKHTPpxNo8smexYW