### PR TITLE
Rename primitives.wado to primitive.wado and clean up code

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -213,23 +213,23 @@ Embedded `.wado` files in `wado-compiler/lib/`:
 
 **Core Library (`core/`):**
 
-| Module                         | File                      | Description                                        |
-| ------------------------------ | ------------------------- | -------------------------------------------------- |
-| `core:prelude`                 | `prelude.wado`            | Auto-imported re-exports from prelude sub-modules  |
-| `core:prelude/traits.wado`     | `prelude/traits.wado`     | Trait definitions (Eq, Ord, Iterator, etc.)        |
-| `core:prelude/types.wado`      | `prelude/types.wado`      | Core types (Option, Result, Stream, Future)        |
-| `core:prelude/string.wado`     | `prelude/string.wado`     | String type and string iterators                   |
-| `core:prelude/array.wado`      | `prelude/array.wado`      | Array type and array iterators                     |
-| `core:prelude/int128.wado`     | `prelude/int128.wado`     | u128/i128 types (re-exported from prelude)         |
-| `core:prelude/primitive.wado`  | `prelude/primitive.wado`  | Primitive type trait implementations               |
-| `core:prelude/format.wado`     | `prelude/format.wado`     | Format traits (Display, Formatter)                 |
-| `core:prelude/fpfmt.wado`      | `prelude/fpfmt.wado`      | Float-to-string formatting (pure Wado)             |
-| `core:cli`                     | `cli.wado`                | CLI output (println, eprintln, etc.)               |
-| `core:collections`             | `collections.wado`        | TreeMap and other collections                      |
-| `core:zlib`                    | `zlib.wado`               | Compression (zlib/deflate)                         |
-| `core:base64`                  | `base64.wado`             | Base64 encoding/decoding (RFC 4648)                |
-| `core:internal`                | `internal.wado`           | Compiler-generated code support, panic/unreachable |
-| `core:builtin`                 | `builtin.wado`            | Compiler intrinsics with `#[canonical(...)]` attrs |
+| Module                        | File                     | Description                                        |
+| ----------------------------- | ------------------------ | -------------------------------------------------- |
+| `core:prelude`                | `prelude.wado`           | Auto-imported re-exports from prelude sub-modules  |
+| `core:prelude/traits.wado`    | `prelude/traits.wado`    | Trait definitions (Eq, Ord, Iterator, etc.)        |
+| `core:prelude/types.wado`     | `prelude/types.wado`     | Core types (Option, Result, Stream, Future)        |
+| `core:prelude/string.wado`    | `prelude/string.wado`    | String type and string iterators                   |
+| `core:prelude/array.wado`     | `prelude/array.wado`     | Array type and array iterators                     |
+| `core:prelude/int128.wado`    | `prelude/int128.wado`    | u128/i128 types (re-exported from prelude)         |
+| `core:prelude/primitive.wado` | `prelude/primitive.wado` | Primitive type trait implementations               |
+| `core:prelude/format.wado`    | `prelude/format.wado`    | Format traits (Display, Formatter)                 |
+| `core:prelude/fpfmt.wado`     | `prelude/fpfmt.wado`     | Float-to-string formatting (pure Wado)             |
+| `core:cli`                    | `cli.wado`               | CLI output (println, eprintln, etc.)               |
+| `core:collections`            | `collections.wado`       | TreeMap and other collections                      |
+| `core:zlib`                   | `zlib.wado`              | Compression (zlib/deflate)                         |
+| `core:base64`                 | `base64.wado`            | Base64 encoding/decoding (RFC 4648)                |
+| `core:internal`               | `internal.wado`          | Compiler-generated code support, panic/unreachable |
+| `core:builtin`                | `builtin.wado`           | Compiler intrinsics with `#[canonical(...)]` attrs |
 
 **WASI Library (`wasi/`):**
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -221,7 +221,7 @@ Embedded `.wado` files in `wado-compiler/lib/`:
 | `core:prelude/string.wado`     | `prelude/string.wado`     | String type and string iterators                   |
 | `core:prelude/array.wado`      | `prelude/array.wado`      | Array type and array iterators                     |
 | `core:prelude/int128.wado`     | `prelude/int128.wado`     | u128/i128 types (re-exported from prelude)         |
-| `core:prelude/primitives.wado` | `prelude/primitives.wado` | Primitive type trait implementations               |
+| `core:prelude/primitive.wado`  | `prelude/primitive.wado`  | Primitive type trait implementations               |
 | `core:prelude/format.wado`     | `prelude/format.wado`     | Format traits (Display, Formatter)                 |
 | `core:prelude/fpfmt.wado`      | `prelude/fpfmt.wado`      | Float-to-string formatting (pure Wado)             |
 | `core:cli`                     | `cli.wado`                | CLI output (println, eprintln, etc.)               |

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -46,7 +46,7 @@ pub use {
     WaitableSet, Subtask, ErrorContext,
 } from "core:prelude/types.wado";
 use _ from "core:prelude/fpfmt.wado";
-use _ from "core:prelude/primitives.wado";
+use _ from "core:prelude/primitive.wado";
 pub use { String, StrUtf8ByteIter, StrCharIter } from "core:prelude/string.wado";
 pub use { Array, ArrayIter, EnumerateIter, MapIter, FilterIter } from "core:prelude/array.wado";
 pub use { panic, unreachable } from "core:internal";

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -39,13 +39,11 @@ fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {
 
 /// Count decimal digits of a non-negative i64 value.
 fn count_digits_i64(val: i64) -> i32 {
-    let zero: i64 = 0;
-    if val == zero {
+    if val == 0 {
         return 1;
     }
-    let ten: i64 = 10;
     let mut n: i32 = 0;
-    for let mut t: i64 = val; t > zero; t = t / ten {
+    for let mut t = val; t > 0; t = t / 10 {
         n += 1;
     }
     return n;
@@ -53,28 +51,25 @@ fn count_digits_i64(val: i64) -> i32 {
 
 /// Write `digit_count` decimal digits of `abs_val` backwards into `arr` starting at `offset`.
 fn write_decimal_digits(arr: builtin::array<u8>, offset: i32, abs_val: i64, digit_count: i32) {
-    let zero: i64 = 0;
-    let ten: i64 = 10;
     let mut pos = offset + digit_count;
-    if abs_val == zero {
+    if abs_val == 0 {
         builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
-        for let mut temp: i64 = abs_val; temp > zero; temp = temp / ten {
+        for let mut temp = abs_val; temp > 0; temp = temp / 10 {
             pos -= 1;
-            builtin::array_set_u8(arr, pos, ('0' as i32 + (temp % ten) as i32) as u8);
+            builtin::array_set_u8(arr, pos, ('0' as i32 + (temp % 10) as i32) as u8);
         }
     }
 }
 
 /// Write `digit_count` digits of `abs_val` in given base backwards into `arr` at `offset`.
 fn write_base_digits(arr: builtin::array<u8>, offset: i32, abs_val: i64, digit_count: i32, base: i32, upper: bool) {
-    let zero: i64 = 0;
-    let base64: i64 = base as i64;
+    let base64 = base as i64;
     let mut pos = offset + digit_count;
-    if abs_val == zero {
+    if abs_val == 0 {
         builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
-        for let mut temp: i64 = abs_val; temp > zero; temp = temp / base64 {
+        for let mut temp = abs_val; temp > 0; temp = temp / base64 {
             pos -= 1;
             let digit: i32 = (temp % base64) as i32;
             let ch = if digit < 10 {
@@ -91,13 +86,12 @@ fn write_base_digits(arr: builtin::array<u8>, offset: i32, abs_val: i64, digit_c
 
 /// Count digits of a non-negative i64 value in the given base.
 fn count_digits_base(val: i64, base: i32) -> i32 {
-    let zero: i64 = 0;
-    if val == zero {
+    if val == 0 {
         return 1;
     }
-    let base64: i64 = base as i64;
+    let base64 = base as i64;
     let mut n: i32 = 0;
-    for let mut t: i64 = val; t > zero; t = t / base64 {
+    for let mut t = val; t > 0; t = t / base64 {
         n += 1;
     }
     return n;
@@ -106,20 +100,18 @@ fn count_digits_base(val: i64, base: i32) -> i32 {
 /// Count digits of a u64 value (as raw i64 bits) in the given power-of-2 base.
 /// `bits_per_digit` is log2(base): 1 for binary, 3 for octal, 4 for hex.
 fn count_digits_u64_base(val_i64: i64, bits_per_digit: i32) -> i32 {
-    let zero: i64 = 0;
-    if val_i64 == zero {
+    if val_i64 == 0 {
         return 1;
     }
     // Count leading zeros manually: find highest set bit
     let mut highest_bit: i32 = 0;
     // Check high 32 bits
     let high32: i64 = val_i64 >> 32 & 0xFFFFFFFF;
-    if high32 != zero {
+    if high32 != 0 {
         // Bit is somewhere in bits 32..63
         let mut b: i32 = 63;
         while b >= 32 {
-            let one: i64 = 1;
-            if val_i64 >> b as i64 & one != zero {
+            if val_i64 >> b as i64 & 1 != 0 {
                 highest_bit = b;
                 break;
             }
@@ -129,8 +121,7 @@ fn count_digits_u64_base(val_i64: i64, bits_per_digit: i32) -> i32 {
         // Bit is somewhere in bits 0..31
         let mut b: i32 = 31;
         while b >= 0 {
-            let one: i64 = 1;
-            if val_i64 >> b as i64 & one != zero {
+            if val_i64 >> b as i64 & 1 != 0 {
                 highest_bit = b;
                 break;
             }
@@ -142,14 +133,13 @@ fn count_digits_u64_base(val_i64: i64, bits_per_digit: i32) -> i32 {
 
 /// Write digits of a u64 value (as raw i64 bits) in a power-of-2 base.
 fn write_u64_base_digits(arr: builtin::array<u8>, offset: i32, val_i64: i64, digit_count: i32, bits_per_digit: i32, mask: i32, upper: bool) {
-    let zero: i64 = 0;
-    let mask64: i64 = mask as i64;
+    let mask64 = mask as i64;
     let mut pos = offset + digit_count;
-    if val_i64 == zero {
+    if val_i64 == 0 {
         builtin::array_set_u8(arr, offset, '0' as u8);
     } else {
         let mut temp: i64 = val_i64;
-        while temp != zero {
+        while temp != 0 {
             pos -= 1;
             let digit: i32 = (temp & mask64) as i32;
             let ch = if digit < 10 {
@@ -444,13 +434,9 @@ impl i64 {
 
     fn fmt_decimal(&self, f: &mut Formatter) {
         let value = *self;
-        let zero_i64: i64 = 0;
-        let is_negative = value < zero_i64;
-        let i64_max: i64 = 9223372036854775807;
-        let one_i64: i64 = 1;
-        let i64_min: i64 = zero_i64 - i64_max - one_i64;
+        let is_negative = value < 0;
 
-        if value == i64_min {
+        if value == i64::MIN {
             // i64::MIN = -9223372036854775808: last digit '8', remaining 922337203685477580
             let remaining: i64 = 922337203685477580;
             let remaining_digits = count_digits_i64(remaining);
@@ -460,7 +446,7 @@ impl i64 {
             write_decimal_digits(repr, offset, remaining, remaining_digits);
             builtin::array_set_u8(repr, offset + remaining_digits, '8' as u8);
         } else {
-            let abs_val: i64 = if is_negative { zero_i64 - value } else { value };
+            let abs_val = if is_negative { 0 - value } else { value };
             let digit_count = count_digits_i64(abs_val);
             let offset = f.prepare_int_write(is_negative, "", digit_count);
             write_decimal_digits(f.buf.internal_raw_bytes(), offset, abs_val, digit_count);
@@ -513,10 +499,8 @@ impl u64 {
 
     fn fmt_decimal(&self, f: &mut Formatter) {
         let val_i64 = *self as i64;
-        let zero: i64 = 0;
-        let ten: i64 = 10;
 
-        if val_i64 == zero {
+        if val_i64 == 0 {
             let offset = f.prepare_int_write(false, "", 1);
             builtin::array_set_u8(f.buf.internal_raw_bytes(), offset, '0' as u8);
             return;
@@ -525,18 +509,18 @@ impl u64 {
         // Count digits using unsigned division
         let mut digit_count: i32 = 0;
         let offset_div: i64 = 1844674407370955161;
-        let mut temp: i64 = val_i64;
-        while temp != zero {
+        let mut temp = val_i64;
+        while temp != 0 {
             digit_count += 1;
-            if temp >= zero {
-                temp = temp / ten;
+            if temp >= 0 {
+                temp = temp / 10;
             } else {
-                let signed_rem: i64 = temp % ten;
-                let rem_adjusted: i64 = signed_rem + 6;
-                let signed_quot: i64 = temp / ten;
+                let signed_rem = temp % 10;
+                let rem_adjusted = signed_rem + 6;
+                let signed_quot = temp / 10;
                 let mut carry: i64 = 0;
-                if rem_adjusted < zero {
-                    carry = 0 - 1;
+                if rem_adjusted < 0 {
+                    carry = -1;
                 }
                 temp = signed_quot + offset_div + carry;
             }
@@ -548,24 +532,24 @@ impl u64 {
         // Write digits using unsigned division (backwards)
         let mut pos = offset + digit_count;
         temp = val_i64;
-        while temp != zero {
+        while temp != 0 {
             pos -= 1;
             let mut digit: i32 = 0;
-            if temp >= zero {
-                digit = (temp % ten) as i32;
-                temp = temp / ten;
+            if temp >= 0 {
+                digit = (temp % 10) as i32;
+                temp = temp / 10;
             } else {
-                let signed_rem: i64 = temp % ten;
-                let rem_adjusted: i64 = signed_rem + 6;
-                if rem_adjusted >= zero {
+                let signed_rem = temp % 10;
+                let rem_adjusted = signed_rem + 6;
+                if rem_adjusted >= 0 {
                     digit = rem_adjusted as i32;
                 } else {
-                    digit = (rem_adjusted + ten) as i32;
+                    digit = (rem_adjusted + 10) as i32;
                 }
-                let signed_quot: i64 = temp / ten;
+                let signed_quot = temp / 10;
                 let mut carry: i64 = 0;
-                if rem_adjusted < zero {
-                    carry = 0 - 1;
+                if rem_adjusted < 0 {
+                    carry = -1;
                 }
                 temp = signed_quot + offset_div + carry;
             }
@@ -889,7 +873,7 @@ impl f32 {
     }
 
     pub fn is_finite(&self) -> bool {
-        return *self - *self == 0.0 as f32;
+        return *self - *self == 0.0;
     }
 
     pub fn parse(s: String) -> Option<f32> {
@@ -1475,16 +1459,12 @@ impl Binary for u32 {
 impl Binary for i64 {
     pub fn fmt(&self, f: &mut Formatter) {
         let v = *self;
-        let zero_i64: i64 = 0;
-        let is_neg = v < zero_i64;
-        let i64_max: i64 = 9223372036854775807;
-        let one_i64: i64 = 1;
-        let i64_min: i64 = zero_i64 - i64_max - one_i64;
-        if v == i64_min {
+        let is_neg = v < 0;
+        if v == i64::MIN {
             let half: i64 = 4611686018427387904;
             half.fmt_base(true, f, 2, false);
         } else {
-            let abs_val: i64 = if is_neg { zero_i64 - v } else { v };
+            let abs_val = if is_neg { 0 - v } else { v };
             abs_val.fmt_base(is_neg, f, 2, false);
         }
     }
@@ -1541,16 +1521,12 @@ impl Octal for u32 {
 impl Octal for i64 {
     pub fn fmt(&self, f: &mut Formatter) {
         let v = *self;
-        let zero_i64: i64 = 0;
-        let is_neg = v < zero_i64;
-        let i64_max: i64 = 9223372036854775807;
-        let one_i64: i64 = 1;
-        let i64_min: i64 = zero_i64 - i64_max - one_i64;
-        if v == i64_min {
+        let is_neg = v < 0;
+        if v == i64::MIN {
             let half: i64 = 4611686018427387904;
             half.fmt_base(true, f, 8, false);
         } else {
-            let abs_val: i64 = if is_neg { zero_i64 - v } else { v };
+            let abs_val = if is_neg { 0 - v } else { v };
             abs_val.fmt_base(is_neg, f, 8, false);
         }
     }
@@ -1607,16 +1583,12 @@ impl LowerHex for u32 {
 impl LowerHex for i64 {
     pub fn fmt(&self, f: &mut Formatter) {
         let v = *self;
-        let zero_i64: i64 = 0;
-        let is_neg = v < zero_i64;
-        let i64_max: i64 = 9223372036854775807;
-        let one_i64: i64 = 1;
-        let i64_min: i64 = zero_i64 - i64_max - one_i64;
-        if v == i64_min {
+        let is_neg = v < 0;
+        if v == i64::MIN {
             let half: i64 = 4611686018427387904;
             half.fmt_base(true, f, 16, false);
         } else {
-            let abs_val: i64 = if is_neg { zero_i64 - v } else { v };
+            let abs_val = if is_neg { 0 - v } else { v };
             abs_val.fmt_base(is_neg, f, 16, false);
         }
     }
@@ -1673,16 +1645,12 @@ impl UpperHex for u32 {
 impl UpperHex for i64 {
     pub fn fmt(&self, f: &mut Formatter) {
         let v = *self;
-        let zero_i64: i64 = 0;
-        let is_neg = v < zero_i64;
-        let i64_max: i64 = 9223372036854775807;
-        let one_i64: i64 = 1;
-        let i64_min: i64 = zero_i64 - i64_max - one_i64;
-        if v == i64_min {
+        let is_neg = v < 0;
+        if v == i64::MIN {
             let half: i64 = 4611686018427387904;
             half.fmt_base(true, f, 16, true);
         } else {
-            let abs_val: i64 = if is_neg { zero_i64 - v } else { v };
+            let abs_val = if is_neg { 0 - v } else { v };
             abs_val.fmt_base(is_neg, f, 16, true);
         }
     }

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -215,7 +215,7 @@ fn cached_core_stdlib() -> &'static IndexMap<ModuleSource, Module> {
             ("prelude/format.wado", stdlib::CORE_PRELUDE_FORMAT),
             ("prelude/fpfmt.wado", stdlib::CORE_PRELUDE_FPFMT),
             ("prelude/int128.wado", stdlib::CORE_PRELUDE_INT128),
-            ("prelude/primitives.wado", stdlib::CORE_PRELUDE_PRIMITIVES),
+            ("prelude/primitive.wado", stdlib::CORE_PRELUDE_PRIMITIVE),
             ("prelude/string.wado", stdlib::CORE_PRELUDE_STRING),
             ("prelude/traits.wado", stdlib::CORE_PRELUDE_TRAITS),
             ("prelude/types.wado", stdlib::CORE_PRELUDE_TYPES),

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -3944,7 +3944,7 @@ impl Monomorphizer {
 /// to set the correct `module_source` so DCE can find the target function.
 fn module_source_for_trait_impl(type_table: &TypeTable, type_id: TypeId) -> Option<ModuleSource> {
     match type_table.get(type_id) {
-        ResolvedType::Primitive(_) => Some(ModuleSource::primitives()),
+        ResolvedType::Primitive(_) => Some(ModuleSource::primitive()),
         ResolvedType::BuiltinArray(_) => Some(ModuleSource::prelude()),
         ResolvedType::Struct { module_source, .. }
         | ResolvedType::GenericInstance { module_source, .. }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -173,10 +173,10 @@ impl ModuleSource {
         Self::core("prelude/int128.wado")
     }
 
-    /// `core:prelude/primitives.wado` — primitive type methods.
+    /// `core:prelude/primitive.wado` — primitive type methods.
     #[must_use]
-    pub fn primitives() -> Self {
-        Self::core("prelude/primitives.wado")
+    pub fn primitive() -> Self {
+        Self::core("prelude/primitive.wado")
     }
 
     /// `core:prelude/types.wado` — core type definitions.

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -777,7 +777,7 @@ fn analyze_expr(
                         // (e.g., i32^Ord::cmp, char::is_ascii_space)
                         let prim_name = prim.as_str().to_string();
                         let method_id = FunctionId::Method(MethodName::new(
-                            ModuleSource::primitives(),
+                            ModuleSource::primitive(),
                             prim_name,
                             trait_name.clone(),
                             method_name.clone(),
@@ -1057,12 +1057,12 @@ fn add_to_string_callee(type_id: TypeId, type_table: &TypeTable, analysis: &mut 
     let base_type_id = type_table.get_ultimate_base_type(type_id);
     match type_table.get(base_type_id) {
         ResolvedType::Primitive(prim) => {
-            // Primitive to_string methods are defined in core:prelude/primitives as impl blocks
+            // Primitive to_string methods are defined in core:prelude/primitive as impl blocks
             // e.g., impl i32 { fn to_string(&self) -> String { ... } }
             let prim_name = prim.as_str();
             // Method format: module_source/StructName::method_name
             let method_id = FunctionId::Method(MethodName::new(
-                ModuleSource::primitives(),
+                ModuleSource::primitive(),
                 prim_name.to_string(),
                 None,
                 "to_string".to_string(),

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -55,10 +55,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 module_source,
                 ..
             } => (name.clone(), module_source.clone()),
-            // Primitive types have impl blocks in core:prelude/primitives
+            // Primitive types have impl blocks in core:prelude/primitive
             ResolvedType::Primitive(_) => (
                 self.type_table.borrow().mangle_type_name(base_type_id),
-                ModuleSource::primitives(),
+                ModuleSource::primitive(),
             ),
             // Enum types - use enum name and its defining module
             ResolvedType::Enum {
@@ -707,7 +707,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             ResolvedType::Primitive(prim) => {
                 let name = prim.as_str().to_string();
-                (name.clone(), ModuleSource::primitives(), name, vec![])
+                (name.clone(), ModuleSource::primitive(), name, vec![])
             }
             ResolvedType::Enum {
                 name,

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -131,7 +131,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
     /// Find the module source for a struct by name
     pub(super) fn find_struct_module_source(&self, struct_name: &str) -> ModuleSource {
-        // Check if it's a primitive type - impl blocks live in core:prelude/primitives.wado
+        // Check if it's a primitive type - impl blocks live in core:prelude/primitive.wado
         // Note: i128/u128 are structs (in prelude/int128.wado), not primitives
         if matches!(
             struct_name,
@@ -147,7 +147,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 | "bool"
                 | "char"
         ) {
-            return ModuleSource::primitives();
+            return ModuleSource::primitive();
         }
 
         // Check current module

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -29,7 +29,7 @@ pub const CORE_BUILTIN: &str = include_str!("../lib/core/builtin.wado");
 pub const CORE_PRELUDE_TRAITS: &str = include_str!("../lib/core/prelude/traits.wado");
 pub const CORE_PRELUDE_INT128: &str = include_str!("../lib/core/prelude/int128.wado");
 pub const CORE_PRELUDE_TYPES: &str = include_str!("../lib/core/prelude/types.wado");
-pub const CORE_PRELUDE_PRIMITIVES: &str = include_str!("../lib/core/prelude/primitives.wado");
+pub const CORE_PRELUDE_PRIMITIVE: &str = include_str!("../lib/core/prelude/primitive.wado");
 pub const CORE_PRELUDE_FORMAT: &str = include_str!("../lib/core/prelude/format.wado");
 pub const CORE_PRELUDE_ARRAY: &str = include_str!("../lib/core/prelude/array.wado");
 pub const CORE_PRELUDE_FPFMT: &str = include_str!("../lib/core/prelude/fpfmt.wado");
@@ -60,7 +60,7 @@ pub fn get_stdlib_module(import_path: &str) -> Option<&'static str> {
         "core:prelude/traits.wado" => Some(CORE_PRELUDE_TRAITS),
         "core:prelude/int128.wado" => Some(CORE_PRELUDE_INT128),
         "core:prelude/types.wado" => Some(CORE_PRELUDE_TYPES),
-        "core:prelude/primitives.wado" => Some(CORE_PRELUDE_PRIMITIVES),
+        "core:prelude/primitive.wado" => Some(CORE_PRELUDE_PRIMITIVE),
         "core:prelude/string.wado" => Some(CORE_PRELUDE_STRING),
         "core:prelude/format.wado" => Some(CORE_PRELUDE_FORMAT),
         "core:prelude/array.wado" => Some(CORE_PRELUDE_ARRAY),
@@ -149,8 +149,8 @@ mod tests {
 
     #[test]
     fn test_get_prelude_primitives() {
-        let source = get_stdlib_module("core:prelude/primitives.wado");
-        assert!(source.is_some(), "primitives module should exist");
+        let source = get_stdlib_module("core:prelude/primitive.wado");
+        assert!(source.is_some(), "primitive module should exist");
         assert!(
             source.unwrap().contains("impl i32"),
             "should contain impl i32"

--- a/wado-compiler/src/synthesis/inspect.rs
+++ b/wado-compiler/src/synthesis/inspect.rs
@@ -991,7 +991,7 @@ fn lower_hex_fmt(
         TirExprKind::MethodCall {
             receiver: Box::new(receiver),
             func: FunctionRef {
-                module_source: ModuleSource::primitives(),
+                module_source: ModuleSource::primitive(),
                 name: mangled,
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
@@ -1012,12 +1012,12 @@ fn lower_hex_fmt(
 
 fn display_impl_module(type_id: TypeId, tt: &Rc<RefCell<TypeTable>>) -> ModuleSource {
     match tt.borrow().get(type_id).clone() {
-        ResolvedType::Primitive(_) => ModuleSource::primitives(),
+        ResolvedType::Primitive(_) => ModuleSource::primitive(),
         ResolvedType::Struct { name, .. } if name == "String" => ModuleSource::format(),
         ResolvedType::Struct { module_source, .. } | ResolvedType::Enum { module_source, .. } => {
             module_source
         }
-        _ => ModuleSource::primitives(),
+        _ => ModuleSource::primitive(),
     }
 }
 

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -418,7 +418,7 @@ fn default_value_for_type(type_id: TypeId, type_table: &TypeTable, span: Span) -
     // (primitives and stdlib types). User-defined structs fall back to null.
     let (base_name, module_source, type_args) = match type_table.get(type_id) {
         crate::tir::ResolvedType::Primitive(p) => {
-            (p.as_str().to_string(), ModuleSource::primitives(), vec![])
+            (p.as_str().to_string(), ModuleSource::primitive(), vec![])
         }
         crate::tir::ResolvedType::Struct {
             name,

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -1027,13 +1027,13 @@ fn trait_impl_module(
     tt: &Rc<RefCell<TypeTable>>,
 ) -> ModuleSource {
     match tt.borrow().get(type_id).clone() {
-        ResolvedType::Primitive(_) => ModuleSource::primitives(),
+        ResolvedType::Primitive(_) => ModuleSource::primitive(),
         ResolvedType::Struct { name, .. } if name == "String" => ModuleSource::format(),
         ResolvedType::Struct { module_source, .. }
         | ResolvedType::Enum { module_source, .. }
         | ResolvedType::Variant { module_source, .. }
         | ResolvedType::Newtype { module_source, .. } => module_source,
-        _ => ModuleSource::primitives(),
+        _ => ModuleSource::primitive(),
     }
 }
 

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -2145,7 +2145,7 @@ fn strip_refs(type_id: TypeId, tt: &TypeTable) -> TypeId {
 fn inspect_impl_module(type_id: TypeId, tt: &TypeTable, default: &ModuleSource) -> ModuleSource {
     use crate::tir::ResolvedType;
     match tt.get(type_id).clone() {
-        ResolvedType::Primitive(_) => ModuleSource::primitives(),
+        ResolvedType::Primitive(_) => ModuleSource::primitive(),
         ResolvedType::Struct { ref name, .. } if name == "String" => ModuleSource::format(),
         ResolvedType::Struct {
             ref module_source, ..

--- a/wado-compiler/tests/fixtures.golden/allocator_free_rewind.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/allocator_free_rewind.wir.wado
@@ -596,8 +596,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -621,8 +619,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/allocator_grow_large.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/allocator_grow_large.wir.wado
@@ -349,8 +349,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -374,8 +372,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/allocator_grow_repeated.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/allocator_grow_repeated.wir.wado
@@ -362,8 +362,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -387,8 +385,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_append_collapse.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_append_collapse.wir.wado
@@ -1559,8 +1559,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1584,8 +1582,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1631,45 +1627,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check.wir.wado
@@ -412,8 +412,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -437,8 +435,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_const_wir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_const_wir.wir.wado
@@ -389,8 +389,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -414,8 +412,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard.wir.wado
@@ -418,8 +418,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -443,8 +441,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard_wir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard_wir.wir.wado
@@ -359,8 +359,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -384,8 +382,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_after_mutation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_after_mutation.wir.wado
@@ -337,8 +337,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -362,8 +360,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_loop_dynamic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_loop_dynamic.wir.wado
@@ -472,8 +472,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -497,8 +495,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_redundant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_redundant.wir.wado
@@ -423,8 +423,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -448,8 +446,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_explicit_cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_explicit_cast.wir.wado
@@ -383,8 +383,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -408,8 +406,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline.wir.wado
@@ -390,8 +390,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -415,8 +413,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_btree.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_btree.wir.wado
@@ -391,8 +391,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -416,8 +414,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_compare.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_compare.wir.wado
@@ -383,8 +383,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -408,8 +406,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_generic.wir.wado
@@ -394,8 +394,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -419,8 +417,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_loop.wir.wado
@@ -467,8 +467,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -492,8 +490,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_method.wir.wado
@@ -431,8 +431,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -456,8 +454,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_multi.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_multi.wir.wado
@@ -508,8 +508,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -533,8 +531,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_nested.wir.wado
@@ -452,8 +452,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -477,8 +475,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.wir.wado
@@ -410,8 +410,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -435,8 +433,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_large_literal_dynamic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_large_literal_dynamic.wir.wado
@@ -1521,8 +1521,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1546,8 +1544,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_literal_coerce_u8.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_literal_coerce_u8.wir.wado
@@ -664,8 +664,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -689,8 +687,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -736,45 +732,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/array_new_data_f64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_f64.wir.wado
@@ -2032,8 +2032,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -2057,8 +2055,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_new_data_i32.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_i32.wir.wado
@@ -997,8 +997,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1022,8 +1020,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_new_data_mixed.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_mixed.wir.wado
@@ -1287,8 +1287,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1312,8 +1310,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_new_data_u8.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new_data_u8.wir.wado
@@ -1030,8 +1030,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1055,8 +1053,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_param_coercion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_param_coercion.wir.wado
@@ -363,8 +363,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -388,8 +386,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_return.wir.wado
@@ -389,8 +389,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -414,8 +412,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i16.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i16.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i32.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i32.wir.wado
@@ -298,8 +298,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -323,8 +321,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i64.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -354,45 +350,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/array_specialized_i8.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_i8.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_tuple.wir.wado
@@ -328,8 +328,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -353,8 +351,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u16.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u16.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u32.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u32.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u64.wir.wado
@@ -292,33 +292,31 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -332,24 +330,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l16;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b20: block {
         l21: loop {
@@ -362,19 +360,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l21;

--- a/wado-compiler/tests/fixtures.golden/array_specialized_u8.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized_u8.wir.wado
@@ -300,8 +300,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -325,8 +323,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_tuple_unit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_tuple_unit.wir.wado
@@ -305,8 +305,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -330,8 +328,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/array_type_annotation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_type_annotation.wir.wado
@@ -383,8 +383,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -408,8 +406,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_fail_intermediate.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_intermediate.wir.wado
@@ -320,8 +320,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -345,8 +343,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_fail_side_effect.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_side_effect.wir.wado
@@ -349,8 +349,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -374,8 +372,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_fail_simple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_simple.wir.wado
@@ -283,8 +283,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -308,8 +306,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_fail_with_message.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_fail_with_message.wir.wado
@@ -286,8 +286,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -311,8 +309,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_char.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_char.wir.wado
@@ -289,8 +289,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -314,8 +312,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_enum.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_enum.wir.wado
@@ -297,8 +297,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -322,8 +320,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_float.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_float.wir.wado
@@ -1400,8 +1400,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1425,8 +1423,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_if.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_if.wir.wado
@@ -288,8 +288,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -313,8 +311,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_matches.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_matches.wir.wado
@@ -300,8 +300,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -325,8 +323,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_string.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_struct.wir.wado
@@ -292,8 +292,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -317,8 +315,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_variant.wir.wado
@@ -317,8 +317,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -342,8 +340,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/associated_const_integers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_const_integers.wir.wado
@@ -565,8 +565,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -590,8 +588,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -657,77 +653,71 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -741,24 +731,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l25;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b29: block {
         l30: loop {
@@ -771,19 +761,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l30;

--- a/wado-compiler/tests/fixtures.golden/associated_const_user_defined.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_const_user_defined.wir.wado
@@ -339,8 +339,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -364,8 +362,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/associated_type_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_basic.wir.wado
@@ -254,8 +254,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -279,8 +277,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/associated_type_index_assign.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_index_assign.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/associated_type_index_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_index_mut.wir.wado
@@ -266,8 +266,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -291,8 +289,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/associated_type_index_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/associated_type_index_trait.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/auto_deref_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref_for_of.wir.wado
@@ -518,8 +518,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -543,8 +541,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/auto_deref_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref_method.wir.wado
@@ -611,8 +611,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -636,8 +634,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/auto_deref_template.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref_template.wir.wado
@@ -623,8 +623,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -648,8 +646,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/base64_decode.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/base64_decode.wir.wado
@@ -1644,8 +1644,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1669,8 +1667,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/base64_encode.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/base64_encode.wir.wado
@@ -1382,8 +1382,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1407,8 +1405,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/builtin_clz_reinterpret.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/builtin_clz_reinterpret.wir.wado
@@ -1768,8 +1768,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1793,8 +1791,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1899,45 +1895,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/char_cast_from_u32_fn.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/char_cast_from_u32_fn.wir.wado
@@ -772,8 +772,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -797,8 +795,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/char_cast_from_u8.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/char_cast_from_u8.wir.wado
@@ -428,8 +428,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -453,8 +451,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/cli_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cli_args.wir.wado
@@ -328,8 +328,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -353,8 +351,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure-in-generic-method-delegation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure-in-generic-method-delegation.wir.wado
@@ -269,8 +269,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -294,8 +292,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_block_body.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_body.wir.wado
@@ -297,8 +297,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -322,8 +320,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_block_for.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_for.wir.wado
@@ -288,8 +288,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -313,8 +311,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_block_if.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_if.wir.wado
@@ -288,8 +288,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -313,8 +311,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_block_multi_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_multi_types.wir.wado
@@ -288,8 +288,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -313,8 +311,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_block_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_nested.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_block_while.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_block_while.wir.wado
@@ -288,8 +288,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -313,8 +311,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_call_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_call_basic.wir.wado
@@ -252,8 +252,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -277,8 +275,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_call_multi_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_call_multi_args.wir.wado
@@ -262,8 +262,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -287,8 +285,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_call_multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_call_multiple.wir.wado
@@ -282,8 +282,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -307,8 +305,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_capture_fn_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_capture_fn_param.wir.wado
@@ -455,8 +455,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -480,8 +478,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_capture_multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_capture_multiple.wir.wado
@@ -362,8 +362,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -387,8 +385,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_capture_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_capture_struct.wir.wado
@@ -390,8 +390,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -415,8 +413,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param.wir.wado
@@ -263,8 +263,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -288,8 +286,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_capture.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_capture.wir.wado
@@ -267,8 +267,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -292,8 +290,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_effectful.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_effectful.wir.wado
@@ -303,8 +303,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -328,8 +326,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_multiple.wir.wado
@@ -266,8 +266,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -291,8 +289,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_no_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_no_args.wir.wado
@@ -337,8 +337,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -362,8 +360,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_fn_param_static.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn_param_static.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_function_factory.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_function_factory.wir.wado
@@ -320,8 +320,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -345,8 +343,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_in_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_in_loop.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_chain.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_chain.wir.wado
@@ -430,8 +430,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -455,8 +453,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_filter.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_filter.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_fold.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_fold.wir.wado
@@ -380,8 +380,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -405,8 +403,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_iterator_map.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator_map.wir.wado
@@ -394,8 +394,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -419,8 +417,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.wir.wado
@@ -506,8 +506,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -531,8 +529,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.wir.wado
@@ -559,8 +559,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -584,8 +582,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_mutable_capture.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_mutable_capture.wir.wado
@@ -268,8 +268,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -293,8 +291,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_no_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_no_params.wir.wado
@@ -344,8 +344,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -369,8 +367,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_return_i64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_return_i64.wir.wado
@@ -256,8 +256,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -281,8 +279,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -308,45 +304,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/closure_shared_mutable_state.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_shared_mutable_state.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_sort_by.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_sort_by.wir.wado
@@ -463,8 +463,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -488,8 +486,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/closure_struct_literal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_struct_literal.wir.wado
@@ -274,8 +274,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -299,8 +297,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_args.wir.wado
@@ -343,8 +343,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -368,8 +366,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -415,77 +411,71 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -499,24 +489,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l24;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b28: block {
         l29: loop {
@@ -529,19 +519,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l29;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_binary.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_binary.wir.wado
@@ -375,8 +375,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -400,8 +398,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -427,77 +423,71 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -511,24 +501,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l23;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b27: block {
         l28: loop {
@@ -541,19 +531,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l28;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_const_i64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_const_i64.wir.wado
@@ -309,8 +309,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -334,8 +332,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -361,77 +357,71 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -445,24 +435,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l23;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b27: block {
         l28: loop {
@@ -475,19 +465,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l28;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_if_branch.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_if_branch.wir.wado
@@ -278,8 +278,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -303,8 +301,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -330,45 +326,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_instance_method_arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_instance_method_arg.wir.wado
@@ -259,33 +259,31 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -299,24 +297,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l13;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b17: block {
         l18: loop {
@@ -329,19 +327,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l18;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_let.wir.wado
@@ -451,8 +451,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -476,8 +474,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -543,77 +539,71 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -627,24 +617,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l25;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b29: block {
         l30: loop {
@@ -657,19 +647,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l30;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_method_arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_method_arg.wir.wado
@@ -284,33 +284,31 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -324,24 +322,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l13;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b17: block {
         l18: loop {
@@ -354,19 +352,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l18;

--- a/wado-compiler/tests/fixtures.golden/coerce_int_literal_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_int_literal_return.wir.wado
@@ -335,8 +335,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -360,8 +358,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -407,77 +403,71 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -491,24 +481,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l24;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b28: block {
         l29: loop {
@@ -521,19 +511,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l29;

--- a/wado-compiler/tests/fixtures.golden/coerce_match_arm.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_match_arm.wir.wado
@@ -475,8 +475,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -500,8 +498,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -547,77 +543,71 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -631,24 +621,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l40;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b44: block {
         l45: loop {
@@ -661,19 +651,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l45;

--- a/wado-compiler/tests/fixtures.golden/coerce_struct_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_struct_field.wir.wado
@@ -420,8 +420,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -445,8 +443,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -492,77 +488,71 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -576,24 +566,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l24;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b28: block {
         l29: loop {
@@ -606,19 +596,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l29;

--- a/wado-compiler/tests/fixtures.golden/compound_assign_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/compound_assign_basic.wir.wado
@@ -343,8 +343,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -368,8 +366,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/const_fold_int_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/const_fold_int_basic.wir.wado
@@ -368,8 +368,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -393,8 +391,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/const_fold_int_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/const_fold_int_types.wir.wado
@@ -363,8 +363,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -388,8 +386,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -455,45 +451,41 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/contextual_keyword.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/contextual_keyword.wir.wado
@@ -346,8 +346,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -371,8 +369,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/copy_prop_mutable_source.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/copy_prop_mutable_source.wir.wado
@@ -409,8 +409,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -434,8 +432,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/cross_destruct_patterns.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_destruct_patterns.wir.wado
@@ -543,8 +543,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -568,8 +566,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/cross_module_generic_deep.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_generic_deep.wir.wado
@@ -381,8 +381,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -406,8 +404,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/cross_module_generic_helper.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_generic_helper.wir.wado
@@ -242,8 +242,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -267,8 +265,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/cross_module_generic_import.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_generic_import.wir.wado
@@ -291,8 +291,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -316,8 +314,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/default_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/default_trait.wir.wado
@@ -473,8 +473,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -498,8 +496,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/default_type_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/default_type_params.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
@@ -489,8 +489,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -514,8 +512,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_all_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_all_primitives.wir.wado
@@ -2721,8 +2721,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -2746,8 +2744,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -2872,77 +2868,71 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -2956,24 +2946,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l163;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b167: block {
         l168: loop {
@@ -2986,19 +2976,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l168;

--- a/wado-compiler/tests/fixtures.golden/display_custom.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_custom.wir.wado
@@ -252,8 +252,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -277,8 +275,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_format_base.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_format_base.wir.wado
@@ -617,8 +617,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -642,8 +640,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_format_padding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_format_padding.wir.wado
@@ -775,8 +775,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -800,8 +798,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_formatter_methods.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_formatter_methods.wir.wado
@@ -326,8 +326,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -351,8 +349,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_primitives.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers.wir.wado
@@ -3490,8 +3490,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -3515,8 +3513,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -3541,7 +3537,6 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 }
 
 fn write_base_digits(arr, offset, abs_val, digit_count, base, upper) {
-    let __local_6: i64;
     let base64: i64;
     let pos: i32;
     let temp: i64;
@@ -3578,7 +3573,6 @@ fn write_base_digits(arr, offset, abs_val, digit_count, base, upper) {
 }
 
 fn count_digits_base(val, base) {
-    let __local_2: i64;
     let base64: i64;
     let n: i32;
     let t: i64;
@@ -3604,45 +3598,42 @@ fn count_digits_base(val, base) {
 }
 
 fn count_digits_u64_base(val_i64, bits_per_digit) {
-    let __local_2: i64;
     let highest_bit: i32;
     let high32: i64;
+    let b_4: i32;
     let b_5: i32;
-    let __local_6: i64;
-    let b_7: i32;
-    let __local_8: i64;
     if val_i64 == 0_i64 {
         return 1;
     };
     highest_bit = 0;
     high32 = (val_i64 >> 32_i64) & 4294967295_i64;
     if high32 != 0_i64 {
-        b_5 = 63;
+        b_4 = 63;
         b101: block {
             l102: loop {
-                if (b_5 >= 32) == 0 {
+                if (b_4 >= 32) == 0 {
                     break b101;
                 };
-                if ((val_i64 >> builtin::i64_extend_i32_s(b_5)) & 1_i64) != 0_i64 {
-                    highest_bit = b_5;
+                if ((val_i64 >> builtin::i64_extend_i32_s(b_4)) & 1_i64) != 0_i64 {
+                    highest_bit = b_4;
                     break b101;
                 };
-                b_5 = b_5 - 1;
+                b_4 = b_4 - 1;
                 continue l102;
             };
         };
     } else {
-        b_7 = 31;
+        b_5 = 31;
         b105: block {
             l106: loop {
-                if (b_7 >= 0) == 0 {
+                if (b_5 >= 0) == 0 {
                     break b105;
                 };
-                if ((val_i64 >> builtin::i64_extend_i32_s(b_7)) & 1_i64) != 0_i64 {
-                    highest_bit = b_7;
+                if ((val_i64 >> builtin::i64_extend_i32_s(b_5)) & 1_i64) != 0_i64 {
+                    highest_bit = b_5;
                     break b105;
                 };
-                b_7 = b_7 - 1;
+                b_5 = b_5 - 1;
                 continue l106;
             };
         };
@@ -3651,7 +3642,6 @@ fn count_digits_u64_base(val_i64, bits_per_digit) {
 }
 
 fn write_u64_base_digits(arr, offset, val_i64, digit_count, bits_per_digit, mask, upper) {
-    let __local_7: i64;
     let mask64: i64;
     let pos: i32;
     let temp: i64;
@@ -3992,45 +3982,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
@@ -4166,12 +4152,8 @@ fn u32^LowerHex::fmt(self, f) {
 
 fn i64^LowerHex::fmt(self, f) {
     let v: i64;
-    let __local_3: i64;
     let is_neg: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let abs_val: i64;
     v = self;
     is_neg = v < 0_i64;

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers_float.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers_float.wir.wado
@@ -5084,8 +5084,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -5109,8 +5107,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers_i128.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers_i128.wir.wado
@@ -4936,8 +4936,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -4961,8 +4959,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers_inspect.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers_inspect.wir.wado
@@ -4677,8 +4677,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -4702,8 +4700,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -5136,77 +5132,71 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -5220,24 +5210,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l245;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b249: block {
         l250: loop {
@@ -5250,19 +5240,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l250;

--- a/wado-compiler/tests/fixtures.golden/for_break.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_break.wir.wado
@@ -259,8 +259,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -284,8 +282,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_continue.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_continue.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_let_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_let_basic.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_basic.wir.wado
@@ -314,8 +314,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -339,8 +337,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_break.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_break.wir.wado
@@ -309,8 +309,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -334,8 +332,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_continue.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_continue.wir.wado
@@ -308,8 +308,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -333,8 +331,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_empty.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_empty.wir.wado
@@ -295,8 +295,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -320,8 +318,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_mut.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_nested.wir.wado
@@ -348,8 +348,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -373,8 +371,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_side_effect.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_side_effect.wir.wado
@@ -310,8 +310,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -335,8 +333,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_structs.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_structs.wir.wado
@@ -320,8 +320,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -345,8 +343,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/for_of_tuples.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_tuples.wir.wado
@@ -320,8 +320,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -345,8 +343,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-cast.wir.wado
@@ -642,8 +642,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -667,8 +665,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-custom.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-custom.wir.wado
@@ -780,8 +780,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -805,8 +803,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-enum-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-enum-concrete.wir.wado
@@ -464,8 +464,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -489,8 +487,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-flags-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-flags-concrete.wir.wado
@@ -464,8 +464,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -489,8 +487,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-fn-arg.wir.wado
@@ -553,8 +553,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -578,8 +576,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-nested-generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-nested-generic.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-newtype-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-newtype-concrete.wir.wado
@@ -464,8 +464,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -489,8 +487,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-return.wir.wado
@@ -466,8 +466,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -491,8 +489,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/from-literal-variant-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-variant-concrete.wir.wado
@@ -464,8 +464,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -489,8 +487,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic-array-direct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-array-direct.wir.wado
@@ -267,8 +267,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -292,8 +290,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.wir.wado
@@ -550,8 +550,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -575,8 +573,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic-method-closure-param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-closure-param.wir.wado
@@ -322,8 +322,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -347,8 +345,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic-method-self-call.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-self-call.wir.wado
@@ -298,8 +298,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -323,8 +321,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.wir.wado
@@ -457,8 +457,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -482,8 +480,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic-struct-import.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-import.wir.wado
@@ -411,8 +411,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -436,8 +434,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_generic.wir.wado
@@ -396,8 +396,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -421,8 +419,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_struct.wir.wado
@@ -416,8 +416,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -441,8 +439,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_free_func_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_free_func_basic.wir.wado
@@ -358,8 +358,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -383,8 +381,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -430,45 +426,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_free_func_with_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_free_func_with_struct.wir.wado
@@ -305,8 +305,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -330,8 +328,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -377,45 +373,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_basic.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -347,45 +343,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_calls_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_calls_generic.wir.wado
@@ -272,8 +272,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -297,8 +295,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -344,45 +340,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_multi_instantiations.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_multi_instantiations.wir.wado
@@ -1561,8 +1561,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1586,8 +1584,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1692,45 +1688,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_multi_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_multi_params.wir.wado
@@ -277,8 +277,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -302,8 +300,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -349,45 +345,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_nested_calls.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_nested_calls.wir.wado
@@ -251,8 +251,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -276,8 +274,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_function_returns_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_returns_struct.wir.wado
@@ -279,8 +279,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -304,8 +302,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -351,45 +347,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_two_params_swap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_two_params_swap.wir.wado
@@ -285,8 +285,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -310,8 +308,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -357,45 +353,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_function_with_ref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_with_ref.wir.wado
@@ -274,8 +274,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -299,8 +297,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -346,45 +342,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_method_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_basic.wir.wado
@@ -260,8 +260,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -285,8 +283,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -312,45 +308,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_method_double_generics.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_double_generics.wir.wado
@@ -363,8 +363,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -388,8 +386,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_method_multi_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_multi_params.wir.wado
@@ -287,8 +287,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -312,8 +310,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -359,45 +355,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_method_on_generic_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_on_generic_struct.wir.wado
@@ -1367,8 +1367,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1392,8 +1390,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1478,45 +1474,41 @@ fn Array<u64>::append(self, value) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_method_returns_self_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_returns_self_field.wir.wado
@@ -272,8 +272,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -297,8 +295,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_static_method_call.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_static_method_call.wir.wado
@@ -267,8 +267,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -292,8 +290,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct.wir.wado
@@ -248,8 +248,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -273,8 +271,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_box_trait_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_box_trait_method.wir.wado
@@ -410,8 +410,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -435,8 +433,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_explicit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_explicit.wir.wado
@@ -1656,8 +1656,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1681,8 +1679,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1787,45 +1783,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/generic_struct_func.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_func.wir.wado
@@ -251,8 +251,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -276,8 +274,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_impl.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_impl.wir.wado
@@ -243,8 +243,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -268,8 +266,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_multi_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_multi_params.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_mut.wir.wado
@@ -276,8 +276,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -301,8 +299,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_nested.wir.wado
@@ -248,8 +248,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -273,8 +271,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_types.wir.wado
@@ -1448,8 +1448,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1473,8 +1471,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_with_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_with_struct.wir.wado
@@ -317,8 +317,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -342,8 +340,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/geometry.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/geometry.wir.wado
@@ -273,8 +273,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -298,8 +296,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_basic.wir.wado
@@ -1393,8 +1393,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1418,8 +1416,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_char.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_char.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_const_expr.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_const_expr.wir.wado
@@ -310,8 +310,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -335,8 +333,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_const_promotion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_const_promotion.wir.wado
@@ -397,8 +397,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -422,8 +420,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -469,45 +465,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/global_dce.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_dce.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_dce_cross_module.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_dce_cross_module.wir.wado
@@ -250,8 +250,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -275,8 +273,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_functions.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_functions.wir.wado
@@ -309,8 +309,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -334,8 +332,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_import.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_import.wir.wado
@@ -260,8 +260,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -285,8 +283,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_multimod.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_multimod.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_mutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_mutable.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_negative.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_negative.wir.wado
@@ -240,8 +240,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -265,8 +263,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_negative_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_negative_edge.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -322,45 +318,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/global_object_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_object_array.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_object_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_object_struct.wir.wado
@@ -297,8 +297,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -322,8 +320,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/global_topological_sort.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_topological_sort.wir.wado
@@ -321,8 +321,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -346,8 +344,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/http-fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields.wir.wado
@@ -1471,8 +1471,6 @@ fn "core:internal/cm_lower_list_u8"(data, len) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1496,8 +1494,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/http-request-method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-request-method.wir.wado
@@ -1132,8 +1132,6 @@ fn "core:internal/cm_lower_string"(s) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1157,8 +1155,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/http-request-path.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-request-path.wir.wado
@@ -1135,8 +1135,6 @@ fn "core:internal/cm_lower_string"(s) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1160,8 +1158,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/http-response-ops.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-response-ops.wir.wado
@@ -1157,8 +1157,6 @@ fn "core:internal/cm_lower_string"(s) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1182,8 +1180,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/i64_arithmetic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/i64_arithmetic.wir.wado
@@ -326,8 +326,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -351,8 +349,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -378,45 +374,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/i64_to_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/i64_to_string.wir.wado
@@ -294,8 +294,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -319,8 +317,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -346,45 +342,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/if_expr_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_basic.wir.wado
@@ -259,8 +259,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -284,8 +282,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_expr_complex_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_complex_let.wir.wado
@@ -304,8 +304,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -329,8 +327,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_expr_else_if.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_else_if.wir.wado
@@ -260,8 +260,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -285,8 +283,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_expr_nested_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_nested_let.wir.wado
@@ -280,8 +280,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -305,8 +303,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_expr_no_trailing_semi.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_no_trailing_semi.wir.wado
@@ -240,8 +240,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -265,8 +263,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_expr_with_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_with_let.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_expr_with_trailing_semi.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_expr_with_trailing_semi.wir.wado
@@ -240,8 +240,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -265,8 +263,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_let_init_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_let_init_basic.wir.wado
@@ -244,8 +244,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -269,8 +267,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_let_init_else.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_let_init_else.wir.wado
@@ -247,8 +247,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -272,8 +270,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/if_let_init_mutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/if_let_init_mutable.wir.wado
@@ -242,8 +242,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -267,8 +265,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/import_from_nested_subdir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/import_from_nested_subdir.wir.wado
@@ -242,8 +242,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -267,8 +265,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/import_from_subdir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/import_from_subdir.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/import_transitive_simple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/import_transitive_simple.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/import_with_dot_segments.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/import_with_dot_segments.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_basic.wir.wado
@@ -386,8 +386,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -411,8 +409,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_expression_value.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_expression_value.wir.wado
@@ -445,8 +445,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -470,8 +468,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_conditional.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_conditional.wir.wado
@@ -387,8 +387,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -412,8 +410,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_function.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_function.wir.wado
@@ -461,8 +461,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -486,8 +484,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_in_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_in_loop.wir.wado
@@ -645,8 +645,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -670,8 +668,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_multiple.wir.wado
@@ -1655,8 +1655,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1680,8 +1678,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1786,45 +1782,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/index_assign_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_nested.wir.wado
@@ -548,8 +548,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -573,8 +571,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_assign_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_types.wir.wado
@@ -1752,8 +1752,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1777,8 +1775,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1883,45 +1879,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/index_mut_method_call.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_mut_method_call.wir.wado
@@ -264,8 +264,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -289,8 +287,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_assign.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_assign.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_both.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_both.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_chained.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_chained.wir.wado
@@ -330,8 +330,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -355,8 +353,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_complex_static.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_complex_static.wir.wado
@@ -306,8 +306,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -331,8 +329,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_conditional.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_conditional.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_full_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_full_struct.wir.wado
@@ -420,8 +420,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -445,8 +443,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_function.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_function.wir.wado
@@ -268,8 +268,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -293,8 +291,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_loop.wir.wado
@@ -271,8 +271,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -296,8 +294,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_multiple.wir.wado
@@ -326,8 +326,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -351,8 +349,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_trait_read.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_trait_read.wir.wado
@@ -256,8 +256,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -281,8 +279,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/index_value_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_value_generic.wir.wado
@@ -372,8 +372,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -397,8 +395,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -444,45 +440,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/index_value_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_value_trait.wir.wado
@@ -341,8 +341,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -366,8 +364,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.wir.wado
@@ -276,8 +276,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -301,8 +299,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_nested.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inline_cross_module_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_cross_module_method.wir.wado
@@ -310,8 +310,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -335,8 +333,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inline_early_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_early_return.wir.wado
@@ -274,8 +274,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -299,8 +297,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inline_generic_nested_ref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_generic_nested_ref.wir.wado
@@ -362,8 +362,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -387,8 +385,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inline_match_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_match_tuple.wir.wado
@@ -334,8 +334,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -359,8 +357,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -386,45 +382,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/inline_method_minimal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_method_minimal.wir.wado
@@ -380,8 +380,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -405,8 +403,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inlining_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inlining_test.wir.wado
@@ -249,8 +249,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -274,8 +272,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_array.wir.wado
@@ -458,8 +458,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -483,8 +481,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_array_option.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_array_option.wir.wado
@@ -348,8 +348,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -373,8 +371,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_fallback.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_fallback.wir.wado
@@ -284,8 +284,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -309,8 +307,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_generic_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_generic_struct.wir.wado
@@ -284,8 +284,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -309,8 +307,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_hidden.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_hidden.wir.wado
@@ -293,8 +293,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -318,8 +316,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested.wir.wado
@@ -406,8 +406,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -431,8 +429,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array3_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array3_test.wir.wado
@@ -403,8 +403,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -428,8 +426,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_option_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_option_test.wir.wado
@@ -354,8 +354,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -379,8 +377,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct2_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct2_test.wir.wado
@@ -374,8 +374,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -399,8 +397,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct3_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct3_test.wir.wado
@@ -370,8 +370,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -395,8 +393,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct_test.wir.wado
@@ -368,8 +368,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -393,8 +391,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_tuple_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_tuple_test.wir.wado
@@ -357,8 +357,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -382,8 +380,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_test.wir.wado
@@ -362,8 +362,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -387,8 +385,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_newtype.wir.wado
@@ -1458,8 +1458,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1483,8 +1481,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_no_display.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_no_display.wir.wado
@@ -1651,8 +1651,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1676,8 +1674,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_option.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_option.wir.wado
@@ -269,8 +269,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -294,8 +292,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_option_deeply_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_option_deeply_nested.wir.wado
@@ -320,8 +320,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -345,8 +343,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_option_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_option_nested.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_primitives.wir.wado
@@ -1540,8 +1540,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1565,8 +1563,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_ref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_ref.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_struct.wir.wado
@@ -258,8 +258,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -283,8 +281,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_struct_option_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_struct_option_field.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/inspect_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_tuple.wir.wado
@@ -305,8 +305,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -330,8 +328,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_i16_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i16_basic.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_i16_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i16_edge.wir.wado
@@ -335,8 +335,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -360,8 +358,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_i32_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i32_basic.wir.wado
@@ -346,8 +346,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -371,8 +369,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_i32_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i32_edge.wir.wado
@@ -331,8 +331,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -356,8 +354,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_i64_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i64_edge.wir.wado
@@ -335,8 +335,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -360,8 +358,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -387,45 +383,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/integer_i8_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i8_basic.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_i8_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_i8_edge.wir.wado
@@ -335,8 +335,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -360,8 +358,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_u16_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u16_basic.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_u16_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u16_edge.wir.wado
@@ -315,8 +315,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -340,8 +338,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_u32_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u32_basic.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_u32_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u32_edge.wir.wado
@@ -339,8 +339,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -364,8 +362,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_u64_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u64_basic.wir.wado
@@ -347,33 +347,31 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -387,24 +385,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l13;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b17: block {
         l18: loop {
@@ -417,19 +415,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l18;

--- a/wado-compiler/tests/fixtures.golden/integer_u64_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u64_edge.wir.wado
@@ -336,33 +336,31 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -376,24 +374,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l13;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b17: block {
         l18: loop {
@@ -406,19 +404,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l18;

--- a/wado-compiler/tests/fixtures.golden/integer_u8_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u8_basic.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/integer_u8_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/integer_u8_edge.wir.wado
@@ -315,8 +315,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -340,8 +338,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/iterator_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_basic.wir.wado
@@ -398,8 +398,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -423,8 +421,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/iterator_empty.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_empty.wir.wado
@@ -319,8 +319,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -344,8 +342,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/iterator_into_iter.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_into_iter.wir.wado
@@ -309,8 +309,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -334,8 +332,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-blanket-impl.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-blanket-impl.wir.wado
@@ -465,8 +465,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -490,8 +488,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.wir.wado
@@ -754,8 +754,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -779,8 +777,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.wir.wado
@@ -538,8 +538,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -563,8 +561,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.wir.wado
@@ -710,8 +710,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -735,8 +733,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_basic.wir.wado
@@ -313,8 +313,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -338,8 +336,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_break_label.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_break_label.wir.wado
@@ -356,8 +356,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -381,8 +379,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_expr_simple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_expr_simple.wir.wado
@@ -356,8 +356,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -381,8 +379,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_expr_value.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_expr_value.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_in_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_in_loop.wir.wado
@@ -369,8 +369,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -394,8 +392,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/labeled_block_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block_nested.wir.wado
@@ -359,8 +359,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -384,8 +382,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/likely_unlikely.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/likely_unlikely.wir.wado
@@ -322,8 +322,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -347,8 +345,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/location_literal_line.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/location_literal_line.wir.wado
@@ -238,8 +238,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -263,8 +261,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/location_literal_line_template.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/location_literal_line_template.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/location_literal_submodule.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/location_literal_submodule.wir.wado
@@ -266,8 +266,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -291,8 +289,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/loop_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_basic.wir.wado
@@ -258,8 +258,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -283,8 +281,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/loop_continue.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_continue.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/loop_nested_deep.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_nested_deep.wir.wado
@@ -324,8 +324,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -349,8 +347,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/loop_nested_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_nested_loop.wir.wado
@@ -286,8 +286,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -311,8 +309,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/loop_nested_mixed.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/loop_nested_mixed.wir.wado
@@ -313,8 +313,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -338,8 +336,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/match_arm_nested_if_value.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_arm_nested_if_value.wir.wado
@@ -575,8 +575,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -600,8 +598,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/match_ergonomics_if_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_ergonomics_if_let.wir.wado
@@ -555,8 +555,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -580,8 +578,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/match_ergonomics_match.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_ergonomics_match.wir.wado
@@ -545,8 +545,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -570,8 +568,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/match_never_arm.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_never_arm.wir.wado
@@ -515,8 +515,6 @@ fn "core:internal/unreachable"() {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -540,8 +538,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/match_option_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_option_basic.wir.wado
@@ -301,8 +301,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -326,8 +324,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/matches_option_guard_char.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/matches_option_guard_char.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/mut_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param.wir.wado
@@ -1679,8 +1679,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1704,8 +1702,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/mut_param_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param_basic.wir.wado
@@ -390,8 +390,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -415,8 +413,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/mut_param_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param_string.wir.wado
@@ -1076,8 +1076,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1101,8 +1099,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/mut_param_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param_struct.wir.wado
@@ -799,8 +799,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -824,8 +822,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/nested_array_3deep_iterate_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_3deep_iterate_test.wir.wado
@@ -608,8 +608,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -633,8 +631,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/nested_array_iterate_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_iterate_test.wir.wado
@@ -483,8 +483,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -508,8 +506,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/nested_array_method_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_method_test.wir.wado
@@ -406,8 +406,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -431,8 +429,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/nested_array_mutate_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_mutate_test.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/nested_array_option_access_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array_option_access_test.wir.wado
@@ -458,8 +458,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -483,8 +481,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/never_as_bottom_type.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/never_as_bottom_type.wir.wado
@@ -616,8 +616,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -641,8 +639,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/never_let_binding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/never_let_binding.wir.wado
@@ -371,8 +371,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -396,8 +394,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_chained.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_chained.wir.wado
@@ -377,8 +377,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -402,8 +400,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_chained_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_chained_method.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_integer_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_integer_types.wir.wado
@@ -432,8 +432,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -457,8 +455,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -524,45 +520,41 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/newtype_method_inheritance.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_method_inheritance.wir.wado
@@ -305,8 +305,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -330,8 +328,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_multiple_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_multiple_params.wir.wado
@@ -258,8 +258,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -283,8 +281,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_return_type.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_return_type.wir.wado
@@ -319,8 +319,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -344,8 +342,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_static_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_static_method.wir.wado
@@ -246,8 +246,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -271,8 +269,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/newtype_trait_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_trait_method.wir.wado
@@ -250,8 +250,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -275,8 +273,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/number_literal_coercion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/number_literal_coercion.wir.wado
@@ -1655,8 +1655,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1680,8 +1678,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1786,45 +1782,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/opt_const_fold.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_const_fold.wir.wado
@@ -1707,8 +1707,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1732,8 +1730,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_const_fold_div_zero.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_const_fold_div_zero.wir.wado
@@ -241,8 +241,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -266,8 +264,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_const_prop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_const_prop.wir.wado
@@ -1415,8 +1415,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1440,8 +1438,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_crossmod_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_crossmod_array.wir.wado
@@ -1269,8 +1269,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1294,8 +1292,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_inline_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_array.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_inline_attr.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_attr.wir.wado
@@ -411,8 +411,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -436,8 +434,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_inline_multireturn.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_multireturn.wir.wado
@@ -308,8 +308,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -333,8 +331,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_inline_recursive.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_inline_recursive.wir.wado
@@ -301,8 +301,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -326,8 +324,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_box_parameter.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_box_parameter.wir.wado
@@ -4126,8 +4126,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -4151,8 +4149,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -4177,7 +4173,6 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 }
 
 fn write_base_digits(arr, offset, abs_val, digit_count, base, upper) {
-    let __local_6: i64;
     let base64: i64;
     let pos: i32;
     let temp: i64;
@@ -4214,7 +4209,6 @@ fn write_base_digits(arr, offset, abs_val, digit_count, base, upper) {
 }
 
 fn count_digits_base(val, base) {
-    let __local_2: i64;
     let base64: i64;
     let n: i32;
     let t: i64;
@@ -4340,45 +4334,41 @@ fn u32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 
@@ -4412,33 +4402,31 @@ fn i64::fmt_base(self, is_negative, f, base, upper) {
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -4452,24 +4440,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l217;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b221: block {
         l222: loop {
@@ -4482,19 +4470,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l222;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_edge_cases.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_edge_cases.wir.wado
@@ -2756,8 +2756,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -2781,8 +2779,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_interprocedural.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_interprocedural.wir.wado
@@ -1706,8 +1706,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1731,8 +1729,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_intraprocedural.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_intraprocedural.wir.wado
@@ -714,8 +714,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -739,8 +737,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_multi_value_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_multi_value_return.wir.wado
@@ -655,8 +655,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -680,8 +678,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_newtype_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_newtype_param.wir.wado
@@ -1962,8 +1962,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1987,8 +1985,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_return_match.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_return_match.wir.wado
@@ -685,8 +685,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -710,8 +708,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -757,33 +753,31 @@ fn i32::fmt_decimal(self, f) {
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -797,24 +791,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l43;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b47: block {
         l48: loop {
@@ -827,19 +821,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l48;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_single_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_single_field.wir.wado
@@ -2421,8 +2421,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -2446,8 +2444,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_variant.wir.wado
@@ -667,8 +667,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -692,8 +690,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/option_i32_struct_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/option_i32_struct_field.wir.wado
@@ -279,8 +279,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -304,8 +302,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
@@ -1011,8 +1011,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1036,8 +1034,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/precedence_assignment.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_assignment.wir.wado
@@ -442,8 +442,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -467,8 +465,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/pub_struct_field_access_ok.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_struct_field_access_ok.wir.wado
@@ -255,8 +255,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -280,8 +278,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/pub_struct_field_same_module.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_struct_field_same_module.wir.wado
@@ -446,8 +446,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -471,8 +469,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_alias_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_alias_mut.wir.wado
@@ -293,8 +293,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -318,8 +316,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_array_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array_basic.wir.wado
@@ -391,8 +391,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -416,8 +414,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_array_ref_element.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array_ref_element.wir.wado
@@ -401,8 +401,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -426,8 +424,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_closure_capture.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_closure_capture.wir.wado
@@ -290,8 +290,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -315,8 +313,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_closure_mut_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_closure_mut_param.wir.wado
@@ -259,8 +259,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -284,8 +282,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_conditional_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_conditional_mut.wir.wado
@@ -297,8 +297,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -322,8 +320,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_deref_assign_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_deref_assign_struct.wir.wado
@@ -298,8 +298,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -323,8 +321,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_deref_assign_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_deref_assign_variant.wir.wado
@@ -284,8 +284,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -309,8 +307,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_deref_reassign.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_deref_reassign.wir.wado
@@ -295,8 +295,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -320,8 +318,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_edge_coercion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_coercion.wir.wado
@@ -243,8 +243,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -268,8 +266,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_edge_double_deref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_double_deref.wir.wado
@@ -246,8 +246,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -271,8 +269,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_edge_multi_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_multi_mut.wir.wado
@@ -250,8 +250,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -275,8 +273,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_edge_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_nested.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_edge_temp.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_edge_temp.wir.wado
@@ -241,8 +241,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -266,8 +264,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_loop_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_loop_mut.wir.wado
@@ -300,8 +300,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -325,8 +323,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_method_receivers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_method_receivers.wir.wado
@@ -279,8 +279,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -304,8 +302,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_mut_array_ops.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_mut_array_ops.wir.wado
@@ -440,8 +440,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -465,8 +463,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_nested_mut_write.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_nested_mut_write.wir.wado
@@ -309,8 +309,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -334,8 +332,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_pass_through.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_pass_through.wir.wado
@@ -283,8 +283,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -308,8 +306,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_basic.wir.wado
@@ -264,8 +264,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -289,8 +287,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_read.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_read.wir.wado
@@ -242,8 +242,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -267,8 +265,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_semantic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_semantic.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_primitive_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive_types.wir.wado
@@ -1487,8 +1487,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1512,8 +1510,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -1598,45 +1594,41 @@ fn Array<u64>::append(self, value) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/ref_reassign.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_reassign.wir.wado
@@ -305,8 +305,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -330,8 +328,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_return.wir.wado
@@ -345,8 +345,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -370,8 +368,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_return_local.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_return_local.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_struct_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_basic.wir.wado
@@ -264,8 +264,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -289,8 +287,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_struct_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_mut.wir.wado
@@ -266,8 +266,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -291,8 +289,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_struct_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_nested.wir.wado
@@ -274,8 +274,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -299,8 +297,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_struct_string_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_struct_string_field.wir.wado
@@ -279,8 +279,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -304,8 +302,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_swap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_swap.wir.wado
@@ -312,8 +312,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -337,8 +335,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/ref_tuple_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_tuple_basic.wir.wado
@@ -285,8 +285,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -310,8 +308,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/result-if-let-mismatch.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/result-if-let-mismatch.wir.wado
@@ -267,8 +267,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -292,8 +290,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/result-if-let-ok.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/result-if-let-ok.wir.wado
@@ -267,8 +267,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -292,8 +290,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/result-match.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/result-match.wir.wado
@@ -310,8 +310,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -335,8 +333,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/return_array_var.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/return_array_var.wir.wado
@@ -309,8 +309,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -334,8 +332,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/return_empty_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/return_empty_array.wir.wado
@@ -294,8 +294,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -319,8 +317,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/return_tuple_literal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/return_tuple_literal.wir.wado
@@ -276,8 +276,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -301,8 +299,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/return_tuple_var.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/return_tuple_var.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/scalarize_chain.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/scalarize_chain.wir.wado
@@ -279,8 +279,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -304,8 +302,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/scope_nested_blocks.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/scope_nested_blocks.wir.wado
@@ -314,8 +314,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -339,8 +337,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/scope_shadowing_in_block.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/scope_shadowing_in_block.wir.wado
@@ -273,8 +273,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -298,8 +296,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/select_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/select_basic.wir.wado
@@ -597,8 +597,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -622,8 +620,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/select_no_opt.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/select_no_opt.wir.wado
@@ -288,8 +288,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -313,8 +311,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-custom.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-custom.wir.wado
@@ -651,8 +651,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -676,8 +674,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-fn-arg.wir.wado
@@ -473,8 +473,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -498,8 +496,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-immutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-immutable.wir.wado
@@ -703,8 +703,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -728,8 +726,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
@@ -1258,8 +1258,6 @@ fn parse(d, p) {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1283,8 +1281,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_deserialize_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_deserialize_trait.wir.wado
@@ -352,8 +352,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -377,8 +375,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_error_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_error_types.wir.wado
@@ -349,8 +349,6 @@ fn "core:internal/unreachable"() {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -374,8 +372,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -401,45 +397,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_full_json_serialize.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_full_json_serialize.wir.wado
@@ -1579,8 +1579,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1604,8 +1602,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_generic_trait_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_generic_trait_method.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_json_multi_type_deser.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_multi_type_deser.wir.wado
@@ -901,8 +901,6 @@ fn parse(d, p) {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -926,8 +924,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_serialize_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_serialize_array.wir.wado
@@ -409,8 +409,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -434,8 +432,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_serialize_option.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_serialize_option.wir.wado
@@ -298,8 +298,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -323,8 +321,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_serialize_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_serialize_struct.wir.wado
@@ -299,8 +299,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -324,8 +322,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_serialize_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_serialize_trait.wir.wado
@@ -294,8 +294,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -319,8 +317,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/serde_sub_serializer.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_sub_serializer.wir.wado
@@ -376,8 +376,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -401,8 +399,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/short_circuit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/short_circuit.wir.wado
@@ -482,8 +482,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -507,8 +505,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_basic.wir.wado
@@ -286,8 +286,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -311,8 +309,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_chained.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_chained.wir.wado
@@ -349,8 +349,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -374,8 +372,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_generic.wir.wado
@@ -448,8 +448,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -473,8 +471,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_generic_non_constructor.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_generic_non_constructor.wir.wado
@@ -294,8 +294,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -319,8 +317,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_multi_type_params.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_multi_type_params.wir.wado
@@ -292,8 +292,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -317,8 +315,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -364,45 +360,41 @@ fn i32::fmt_decimal(self, f) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/static_method_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_nested.wir.wado
@@ -336,8 +336,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -361,8 +359,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_nested_generics.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_nested_generics.wir.wado
@@ -403,8 +403,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -428,8 +426,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_non_constructor.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_non_constructor.wir.wado
@@ -297,8 +297,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -322,8 +320,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_user_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_user_generic.wir.wado
@@ -244,8 +244,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -269,8 +267,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/static_method_with_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_with_args.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/store_to_load_forwarding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/store_to_load_forwarding.wir.wado
@@ -378,8 +378,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -403,8 +401,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/stream-cm-stdin-read.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-cm-stdin-read.wir.wado
@@ -349,8 +349,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -374,8 +372,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/stream-read-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-read-basic.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/stream-read-eof.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-read-eof.wir.wado
@@ -404,8 +404,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -429,8 +427,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/stream-read-multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-read-multiple.wir.wado
@@ -421,8 +421,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -446,8 +444,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_basic.wir.wado
@@ -362,8 +362,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -387,8 +385,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_for_of.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_if_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_if_let.wir.wado
@@ -328,8 +328,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -353,8 +351,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_match.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_match.wir.wado
@@ -387,8 +387,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -412,8 +410,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_nested.wir.wado
@@ -327,8 +327,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -352,8 +350,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_rename.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_rename.wir.wado
@@ -354,8 +354,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -379,8 +377,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_wildcard.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_wildcard.wir.wado
@@ -313,8 +313,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -338,8 +336,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_impl_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_basic.wir.wado
@@ -254,8 +254,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -279,8 +277,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_impl_multiple_methods.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_multiple_methods.wir.wado
@@ -327,8 +327,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -352,8 +350,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_impl_two_structs.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl_two_structs.wir.wado
@@ -277,8 +277,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -302,8 +300,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_implicit_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_implicit_basic.wir.wado
@@ -260,8 +260,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -285,8 +283,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_implicit_shorthand.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_implicit_shorthand.wir.wado
@@ -262,8 +262,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -287,8 +285,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_import_alias.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_import_alias.wir.wado
@@ -273,8 +273,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -298,8 +296,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_import_collision.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_import_collision.wir.wado
@@ -299,8 +299,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -324,8 +322,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_literal_restrict_condition.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_literal_restrict_condition.wir.wado
@@ -308,8 +308,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -333,8 +331,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_param_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_param_return.wir.wado
@@ -256,8 +256,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -281,8 +279,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_point_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_point_basic.wir.wado
@@ -260,8 +260,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -285,8 +283,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_point_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_point_mut.wir.wado
@@ -310,8 +310,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -335,8 +333,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_unit_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_unit_field.wir.wado
@@ -326,8 +326,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -351,8 +349,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_with_generic_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_with_generic_field.wir.wado
@@ -247,8 +247,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -272,8 +270,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/struct_with_trait_bound_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_with_trait_bound_generic.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/template_string_i32.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_i32.wir.wado
@@ -286,8 +286,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -311,8 +309,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/template_string_i64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_i64.wir.wado
@@ -289,8 +289,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -314,8 +312,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -341,45 +337,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/template_string_multiline.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_multiline.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_mixed.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_mixed.wir.wado
@@ -307,8 +307,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -332,8 +330,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_safe.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_safe.wir.wado
@@ -561,8 +561,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -586,8 +584,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -633,33 +629,31 @@ fn i32::fmt_decimal(self, f) {
 
 fn u64::fmt_decimal(self, f) {
     let val_i64: i64;
-    let __local_3: i64;
-    let __local_4: i64;
-    let offset_5: i32;
+    let offset_3: i32;
     let digit_count: i32;
-    let __local_7: i64;
+    let __local_5: i64;
     let temp: i64;
-    let signed_rem_9: i64;
-    let rem_adjusted_10: i64;
-    let signed_quot_11: i64;
-    let carry_12: i64;
-    let offset_13: i32;
+    let signed_rem_7: i64;
+    let rem_adjusted_8: i64;
+    let signed_quot_9: i64;
+    let carry_10: i64;
+    let offset_11: i32;
     let repr: ref array<u8>;
     let pos: i32;
     let digit: i32;
-    let signed_rem_17: i64;
-    let rem_adjusted_18: i64;
-    let signed_quot_19: i64;
-    let carry_20: i64;
-    let __local_21: ref String;
-    let __local_22: ref String;
+    let signed_rem_15: i64;
+    let rem_adjusted_16: i64;
+    let signed_quot_17: i64;
+    let carry_18: i64;
+    let __local_19: ref String;
+    let __local_20: ref String;
     val_i64 = self;
     if val_i64 == 0_i64 {
-        offset_5 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
+        offset_3 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, 1);
         builtin::array_set_u8(__inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_21 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_21.repr;
-        }, offset_5, 48);
+            __local_19 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_19.repr;
+        }, offset_3, 48);
         return;
     };
     digit_count = 0;
@@ -673,24 +667,24 @@ fn u64::fmt_decimal(self, f) {
             if temp >= 0_i64 {
                 temp = temp / 10_i64;
             } else {
-                signed_rem_9 = temp % 10_i64;
-                rem_adjusted_10 = signed_rem_9 + 6_i64;
-                signed_quot_11 = temp / 10_i64;
-                carry_12 = 0_i64;
-                if rem_adjusted_10 < 0_i64 {
-                    carry_12 = -1_i64;
+                signed_rem_7 = temp % 10_i64;
+                rem_adjusted_8 = signed_rem_7 + 6_i64;
+                signed_quot_9 = temp / 10_i64;
+                carry_10 = 0_i64;
+                if rem_adjusted_8 < 0_i64 {
+                    carry_10 = -1_i64;
                 };
-                temp = (signed_quot_11 + 1844674407370955161_i64) + carry_12;
+                temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             };
             continue l37;
         };
     };
-    offset_13 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
+    offset_11 = Formatter::prepare_int_write(f, 0, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     repr = __inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-        __local_22 = f.buf;
-        break __inline_String__internal_raw_bytes_1: __local_22.repr;
+        __local_20 = f.buf;
+        break __inline_String__internal_raw_bytes_1: __local_20.repr;
     };
-    pos = offset_13 + digit_count;
+    pos = offset_11 + digit_count;
     temp = val_i64;
     b41: block {
         l42: loop {
@@ -703,19 +697,19 @@ fn u64::fmt_decimal(self, f) {
                 digit = builtin::i32_wrap_i64(temp % 10_i64);
                 temp = temp / 10_i64;
             } else {
-                signed_rem_17 = temp % 10_i64;
-                rem_adjusted_18 = signed_rem_17 + 6_i64;
-                if rem_adjusted_18 >= 0_i64 {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18);
+                signed_rem_15 = temp % 10_i64;
+                rem_adjusted_16 = signed_rem_15 + 6_i64;
+                if rem_adjusted_16 >= 0_i64 {
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16);
                 } else {
-                    digit = builtin::i32_wrap_i64(rem_adjusted_18 + 10_i64);
+                    digit = builtin::i32_wrap_i64(rem_adjusted_16 + 10_i64);
                 };
-                signed_quot_19 = temp / 10_i64;
-                carry_20 = 0_i64;
-                if rem_adjusted_18 < 0_i64 {
-                    carry_20 = -1_i64;
+                signed_quot_17 = temp / 10_i64;
+                carry_18 = 0_i64;
+                if rem_adjusted_16 < 0_i64 {
+                    carry_18 = -1_i64;
                 };
-                temp = (signed_quot_19 + 1844674407370955161_i64) + carry_20;
+                temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             };
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
             continue l42;

--- a/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_unsafe.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_unsafe.wir.wado
@@ -641,8 +641,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -666,8 +664,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tmpl_hoist_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tmpl_hoist_loop.wir.wado
@@ -409,8 +409,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -434,8 +432,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_array_of_ref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_array_of_ref.wir.wado
@@ -369,8 +369,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -394,8 +392,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_crossmod.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_crossmod.wir.wado
@@ -281,8 +281,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -306,8 +304,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_fn.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_fn.wir.wado
@@ -242,8 +242,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -267,8 +265,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_generic_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_generic_return.wir.wado
@@ -258,8 +258,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -283,8 +281,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_impl_block.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_impl_block.wir.wado
@@ -251,8 +251,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -276,8 +274,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param.wir.wado
@@ -232,8 +232,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -257,8 +255,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_builtin.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_builtin.wir.wado
@@ -264,8 +264,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -289,8 +287,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_chain.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_chain.wir.wado
@@ -283,8 +283,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -308,8 +306,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_multi.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_multi.wir.wado
@@ -257,8 +257,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -282,8 +280,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_value.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_method_on_type_param_value.wir.wado
@@ -239,8 +239,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -264,8 +262,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_nested_wrapper.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_nested_wrapper.wir.wado
@@ -243,8 +243,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -268,8 +266,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_ref_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_ref_mut.wir.wado
@@ -249,8 +249,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -274,8 +272,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_ref_type.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_ref_type.wir.wado
@@ -250,8 +250,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -275,8 +273,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_struct_field_bounded.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_struct_field_bounded.wir.wado
@@ -344,8 +344,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -369,8 +367,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_default_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_basic.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_default_count.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default_count.wir.wado
@@ -294,8 +294,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -319,8 +317,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_generic_option_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_generic_option_return.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_inherent_priority.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_inherent_priority.wir.wado
@@ -231,8 +231,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -256,8 +254,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_method_calls_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_method_calls_method.wir.wado
@@ -231,8 +231,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -256,8 +254,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_multiple_traits.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_multiple_traits.wir.wado
@@ -280,8 +280,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -305,8 +303,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_mut_self.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_mut_self.wir.wado
@@ -283,8 +283,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -308,8 +306,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/trait_option_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_option_return.wir.wado
@@ -270,8 +270,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -295,8 +293,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-basic.wir.wado
@@ -679,8 +679,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -704,8 +702,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-cast.wir.wado
@@ -573,8 +573,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -598,8 +596,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-empty.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-empty.wir.wado
@@ -458,8 +458,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -483,8 +481,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.wir.wado
@@ -523,8 +523,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -548,8 +546,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.wir.wado
@@ -573,8 +573,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -598,8 +596,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.wir.wado
@@ -598,8 +598,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -623,8 +621,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap_btree.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree.wir.wado
@@ -735,8 +735,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -760,8 +758,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/treemap_btree2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree2.wir.wado
@@ -766,8 +766,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -791,8 +789,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_basic.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_bracket_index.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_bracket_index.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_basic.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_for_of.wir.wado
@@ -335,8 +335,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -360,8 +358,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_if_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_if_let.wir.wado
@@ -350,8 +350,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -375,8 +373,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_match.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_match.wir.wado
@@ -438,8 +438,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -463,8 +461,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_mut.wir.wado
@@ -312,8 +312,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -337,8 +335,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_nested.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_wildcard.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_wildcard.wir.wado
@@ -265,8 +265,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -290,8 +288,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_elision_multivalue.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_elision_multivalue.wir.wado
@@ -424,8 +424,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -449,8 +447,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;
@@ -476,45 +472,41 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn i64::fmt_decimal(self, f) {
     let value: i64;
-    let __local_3: i64;
     let is_negative: bool;
-    let __local_5: i64;
-    let __local_6: i64;
-    let __local_7: i64;
-    let __local_8: i64;
+    let __local_4: i64;
     let remaining_digits: i32;
-    let digit_count_10: i32;
-    let offset_11: i32;
+    let digit_count_6: i32;
+    let offset_7: i32;
     let repr: ref array<u8>;
     let abs_val: i64;
-    let digit_count_14: i32;
-    let offset_15: i32;
-    let __local_16: ref String;
-    let __local_17: ref String;
+    let digit_count_10: i32;
+    let offset_11: i32;
+    let __local_12: ref String;
+    let __local_13: ref String;
     value = self;
     is_negative = value < 0_i64;
     if value == -9223372036854775808_i64 {
         remaining_digits = count_digits_i64(922337203685477580_i64);
-        digit_count_10 = remaining_digits + 1;
-        offset_11 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
+        digit_count_6 = remaining_digits + 1;
+        offset_7 = Formatter::prepare_int_write(f, 1, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
         repr = __inline_String__internal_raw_bytes_0: block -> ref array<u8> {
-            __local_16 = f.buf;
-            break __inline_String__internal_raw_bytes_0: __local_16.repr;
+            __local_12 = f.buf;
+            break __inline_String__internal_raw_bytes_0: __local_12.repr;
         };
-        write_decimal_digits(repr, offset_11, 922337203685477580_i64, remaining_digits);
-        builtin::array_set_u8(repr, offset_11 + remaining_digits, 56);
+        write_decimal_digits(repr, offset_7, 922337203685477580_i64, remaining_digits);
+        builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = if is_negative -> i64 {
             0_i64 - value;
         } else {
             value;
         };
-        digit_count_14 = count_digits_i64(abs_val);
-        offset_15 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_14);
+        digit_count_10 = count_digits_i64(abs_val);
+        offset_11 = Formatter::prepare_int_write(f, is_negative, String { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
         write_decimal_digits(__inline_String__internal_raw_bytes_1: block -> ref array<u8> {
-            __local_17 = f.buf;
-            break __inline_String__internal_raw_bytes_1: __local_17.repr;
-        }, offset_15, abs_val, digit_count_14);
+            __local_13 = f.buf;
+            break __inline_String__internal_raw_bytes_1: __local_13.repr;
+        }, offset_11, abs_val, digit_count_10);
     };
 }
 

--- a/wado-compiler/tests/fixtures.golden/tuple_heterogeneous.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_heterogeneous.wir.wado
@@ -276,8 +276,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -301,8 +299,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_nested.wir.wado
@@ -295,8 +295,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -320,8 +318,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_param.wir.wado
@@ -248,8 +248,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -273,8 +271,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_return.wir.wado
@@ -260,8 +260,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -285,8 +283,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_single.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_single.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_struct_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_struct_field.wir.wado
@@ -674,8 +674,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -699,8 +697,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_trailing_comma.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_trailing_comma.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_type_annotation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_type_annotation.wir.wado
@@ -276,8 +276,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -301,8 +299,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/tuple_unit_element.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_unit_element.wir.wado
@@ -245,8 +245,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -270,8 +268,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/type_cast_comprehensive.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/type_cast_comprehensive.wir.wado
@@ -3632,8 +3632,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -3657,8 +3655,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/u64_arithmetic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/u64_arithmetic.wir.wado
@@ -742,8 +742,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -767,8 +765,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/value_semantics_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_array.wir.wado
@@ -382,8 +382,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -407,8 +405,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/value_semantics_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_struct.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/value_semantics_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics_tuple.wir.wado
@@ -275,8 +275,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -300,8 +298,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/variant_construct_literal_coercion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_construct_literal_coercion.wir.wado
@@ -887,8 +887,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -912,8 +910,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_simple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_simple.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/variant_in_struct_simple_module.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_in_struct_simple_module.wir.wado
@@ -253,8 +253,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -278,8 +276,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/variant_infer_option_none.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_infer_option_none.wir.wado
@@ -287,8 +287,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -312,8 +310,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/variant_infer_option_some.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_infer_option_some.wir.wado
@@ -351,8 +351,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -376,8 +374,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/variant_infer_result_annotated.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_infer_result_annotated.wir.wado
@@ -346,8 +346,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -371,8 +369,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasi_cli.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_cli.wir.wado
@@ -438,8 +438,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -463,8 +461,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasi_cli_terminal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_cli_terminal.wir.wado
@@ -513,8 +513,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -538,8 +536,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem.wir.wado
@@ -422,8 +422,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -447,8 +445,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_global.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_global.wir.wado
@@ -263,8 +263,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -288,8 +286,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_method.wir.wado
@@ -298,8 +298,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -323,8 +321,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_newtype.wir.wado
@@ -1364,8 +1364,6 @@ fn __initialize_module() {
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -1389,8 +1387,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_struct.wir.wado
@@ -279,8 +279,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -304,8 +302,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_variant.wir.wado
@@ -302,8 +302,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -327,8 +325,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/while_break.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/while_break.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/while_continue.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/while_continue.wir.wado
@@ -261,8 +261,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -286,8 +284,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/while_let_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/while_let_basic.wir.wado
@@ -303,8 +303,6 @@ fn "core:internal/wait_for_subtask"(packed) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -328,8 +326,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wir_issue6_circular_struct_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wir_issue6_circular_struct_variant.wir.wado
@@ -420,8 +420,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -445,8 +443,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/fixtures.golden/wir_issue8_cross_module_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wir_issue8_cross_module_variant.wir.wado
@@ -522,8 +522,6 @@ fn "core:internal/panic"(message) {  // from core:internal
 }
 
 fn count_digits_i64(val) {
-    let __local_1: i64;
-    let __local_2: i64;
     let n: i32;
     let t: i64;
     if val == 0_i64 {
@@ -547,8 +545,6 @@ fn count_digits_i64(val) {
 }
 
 fn write_decimal_digits(arr, offset, abs_val, digit_count) {
-    let __local_4: i64;
-    let __local_5: i64;
     let pos: i32;
     let temp: i64;
     pos = offset + digit_count;

--- a/wado-compiler/tests/format.fixtures.golden/all.optimize.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.optimize.wado
@@ -58,7 +58,7 @@ pub struct "Box<i32>" {
 
 // --- Module: core:prelude/int128.wado ---
 
-// --- Module: core:prelude/primitives.wado ---
+// --- Module: core:prelude/primitive.wado ---
 
 // --- Module: core:prelude/string.wado ---
 pub struct String {

--- a/wado-compiler/tests/format.fixtures.golden/mess.optimize.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.optimize.wado
@@ -54,7 +54,7 @@ fn i32_clz(x: i32) -> i32;
 
 // --- Module: core:prelude/int128.wado ---
 
-// --- Module: core:prelude/primitives.wado ---
+// --- Module: core:prelude/primitive.wado ---
 
 // --- Module: core:prelude/string.wado ---
 

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.optimize.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.optimize.wado
@@ -52,7 +52,7 @@ fn i32_clz(x: i32) -> i32;
 
 // --- Module: core:prelude/int128.wado ---
 
-// --- Module: core:prelude/primitives.wado ---
+// --- Module: core:prelude/primitive.wado ---
 
 // --- Module: core:prelude/string.wado ---
 

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.optimize.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.optimize.wado
@@ -52,7 +52,7 @@ fn i32_clz(x: i32) -> i32;
 
 // --- Module: core:prelude/int128.wado ---
 
-// --- Module: core:prelude/primitives.wado ---
+// --- Module: core:prelude/primitive.wado ---
 
 // --- Module: core:prelude/string.wado ---
 

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -342,7 +342,7 @@ let y = 2;
 
 #[test]
 fn test_format_wildcard_import() {
-    let source = r#"use _ from "core:prelude/primitives.wado";
+    let source = r#"use _ from "core:prelude/primitive.wado";
 
 fn run() {
     let x = 1;
@@ -350,7 +350,7 @@ fn run() {
 "#;
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
-        formatted.contains(r#"use _ from "core:prelude/primitives.wado";"#),
+        formatted.contains(r#"use _ from "core:prelude/primitive.wado";"#),
         "wildcard import should be preserved: {}",
         formatted
     );


### PR DESCRIPTION
## Summary
This PR renames the `primitives.wado` module to `primitive.wado` and performs comprehensive code cleanup throughout the codebase to remove unnecessary variable declarations and simplify expressions.

## Key Changes

### Module Rename
- Renamed `lib/core/prelude/primitives.wado` to `lib/core/prelude/primitive.wado`
- Updated all references in the codebase:
  - `stdlib.rs`: Updated constant name from `CORE_PRELUDE_PRIMITIVES` to `CORE_PRELUDE_PRIMITIVE`
  - `name.rs`: Renamed `ModuleSource::primitives()` method to `ModuleSource::primitive()`
  - `loader.rs`: Updated module path mapping
  - `prelude.wado`: Updated import statement
  - All compiler modules (dce.rs, method_call.rs, method_lookup.rs, inspect.rs, template.rs, monomorphize.rs, serde_synth.rs, traits.rs)
  - Test files and documentation

### Code Cleanup in primitive.wado
Removed unnecessary variable declarations and simplified expressions throughout:
- Eliminated explicit `zero: i64 = 0` declarations, using literal `0` instead
- Removed `ten: i64 = 10` declarations, using literal `10` directly
- Simplified `one: i64 = 1` to literal `1`
- Removed redundant type annotations in variable declarations (e.g., `let mut t: i64 = val` → `let mut t = val`)
- Replaced `i64_max` and `i64_min` calculations with `i64::MIN` constant
- Simplified arithmetic expressions like `0 - 1` to `-1`
- Removed unnecessary casts like `0.0 as f32` to just `0.0`

## Notable Implementation Details
- The rename is purely a naming convention change (singular "primitive" instead of plural "primitives")
- All functionality remains identical; this is a refactoring for code clarity and consistency
- The cleanup reduces code verbosity while maintaining readability and type safety through Rust's type inference

https://claude.ai/code/session_016HC8LZPgQ6TbsLW5S8ocAv