### PR TITLE
Lazily register canonical intrinsics during WIR translation

### DIFF
--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -547,9 +547,9 @@ __DATA__
 -
   6. [x] Route existing `try_translate_stream_method` etc. through the new unified dispatch
 -
-  7. [ ] Remove CM-specific logic from DCE
+  7. [x] Remove CM-specific logic from DCE
 -
-  8. [ ] Update `wasm_plan.rs` to collect canonicals from WIR context
+  8. [x] Update `wasm_plan.rs` to collect canonicals from WIR context
 -
   9. [ ] Remove `method_call.rs` special cases for `Stream::new()` / `Future::new()`
 -

--- a/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
+++ b/docs/wep-2026-03-01-cm-resource-canonical-attrs.md
@@ -551,7 +551,7 @@ __DATA__
 -
   8. [x] Update `wasm_plan.rs` to collect canonicals from WIR context
 -
-  9. [ ] Remove `method_call.rs` special cases for `Stream::new()` / `Future::new()`
+  9. [x] Remove `method_call.rs` special cases for `Stream::new()` / `Future::new()`
 -
   10. [x] Add `#[canonical]` attributes to resource methods in `types.wado`
 -

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -84,17 +84,10 @@ pub fn build_component(project: &Project, core_module: &[u8], wir_module: &WirMo
 
     embed_bundled_modules(&mut builder, &mut ctx, bundled_functions);
 
-    // Merge canonical intrinsics from both sources (deduplicated):
-    //   1. component_plan.canonical_intrinsics — from TIR imports (task-return, realloc, etc.)
-    //   2. wir_module.needed_canonicals — lazily registered by ensure_canonical during WIR translation
-    let mut all_canonical_intrinsics: IndexSet<String> = IndexSet::new();
-    for name in &component_plan.canonical_intrinsics {
-        all_canonical_intrinsics.insert(name.clone());
-    }
-    for name in &wir_module.needed_canonicals {
-        all_canonical_intrinsics.insert(name.clone());
-    }
-    let all_canonical_intrinsics: Vec<String> = all_canonical_intrinsics.into_iter().collect();
+    // Canonical intrinsics are discovered lazily during WIR translation via ensure_canonical().
+    // They are stored in wir_module.needed_canonicals — the single source of truth.
+    let all_canonical_intrinsics: Vec<String> =
+        wir_module.needed_canonicals.iter().cloned().collect();
 
     // HTTP response types for future<T> canonical intrinsics
     let needs_future = all_canonical_intrinsics.iter().any(|n| {

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -243,10 +243,6 @@ pub fn analyze_project(project: &mut Project) {
             .world_registry
             .get(&project.target_world)
             .is_some_and(crate::world_registry::WorldInfo::has_async_export);
-    let has_http_handler_export = project
-        .world_registry
-        .get(&project.target_world)
-        .is_some_and(crate::world_registry::WorldInfo::has_http_handler_export);
     if has_async_export {
         // TaskReturn is always needed for async exports.
         // For Result-returning exports (e.g., HTTP handler), synthesis::cm_adapter computes
@@ -270,14 +266,10 @@ pub fn analyze_project(project: &mut Project) {
 
         // Waitable-set builtins (waitable_set_new, waitable_join, waitable_set_wait, subtask_drop)
         // are added automatically via reachability from internal::wait_for_subtask
-
-        // HTTP handler exports need future intrinsics for response creation
-        // (trailers parameter to response.new is a future)
-        if has_http_handler_export {
-            add_import_by_name(&mut imports, "future_new");
-            add_import_by_name(&mut imports, "future_write");
-            add_import_by_name(&mut imports, "future_drop_writable");
-        }
+        //
+        // HTTP handler exports need future intrinsics (future-new, future-write,
+        // future-drop-writable) for response creation, but these are now registered
+        // lazily by WIR synthesis via ensure_canonical() — no DCE injection needed.
     }
 
     // Store imports in the entry module

--- a/wado-compiler/src/wasm_plan.rs
+++ b/wado-compiler/src/wasm_plan.rs
@@ -14,13 +14,12 @@ use crate::world_registry::WorldExportInfo;
 ///
 /// Computed by `wasm_plan`, consumed by codegen. Contains all the structural
 /// decisions about what the component needs, so codegen can focus on encoding.
+///
+/// Canonical intrinsics (e.g., "stream-read", "task-return") are NOT stored here.
+/// They are discovered lazily during WIR translation via `WirContext::ensure_canonical`
+/// and stored in `WirModule::needed_canonicals`.
 #[derive(Debug, Clone, Default)]
 pub struct ComponentPlan {
-    /// Canonical intrinsics needed (e.g., "stream-new", "task-return").
-    /// These are TIR imports with namespace "wasi".
-    pub canonical_intrinsics: Vec<String>,
-    /// Whether future intrinsics are needed (future-new, future-write, etc.).
-    pub needs_future_intrinsics: bool,
     /// Bundled module function names (e.g., "`libm_sin`").
     /// These are TIR imports with namespace "bundled".
     pub bundled_functions: Vec<String>,
@@ -67,24 +66,11 @@ pub struct TestExportPlan {
 ///
 /// Scans TIR imports and world registry to determine what the component needs.
 /// Called by `wir_build::plan_project` at the start of the WIR pipeline.
+///
+/// Canonical intrinsics are NOT collected here — they are discovered lazily
+/// during WIR translation via `WirContext::ensure_canonical`.
 pub fn build_component_plan(project: &Project) -> ComponentPlan {
     let entry_tir = project.entry_module();
-
-    // Collect canonical intrinsics from TIR imports with namespace "wasi"
-    let canonical_intrinsics: Vec<String> = entry_tir
-        .imports
-        .iter()
-        .filter(|i| i.namespace == "wasi")
-        .map(|i| i.canonical_name.clone())
-        .collect();
-
-    // Check if future intrinsics are needed
-    let needs_future_intrinsics = canonical_intrinsics.iter().any(|name| {
-        matches!(
-            name.as_str(),
-            "future-new" | "future-write" | "future-drop-writable" | "future-drop-readable"
-        )
-    });
 
     // Collect bundled module functions from TIR imports with namespace "bundled"
     let bundled_functions: Vec<String> = entry_tir
@@ -128,8 +114,6 @@ pub fn build_component_plan(project: &Project) -> ComponentPlan {
     };
 
     ComponentPlan {
-        canonical_intrinsics,
-        needs_future_intrinsics,
         bundled_functions,
         world_exports,
         test_exports,

--- a/wado-compiler/src/wir_build/functions.rs
+++ b/wado-compiler/src/wir_build/functions.rs
@@ -72,6 +72,14 @@ fn register_imports(ctx: &mut WirContext<'_>) {
             name,
         );
 
+        // Track "wasi" namespace imports as needed canonical intrinsics.
+        // This ensures they appear in WirModule::needed_canonicals, which is
+        // the single source of truth for component codegen.
+        if import.namespace == "wasi" {
+            ctx.needed_canonicals
+                .insert(import.canonical_name.clone(), func_id.clone());
+        }
+
         // Also register under the TIR builtin function name so call sites can resolve.
         // e.g., "builtin/realloc" → same WirFuncId as "mem/realloc"
         if !import.func_name.is_empty() {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1646,13 +1646,12 @@ impl FunctionTranslator<'_, '_> {
                         .iter()
                         .map(|a| self.ctx.type_id_to_wir_type(self.type_table, a.type_id))
                         .collect();
-                    let results = if expr.type_id == TypeTable::UNIT
-                        || expr.type_id == TypeTable::NEVER
-                    {
-                        vec![]
-                    } else {
-                        vec![self.ctx.type_id_to_wir_type(self.type_table, expr.type_id)]
-                    };
+                    let results =
+                        if expr.type_id == TypeTable::UNIT || expr.type_id == TypeTable::NEVER {
+                            vec![]
+                        } else {
+                            vec![self.ctx.type_id_to_wir_type(self.type_table, expr.type_id)]
+                        };
                     self.ctx.ensure_canonical(local_name, params, results)
                 };
                 WirInstr::Call {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1633,15 +1633,31 @@ impl FunctionTranslator<'_, '_> {
             } => {
                 let translated_args: Vec<WirInstr> =
                     args.iter().map(|a| self.translate_expr(a)).collect();
-                // Look up in WASI imports
-                if let Some(func_id) = self.ctx.func_map.get(&format!("wasi/{local_name}")) {
-                    WirInstr::Call {
-                        func_id: func_id.clone(),
-                        args: translated_args,
-                    }
+                // Look up in WASI imports (registered by register_imports from TIR imports)
+                let func_id = if let Some(func_id) =
+                    self.ctx.func_map.get(&format!("wasi/{local_name}"))
+                {
+                    func_id.clone()
                 } else {
-                    eprintln!("[WIR] unresolved CmRawCall: local_name={local_name}");
-                    WirInstr::Unreachable
+                    // Not pre-registered — lazily register as a canonical intrinsic.
+                    // This handles canonical imports (e.g., "task-return") that may not
+                    // be in TIR imports but are needed by CM adapter synthesis.
+                    let params: Vec<WirType> = args
+                        .iter()
+                        .map(|a| self.ctx.type_id_to_wir_type(self.type_table, a.type_id))
+                        .collect();
+                    let results = if expr.type_id == TypeTable::UNIT
+                        || expr.type_id == TypeTable::NEVER
+                    {
+                        vec![]
+                    } else {
+                        vec![self.ctx.type_id_to_wir_type(self.type_table, expr.type_id)]
+                    };
+                    self.ctx.ensure_canonical(local_name, params, results)
+                };
+                WirInstr::Call {
+                    func_id,
+                    args: translated_args,
                 }
             }
 


### PR DESCRIPTION
## Summary
This PR refactors canonical intrinsic registration to use lazy discovery during WIR translation instead of pre-computing them during the planning phase. This enables support for canonical imports that may not be explicitly listed in TIR imports but are needed by CM adapter synthesis (e.g., "task-return").

## Key Changes

- **WIR translation (`translate.rs`)**: Modified `CmRawCall` handling to lazily register canonical intrinsics via `WirContext::ensure_canonical()` when they are not found in the pre-registered function map. This includes computing parameter and return types from the call expression.

- **Component planning (`wasm_plan.rs`)**: Removed `canonical_intrinsics` and `needs_future_intrinsics` fields from `ComponentPlan`. These are no longer pre-computed; instead, canonical intrinsics are discovered on-demand during WIR translation and stored in `WirModule::needed_canonicals`.

- **Import registration (`functions.rs`)**: Updated `register_imports()` to track "wasi" namespace imports in `needed_canonicals` as they are registered, ensuring they appear in the single source of truth for component codegen.

- **Code generation (`component.rs`)**: Simplified canonical intrinsic collection to use only `wir_module.needed_canonicals` (the single source of truth) instead of merging from both `component_plan` and `wir_module`.

- **DCE analysis (`dce.rs`)**: Removed HTTP handler export detection and manual injection of future intrinsics. These are now registered lazily by WIR synthesis via `ensure_canonical()`.

- **Documentation**: Updated WEP checklist to reflect completion of lazy canonical intrinsic registration tasks.

## Implementation Details

The lazy registration approach allows canonical intrinsics to be discovered during WIR translation when they are actually needed, rather than requiring them to be pre-declared in TIR imports. This is particularly important for CM adapter synthesis, which may generate calls to canonical intrinsics that weren't explicitly imported by the original TIR module.

https://claude.ai/code/session_01PTAAKQ691JBD8JbnRoKBbK