### PR TITLE
Require explicit `return` for functions with non-unit return types

### DIFF
--- a/wado-compiler/src/resolver/closure.rs
+++ b/wado-compiler/src/resolver/closure.rs
@@ -10,7 +10,7 @@ use crate::tir::{
 use crate::token::Span;
 
 use super::Resolver;
-use super::types::FunctionContext;
+use super::types::{FunctionContext, TypeError};
 use indexmap::IndexMap;
 
 impl<H: CompilerHost> Resolver<'_, H> {
@@ -107,8 +107,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .collect();
 
         // Step 7: Determine return type
+        // For block bodies, only explicit `return` counts; expression bodies use their type
         let return_type = if let TirExprKind::Block(ref block) = body.kind {
-            Self::find_return_type_in_block(block).unwrap_or(body.type_id)
+            if let Some(t) = Self::find_return_type_in_block(block) {
+                t
+            } else {
+                // Error if block has a trailing non-unit expression without `return`
+                if body.type_id != TypeTable::UNIT && body.type_id != TypeTable::NEVER {
+                    let _ = self.logger.error(TypeError::MissingReturn {
+                        return_type: self.type_table.borrow().type_name(body.type_id),
+                        span: closure.span,
+                    });
+                }
+                TypeTable::UNIT
+            }
         } else {
             body.type_id
         };
@@ -186,10 +198,21 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .collect();
 
         // Determine return type:
-        // - For block bodies, check for return statements
-        // - Fall back to the body expression's type
+        // - For block bodies, only explicit `return` counts
+        // - For expression bodies, use the expression's type
         let return_type = if let TirExprKind::Block(ref block) = body.kind {
-            Self::find_return_type_in_block(block).unwrap_or(body.type_id)
+            if let Some(t) = Self::find_return_type_in_block(block) {
+                t
+            } else {
+                // Error if block has a trailing non-unit expression without `return`
+                if body.type_id != TypeTable::UNIT && body.type_id != TypeTable::NEVER {
+                    let _ = self.logger.error(TypeError::MissingReturn {
+                        return_type: self.type_table.borrow().type_name(body.type_id),
+                        span: closure.span,
+                    });
+                }
+                TypeTable::UNIT
+            }
         } else {
             body.type_id
         };

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1678,6 +1678,21 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
                 None
             }
+            TirStmtKind::IfPattern {
+                then_block,
+                else_block,
+                ..
+            } => {
+                if let Some(t) = Self::find_return_type_in_block(then_block) {
+                    return Some(t);
+                }
+                if let Some(else_blk) = else_block
+                    && let Some(t) = Self::find_return_type_in_block(else_blk)
+                {
+                    return Some(t);
+                }
+                None
+            }
             TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
                 Self::find_return_type_in_block(body)
             }

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -318,15 +318,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .map(|b| self.resolve_block(b, &mut ctx, None));
 
         // Validate: non-unit return type requires explicit `return` in the body
-        if return_type != TypeTable::UNIT && return_type != TypeTable::NEVER {
-            if let Some(ref body) = body {
-                if Self::find_return_type_in_block(body).is_none() {
-                    let _ = self.logger.error(TypeError::MissingReturn {
-                        return_type: self.type_table.borrow().type_name(return_type),
-                        span: func.span,
-                    });
-                }
-            }
+        if return_type != TypeTable::UNIT
+            && return_type != TypeTable::NEVER
+            && let Some(ref body) = body
+            && Self::find_return_type_in_block(body).is_none()
+        {
+            let _ = self.logger.error(TypeError::MissingReturn {
+                return_type: self.type_table.borrow().type_name(return_type),
+                span: func.span,
+            });
         }
 
         // Convert AST type params to TIR type params (while type params still in scope)
@@ -594,15 +594,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .map(|b| self.resolve_block(b, &mut ctx, None));
 
         // Validate: non-unit return type requires explicit `return` in the body
-        if return_type != TypeTable::UNIT && return_type != TypeTable::NEVER {
-            if let Some(ref body) = body {
-                if Self::find_return_type_in_block(body).is_none() {
-                    let _ = self.logger.error(TypeError::MissingReturn {
-                        return_type: self.type_table.borrow().type_name(return_type),
-                        span: func.span,
-                    });
-                }
-            }
+        if return_type != TypeTable::UNIT
+            && return_type != TypeTable::NEVER
+            && let Some(ref body) = body
+            && Self::find_return_type_in_block(body).is_none()
+        {
+            let _ = self.logger.error(TypeError::MissingReturn {
+                return_type: self.type_table.borrow().type_name(return_type),
+                span: func.span,
+            });
         }
 
         // Convert AST type params to TIR type params (while type params still in scope)

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -317,6 +317,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .as_ref()
             .map(|b| self.resolve_block(b, &mut ctx, None));
 
+        // Validate: non-unit return type requires explicit `return` in the body
+        if return_type != TypeTable::UNIT && return_type != TypeTable::NEVER {
+            if let Some(ref body) = body {
+                if Self::find_return_type_in_block(body).is_none() {
+                    let _ = self.logger.error(TypeError::MissingReturn {
+                        return_type: self.type_table.borrow().type_name(return_type),
+                        span: func.span,
+                    });
+                }
+            }
+        }
+
         // Convert AST type params to TIR type params (while type params still in scope)
         let type_params: Vec<crate::tir::TirTypeParam> = func
             .type_params
@@ -580,6 +592,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .body
             .as_ref()
             .map(|b| self.resolve_block(b, &mut ctx, None));
+
+        // Validate: non-unit return type requires explicit `return` in the body
+        if return_type != TypeTable::UNIT && return_type != TypeTable::NEVER {
+            if let Some(ref body) = body {
+                if Self::find_return_type_in_block(body).is_none() {
+                    let _ = self.logger.error(TypeError::MissingReturn {
+                        return_type: self.type_table.borrow().type_name(return_type),
+                        span: func.span,
+                    });
+                }
+            }
+        }
 
         // Convert AST type params to TIR type params (while type params still in scope)
         let type_params: Vec<crate::tir::TirTypeParam> = func

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -148,10 +148,7 @@ pub enum TypeError {
     DuplicateField { name: String, span: Span },
 
     /// Function/method/closure with return type but no return statement
-    MissingReturn {
-        return_type: String,
-        span: Span,
-    },
+    MissingReturn { return_type: String, span: Span },
 }
 
 impl std::fmt::Display for TypeError {

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -146,6 +146,12 @@ pub enum TypeError {
 
     /// Duplicate field name in struct literal
     DuplicateField { name: String, span: Span },
+
+    /// Function/method/closure with return type but no return statement
+    MissingReturn {
+        return_type: String,
+        span: Span,
+    },
 }
 
 impl std::fmt::Display for TypeError {
@@ -256,6 +262,13 @@ impl std::fmt::Display for TypeError {
                     span.line, span.column, name
                 )
             }
+            TypeError::MissingReturn { return_type, span } => {
+                write!(
+                    f,
+                    "{}:{}: function with return type '{}' must use explicit `return`",
+                    span.line, span.column, return_type
+                )
+            }
         }
     }
 }
@@ -349,6 +362,11 @@ impl From<TypeError> for crate::compiler_host::Diagnostic {
             TypeError::DuplicateField { name, span } => (
                 Code::DuplicateDefinition,
                 format!("duplicate field '{name}' in struct literal"),
+                *span,
+            ),
+            TypeError::MissingReturn { return_type, span } => (
+                Code::TypeMismatch,
+                format!("function with return type '{return_type}' must use explicit `return`"),
                 *span,
             ),
         };

--- a/wado-compiler/tests/fixtures/missing_return_closure.wado
+++ b/wado-compiler/tests/fixtures/missing_return_closure.wado
@@ -1,0 +1,11 @@
+// Closure with block body requires explicit `return` to return a value.
+export fn run() {
+    let f = |x: i32| {
+        let d = x * 2;
+        d
+    };
+    let _ = f(5);
+}
+
+__DATA__
+{"compile_error": "function with return type 'i32' must use explicit `return`"}

--- a/wado-compiler/tests/fixtures/missing_return_closure_semicolon.wado
+++ b/wado-compiler/tests/fixtures/missing_return_closure_semicolon.wado
@@ -1,0 +1,11 @@
+// Semicolons don't affect semantics in closures either.
+export fn run() {
+    let f = |x: i32| {
+        let d = x * 2;
+        d;
+    };
+    let _ = f(5);
+}
+
+__DATA__
+{"compile_error": "function with return type 'i32' must use explicit `return`"}

--- a/wado-compiler/tests/fixtures/missing_return_fn.wado
+++ b/wado-compiler/tests/fixtures/missing_return_fn.wado
@@ -1,0 +1,12 @@
+// Function with return type but no explicit `return` is a compile error.
+fn double(x: i32) -> i32 {
+    let d = x * 2;
+    d
+}
+
+export fn run() {
+    let _ = double(5);
+}
+
+__DATA__
+{"compile_error": "function with return type 'i32' must use explicit `return`"}

--- a/wado-compiler/tests/fixtures/missing_return_fn_semicolon.wado
+++ b/wado-compiler/tests/fixtures/missing_return_fn_semicolon.wado
@@ -1,0 +1,13 @@
+// Semicolons are just separators and don't affect semantics.
+// A trailing expression with a semicolon still requires explicit `return`.
+fn double(x: i32) -> i32 {
+    let d = x * 2;
+    d;
+}
+
+export fn run() {
+    let _ = double(5);
+}
+
+__DATA__
+{"compile_error": "function with return type 'i32' must use explicit `return`"}

--- a/wado-compiler/tests/fixtures/missing_return_method.wado
+++ b/wado-compiler/tests/fixtures/missing_return_method.wado
@@ -1,0 +1,20 @@
+// Method with return type but no explicit `return` is a compile error.
+struct Pair {
+    a: i32,
+    b: i32,
+}
+
+impl Pair {
+    fn sum(&self) -> i32 {
+        let s = self.a + self.b;
+        s
+    }
+}
+
+export fn run() {
+    let p = Pair { a: 3, b: 7 };
+    let _ = p.sum();
+}
+
+__DATA__
+{"compile_error": "function with return type 'i32' must use explicit `return`"}


### PR DESCRIPTION
## Summary
This PR enforces a stricter return type checking rule: functions, methods, and closures with non-unit return types must use explicit `return` statements in block bodies. Trailing expressions without `return` are no longer implicitly returned and will now produce a compile error.

## Key Changes

- **New error type**: Added `TypeError::MissingReturn` to report when a function has a declared return type but lacks an explicit `return` statement in its block body.

- **Function validation** (`item.rs`): Added validation after resolving function bodies to check that non-unit return types have explicit `return` statements. Applied to both regular functions and methods.

- **Closure validation** (`closure.rs`): Updated closure return type resolution to detect missing `return` statements and emit errors. Handles both explicit closures and inferred closure types.

- **Expression analysis** (`expr.rs`): Enhanced `find_return_type_in_block` to properly handle `IfPattern` statements when searching for explicit returns.

- **Error reporting** (`types.rs`): Implemented display formatting and diagnostic conversion for the new `MissingReturn` error type.

- **Test fixtures**: Added comprehensive test cases covering:
  - Functions with missing returns
  - Methods with missing returns
  - Closures with missing returns
  - Edge cases with semicolons (which don't affect semantics)

## Implementation Details

The validation distinguishes between:
- **Block bodies**: Only explicit `return` statements count; trailing expressions are ignored
- **Expression bodies**: The expression type is used directly (e.g., `|x| x * 2` without braces)
- **Unit and Never types**: Exempt from the requirement (unit is the default, never doesn't return)

This change makes the language's return semantics more explicit and prevents subtle bugs from accidentally omitting `return` keywords.

https://claude.ai/code/session_013a38i2QrFKdcnZkYWHRepo