### PR TITLE
Fix typo: rename `make wado-test` to `make test-wado` in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ Run `make on-task-started` to install mise and all required development tools au
 
 ```sh
 make test        # test Rust crates (included in on-task-done)
-make wado-test   # test Wado modules (included in on-task-done)
+make test-wado   # test Wado modules (included in on-task-done)
 make format      # format Rust files and Markdown files
 make format-wado # format Wado source files
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Use the provided Makefile task to set up everything automatically:
 make on-task-started  # installs mise and all project tools
 ```
 
-See [.mise.toml](.mise.toml) for the list of managed tools.
+See [mise.toml](mise.toml) for the list of managed tools.
 
 ### Build and Test
 


### PR DESCRIPTION
The Makefile target is `test-wado`, not `wado-test`.

https://claude.ai/code/session_01AcN4hjmGtJUyVL2NnYr7Ky