### PR TITLE
Replace indexmap default hasher with rustc-hash FxHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,6 +2733,7 @@ dependencies = [
  "http",
  "http-body-util",
  "indexmap 2.13.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { version = "1" }
 fluent-uri = { version = "0.4" }
 glob = { version = "0.3" }
 indexmap = { version = "2" }
+rustc-hash = { version = "2" }
 libm = { version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 disallowed-types = [
-    { path = "std::collections::HashMap", reason = "Use indexmap::IndexMap for deterministic iteration order" },
-    { path = "std::collections::HashSet", reason = "Use indexmap::IndexSet for deterministic iteration order" },
+    { path = "std::collections::HashMap", reason = "Use crate::hashmap::IndexMap for deterministic iteration order with FxHash" },
+    { path = "std::collections::HashSet", reason = "Use crate::hashmap::IndexSet for deterministic iteration order with FxHash" },
 ]

--- a/wado-compiler/Cargo.toml
+++ b/wado-compiler/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 fluent-uri = { workspace = true }
 indexmap = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -156,7 +156,7 @@ pub struct Analyzer<'a, H: CompilerHost> {
     /// Logger for emitting diagnostics
     logger: &'a Logger<'a, H>,
     /// Modules loaded implicitly by the compiler (not by user imports)
-    implicit_modules: indexmap::IndexSet<ModuleSource>,
+    implicit_modules: crate::hashmap::IndexSet<ModuleSource>,
 }
 
 impl<'a, H: CompilerHost> Analyzer<'a, H> {
@@ -165,7 +165,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         Self {
             symbols: SymbolTable::new(),
             logger,
-            implicit_modules: indexmap::IndexSet::new(),
+            implicit_modules: crate::hashmap::IndexSet::default(),
         }
     }
 
@@ -420,9 +420,9 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
     /// * `implicit_modules` - Set of implicitly loaded modules
     pub fn analyze_loaded_modules(
         &mut self,
-        modules: &indexmap::IndexMap<ModuleSource, Module>,
+        modules: &crate::hashmap::IndexMap<ModuleSource, Module>,
         _entry_source: &ModuleSource,
-        implicit_modules: indexmap::IndexSet<ModuleSource>,
+        implicit_modules: crate::hashmap::IndexSet<ModuleSource>,
     ) -> Result<(), Bail> {
         self.implicit_modules = implicit_modules;
 
@@ -444,7 +444,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
 
     fn validate_all_imports(
         &mut self,
-        modules: &indexmap::IndexMap<ModuleSource, Module>,
+        modules: &crate::hashmap::IndexMap<ModuleSource, Module>,
     ) -> Result<(), Bail> {
         for (source, module) in modules {
             self.logger.set_file(source.diagnostic_filename());
@@ -462,7 +462,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         &mut self,
         module: &Module,
         module_source: &ModuleSource,
-        all_modules: &indexmap::IndexMap<ModuleSource, Module>,
+        all_modules: &crate::hashmap::IndexMap<ModuleSource, Module>,
     ) {
         for item in &module.items {
             if let Item::Use(use_decl) = item {
@@ -526,7 +526,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         &mut self,
         module: &Module,
         from_module_source: &ModuleSource,
-        all_modules: &indexmap::IndexMap<ModuleSource, Module>,
+        all_modules: &crate::hashmap::IndexMap<ModuleSource, Module>,
     ) -> Result<(), Bail> {
         for item in &module.items {
             if let Item::Use(use_decl) = item {
@@ -604,7 +604,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
     }
 
     /// Get a copy of the implicit modules set
-    pub fn get_implicit_modules(&self) -> &indexmap::IndexSet<ModuleSource> {
+    pub fn get_implicit_modules(&self) -> &crate::hashmap::IndexSet<ModuleSource> {
         &self.implicit_modules
     }
 }

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1,7 +1,7 @@
 // AST definitions for Wado
 
-use crate::token::Span;
 use crate::hashmap::IndexSet;
+use crate::token::Span;
 
 #[derive(Debug, Clone)]
 pub struct Module {

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1,7 +1,7 @@
 // AST definitions for Wado
 
 use crate::token::Span;
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 #[derive(Debug, Clone)]
 pub struct Module {
@@ -33,7 +33,7 @@ impl Module {
             inner_attributes: Vec::new(),
             shebang: None,
             data_section: None,
-            include_paths: IndexSet::new(),
+            include_paths: IndexSet::default(),
         }
     }
 

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -11,9 +11,9 @@
 //! - Resolve cross-module references (that's the resolve phase)
 //! - Perform type checking (that's the resolve phase)
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::ast::{
     AssertStmt, Block, ClosureExpr, Condition, Expr, ExprStmt, ForOfStmt, ForStmt, Function,
@@ -47,7 +47,7 @@ struct Scope {
 impl Scope {
     fn new() -> Self {
         Self {
-            bindings: IndexMap::new(),
+            bindings: IndexMap::default(),
         }
     }
 }
@@ -156,7 +156,7 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
             scopes: vec![Scope::new()], // Global scope
             logger,
             current_depth: 0,
-            local_names_in_function: IndexSet::new(),
+            local_names_in_function: IndexSet::default(),
         }
     }
 

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -3,7 +3,7 @@
 //! This module collects function signatures from lib/core/builtin.wado
 //! and provides type information for code generation.
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 use std::cell::RefCell;
 
 use crate::ast::{Function, Type};

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -15,9 +15,9 @@ use super::postprocess;
 use crate::ast::Type;
 use crate::bundled::wado_bundled_libm_wasm;
 use crate::component_model::{CmInstanceTypeGen, WasiFunctionInfo};
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::project::Project;
 use crate::wir::{CanonicalIntrinsic, CmFuturePayload, CmScalarType, WirModule};
-use crate::hashmap::{IndexMap, IndexSet};
 use wasm_encoder::{
     Alias, CanonicalOption, ComponentBuilder, ComponentExportKind, ComponentOuterAliasKind,
     ComponentValType, ExportKind, InstanceType, ModuleArg, PrimitiveValType, TypeBounds,

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -17,7 +17,7 @@ use crate::bundled::wado_bundled_libm_wasm;
 use crate::component_model::{CmInstanceTypeGen, WasiFunctionInfo};
 use crate::project::Project;
 use crate::wir::{CanonicalIntrinsic, CmFuturePayload, CmScalarType, WirModule};
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 use wasm_encoder::{
     Alias, CanonicalOption, ComponentBuilder, ComponentExportKind, ComponentOuterAliasKind,
     ComponentValType, ExportKind, InstanceType, ModuleArg, PrimitiveValType, TypeBounds,
@@ -142,7 +142,7 @@ pub fn build_component(project: &Project, core_module: &[u8], wir_module: &WirMo
     }
 
     // Collect available WASI functions
-    let mut available_wasi_funcs: IndexSet<String> = IndexSet::new();
+    let mut available_wasi_funcs: IndexSet<String> = IndexSet::default();
     for interface in project.wasi_registry.interfaces() {
         for func in &interface.functions {
             let local_name = func.local_alias_name();
@@ -624,14 +624,14 @@ fn build_scalar_future_types(
     ctx: &mut ComponentModelContext,
     canonical_intrinsics: &[CanonicalIntrinsic],
 ) -> IndexSet<(CmScalarType, u32)> {
-    let mut scalars: IndexSet<CmScalarType> = IndexSet::new();
+    let mut scalars: IndexSet<CmScalarType> = IndexSet::default();
     for intrinsic in canonical_intrinsics {
         if let Some(CmFuturePayload::Scalar(scalar)) = intrinsic.future_payload() {
             scalars.insert(scalar);
         }
     }
 
-    let mut result = IndexSet::new();
+    let mut result = IndexSet::default();
     for scalar in &scalars {
         let prim = cm_scalar_to_primitive(*scalar);
         let type_name = format!("future-{scalar}");
@@ -1064,9 +1064,9 @@ fn generate_wasi_imports(
             let mut instance_type = InstanceType::new();
             let mut local_type_idx = 0u32;
 
-            let mut resource_type_indices: IndexMap<String, u32> = IndexMap::new();
-            let mut own_resource_type_indices: IndexMap<String, u32> = IndexMap::new();
-            let mut borrow_resource_type_indices: IndexMap<String, u32> = IndexMap::new();
+            let mut resource_type_indices: IndexMap<String, u32> = IndexMap::default();
+            let mut own_resource_type_indices: IndexMap<String, u32> = IndexMap::default();
+            let mut borrow_resource_type_indices: IndexMap<String, u32> = IndexMap::default();
             for resource_name in &needed_resources {
                 if let Some(cm_name) = project.wasi_registry.get_resource_cm_name(resource_name) {
                     instance_type.export(
@@ -1137,8 +1137,8 @@ fn generate_wasi_imports(
                 }
             }
 
-            let mut enum_type_indices: IndexMap<String, u32> = IndexMap::new();
-            let mut enum_export_indices: IndexMap<String, u32> = IndexMap::new();
+            let mut enum_type_indices: IndexMap<String, u32> = IndexMap::default();
+            let mut enum_export_indices: IndexMap<String, u32> = IndexMap::default();
             let interface_path = &interface_info.path;
 
             for enum_name in &needed_enums {
@@ -1169,7 +1169,7 @@ fn generate_wasi_imports(
             }
 
             // Emit flags types in the instance type
-            let mut flags_export_indices: IndexMap<String, u32> = IndexMap::new();
+            let mut flags_export_indices: IndexMap<String, u32> = IndexMap::default();
             for flags_name in &needed_flags {
                 if let Some(members) = project.wasi_registry.get_flags_members(flags_name) {
                     instance_type
@@ -1878,7 +1878,7 @@ fn import_interfaces_with_resources(
         .collect();
 
     // Phase 1: Import resource-defining interfaces
-    let mut imported_source_interfaces: IndexSet<String> = IndexSet::new();
+    let mut imported_source_interfaces: IndexSet<String> = IndexSet::default();
     for interface_info in &interfaces_with_resources {
         let Some((resource_wado_name, _resource_cm_name)) = &interface_info.resource_type else {
             continue;
@@ -2085,9 +2085,9 @@ fn import_resource_using_interfaces(
             let mut local_type_idx = 0u32;
 
             // Maps: resource_name -> (alias_local_idx, own_local_idx, borrow_local_idx)
-            let mut resource_alias_indices: IndexMap<String, u32> = IndexMap::new();
-            let mut own_resource_type_indices: IndexMap<String, u32> = IndexMap::new();
-            let mut borrow_resource_type_indices: IndexMap<String, u32> = IndexMap::new();
+            let mut resource_alias_indices: IndexMap<String, u32> = IndexMap::default();
+            let mut own_resource_type_indices: IndexMap<String, u32> = IndexMap::default();
+            let mut borrow_resource_type_indices: IndexMap<String, u32> = IndexMap::default();
 
             for resource_name in &needed_resources {
                 if let Some(cm_name) = project.wasi_registry.get_resource_cm_name(resource_name) {

--- a/wado-compiler/src/codegen/component_context.rs
+++ b/wado-compiler/src/codegen/component_context.rs
@@ -4,7 +4,7 @@
 //! (types, instances, core functions, modules) to eliminate hardcoded magic
 //! numbers when building Wasm Components with wasm-encoder.
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 /// Tracks component-level indices for types, instances, and core functions.
 /// Used alongside wasm-encoder's `ComponentBuilder` to eliminate magic numbers.
@@ -41,18 +41,18 @@ impl ComponentModelContext {
     /// Create a new context with all indices starting at 0
     pub fn new() -> Self {
         Self {
-            type_names: IndexMap::new(),
+            type_names: IndexMap::default(),
             next_type_idx: 0,
-            instance_names: IndexMap::new(),
+            instance_names: IndexMap::default(),
             next_instance_idx: 0,
-            core_func_names: IndexMap::new(),
+            core_func_names: IndexMap::default(),
             next_core_func_idx: 0,
             core_memory_idx: None,
-            comp_func_names: IndexMap::new(),
+            comp_func_names: IndexMap::default(),
             next_comp_func_idx: 0,
-            core_module_names: IndexMap::new(),
+            core_module_names: IndexMap::default(),
             next_core_module_idx: 0,
-            core_instance_names: IndexMap::new(),
+            core_instance_names: IndexMap::default(),
             next_core_instance_idx: 0,
         }
     }

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -3,7 +3,7 @@
 //! This module handles the mechanical translation from WIR's tree-structured
 //! representation to flat Wasm instructions and binary encoding.
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::wir::{
     WirAbstractHeapType, WirArrayType, WirCopyType, WirExportDesc, WirFuncType, WirFunction,
@@ -67,17 +67,17 @@ impl<'a> WirEmitter<'a> {
     fn new(wir: &'a WirModule, strip_names: bool) -> Self {
         Self {
             wir,
-            type_index_map: IndexMap::new(),
-            variant_case_types: IndexMap::new(),
-            struct_field_map: IndexMap::new(),
+            type_index_map: IndexMap::default(),
+            variant_case_types: IndexMap::default(),
+            struct_field_map: IndexMap::default(),
             func_index_offset: 0,
-            func_index_map: IndexMap::new(),
-            global_name_map: IndexMap::new(),
-            current_locals: IndexMap::new(),
-            ref_locals: IndexSet::new(),
+            func_index_map: IndexMap::default(),
+            global_name_map: IndexMap::default(),
+            current_locals: IndexMap::default(),
+            ref_locals: IndexSet::default(),
             next_local: 0,
             next_type_idx: 0,
-            variant_pre_assigned: IndexMap::new(),
+            variant_pre_assigned: IndexMap::default(),
             current_branch_hints: Vec::new(),
             all_branch_hints: Vec::new(),
             strip_names,
@@ -325,7 +325,7 @@ impl<'a> WirEmitter<'a> {
     /// Find func type indices that are referenced from struct fields.
     /// These must go in the rec group to avoid forward reference errors.
     fn find_gc_referenced_func_types(&self) -> IndexSet<u32> {
-        let mut gc_func_types = IndexSet::new();
+        let mut gc_func_types = IndexSet::default();
         for typedef in &self.wir.types {
             if let WirTypeDef::Struct(s) = typedef {
                 for field in &s.fields {
@@ -370,7 +370,7 @@ impl<'a> WirEmitter<'a> {
     ) {
         debug_assert!(self.type_index_map.contains_key(&wir_idx));
 
-        let mut field_map = IndexMap::new();
+        let mut field_map = IndexMap::default();
         let fields: Vec<FieldType> = s
             .fields
             .iter()
@@ -415,7 +415,7 @@ impl<'a> WirEmitter<'a> {
             .unwrap_or_default();
 
         // Build field map for the base type
-        let mut field_map = IndexMap::new();
+        let mut field_map = IndexMap::default();
         field_map.insert("discriminant".to_string(), 0);
         self.struct_field_map.insert(wir_idx, field_map);
 
@@ -467,7 +467,7 @@ impl<'a> WirEmitter<'a> {
         // Register field maps for variant case structs
         for (&case_wir_idx, &(variant_wir_idx, case_idx)) in &self.wir.variant_case_info {
             if variant_wir_idx == wir_idx {
-                let mut case_field_map = IndexMap::new();
+                let mut case_field_map = IndexMap::default();
                 case_field_map.insert("discriminant".to_string(), 0);
                 if let Some(case_def) = v.cases.get(case_idx as usize) {
                     for (j, _) in case_def.payload.iter().enumerate() {
@@ -2672,7 +2672,7 @@ impl<'a> WirEmitter<'a> {
     /// Collect all function indices referenced by `RefFunc` instructions.
     /// These need to be declared in a declarative element segment.
     fn collect_ref_func_indices(&self) -> Vec<u32> {
-        let mut indices = IndexSet::new();
+        let mut indices = IndexSet::default();
         for (i, func) in self.wir.functions.iter().enumerate() {
             if self
                 .wir

--- a/wado-compiler/src/codegen/postprocess.rs
+++ b/wado-compiler/src/codegen/postprocess.rs
@@ -3,7 +3,7 @@
 //! This module provides utilities to transform Wasm modules, such as
 //! converting memory definitions to imports and dead code elimination.
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use walrus::passes;
 use wasm_encoder::{

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -296,7 +296,7 @@ pub trait CompilerHost: Send + Sync {
 #[derive(Debug, Default)]
 pub struct InMemoryCompilerHost {
     /// Source files by path (stored as raw bytes)
-    sources: indexmap::IndexMap<String, Vec<u8>>,
+    sources: crate::hashmap::IndexMap<String, Vec<u8>>,
     /// Collected diagnostics
     diagnostics: std::sync::Mutex<Vec<Diagnostic>>,
 }

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use wasm_encoder::ValType;
 
@@ -1089,7 +1089,7 @@ impl CmInstanceTypeGen {
     pub fn new(start_idx: u32) -> Self {
         Self {
             next_idx: start_idx,
-            cache: IndexMap::new(),
+            cache: IndexMap::default(),
         }
     }
 
@@ -1846,12 +1846,12 @@ fn is_primitive_type_supported_with_types(
 
 /// Check if a parameter type is supported (without enum/resource knowledge)
 pub fn is_param_type_supported(ty: &Type) -> bool {
-    is_param_type_supported_with_types(ty, &IndexSet::new(), &IndexSet::new())
+    is_param_type_supported_with_types(ty, &IndexSet::default(), &IndexSet::default())
 }
 
 /// Check if a return type is supported (without enum/resource knowledge)
 pub fn is_return_type_supported(ty: &Type) -> bool {
-    is_return_type_supported_with_types(ty, &IndexSet::new(), &IndexSet::new())
+    is_return_type_supported_with_types(ty, &IndexSet::default(), &IndexSet::default())
 }
 
 /// Check if all types in a WASI function are supported for Component Model generation

--- a/wado-compiler/src/doc.rs
+++ b/wado-compiler/src/doc.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 use serde::Serialize;
 
 use crate::ast::{
@@ -798,7 +798,7 @@ fn collect_pub_use_sources(module: &Module) -> Vec<String> {
 
 /// Collect item names from `pub use { Name1, Name2 } from "..."` declarations.
 fn collect_pub_use_names(module: &Module) -> IndexSet<String> {
-    let mut names = IndexSet::new();
+    let mut names = IndexSet::default();
     for item in &module.items {
         if let Item::Use(u) = item
             && u.is_pub
@@ -982,7 +982,7 @@ fn collect_primitive_types_from_module(
     module: &Module,
     comments: &CommentMap,
 ) -> Vec<DocPrimitiveType> {
-    use indexmap::IndexMap;
+    use crate::hashmap::IndexMap;
 
     let mut impls: Vec<&ImplBlock> = Vec::new();
     for item in &module.items {
@@ -991,7 +991,7 @@ fn collect_primitive_types_from_module(
         }
     }
 
-    let mut by_name: IndexMap<&str, DocPrimitiveType> = IndexMap::new();
+    let mut by_name: IndexMap<&str, DocPrimitiveType> = IndexMap::default();
 
     for &prim_name in PRIMITIVE_TYPE_NAMES {
         let (methods, trait_impls) = collect_impl_methods_for_type(prim_name, &impls, comments);

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -7,7 +7,7 @@
 //! Effect checking runs after type resolution (TIR construction) and before
 //! lowering. It operates on the TIR and produces errors for any effect violations.
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::compiler_host::CompilerHost;
 use crate::logger::{Bail, Logger};
@@ -82,7 +82,7 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
         Self {
             modules,
             logger,
-            current_effects: IndexSet::new(),
+            current_effects: IndexSet::default(),
         }
     }
 

--- a/wado-compiler/src/hashmap.rs
+++ b/wado-compiler/src/hashmap.rs
@@ -1,0 +1,2 @@
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+pub type IndexSet<V> = indexmap::IndexSet<V, rustc_hash::FxBuildHasher>;

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -81,6 +81,7 @@ pub mod component_model;
 pub mod desugar;
 pub mod doc;
 pub mod effect_check;
+pub mod hashmap;
 pub mod lexer;
 pub mod loader;
 pub mod logger;
@@ -129,7 +130,7 @@ pub use token::Span;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 /// Result of compiling a Wado source file
 #[derive(Debug)]

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -5,9 +5,9 @@
 
 use std::collections::VecDeque;
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::ast::{Item, Module};
 use crate::bind;
@@ -221,7 +221,7 @@ fn cached_core_stdlib() -> &'static IndexMap<ModuleSource, Module> {
             ("prelude/types.wado", stdlib::CORE_PRELUDE_TYPES),
             ("zlib", stdlib::CORE_ZLIB),
         ];
-        let mut cache = IndexMap::with_capacity(core_modules.len());
+        let mut cache = IndexMap::with_capacity_and_hasher(core_modules.len(), Default::default());
         for &(name, source) in core_modules {
             let module_source = ModuleSource::Core {
                 name: name.to_string(),
@@ -276,9 +276,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             host,
             log_level,
             logger: Logger::new(host, log_level),
-            loaded: IndexMap::new(),
-            loading: IndexSet::new(),
-            implicit_modules: IndexSet::new(),
+            loaded: IndexMap::default(),
+            loading: IndexSet::default(),
+            implicit_modules: IndexSet::default(),
         }
     }
 
@@ -613,14 +613,14 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     /// Scan all loaded modules for `#include_str`/`#include_bytes` and load referenced files.
     async fn load_included_files(&self) -> Result<IndexMap<[String; 2], Vec<u8>>, LoadError> {
         // Collect (module_source, raw_path) pairs
-        let mut pairs: IndexSet<[String; 2]> = IndexSet::new();
+        let mut pairs: IndexSet<[String; 2]> = IndexSet::default();
         for (module_source, module) in &self.loaded {
             let ms_str = module_source.to_string();
             for raw_path in module.include_paths() {
                 pairs.insert([ms_str.clone(), raw_path.clone()]);
             }
         }
-        let mut included = IndexMap::new();
+        let mut included = IndexMap::default();
         for pair in pairs {
             let [ref ms_str, ref raw_path] = pair;
             // Resolve path relative to the module source's directory

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -18,7 +18,7 @@ mod pattern;
 mod string;
 mod wide_int;
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::name::ModuleSource;
 use crate::project::Project;
@@ -40,7 +40,9 @@ use wide_int::lower_wide_int_match_patterns;
 ///
 /// Note: All loop constructs are desugared at the AST level in desugar.rs.
 pub fn lower(module: TirModule) -> TirModule {
-    let modules = IndexMap::from([(module.module_source.clone(), module)]);
+    let mut modules = IndexMap::default();
+    modules.insert(module.module_source.clone(), module);
+    let modules = modules;
     let mut modules = lower_modules_indexed(modules);
     modules.pop().unwrap().1
 }
@@ -98,7 +100,7 @@ pub fn lower_modules_indexed(
 ) -> IndexMap<ModuleSource, TirModule> {
     // Build a global variant map from ALL modules so that cross-module pattern
     // matching works (e.g., `if let Greater = ord` where Ordering is from another module)
-    let mut global_variant_map: IndexMap<String, Vec<(String, u32)>> = IndexMap::new();
+    let mut global_variant_map: IndexMap<String, Vec<(String, u32)>> = IndexMap::default();
     for module in modules.values() {
         for variant in &module.variants {
             let cases: Vec<(String, u32)> = variant

--- a/wado-compiler/src/lower/boxing.rs
+++ b/wado-compiler/src/lower/boxing.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::{ModuleSource, mangle_generic_name};
 use crate::tir::{
@@ -33,14 +33,14 @@ pub(super) struct BoxLowerer {
 impl BoxLowerer {
     pub(super) fn new() -> Self {
         Self {
-            box_struct_types: IndexMap::new(),
-            box_type_ids: IndexSet::new(),
+            box_struct_types: IndexMap::default(),
+            box_type_ids: IndexSet::default(),
             generated_structs: Vec::new(),
             box_module_source: ModuleSource::Core {
                 name: "internal".to_string(),
             },
-            struct_fields_map: IndexMap::new(),
-            variant_names: IndexSet::<String>::new(),
+            struct_fields_map: IndexMap::default(),
+            variant_names: IndexSet::default(),
         }
     }
 
@@ -389,7 +389,7 @@ impl BoxLowerer {
         {
             let type_table = module.type_table.borrow();
             for global in &mut module.globals {
-                self.transform_expr(&mut global.initializer, &IndexSet::new(), &type_table);
+                self.transform_expr(&mut global.initializer, &IndexSet::default(), &type_table);
             }
         }
 
@@ -403,7 +403,7 @@ impl BoxLowerer {
         // Boxing is required for:
         // - Primitives (except i128/u128 which are already GC types)
         // - Variant types (subtype hierarchy prevents field-by-field deref assignment)
-        let mut needs_box_base: IndexSet<TypeId> = IndexSet::new();
+        let mut needs_box_base: IndexSet<TypeId> = IndexSet::default();
         let mut newtype_pairs: Vec<(TypeId, TypeId)> = Vec::new(); // (alias, base)
 
         for type_id in type_table.iter_type_ids().collect::<Vec<_>>() {

--- a/wado-compiler/src/lower/closure.rs
+++ b/wado-compiler/src/lower/closure.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::fmt::Write as _;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::{LocalMethodName, MethodName, ModuleSource};
 use crate::tir::{
@@ -86,11 +86,11 @@ impl ClosureLowerer {
             module_source: module_source.clone(),
             collected_closures: Vec::new(),
             functor_infos: Vec::new(),
-            local_to_closure: IndexMap::new(),
-            specializable: IndexSet::new(),
+            local_to_closure: IndexMap::default(),
+            specializable: IndexSet::default(),
             generated_structs: Vec::new(),
             generated_functions: Vec::new(),
-            fn_param_specializations: IndexMap::new(),
+            fn_param_specializations: IndexMap::default(),
         }
     }
 
@@ -800,7 +800,7 @@ impl ClosureLowerer {
                 span: collected.span,
                 local_count,
                 local_types,
-                address_taken_locals: IndexSet::new(),
+                address_taken_locals: IndexSet::default(),
                 is_cm_adapter: false,
                 inline_hint: InlineHint::Auto,
                 comp_features: 0,
@@ -1573,7 +1573,7 @@ impl ClosureLowerer {
         type_table: &mut TypeTable,
     ) {
         // Build a map from function name to function for quick lookup
-        let mut func_by_name: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::new();
+        let mut func_by_name: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::default();
         for func_rc in func_refs {
             let func = func_rc.borrow();
             func_by_name.insert(func.name.clone(), Rc::clone(func_rc));

--- a/wado-compiler/src/lower/globals.rs
+++ b/wado-compiler/src/lower/globals.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::ModuleSource;
 use crate::tir::FunctionRef;
@@ -209,7 +209,7 @@ pub(super) fn lower_global_initializers(module: &mut TirModule) {
         span,
         local_count,
         local_types: merged_local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -333,10 +333,10 @@ fn topological_sort_global_inits(
         .collect();
 
     // Build dependency graph: deps[i] = set of indices that i depends on
-    let mut deps: Vec<IndexSet<usize>> = vec![IndexSet::new(); lazy_inits.len()];
+    let mut deps: Vec<IndexSet<usize>> = vec![IndexSet::default(); lazy_inits.len()];
 
     for (i, (_, _, _, _, initializer, _)) in lazy_inits.iter().enumerate() {
-        let mut refs = IndexSet::new();
+        let mut refs = IndexSet::default();
         collect_global_refs(initializer, &mut refs);
 
         for ref_name in refs {
@@ -717,7 +717,7 @@ pub(super) fn generate_initialize_modules(modules: &mut IndexMap<ModuleSource, T
         span,
         local_count: 0,
         local_types: Vec::new(),
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,

--- a/wado-compiler/src/lower/pattern.rs
+++ b/wado-compiler/src/lower/pattern.rs
@@ -218,7 +218,8 @@ pub(super) fn lower_patterns(
     }
 
     // Build struct fields map from module structs
-    let mut struct_fields_map: IndexMap<(String, ModuleSource), Vec<TirField>> = IndexMap::default();
+    let mut struct_fields_map: IndexMap<(String, ModuleSource), Vec<TirField>> =
+        IndexMap::default();
     for s in &module.structs {
         struct_fields_map.insert(
             (s.name.clone(), module.module_source.clone()),

--- a/wado-compiler/src/lower/pattern.rs
+++ b/wado-compiler/src/lower/pattern.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::name::ModuleSource;
 use crate::tir::FunctionRef;
@@ -218,7 +218,7 @@ pub(super) fn lower_patterns(
     }
 
     // Build struct fields map from module structs
-    let mut struct_fields_map: IndexMap<(String, ModuleSource), Vec<TirField>> = IndexMap::new();
+    let mut struct_fields_map: IndexMap<(String, ModuleSource), Vec<TirField>> = IndexMap::default();
     for s in &module.structs {
         struct_fields_map.insert(
             (s.name.clone(), module.module_source.clone()),

--- a/wado-compiler/src/lower/string.rs
+++ b/wado-compiler/src/lower/string.rs
@@ -1,4 +1,4 @@
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::LocalMethodName;
 use crate::tir::{TirBlock, TirExpr, TirExprKind, TirModule, TirStmt, TirStmtKind};
@@ -17,10 +17,10 @@ pub(super) struct StringCollector {
 impl StringCollector {
     pub(super) fn new() -> Self {
         Self {
-            strings: IndexSet::new(),
-            bytes: IndexSet::new(),
-            function_strings: IndexMap::new(),
-            function_method_info: IndexMap::new(),
+            strings: IndexSet::default(),
+            bytes: IndexSet::default(),
+            function_strings: IndexMap::default(),
+            function_method_info: IndexMap::default(),
             current_function: None,
         }
     }

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -68,7 +68,8 @@ pub fn monomorphize_modules_indexed(
     // (a struct name can appear in multiple modules due to shadowing)
     // This includes private structs as they may be needed for instantiating public structs
     // (e.g., TreeMap uses TreeMapNode internally)
-    let mut all_generic_structs: IndexMap<String, Vec<(ModuleSource, TirStruct)>> = IndexMap::default();
+    let mut all_generic_structs: IndexMap<String, Vec<(ModuleSource, TirStruct)>> =
+        IndexMap::default();
     for (module_source, module) in &modules {
         for tir_struct in &module.structs {
             if !tir_struct.type_params.is_empty() {

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::{LocalMethodName, MethodName, ModuleSource, mangle_generic_name};
 use crate::project::Project;
@@ -54,7 +54,7 @@ pub fn monomorphize_modules_indexed(
     modules: IndexMap<ModuleSource, TirModule>,
 ) -> IndexMap<ModuleSource, TirModule> {
     // First pass: collect all generic functions from all modules
-    let mut all_generic_functions: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::new();
+    let mut all_generic_functions: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::default();
     for (_, module) in &modules {
         for func_rc in &module.functions {
             let func = func_rc.borrow();
@@ -68,7 +68,7 @@ pub fn monomorphize_modules_indexed(
     // (a struct name can appear in multiple modules due to shadowing)
     // This includes private structs as they may be needed for instantiating public structs
     // (e.g., TreeMap uses TreeMapNode internally)
-    let mut all_generic_structs: IndexMap<String, Vec<(ModuleSource, TirStruct)>> = IndexMap::new();
+    let mut all_generic_structs: IndexMap<String, Vec<(ModuleSource, TirStruct)>> = IndexMap::default();
     for (module_source, module) in &modules {
         for tir_struct in &module.structs {
             if !tir_struct.type_params.is_empty() {
@@ -109,7 +109,7 @@ pub fn monomorphize_modules_indexed(
     // Maps function name (e.g., "i32^Stringify::to_str") → module source.
     // This enables correct module resolution when monomorphizing type param
     // receiver calls (e.g., T^Trait::method → ConcreteType^Trait::method).
-    let mut trait_method_locations: IndexMap<String, ModuleSource> = IndexMap::new();
+    let mut trait_method_locations: IndexMap<String, ModuleSource> = IndexMap::default();
     for (module_source, module) in &modules {
         for func_rc in &module.functions {
             let func = func_rc.borrow();
@@ -158,7 +158,7 @@ fn monomorphize_with_externals(
 
     // Find modules whose structs are shadowed by the entry module's definitions
     // This is computed globally, not per-module, because we want consistent shadowing
-    let mut shadowed_modules: IndexSet<ModuleSource> = IndexSet::new();
+    let mut shadowed_modules: IndexSet<ModuleSource> = IndexSet::default();
     for entry_struct_name in entry_generic_struct_names {
         if let Some(sources) = all_generic_structs_with_sources.get(entry_struct_name) {
             // Find external modules that define this struct (not the entry module)
@@ -171,7 +171,7 @@ fn monomorphize_with_externals(
     }
 
     // Build generic structs map based on whether this is the entry module or not
-    let mut all_generic_structs: IndexMap<String, TirStruct> = IndexMap::new();
+    let mut all_generic_structs: IndexMap<String, TirStruct> = IndexMap::default();
 
     if is_entry_module {
         // Entry module: use its own structs + non-shadowed external structs
@@ -259,15 +259,15 @@ impl Monomorphizer {
     fn new(current_module_source: ModuleSource) -> Self {
         Self {
             current_module_source,
-            instantiated: IndexMap::new(),
+            instantiated: IndexMap::default(),
             pending: Vec::new(),
-            type_substitutions: IndexMap::new(),
-            type_to_mangled_name: IndexMap::new(),
-            function_instantiated: IndexMap::new(),
+            type_substitutions: IndexMap::default(),
+            type_to_mangled_name: IndexMap::default(),
+            function_instantiated: IndexMap::default(),
             function_pending: Vec::new(),
-            mangled_struct_to_key: IndexMap::new(),
-            mangled_func_to_key: IndexMap::new(),
-            trait_method_locations: IndexMap::new(),
+            mangled_struct_to_key: IndexMap::default(),
+            mangled_func_to_key: IndexMap::default(),
+            trait_method_locations: IndexMap::default(),
         }
     }
 
@@ -2219,7 +2219,7 @@ impl Monomorphizer {
 
         // Build substitution map: type param index -> concrete type
         // Include both method-level type params AND impl block type params
-        let mut substitution: IndexMap<u32, TypeId> = IndexMap::new();
+        let mut substitution: IndexMap<u32, TypeId> = IndexMap::default();
 
         // Add impl block type params first (e.g., T from impl Counter<T>)
         // Use param.index for lookup so that impls with concrete type args at earlier positions

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1355,12 +1355,12 @@ mod tests {
 
     #[test]
     fn test_struct_name_hash_eq() {
-        use indexmap::IndexSet;
+        use crate::hashmap::IndexSet;
         let s1 = StructName::from_path_and_name(&["./geometry.wado".to_string()], "Point");
         let s2 = StructName::from_path_and_name(&["./geometry.wado".to_string()], "Point");
         let s3 = StructName::from_path_and_name(&["./other.wado".to_string()], "Point");
 
-        let mut set = IndexSet::new();
+        let mut set = IndexSet::default();
         set.insert(s1.clone());
         assert!(set.contains(&s2));
         assert!(!set.contains(&s3));

--- a/wado-compiler/src/optimize/const_global_promotion.rs
+++ b/wado-compiler/src/optimize/const_global_promotion.rs
@@ -16,10 +16,10 @@
 //! - Promoted constants become available for constant propagation
 //! - Dependent globals may then also fold to constants and get promoted
 
+use crate::hashmap::IndexMap;
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind};
-use crate::hashmap::IndexMap;
 
 type GlobalKey = (ModuleSource, String);
 

--- a/wado-compiler/src/optimize/const_global_promotion.rs
+++ b/wado-compiler/src/optimize/const_global_promotion.rs
@@ -19,7 +19,7 @@
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind};
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 type GlobalKey = (ModuleSource, String);
 
@@ -40,7 +40,7 @@ fn promote_in_module(project: &mut Project, module_source: &ModuleSource) -> boo
     let module = &project.tir_modules[module_source];
 
     // Build a lookup of promotable globals: currently Wasm-mutable but user-declared immutable
-    let mut promotable_globals: IndexMap<GlobalKey, usize> = IndexMap::new();
+    let mut promotable_globals: IndexMap<GlobalKey, usize> = IndexMap::default();
     for (idx, global) in module.globals.iter().enumerate() {
         if global.mutable && !global.wado_mutable {
             promotable_globals.insert((global.module_source.clone(), global.name.clone()), idx);
@@ -52,7 +52,7 @@ fn promote_in_module(project: &mut Project, module_source: &ModuleSource) -> boo
     }
 
     // Scan all functions for GlobalVarSet to promotable globals with constant values
-    let mut promotions: IndexMap<GlobalKey, TirExprKind> = IndexMap::new();
+    let mut promotions: IndexMap<GlobalKey, TirExprKind> = IndexMap::default();
     for func_rc in &module.functions {
         let func = func_rc.borrow();
         let Some(body) = &func.body else { continue };

--- a/wado-compiler/src/optimize/const_prop.rs
+++ b/wado-compiler/src/optimize/const_prop.rs
@@ -12,10 +12,10 @@
 //! Therefore, any global with `mutable == false` at optimization time is guaranteed
 //! to have a constant initializer.
 
+use crate::hashmap::IndexMap;
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind};
-use crate::hashmap::IndexMap;
 
 /// A constant value extracted from a global variable's initializer.
 #[derive(Debug, Clone)]

--- a/wado-compiler/src/optimize/const_prop.rs
+++ b/wado-compiler/src/optimize/const_prop.rs
@@ -15,7 +15,7 @@
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind};
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 /// A constant value extracted from a global variable's initializer.
 #[derive(Debug, Clone)]
@@ -66,7 +66,7 @@ type GlobalKey = (ModuleSource, String);
 /// Collect all constant globals from the project.
 /// Returns a map from (`module_source`, name) to the constant value.
 fn collect_constant_globals(project: &Project) -> IndexMap<GlobalKey, ConstValue> {
-    let mut constants: IndexMap<GlobalKey, ConstValue> = IndexMap::new();
+    let mut constants: IndexMap<GlobalKey, ConstValue> = IndexMap::default();
 
     for module in project.tir_modules.values() {
         for global in &module.globals {

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -15,8 +15,8 @@ use crate::tir::{
     ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp,
     TypeId, TypeTable,
 };
-use indexmap::IndexMap;
-use indexmap::IndexSet;
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 
 /// Information about a copy binding that may be eliminable.
 /// Pattern: `let x: T = y` where y is a local variable or simple literal
@@ -105,7 +105,7 @@ fn analyze_copy_binding(stmt: &TirStmt) -> Option<CopyBinding> {
 
 /// Collect usage information for all locals in a function body.
 fn collect_local_usage(body: &TirBlock) -> IndexMap<u32, LocalUsage> {
-    let mut usage: IndexMap<u32, LocalUsage> = IndexMap::new();
+    let mut usage: IndexMap<u32, LocalUsage> = IndexMap::default();
     collect_usage_in_block(body, &mut usage, false);
     usage
 }
@@ -1094,7 +1094,7 @@ fn propagate_copies_in_function(func: &mut TirFunction, type_table: &TypeTable) 
         // (e.g., `let a = 5; let x = a`).
         let target_set: IndexSet<u32> = eliminable.iter().map(|b| b.target_local).collect();
 
-        let mut substitutions: IndexMap<u32, CopySource> = IndexMap::new();
+        let mut substitutions: IndexMap<u32, CopySource> = IndexMap::default();
         let mut has_deferred = false;
 
         for binding in eliminable {

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -10,13 +10,13 @@
 //! - For local-to-local copies: the source is not modified after the copy
 //! - For value types: the source is dead after the binding (`read_count` is 1)
 
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 use crate::project::Project;
 use crate::tir::{
     ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp,
     TypeId, TypeTable,
 };
-use crate::hashmap::IndexMap;
-use crate::hashmap::IndexSet;
 
 /// Information about a copy binding that may be eliminable.
 /// Pattern: `let x: T = y` where y is a local variable or simple literal

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -10,6 +10,7 @@
 
 use crate::hashmap::IndexSet;
 
+use crate::hashmap::IndexMap;
 use crate::name::{
     FreeFunctionName, FunctionId, MethodName, ModuleSource, mangle_generic_name,
     mangle_local_method, mangle_local_trait_method, mangle_method_generic,
@@ -19,7 +20,6 @@ use crate::tir::{
     ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirImport, TirModule, TirStmt,
     TirStmtKind, TypeId, TypeTable,
 };
-use crate::hashmap::IndexMap;
 
 /// Call graph: function ID -> set of called function IDs
 type CallGraph = IndexMap<FunctionId, IndexSet<FunctionId>>;
@@ -2789,10 +2789,10 @@ mod tests {
     #[test]
     fn test_transitive_reachability() {
         let mut call_graph = IndexMap::default();
-        call_graph.insert(free_fn("run"), IndexSet::from([free_fn("foo")]));
-        call_graph.insert(free_fn("foo"), IndexSet::from([free_fn("bar")]));
+        call_graph.insert(free_fn("run"), IndexSet::from_iter([free_fn("foo")]));
+        call_graph.insert(free_fn("foo"), IndexSet::from_iter([free_fn("bar")]));
         call_graph.insert(free_fn("bar"), IndexSet::default());
-        call_graph.insert(free_fn("unused"), IndexSet::from([free_fn("bar")]));
+        call_graph.insert(free_fn("unused"), IndexSet::from_iter([free_fn("bar")]));
 
         let reachable = compute_reachable(&call_graph, &free_fn("run"));
         assert!(reachable.contains(&free_fn("run")));

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -8,7 +8,7 @@
 //! 2. **Constant branch pruning**: When an `if` condition is a compile-time boolean
 //!    literal, the dead branch is eliminated and the taken branch is inlined in place.
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use crate::name::{
     FreeFunctionName, FunctionId, MethodName, ModuleSource, mangle_generic_name,
@@ -19,7 +19,7 @@ use crate::tir::{
     ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirImport, TirModule, TirStmt,
     TirStmtKind, TypeId, TypeTable,
 };
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 /// Call graph: function ID -> set of called function IDs
 type CallGraph = IndexMap<FunctionId, IndexSet<FunctionId>>;
@@ -72,7 +72,7 @@ pub fn analyze_project(project: &mut Project) {
     }
 
     // Compute reachable functions from all entry points
-    let mut reachable = IndexSet::new();
+    let mut reachable = IndexSet::default();
     for entry_name in &entry_func_names {
         let entry_func = FunctionId::Free(FreeFunctionName::from_module_source(
             &project.entry_module_source,
@@ -116,7 +116,7 @@ pub fn analyze_project(project: &mut Project) {
     }
 
     // Collect used WASI functions from reachable functions
-    let mut used_wasi_functions: IndexSet<String> = IndexSet::new();
+    let mut used_wasi_functions: IndexSet<String> = IndexSet::default();
     for func_id in &reachable {
         if let Some(effects) = effect_usage.get(func_id) {
             for (effect_name, op_name) in effects {
@@ -188,7 +188,7 @@ pub fn analyze_project(project: &mut Project) {
     }
 
     // Collect imports using registry lookup instead of hard-coded match
-    let mut imports: IndexSet<TirImport> = IndexSet::new();
+    let mut imports: IndexSet<TirImport> = IndexSet::default();
 
     // Helper to add an import from builtin registry by function name
     let add_import_by_name = |imports: &mut IndexSet<TirImport>, name: &str| {
@@ -267,7 +267,7 @@ pub fn analyze_project(project: &mut Project) {
     // Filter string literals in each module to only include strings from reachable functions
     for module in project.tir_modules.values_mut() {
         let module_source = &module.module_source;
-        let mut reachable_strings: IndexSet<String> = IndexSet::new();
+        let mut reachable_strings: IndexSet<String> = IndexSet::default();
 
         for (func_name, strings) in &module.function_strings {
             // Build function ID(s) to check if it's reachable
@@ -317,9 +317,9 @@ pub fn analyze_project(project: &mut Project) {
 fn build_analysis_graph(
     modules: &IndexMap<ModuleSource, TirModule>,
 ) -> (CallGraph, EffectUsageMap, CanonicalMethodUsageMap) {
-    let mut call_graph: CallGraph = IndexMap::new();
-    let mut effect_usage: EffectUsageMap = IndexMap::new();
-    let mut canonical_method_usage: CanonicalMethodUsageMap = IndexMap::new();
+    let mut call_graph: CallGraph = IndexMap::default();
+    let mut effect_usage: EffectUsageMap = IndexMap::default();
+    let mut canonical_method_usage: CanonicalMethodUsageMap = IndexMap::default();
 
     for (module_source, module) in modules {
         let type_table = &*module.type_table.borrow();
@@ -1085,7 +1085,7 @@ fn compute_reachable(
     call_graph: &IndexMap<FunctionId, IndexSet<FunctionId>>,
     entry: &FunctionId,
 ) -> IndexSet<FunctionId> {
-    let mut reachable = IndexSet::new();
+    let mut reachable = IndexSet::default();
     let mut worklist = vec![entry.clone()];
 
     while let Some(func) = worklist.pop() {
@@ -1219,7 +1219,7 @@ fn is_generic_func_reachable(
 /// A type is reachable if it's used in any reachable function's signature,
 /// locals, or expressions.
 fn compute_reachable_types(project: &Project) -> IndexSet<TypeId> {
-    let mut reachable_types: IndexSet<TypeId> = IndexSet::new();
+    let mut reachable_types: IndexSet<TypeId> = IndexSet::default();
 
     // Always include primitive types (TypeId 0-17)
     for i in 0..18 {
@@ -1905,7 +1905,7 @@ pub fn remove_unreachable_types(project: &mut Project) {
 pub fn remove_unreachable_globals(project: &mut Project) {
     // Phase 1: Collect all GlobalVarGet references from surviving functions.
     // Key: (module_source path as string, global name)
-    let mut used_globals: IndexSet<(String, String)> = IndexSet::new();
+    let mut used_globals: IndexSet<(String, String)> = IndexSet::default();
 
     for module in project.tir_modules.values() {
         for func_rc in &module.functions {
@@ -2779,7 +2779,7 @@ mod tests {
 
     #[test]
     fn test_empty_reachable_set() {
-        let call_graph = IndexMap::new();
+        let call_graph = IndexMap::default();
         let entry = free_fn("run");
         let reachable = compute_reachable(&call_graph, &entry);
         assert!(reachable.contains(&free_fn("run")));
@@ -2788,10 +2788,10 @@ mod tests {
 
     #[test]
     fn test_transitive_reachability() {
-        let mut call_graph = IndexMap::new();
+        let mut call_graph = IndexMap::default();
         call_graph.insert(free_fn("run"), IndexSet::from([free_fn("foo")]));
         call_graph.insert(free_fn("foo"), IndexSet::from([free_fn("bar")]));
-        call_graph.insert(free_fn("bar"), IndexSet::new());
+        call_graph.insert(free_fn("bar"), IndexSet::default());
         call_graph.insert(free_fn("unused"), IndexSet::from([free_fn("bar")]));
 
         let reachable = compute_reachable(&call_graph, &free_fn("run"));

--- a/wado-compiler/src/optimize/field_scalarize.rs
+++ b/wado-compiler/src/optimize/field_scalarize.rs
@@ -31,7 +31,7 @@ use crate::tir::{
     FunctionRef, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind,
     TirUnaryOp, TypeId, TypeTable,
 };
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 const MIN_ACCESS_COUNT: usize = 4;
 
@@ -61,7 +61,7 @@ pub fn scalarize_hot_fields(project: &mut Project) -> bool {
 fn build_field_usage_cache(
     modules: &IndexMap<ModuleSource, crate::tir::TirModule>,
 ) -> FieldUsageCache {
-    let mut cache = FieldUsageCache::new();
+    let mut cache = FieldUsageCache::default();
     for (module_source, module) in modules {
         let type_table = module.type_table.borrow();
         for func_rc in &module.functions {
@@ -83,12 +83,12 @@ fn analyze_function_field_usage(
     type_table: &TypeTable,
 ) -> IndexMap<u32, ParamFieldUsage> {
     let Some(ref body) = func.body else {
-        return IndexMap::new();
+        return IndexMap::default();
     };
 
     // Build mapping: local_index → param_position for struct-typed params
-    let mut local_to_position: IndexMap<u32, u32> = IndexMap::new();
-    let mut struct_param_locals: IndexSet<u32> = IndexSet::new();
+    let mut local_to_position: IndexMap<u32, u32> = IndexMap::default();
+    let mut struct_param_locals: IndexSet<u32> = IndexSet::default();
 
     for (position, param) in func.params.iter().enumerate() {
         if is_gc_heap_type(param.type_id, type_table) {
@@ -98,11 +98,11 @@ fn analyze_function_field_usage(
     }
 
     if struct_param_locals.is_empty() {
-        return IndexMap::new();
+        return IndexMap::default();
     }
 
-    let mut field_sets: IndexMap<u32, IndexSet<u32>> = IndexMap::new();
-    let mut conservative_locals: IndexSet<u32> = IndexSet::new();
+    let mut field_sets: IndexMap<u32, IndexSet<u32>> = IndexMap::default();
+    let mut conservative_locals: IndexSet<u32> = IndexSet::default();
 
     collect_param_field_usage_in_block(
         body,
@@ -113,7 +113,7 @@ fn analyze_function_field_usage(
     );
 
     // Convert from local_index-keyed to position-keyed
-    let mut result: IndexMap<u32, ParamFieldUsage> = IndexMap::new();
+    let mut result: IndexMap<u32, ParamFieldUsage> = IndexMap::default();
     for (&local_idx, &position) in &local_to_position {
         if conservative_locals.contains(&local_idx) {
             result.insert(position, None);
@@ -794,7 +794,7 @@ fn scalarize_loop(
     cache: &FieldUsageCache,
 ) -> ScalarizeResult {
     // Step 1: Count field accesses (reads + writes) in the loop body
-    let mut access_counts: IndexMap<(u32, u32), FieldAccessInfo> = IndexMap::new();
+    let mut access_counts: IndexMap<(u32, u32), FieldAccessInfo> = IndexMap::default();
     count_field_accesses_in_block(loop_body, &mut access_counts, type_table);
 
     // Step 2: Select candidates - fields accessed frequently enough,
@@ -1268,7 +1268,7 @@ fn replace_in_block(
                 // Calls inside the condition can modify scalarized fields (e.g.
                 // `if !self.expect_byte(b)` where expect_byte mutates self.pos).
                 // Insert write-back before the If and re-read after it.
-                let mut cond_sync: IndexSet<(u32, u32)> = IndexSet::new();
+                let mut cond_sync: IndexSet<(u32, u32)> = IndexSet::default();
                 compute_sync_fields_in_expr(
                     condition,
                     candidates,
@@ -1301,7 +1301,7 @@ fn replace_in_block(
                 ..
             } => {
                 // Same as If: calls in the scrutinee can modify scalarized fields.
-                let mut scrut_sync: IndexSet<(u32, u32)> = IndexSet::new();
+                let mut scrut_sync: IndexSet<(u32, u32)> = IndexSet::default();
                 compute_sync_fields_in_expr(
                     scrutinee,
                     candidates,
@@ -1391,7 +1391,7 @@ fn compute_sync_fields(
     type_table: &TypeTable,
     cache: &FieldUsageCache,
 ) -> IndexSet<(u32, u32)> {
-    let mut result = IndexSet::new();
+    let mut result = IndexSet::default();
     compute_sync_fields_in_stmt(stmt, candidates, type_table, cache, &mut result);
     result
 }

--- a/wado-compiler/src/optimize/field_scalarize.rs
+++ b/wado-compiler/src/optimize/field_scalarize.rs
@@ -25,13 +25,13 @@
 //! on each struct-typed parameter. If the callee cannot be resolved or passes the struct
 //! transitively to another unknown call, all fields are conservatively synced.
 
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{
     FunctionRef, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind,
     TirUnaryOp, TypeId, TypeTable,
 };
-use crate::hashmap::{IndexMap, IndexSet};
 
 const MIN_ACCESS_COUNT: usize = 4;
 

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -3,14 +3,14 @@
 //! This module provides function inlining for small, pure functions.
 //! It uses labeled block expressions for cleaner value handling.
 
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 use crate::name::ModuleSource;
 use crate::project::Project;
 use crate::tir::{
     CallArg, FunctionRef, InlineHint, PrimitiveType, ResolvedType, TirBlock, TirExpr, TirExprKind,
     TirFunction, TirModule, TirPattern, TirStmt, TirStmtKind, TirUnaryOp, TypeId, TypeTable,
 };
-use crate::hashmap::IndexMap;
-use crate::hashmap::IndexSet;
 
 // The inline threshold is based on expression count, which provides a more
 // accurate measure of function complexity than statement count.

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -9,8 +9,8 @@ use crate::tir::{
     CallArg, FunctionRef, InlineHint, PrimitiveType, ResolvedType, TirBlock, TirExpr, TirExprKind,
     TirFunction, TirModule, TirPattern, TirStmt, TirStmtKind, TirUnaryOp, TypeId, TypeTable,
 };
-use indexmap::IndexMap;
-use indexmap::IndexSet;
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 
 // The inline threshold is based on expression count, which provides a more
 // accurate measure of function complexity than statement count.
@@ -197,10 +197,10 @@ fn is_inline_eligible(
 
 /// Detect recursive functions using call graph analysis
 fn find_recursive_functions(modules: &IndexMap<ModuleSource, TirModule>) -> IndexSet<String> {
-    let mut recursive = IndexSet::new();
+    let mut recursive = IndexSet::default();
 
     // Build a simple call graph: function name -> called function names
-    let mut call_graph: IndexMap<String, IndexSet<String>> = IndexMap::new();
+    let mut call_graph: IndexMap<String, IndexSet<String>> = IndexMap::default();
 
     for module in modules.values() {
         for func_rc in &module.functions {
@@ -212,7 +212,7 @@ fn find_recursive_functions(modules: &IndexMap<ModuleSource, TirModule>) -> Inde
 
     // Find functions that can reach themselves
     for func_name in call_graph.keys() {
-        if can_reach(&call_graph, func_name, func_name, &mut IndexSet::new()) {
+        if can_reach(&call_graph, func_name, func_name, &mut IndexSet::default()) {
             recursive.insert(func_name.clone());
         }
     }
@@ -222,7 +222,7 @@ fn find_recursive_functions(modules: &IndexMap<ModuleSource, TirModule>) -> Inde
 
 /// Collect all function names called from a function
 fn collect_callees_from_function(func: &TirFunction) -> IndexSet<String> {
-    let mut callees = IndexSet::new();
+    let mut callees = IndexSet::default();
     if let Some(body) = &func.body {
         collect_callees_from_block(body, &mut callees);
     }
@@ -457,10 +457,10 @@ pub fn inline_functions(project: &mut Project, inline_threshold: usize) -> bool 
 
     // Collect inline candidates from all modules
     // Key: (module_source, func_name), Value: cloned function
-    let mut inline_candidates: IndexMap<(ModuleSource, String), TirFunction> = IndexMap::new();
+    let mut inline_candidates: IndexMap<(ModuleSource, String), TirFunction> = IndexMap::default();
 
     // Also collect function_strings for each candidate (to update caller's strings after inlining)
-    let mut candidate_strings: IndexMap<(ModuleSource, String), Vec<String>> = IndexMap::new();
+    let mut candidate_strings: IndexMap<(ModuleSource, String), Vec<String>> = IndexMap::default();
 
     for (module_source, module) in &project.tir_modules {
         for func_rc in &module.functions {
@@ -521,7 +521,7 @@ pub fn inline_functions(project: &mut Project, inline_threshold: usize) -> bool 
                 }
 
                 // Update function_strings: add strings from inlined functions to the caller
-                let mut all_inlined_strings: IndexSet<String> = IndexSet::new();
+                let mut all_inlined_strings: IndexSet<String> = IndexSet::default();
                 for inlined_key in inlined_funcs {
                     if let Some(inlined_strings) = candidate_strings.get(&inlined_key) {
                         all_inlined_strings.extend(inlined_strings.iter().cloned());
@@ -1079,7 +1079,7 @@ fn try_inline_call_expr(
     // IMPORTANT: Push param types first to match index assignment order
     // (params get indices local_offset+0, local_offset+1, ..., then non-params follow)
     let mut block_stmts = Vec::new();
-    let mut param_to_local: IndexMap<u32, u32> = IndexMap::new();
+    let mut param_to_local: IndexMap<u32, u32> = IndexMap::default();
 
     for (i, (param, arg)) in candidate.params.iter().zip(args.iter()).enumerate() {
         let new_local_index = local_offset + i as u32;
@@ -1198,7 +1198,7 @@ fn try_inline_method_call_expr(
     // IMPORTANT: Push param types first to match index assignment order
     // For methods, first param is `self` (receiver), then the rest are args
     let mut block_stmts = Vec::new();
-    let mut param_to_local: IndexMap<u32, u32> = IndexMap::new();
+    let mut param_to_local: IndexMap<u32, u32> = IndexMap::default();
 
     // Bind receiver to first parameter (self).
     // For &mut self receivers, wrap in a MutRef expression so that field

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -4,13 +4,13 @@
 //! It identifies field accesses on variables that don't change within a loop and moves
 //! those accesses before the loop.
 
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 use crate::project::Project;
 use crate::tir::{
     ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirPattern, TirStmt, TirStmtKind,
     TirUnaryOp, TypeId, TypeTable,
 };
-use crate::hashmap::IndexMap;
-use crate::hashmap::IndexSet;
 
 /// Tracks which variables and fields are modified within a loop.
 ///

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -9,8 +9,8 @@ use crate::tir::{
     ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirPattern, TirStmt, TirStmtKind,
     TirUnaryOp, TypeId, TypeTable,
 };
-use indexmap::IndexMap;
-use indexmap::IndexSet;
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 
 /// Tracks which variables and fields are modified within a loop.
 ///
@@ -85,7 +85,7 @@ fn licm_block(
         match &mut stmt.kind {
             TirStmtKind::Loop { body } => {
                 // Apply LICM to the loop body
-                let empty_set = IndexSet::new();
+                let empty_set = IndexSet::default();
                 let hoist_stmts = licm_loop(body, local_count, local_types, type_table, &empty_set);
 
                 if !hoist_stmts.is_empty() {
@@ -162,7 +162,7 @@ fn licm_loop(
 
         // Step 3: Find field accesses that can be hoisted
         let mut candidates = Vec::new();
-        let mut seen = IndexSet::new();
+        let mut seen = IndexSet::default();
         let mut next_local = *local_count;
         find_hoist_candidates_in_block(
             loop_body,
@@ -630,7 +630,7 @@ fn collect_immutable_ref_bindings(
     block: &TirBlock,
     type_table: &TypeTable,
 ) -> IndexMap<u32, LicmRefBinding> {
-    let mut bindings = IndexMap::new();
+    let mut bindings = IndexMap::default();
     collect_licm_ref_bindings_in_block(block, type_table, &mut bindings);
     bindings
 }

--- a/wado-compiler/src/optimize/ref_elim.rs
+++ b/wado-compiler/src/optimize/ref_elim.rs
@@ -23,11 +23,11 @@
 //! Pass 2 (transform): Single traversal to replace eliminable field accesses
 //!   and remove dead let statements.
 
+use crate::hashmap::IndexMap;
 use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp, TypeTable,
 };
-use crate::hashmap::IndexMap;
 
 /// Per-binding analysis state, keyed by the ref local index.
 struct RefInfo {

--- a/wado-compiler/src/optimize/ref_elim.rs
+++ b/wado-compiler/src/optimize/ref_elim.rs
@@ -27,7 +27,7 @@ use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp, TypeTable,
 };
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 /// Per-binding analysis state, keyed by the ref local index.
 struct RefInfo {
@@ -460,7 +460,7 @@ fn eliminate_refs_in_function(func: &mut TirFunction, _type_table: &TypeTable) -
     };
 
     // Pass 1: Collect all ref bindings and analyze uses in a single traversal.
-    let mut refs: IndexMap<u32, RefInfo> = IndexMap::new();
+    let mut refs: IndexMap<u32, RefInfo> = IndexMap::default();
     analyze_refs_in_block(body, &mut refs);
 
     // Filter to only eliminable bindings

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -29,8 +29,8 @@ use crate::tir::{
     TypeId, TypeTable,
 };
 use crate::token::Span;
-use indexmap::IndexMap;
-use indexmap::IndexSet;
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 
 /// Information about a struct/tuple local that may be decomposable.
 struct SroaCandidate {
@@ -82,8 +82,8 @@ fn sroa_in_function(func: &mut TirFunction, type_table: &TypeTable) -> bool {
     let soft_escaped = find_soft_escaped_locals(body, &candidates, &escaped);
 
     // Filter candidates: non-escaped are "safe", soft-escaped are "reconstruct".
-    let mut safe_set: IndexSet<u32> = IndexSet::new();
-    let mut reconstruct_set: IndexSet<u32> = IndexSet::new();
+    let mut safe_set: IndexSet<u32> = IndexSet::default();
+    let mut reconstruct_set: IndexSet<u32> = IndexSet::default();
     for c in &candidates {
         if !escaped.contains(&c.local_index) {
             safe_set.insert(c.local_index);
@@ -104,9 +104,9 @@ fn sroa_in_function(func: &mut TirFunction, type_table: &TypeTable) -> bool {
 
     // Step 3: Allocate scalar locals for each field of each SROA'd candidate.
     // Map: (original_local, field_index) → new_local_index
-    let mut field_local_map: IndexMap<(u32, u32), u32> = IndexMap::new();
+    let mut field_local_map: IndexMap<(u32, u32), u32> = IndexMap::default();
     // Map: (original_local, field_index) → (new_local_name, field_type)
-    let mut field_info_map: IndexMap<(u32, u32), (String, TypeId)> = IndexMap::new();
+    let mut field_info_map: IndexMap<(u32, u32), (String, TypeId)> = IndexMap::default();
 
     for candidate in &candidates {
         if !all_sroa.contains(&candidate.local_index) {
@@ -124,8 +124,8 @@ fn sroa_in_function(func: &mut TirFunction, type_table: &TypeTable) -> bool {
     }
 
     // Collect mutability and reconstruction info for SROA'd candidates.
-    let mut candidate_mut: IndexMap<u32, bool> = IndexMap::new();
-    let mut reconstruct_info: IndexMap<u32, ReconstructInfo> = IndexMap::new();
+    let mut candidate_mut: IndexMap<u32, bool> = IndexMap::default();
+    let mut reconstruct_info: IndexMap<u32, ReconstructInfo> = IndexMap::default();
     for candidate in &candidates {
         if !all_sroa.contains(&candidate.local_index) {
             continue;
@@ -336,7 +336,7 @@ fn collect_candidates_in_expr(
 /// Escape analysis: find all candidate locals that escape (used in non-field-access positions).
 fn find_escaped_locals(body: &TirBlock, candidates: &[SroaCandidate]) -> IndexSet<u32> {
     let candidate_set: IndexSet<u32> = candidates.iter().map(|c| c.local_index).collect();
-    let mut escaped = IndexSet::new();
+    let mut escaped = IndexSet::default();
     check_escape_in_block(body, &candidate_set, &mut escaped);
     escaped
 }
@@ -609,15 +609,15 @@ fn find_soft_escaped_locals(
         .filter(|idx| escaped.contains(idx))
         .collect();
     if escaped_candidates.is_empty() {
-        return IndexSet::new();
+        return IndexSet::default();
     }
 
     // Check: does every non-field-access use of this candidate appear as a call arg or return?
-    let mut hard_escaped = IndexSet::new();
+    let mut hard_escaped = IndexSet::default();
     check_soft_escape_in_block(body, &escaped_candidates, &mut hard_escaped);
 
     // Soft-escaped = escaped but NOT hard-escaped, AND has at least one field access
-    let mut has_field_access = IndexSet::new();
+    let mut has_field_access = IndexSet::default();
     check_has_field_access(body, &escaped_candidates, &mut has_field_access);
 
     escaped_candidates

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -23,14 +23,14 @@
 //! This is the single most impactful optimization for WasmGC-targeting compilers,
 //! as struct allocations are GC-managed heap objects.
 
+use crate::hashmap::IndexMap;
+use crate::hashmap::IndexSet;
 use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirStructField, TirUnaryOp,
     TypeId, TypeTable,
 };
 use crate::token::Span;
-use crate::hashmap::IndexMap;
-use crate::hashmap::IndexSet;
 
 /// Information about a struct/tuple local that may be decomposable.
 struct SroaCandidate {

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -26,7 +26,7 @@ use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp, TypeTable,
 };
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 /// A forwardable value: a scalar literal.
 /// We only forward literals (not locals) to avoid complications with
@@ -107,7 +107,7 @@ impl KnownValues {
 
 /// Collect all locals that are assigned within a block (including nested blocks).
 fn collect_modified_locals(block: &TirBlock) -> IndexSet<u32> {
-    let mut modified = IndexSet::new();
+    let mut modified = IndexSet::default();
     for stmt in &block.stmts {
         collect_modified_in_stmt(stmt, &mut modified);
     }
@@ -287,7 +287,7 @@ fn collect_modified_in_expr(expr: &TirExpr, modified: &mut IndexSet<u32>) {
 /// - Captured by a closure
 /// - Assigned through dereference (*ptr = ...)
 fn collect_unsafe_locals(body: &TirBlock) -> IndexSet<u32> {
-    let mut unsafe_locals = IndexSet::new();
+    let mut unsafe_locals = IndexSet::default();
     collect_unsafe_in_block(body, &mut unsafe_locals);
     unsafe_locals
 }
@@ -748,7 +748,7 @@ fn forward_in_expr(
         }
         TirExprKind::Match { expr: inner, arms } => {
             changed |= forward_in_expr(inner, known, unsafe_locals, type_table);
-            let mut modified = IndexSet::new();
+            let mut modified = IndexSet::default();
             for arm in arms.iter() {
                 if let Some(guard) = &arm.guard {
                     collect_modified_in_expr(guard, &mut modified);
@@ -780,7 +780,7 @@ fn forward_in_expr(
             ..
         } => {
             changed |= forward_in_expr(scrutinee, known, unsafe_locals, type_table);
-            let mut modified = IndexSet::new();
+            let mut modified = IndexSet::default();
             for arm in arms.iter() {
                 modified.extend(collect_modified_locals(arm));
             }

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -22,11 +22,11 @@
 //! invalidated (selective invalidation), allowing known values for unmodified
 //! locals to survive through assert branches and similar patterns.
 
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp, TypeTable,
 };
-use crate::hashmap::{IndexMap, IndexSet};
 
 /// A forwardable value: a scalar literal.
 /// We only forward literals (not locals) to avoid complications with

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -39,7 +39,7 @@ use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TypeId, TypeTable,
 };
 use crate::token::Span;
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 /// Apply template string buffer hoisting to all functions in the project.
 pub fn hoist_template_buffers(project: &mut Project) -> bool {
@@ -165,7 +165,7 @@ fn hoist_tmpl_from_loop(
 /// Collect local indices that "escape" — used as a non-receiver function argument
 /// or stored in a struct/array/collection.
 fn collect_escaping_locals(block: &TirBlock) -> IndexSet<u32> {
-    let mut escaping = IndexSet::new();
+    let mut escaping = IndexSet::default();
     for stmt in &block.stmts {
         collect_escaping_in_stmt(stmt, &mut escaping);
     }

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -34,12 +34,12 @@
 //! the result must be bound to a Let variable that is only used as a method
 //! receiver (`self`), never passed as a regular function argument.
 
+use crate::hashmap::IndexSet;
 use crate::project::Project;
 use crate::tir::{
     TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TypeId, TypeTable,
 };
 use crate::token::Span;
-use crate::hashmap::IndexSet;
 
 /// Apply template string buffer hoisting to all functions in the project.
 pub fn hoist_template_buffers(project: &mut Project) -> bool {

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -33,7 +33,7 @@ pub struct Parser {
     /// Content of the __DATA__ section, passed from the lexer.
     data_section: Option<String>,
     /// Paths referenced by `#include_str` / `#include_bytes`, collected as they are parsed.
-    include_paths: indexmap::IndexSet<String>,
+    include_paths: crate::hashmap::IndexSet<String>,
 }
 
 #[derive(Debug)]
@@ -78,7 +78,7 @@ impl Parser {
             restrict_struct_literals: false,
             shebang: None,
             data_section: None,
-            include_paths: indexmap::IndexSet::new(),
+            include_paths: crate::hashmap::IndexSet::default(),
         }
     }
 
@@ -95,7 +95,7 @@ impl Parser {
             restrict_struct_literals: false,
             shebang,
             data_section,
-            include_paths: indexmap::IndexSet::new(),
+            include_paths: crate::hashmap::IndexSet::default(),
         }
     }
 

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -10,12 +10,12 @@
 
 use crate::builtin_registry::BuiltinRegistry;
 use crate::component_model::WasiRegistry;
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::name::{FunctionId, ModuleSource};
 use crate::symbol::SymbolTable;
 use crate::tir::{TirModule, TypeId};
 use crate::wasm_plan::ComponentPlan;
 use crate::world_registry::{self, WorldRegistry};
-use crate::hashmap::{IndexMap, IndexSet};
 
 /// A Wado project ready for code generation.
 ///

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -15,7 +15,7 @@ use crate::symbol::SymbolTable;
 use crate::tir::{TirModule, TypeId};
 use crate::wasm_plan::ComponentPlan;
 use crate::world_registry::{self, WorldRegistry};
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 /// A Wado project ready for code generation.
 ///
@@ -93,8 +93,8 @@ impl Project {
             world_registry,
             builtin_registry,
             // Usage analysis fields default to empty/false
-            reachable_functions: IndexSet::new(),
-            used_wasi_functions: IndexSet::new(),
+            reachable_functions: IndexSet::default(),
+            used_wasi_functions: IndexSet::default(),
             // Codegen options
             strip_names: false,
             skip_validation: false,
@@ -102,7 +102,7 @@ impl Project {
             // CM export characteristics
             has_http_handler_export: false,
             // CM export adapter mapping
-            export_adapter_names: IndexMap::new(),
+            export_adapter_names: IndexMap::default(),
             task_return_flat_params: None,
             // Wasm plan
             component_plan: None,

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -28,7 +28,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, Item, Module};
 use crate::builtin_registry::BuiltinRegistry;
@@ -132,6 +132,8 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// Pre-loaded file contents for `#include_str` / `#include_bytes`.
     /// Key: `[module_source_display, raw_path]`, value: raw bytes.
     included_files: &'a IndexMap<[String; 2], Vec<u8>>,
+    /// Cached flat set of all known type names for fast `is_known_type_name` lookups.
+    known_type_names_cache: IndexSet<String>,
 }
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -150,41 +152,91 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             type_table,
             symbols,
             loaded_modules,
-            newtypes: IndexMap::new(),
-            struct_fields: IndexMap::new(),
-            variant_cases: IndexMap::new(),
-            enum_cases: IndexMap::new(),
-            flags_cases: IndexMap::new(),
-            resource_types: IndexMap::new(),
-            all_newtypes: IndexMap::new(),
-            all_struct_fields: IndexMap::new(),
-            all_variant_cases: IndexMap::new(),
-            all_enum_cases: IndexMap::new(),
-            all_flags_cases: IndexMap::new(),
-            all_resource_types: IndexMap::new(),
-            function_return_types: IndexMap::new(),
-            imported_functions: IndexSet::new(),
+            newtypes: IndexMap::default(),
+            struct_fields: IndexMap::default(),
+            variant_cases: IndexMap::default(),
+            enum_cases: IndexMap::default(),
+            flags_cases: IndexMap::default(),
+            resource_types: IndexMap::default(),
+            all_newtypes: IndexMap::default(),
+            all_struct_fields: IndexMap::default(),
+            all_variant_cases: IndexMap::default(),
+            all_enum_cases: IndexMap::default(),
+            all_flags_cases: IndexMap::default(),
+            all_resource_types: IndexMap::default(),
+            function_return_types: IndexMap::default(),
+            imported_functions: IndexSet::default(),
             logger,
             current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
             current_module_items: Vec::new(),
-            current_type_params: IndexMap::new(),
-            current_type_param_bounds: IndexMap::new(),
-            generic_struct_names: IndexSet::new(),
-            generic_function_params: IndexMap::new(),
-            generic_method_params: IndexMap::new(),
-            current_associated_type_bindings: IndexMap::new(),
+            current_type_params: IndexMap::default(),
+            current_type_param_bounds: IndexMap::default(),
+            generic_struct_names: IndexSet::default(),
+            generic_function_params: IndexMap::default(),
+            generic_method_params: IndexMap::default(),
+            current_associated_type_bindings: IndexMap::default(),
             current_self_type: None,
             wasi_registry,
             builtin_registry,
-            current_module_globals: IndexMap::new(),
-            imported_globals: IndexMap::new(),
-            associated_constants: IndexMap::new(),
-            module_type_maps_cache: IndexMap::new(),
+            current_module_globals: IndexMap::default(),
+            imported_globals: IndexMap::default(),
+            associated_constants: IndexMap::default(),
+            module_type_maps_cache: IndexMap::default(),
             trait_impl_index,
             trait_decl_index,
             blanket_trait_impl_index,
             included_files,
+            known_type_names_cache: IndexSet::default(),
         }
+    }
+
+    /// Build the flat set of all known type names from current and cross-module maps.
+    fn rebuild_known_type_names_cache(&mut self) {
+        let mut cache = IndexSet::default();
+        for name in self.struct_fields.keys() {
+            cache.insert(name.clone());
+        }
+        for m in self.all_struct_fields.values() {
+            for name in m.keys() {
+                cache.insert(name.clone());
+            }
+        }
+        for name in self.variant_cases.keys() {
+            cache.insert(name.clone());
+        }
+        for m in self.all_variant_cases.values() {
+            for name in m.keys() {
+                cache.insert(name.clone());
+            }
+        }
+        for name in self.enum_cases.keys() {
+            cache.insert(name.clone());
+        }
+        for m in self.all_enum_cases.values() {
+            for name in m.keys() {
+                cache.insert(name.clone());
+            }
+        }
+        for name in self.flags_cases.keys() {
+            cache.insert(name.clone());
+        }
+        for m in self.all_flags_cases.values() {
+            for name in m.keys() {
+                cache.insert(name.clone());
+            }
+        }
+        for name in self.newtypes.keys() {
+            cache.insert(name.clone());
+        }
+        for m in self.all_newtypes.values() {
+            for name in m.keys() {
+                cache.insert(name.clone());
+            }
+        }
+        for name in crate::tir::PrimitiveType::all_primitive_names() {
+            cache.insert(name.to_string());
+        }
+        self.known_type_names_cache = cache;
     }
 
     /// Resolve a module, converting AST to TIR
@@ -569,7 +621,7 @@ pub fn resolve_module<H: CompilerHost>(
 ) -> Result<TirModule, Bail> {
     let type_table = std::cell::RefCell::new(crate::tir::TypeTable::new());
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
-    let empty_included = IndexMap::new();
+    let empty_included = IndexMap::default();
     let mut resolver = Resolver::new(
         symbols,
         loaded_modules,

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1,6 +1,6 @@
 //! Function call resolution.
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::ast::{self, Expr, Item, Type};
 use crate::compiler_host::CompilerHost;
@@ -521,7 +521,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // callee's types, not the caller's (which may have same-named different types).
                 let callee_module_ast = self.loaded_modules.get(callee_module);
                 let (callee_imported, callee_original_names) = callee_module_ast.map_or_else(
-                    || (IndexMap::new(), IndexMap::new()),
+                    || (IndexMap::default(), IndexMap::default()),
                     |m| Self::build_imported_type_sources(m, callee_module),
                 );
                 let callee_newtypes = Self::build_module_map(
@@ -1012,7 +1012,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         payload: Option<&TirExpr>,
         expected_type: Option<TypeId>,
     ) -> TypeId {
-        let mut type_param_map: IndexMap<TypeId, TypeId> = IndexMap::new();
+        let mut type_param_map: IndexMap<TypeId, TypeId> = IndexMap::default();
         // Track the canonical module_source from expected_type if available.
         // This ensures the created GenericInstance uses the same module_source
         // as the type annotation (e.g., ModuleSource::prelude() for Option/Result),

--- a/wado-compiler/src/resolver/closure.rs
+++ b/wado-compiler/src/resolver/closure.rs
@@ -1,6 +1,6 @@
 //! Closure expression resolution (mutable and immutable captures).
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use crate::ast::{self};
 use crate::compiler_host::CompilerHost;
@@ -11,7 +11,7 @@ use crate::token::Span;
 
 use super::Resolver;
 use super::types::{FunctionContext, TypeError};
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 impl<H: CompilerHost> Resolver<'_, H> {
     pub(super) fn resolve_mutable_closure(
@@ -21,13 +21,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
         span: Span,
     ) -> TirExpr {
         // Step 1: Find all directly-assigned outer mutable variables
-        let mut assigned_names: IndexSet<String> = IndexSet::new();
+        let mut assigned_names: IndexSet<String> = IndexSet::default();
         Self::collect_mutated_vars(&closure.body, &mut assigned_names);
 
         // Step 2: For each assigned name that is an outer mutable variable,
         // create a `&mut T` reference in the outer context
         let mut ref_stmts: Vec<TirStmt> = Vec::new();
-        let mut deref_overrides: IndexMap<String, (String, TypeId)> = IndexMap::new();
+        let mut deref_overrides: IndexMap<String, (String, TypeId)> = IndexMap::default();
 
         for var_name in &assigned_names {
             if let Some(local) = ctx.lookup(var_name)

--- a/wado-compiler/src/resolver/coercion.rs
+++ b/wado-compiler/src/resolver/coercion.rs
@@ -8,7 +8,7 @@ use crate::tir::{
     TirStmtKind, TypeId, TypeTable,
 };
 use crate::token::Span;
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use super::Resolver;
 use super::types::{FunctionContext, TypeError};
@@ -559,7 +559,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         );
 
         // Check for duplicate field names
-        let mut seen_fields: IndexSet<&str> = IndexSet::new();
+        let mut seen_fields: IndexSet<&str> = IndexSet::default();
         for field in &struct_lit.fields {
             if !seen_fields.insert(field.name.as_str()) {
                 let _ = self.logger.error(TypeError::DuplicateField {

--- a/wado-compiler/src/resolver/coercion.rs
+++ b/wado-compiler/src/resolver/coercion.rs
@@ -2,13 +2,13 @@
 
 use crate::ast::{self, Expr, Literal, UnaryOp};
 use crate::compiler_host::CompilerHost;
+use crate::hashmap::IndexSet;
 use crate::name::{LocalMethodName, MethodName, ModuleSource};
 use crate::tir::{
     CallArg, FunctionRef, MonomorphInfo, ResolvedType, TirBlock, TirExpr, TirExprKind, TirStmt,
     TirStmtKind, TypeId, TypeTable,
 };
 use crate::token::Span;
-use crate::hashmap::IndexSet;
 
 use super::Resolver;
 use super::types::{FunctionContext, TypeError};

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1,7 +1,7 @@
 //! Expression resolution (literals, identifiers, field access, index,
 //! if-expressions, match, cast, struct/tuple literals, etc.).
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, Expr, IfExpr, Item, Literal, MatchArm};
 use crate::compiler_host::CompilerHost;
@@ -2002,7 +2002,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
 
         // Build a map from type param TypeId to concrete TypeId
-        let mut type_param_map: IndexMap<TypeId, TypeId> = IndexMap::new();
+        let mut type_param_map: IndexMap<TypeId, TypeId> = IndexMap::default();
 
         for (struct_field, (_, expected_type_id, _)) in fields.iter().zip(struct_info.fields.iter())
         {

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -1,6 +1,6 @@
 //! Method and trait lookup, trait implementation search, bounds checking.
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, BinaryOp, Expr, Function, Item, Literal, Type, UnaryOp};
 use crate::compiler_host::CompilerHost;
@@ -60,26 +60,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
     }
 
     /// Check if a name refers to a known type (struct, variant, enum, flags, newtype, or primitive).
-    /// Used to distinguish concrete types from type parameters in impl blocks,
-    /// since the parser treats all args in `<String, V>` as type params.
+    /// Uses pre-built cache for O(1) lookup instead of scanning all module maps.
     pub(super) fn is_known_type_name(&self, name: &str) -> bool {
-        self.struct_fields.contains_key(name)
-            || self
-                .all_struct_fields
-                .values()
-                .any(|m| m.contains_key(name))
-            || self.variant_cases.contains_key(name)
-            || self
-                .all_variant_cases
-                .values()
-                .any(|m| m.contains_key(name))
-            || self.enum_cases.contains_key(name)
-            || self.all_enum_cases.values().any(|m| m.contains_key(name))
-            || self.flags_cases.contains_key(name)
-            || self.all_flags_cases.values().any(|m| m.contains_key(name))
-            || self.newtypes.contains_key(name)
-            || self.all_newtypes.values().any(|m| m.contains_key(name))
-            || crate::tir::PrimitiveType::is_primitive_name(name)
+        self.known_type_names_cache.contains(name)
     }
 
     /// Find the rhs parameter type for an operator trait on a struct type.
@@ -1834,7 +1817,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
             // Build type parameter mapping from impl_ty to concrete types
             let mut type_param_mapping =
-                Self::build_type_param_mapping(&impl_ty, &concrete_type_args, &IndexSet::new());
+                Self::build_type_param_mapping(&impl_ty, &concrete_type_args, &IndexSet::default());
             // Map `Self` to the concrete base type so `&Self` parameters resolve correctly
             type_param_mapping.insert("Self".to_string(), base_type_id);
 
@@ -1842,7 +1825,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             for method in &methods {
                 if method.name == method_name {
                     // Set up associated type bindings
-                    let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::new();
+                    let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::default();
 
                     // Process associated types (e.g., `type Output = Self`)
                     for assoc in &associated_types {
@@ -2480,7 +2463,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         concrete_type_args: &[TypeId],
         declared_type_params: &IndexSet<String>,
     ) -> IndexMap<String, TypeId> {
-        let mut mapping = IndexMap::new();
+        let mut mapping = IndexMap::default();
 
         // Extract type parameter names from impl_ty, tracking positions
         // Position tracking is needed to map type params to the correct concrete arg
@@ -2712,7 +2695,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 None => continue,
             };
 
-            let mut declared_type_params: indexmap::IndexSet<String> = impl_type_params
+            let mut declared_type_params: crate::hashmap::IndexSet<String> = impl_type_params
                 .iter()
                 .map(|p| p.name.clone())
                 .filter(|name| !self.is_known_type_name(name))

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -1,6 +1,6 @@
 //! Single module type/signature collection and name resolution helpers.
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::ast::{self, Item, Module, Type};
 use crate::compiler_host::CompilerHost;
@@ -366,8 +366,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
         Arc<TraitDeclIndex>,
         Arc<BlanketTraitImplIndex>,
     ) {
-        let mut impl_index: TraitImplIndex = IndexMap::new();
-        let mut decl_index: TraitDeclIndex = IndexMap::new();
+        let mut impl_index: TraitImplIndex = IndexMap::default();
+        let mut decl_index: TraitDeclIndex = IndexMap::default();
         let mut blanket_index: BlanketTraitImplIndex = Vec::new();
         for (module_source, module) in modules {
             for (item_idx, item) in module.items.iter().enumerate() {

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -37,7 +37,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
         // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
-        let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> = IndexMap::default();
+        let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> =
+            IndexMap::default();
         let mut all_struct_fields: IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>> =
             IndexMap::default();
         let mut all_variant_cases: IndexMap<ModuleSource, IndexMap<String, VariantInfo>> =

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, Item, Module, Type};
 use crate::builtin_registry::BuiltinRegistry;
@@ -33,21 +33,21 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         logger: &'a Logger<'a, H>,
         included_files: &'a IndexMap<[String; 2], Vec<u8>>,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
-        let mut result = IndexMap::new();
+        let mut result = IndexMap::default();
 
         // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
-        let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> = IndexMap::new();
+        let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> = IndexMap::default();
         let mut all_struct_fields: IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>> =
-            IndexMap::new();
+            IndexMap::default();
         let mut all_variant_cases: IndexMap<ModuleSource, IndexMap<String, VariantInfo>> =
-            IndexMap::new();
+            IndexMap::default();
         let mut all_enum_cases: IndexMap<ModuleSource, IndexMap<String, EnumInfo>> =
-            IndexMap::new();
+            IndexMap::default();
         let mut all_flags_cases: IndexMap<ModuleSource, IndexMap<String, FlagsInfo>> =
-            IndexMap::new();
+            IndexMap::default();
         let mut all_resource_types: IndexMap<ModuleSource, IndexMap<String, ResourceInfo>> =
-            IndexMap::new();
+            IndexMap::default();
 
         // First pass: collect struct, variant, enum, and resource names from all modules (for forward references)
         for (module_source, module) in modules {
@@ -472,7 +472,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
             // Build function_return_types for this module only
             // (functions defined in this module)
-            let mut function_return_types = IndexMap::new();
+            let mut function_return_types = IndexMap::default();
             for item in &module.items {
                 if let Item::Function(func) = item {
                     let return_type = if let Some(ret_ty) = &func.return_type {
@@ -494,7 +494,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
 
             // Collect imported function names from this module's use declarations
-            let mut imported_functions = IndexSet::new();
+            let mut imported_functions = IndexSet::default();
             for item in &module.items {
                 if let Item::Use(use_decl) = item {
                     for use_item in &use_decl.items {
@@ -544,24 +544,26 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 logger,
                 current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"), // Set in resolve_module
                 current_module_items: Vec::new(), // Set in resolve_module
-                current_type_params: IndexMap::new(),
-                current_type_param_bounds: IndexMap::new(),
-                generic_struct_names: IndexSet::new(),
-                generic_function_params: IndexMap::new(),
-                generic_method_params: IndexMap::new(),
-                current_associated_type_bindings: IndexMap::new(),
+                current_type_params: IndexMap::default(),
+                current_type_param_bounds: IndexMap::default(),
+                generic_struct_names: IndexSet::default(),
+                generic_function_params: IndexMap::default(),
+                generic_method_params: IndexMap::default(),
+                current_associated_type_bindings: IndexMap::default(),
                 current_self_type: None,
                 wasi_registry,
                 builtin_registry: &builtin_registry,
-                current_module_globals: IndexMap::new(),
-                imported_globals: IndexMap::new(),
-                associated_constants: IndexMap::new(),
-                module_type_maps_cache: IndexMap::new(),
+                current_module_globals: IndexMap::default(),
+                imported_globals: IndexMap::default(),
+                associated_constants: IndexMap::default(),
+                module_type_maps_cache: IndexMap::default(),
                 trait_impl_index: Arc::clone(&trait_impl_index),
                 trait_decl_index: Arc::clone(&trait_decl_index),
                 blanket_trait_impl_index: Arc::clone(&blanket_trait_impl_index),
                 included_files,
+                known_type_names_cache: IndexSet::default(),
             };
+            resolver.rebuild_known_type_names_cache();
 
             // Set file context so diagnostics emitted during resolution
             // carry the correct module filename (not the entry module).
@@ -586,7 +588,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         imported_type_sources: &IndexMap<String, ModuleSource>,
         import_original_names: &IndexMap<String, String>,
     ) -> IndexMap<String, V> {
-        let mut result = IndexMap::new();
+        let mut result = IndexMap::default();
         // First: add all entries from all modules (arbitrary winner for conflicts)
         for name_map in per_module.values() {
             for (name, value) in name_map {
@@ -621,8 +623,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         module: &Module,
         from_module: &ModuleSource,
     ) -> (IndexMap<String, ModuleSource>, IndexMap<String, String>) {
-        let mut sources = IndexMap::new();
-        let mut original_names = IndexMap::new();
+        let mut sources = IndexMap::default();
+        let mut original_names = IndexMap::default();
         for item in &module.items {
             if let Item::Use(use_decl) = item {
                 let source = name::resolve_import(from_module, &use_decl.source);
@@ -761,7 +763,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Track dependency counts directly (no need for full dependency sets)
         let mut dependency_count: Vec<usize> = vec![0; sources.len()];
         // Track which edges we've already added to avoid duplicates
-        let mut seen_edges: IndexSet<(usize, usize)> = IndexSet::new();
+        let mut seen_edges: IndexSet<(usize, usize)> = IndexSet::default();
         // Build reverse graph: dependents[i] = modules that depend on module i
         let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); sources.len()];
 

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self};
 use crate::name::ModuleSource;
@@ -454,20 +454,20 @@ pub(super) struct FunctionContext {
 impl FunctionContext {
     pub(super) fn new(return_type: TypeId, function_name: String) -> Self {
         Self {
-            scopes: vec![IndexMap::new()], // Start with one scope for function parameters
+            scopes: vec![IndexMap::default()], // Start with one scope for function parameters
             next_local: 0,
             return_type,
             is_async: false,
             task_return_type: None,
             local_types: Vec::new(),
-            address_taken_locals: IndexSet::new(),
-            outer_locals: IndexMap::new(),
-            captured_vars: IndexMap::new(),
+            address_taken_locals: IndexSet::default(),
+            outer_locals: IndexMap::default(),
+            captured_vars: IndexMap::default(),
             labeled_block_targets: Vec::new(),
             active_labels: Vec::new(),
             function_name,
-            deref_overrides: IndexMap::new(),
-            outer_box_types: IndexMap::new(),
+            deref_overrides: IndexMap::default(),
+            outer_box_types: IndexMap::default(),
         }
     }
 
@@ -481,7 +481,7 @@ impl FunctionContext {
         type_table: &RefCell<crate::tir::TypeTable>,
     ) -> Self {
         // Snapshot all locals from outer context
-        let mut outer_locals = IndexMap::new();
+        let mut outer_locals = IndexMap::default();
         for scope in &outer_ctx.scopes {
             for (name, local) in scope {
                 outer_locals.insert(name.clone(), local.clone());
@@ -489,7 +489,7 @@ impl FunctionContext {
         }
 
         // Compute box types for address-taken outer locals
-        let mut outer_box_types = IndexMap::new();
+        let mut outer_box_types = IndexMap::default();
         for scope in &outer_ctx.scopes {
             for (name, local) in scope {
                 if outer_ctx.address_taken_locals.contains(&local.index) {
@@ -503,26 +503,26 @@ impl FunctionContext {
         let function_name = format!("{}::{{closure}}", outer_ctx.function_name);
 
         Self {
-            scopes: vec![IndexMap::new()],
+            scopes: vec![IndexMap::default()],
             next_local: 0,
             return_type,
             is_async: false, // Closures are never async
             task_return_type: None,
             local_types: Vec::new(),
-            address_taken_locals: IndexSet::new(),
+            address_taken_locals: IndexSet::default(),
             outer_locals,
-            captured_vars: IndexMap::new(),
+            captured_vars: IndexMap::default(),
             labeled_block_targets: Vec::new(),
             active_labels: Vec::new(),
             function_name,
-            deref_overrides: IndexMap::new(),
+            deref_overrides: IndexMap::default(),
             outer_box_types,
         }
     }
 
     /// Enter a new scope (for blocks, if/while/for/loop bodies)
     pub(super) fn enter_scope(&mut self) {
-        self.scopes.push(IndexMap::new());
+        self.scopes.push(IndexMap::default());
     }
 
     /// Exit the current scope

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -3,7 +3,7 @@
 //! The symbol table tracks all definitions (functions, types, effects, etc.)
 //! and their metadata. It supports module namespacing and scoped lookups.
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 use std::ops::Index;
 
 use crate::ast::WasiImport;
@@ -446,7 +446,7 @@ impl SymbolTable {
 
     /// Enter a new local scope
     pub fn enter_scope(&mut self) {
-        self.scopes.push(IndexMap::new());
+        self.scopes.push(IndexMap::default());
     }
 
     /// Exit the current local scope

--- a/wado-compiler/src/synthesis/cm_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_adapter.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::Type;
 use crate::cm_abi;
@@ -1529,7 +1529,7 @@ fn make_adapter_function(
         span: synth_span(),
         local_count,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: true,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -4546,7 +4546,7 @@ pub fn generate_adapters(mut project: Project) -> Result<Project, String> {
     // ---- Import adapters ----
 
     // Step 1: Collect all used WASI effect calls and resource method calls
-    let mut seen_effects: IndexSet<String> = IndexSet::new();
+    let mut seen_effects: IndexSet<String> = IndexSet::default();
     for module in project.tir_modules.values() {
         for func_rc in &module.functions {
             let func = func_rc.borrow();
@@ -4563,7 +4563,7 @@ pub fn generate_adapters(mut project: Project) -> Result<Project, String> {
             .get(&project.entry_module_source)
             .map(|m| m.type_table.clone())
             .unwrap_or_else(|| Rc::new(RefCell::new(TypeTable::new())));
-        let mut adapters: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::new();
+        let mut adapters: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::default();
         for qualified_name in &seen_effects {
             if let Some(func_info) = project.wasi_registry.get_function(qualified_name) {
                 let func_info = func_info.clone();
@@ -6667,7 +6667,7 @@ mod tests {
     fn compute_flat_params_empty() {
         let params: Vec<(String, Type)> = vec![];
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert!(flat.is_empty());
     }
@@ -6679,7 +6679,7 @@ mod tests {
             ("b".to_string(), named_type("f64")),
         ];
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert_eq!(flat, vec![cm_abi::CmValType::I32, cm_abi::CmValType::F64]);
     }
@@ -6688,7 +6688,7 @@ mod tests {
     fn compute_flat_params_string() {
         let params = vec![("name".to_string(), named_type("String"))];
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert_eq!(flat, vec![cm_abi::CmValType::I32, cm_abi::CmValType::I32]);
     }
@@ -6701,7 +6701,7 @@ mod tests {
             ("b".to_string(), named_type("f32")),
         ];
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert_eq!(
             flat,
@@ -6722,7 +6722,7 @@ mod tests {
         let mut local_types = Vec::new();
         let mut next_local = 1_u32;
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("i32"),
             &[0],
@@ -6745,7 +6745,7 @@ mod tests {
         let mut local_types = Vec::new();
         let mut next_local = 2_u32;
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("String"),
             &[0, 1],
@@ -6768,7 +6768,7 @@ mod tests {
         let mut local_types = Vec::new();
         let mut next_local = 1_u32;
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("bool"),
             &[0],
@@ -6791,7 +6791,7 @@ mod tests {
         let mut local_types = Vec::new();
         let mut next_local = 0_u32;
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &Type::Tuple(vec![]),
             &[],
@@ -6813,7 +6813,7 @@ mod tests {
         let mut local_types = Vec::new();
         let mut next_local = 1_u32;
         let type_table = TypeTable::new();
-        let tir_modules = IndexMap::new();
+        let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("Request"),
             &[0],

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -5,7 +5,7 @@
 //! - TIR expression and statement builders
 //! - Synthetic function creation
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use crate::name::{LocalMethodName, ModuleSource};
 use crate::tir::{
@@ -372,7 +372,7 @@ pub fn make_synthetic_method(
         span: synth_span(),
         local_count,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,

--- a/wado-compiler/src/synthesis/inspect.rs
+++ b/wado-compiler/src/synthesis/inspect.rs
@@ -16,7 +16,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::{LocalMethodName, MethodName, ModuleSource};
 use crate::tir::{
@@ -85,7 +85,7 @@ impl Default for InspectRegistry {
 impl InspectRegistry {
     pub fn new() -> Self {
         Self {
-            functions: IndexMap::new(),
+            functions: IndexMap::default(),
             pending: Vec::new(),
         }
     }
@@ -139,7 +139,7 @@ fn ensure_inspect_fn(
         span,
         local_count: 2,
         local_types: vec![type_id, fmt_type],
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -261,7 +261,7 @@ impl LocalAlloc {
 /// Collect closure source texts from Let statements in a function body.
 /// Maps `local_index` → `source_text` for closures that have pre-desugar source.
 pub fn collect_closure_sources(block: &TirBlock) -> IndexMap<u32, String> {
-    let mut map = IndexMap::new();
+    let mut map = IndexMap::default();
     collect_closure_sources_block(block, &mut map);
     map
 }

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -6,7 +6,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use crate::name::{LocalMethodName, MethodName, ModuleSource, mangle_local_trait_method};
 use crate::project::Project;
@@ -682,7 +682,7 @@ fn generate_struct_serialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -1202,7 +1202,7 @@ fn generate_struct_deserialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -1382,7 +1382,7 @@ fn generate_lookup_function(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -1524,7 +1524,7 @@ fn generate_enum_serialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -1889,7 +1889,7 @@ fn generate_enum_deserialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -2158,7 +2158,7 @@ fn generate_variant_serialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -2683,7 +2683,7 @@ fn generate_variant_deserialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -2903,7 +2903,7 @@ fn generate_tuple_serialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -3176,7 +3176,7 @@ fn generate_tuple_deserialize(
         span,
         local_count: next_local,
         local_types,
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::name::{LocalMethodName, ModuleSource};
 use crate::tir::{
@@ -47,7 +47,7 @@ pub fn expand_templates(module: &TirModule, tt: &Rc<RefCell<TypeTable>>) {
 
 /// Collect closure source text from the body for `#:?` format.
 fn collect_closure_sources(body: &TirBlock) -> IndexMap<u32, String> {
-    let mut sources = IndexMap::new();
+    let mut sources = IndexMap::default();
     for stmt in &body.stmts {
         collect_closure_sources_stmt(stmt, &mut sources);
     }

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -11,7 +11,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 use crate::name::{LocalMethodName, MethodName, ModuleSource};
 use crate::project::Project;
@@ -862,7 +862,7 @@ fn generate_generic_struct_inspect_fn(
         span,
         local_count,
         local_types: vec![ref_struct_type, fmt_type],
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -1174,7 +1174,7 @@ fn generate_generic_variant_inspect_fn(
         span,
         local_count: 2,
         local_types: vec![ref_variant_type, fmt_type],
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,
@@ -2022,7 +2022,7 @@ fn generate_display_fallback(
         span,
         local_count: 2,
         local_types: vec![ref_type, fmt_type],
-        address_taken_locals: IndexSet::new(),
+        address_taken_locals: IndexSet::default(),
         is_cm_adapter: false,
         inline_hint: InlineHint::Auto,
         comp_features: 0,

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -12,7 +12,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::{LocalMethodName, ModuleSource, TypeNameInfo, format_type_name};
 use crate::token::Span;
@@ -78,7 +78,7 @@ pub struct SubstitutionContext {
 impl SubstitutionContext {
     pub fn new() -> Self {
         Self {
-            substitutions: IndexMap::new(),
+            substitutions: IndexMap::default(),
         }
     }
 
@@ -271,6 +271,13 @@ impl PrimitiveType {
                 | "v128"
         )
     }
+
+    pub fn all_primitive_names() -> &'static [&'static str] {
+        &[
+            "i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "f32", "f64",
+            "bool", "char", "v128",
+        ]
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -436,13 +443,13 @@ impl TypeTable {
 
     pub fn new() -> Self {
         let mut table = Self {
-            types: IndexMap::new(),
-            intern_map: IndexMap::new(),
+            types: IndexMap::default(),
+            intern_map: IndexMap::default(),
             next_id: 0,
             option_module_source: None,
             result_module_source: None,
             default_trait_module_source: None,
-            assoc_type_resolutions: IndexMap::new(),
+            assoc_type_resolutions: IndexMap::default(),
         };
 
         // Pre-populate primitive types matching the constants above
@@ -2370,11 +2377,11 @@ impl TirModule {
             wasm_module: None,
             string_literals: Vec::new(),
             bytes_literals: Vec::new(),
-            function_strings: IndexMap::new(),
-            function_method_info: IndexMap::new(),
-            generic_structs: IndexMap::new(),
-            generic_functions: IndexMap::new(),
-            instantiation_requests: IndexSet::new(),
+            function_strings: IndexMap::default(),
+            function_method_info: IndexMap::default(),
+            generic_structs: IndexMap::default(),
+            generic_functions: IndexMap::default(),
+            instantiation_requests: IndexSet::default(),
             closure_functors: Vec::new(),
         }
     }
@@ -2403,11 +2410,11 @@ impl TirModule {
             wasm_module: None,
             string_literals: Vec::new(),
             bytes_literals: Vec::new(),
-            function_strings: IndexMap::new(),
-            function_method_info: IndexMap::new(),
-            generic_structs: IndexMap::new(),
-            generic_functions: IndexMap::new(),
-            instantiation_requests: IndexSet::new(),
+            function_strings: IndexMap::default(),
+            function_method_info: IndexMap::default(),
+            generic_structs: IndexMap::default(),
+            generic_functions: IndexMap::default(),
+            instantiation_requests: IndexSet::default(),
             closure_functors: Vec::new(),
         }
     }

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -14,8 +14,8 @@ use crate::ast::{
     VariantDecl, WhileStmt, WorldDecl,
 };
 use crate::comment::{Comment, CommentKind, CommentMap};
-use crate::token::Span;
 use crate::hashmap::IndexSet;
+use crate::token::Span;
 
 const MAX_LINE_WIDTH: usize = 120;
 

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -15,7 +15,7 @@ use crate::ast::{
 };
 use crate::comment::{Comment, CommentKind, CommentMap};
 use crate::token::Span;
-use indexmap::IndexSet;
+use crate::hashmap::IndexSet;
 
 const MAX_LINE_WIDTH: usize = 120;
 
@@ -39,7 +39,7 @@ impl<'a> Unparser<'a> {
             comments,
             output: String::new(),
             indent_level: 0,
-            emitted_comments: IndexSet::new(),
+            emitted_comments: IndexSet::default(),
             last_source_line: 0,
         }
     }

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::ModuleSource;
 use crate::token::Span;
@@ -240,13 +240,13 @@ impl WirModule {
             branch_hints: Vec::new(),
             names: WirNames::default(),
             component: WirComponent::default(),
-            variant_case_info: IndexMap::new(),
+            variant_case_info: IndexMap::default(),
             entry_point_path: None,
-            wasm_modules: IndexMap::new(),
-            dead_type_indices: IndexSet::new(),
-            dead_func_indices: IndexSet::new(),
-            dead_global_indices: IndexSet::new(),
-            needed_canonicals: IndexSet::new(),
+            wasm_modules: IndexMap::default(),
+            dead_type_indices: IndexSet::default(),
+            dead_func_indices: IndexSet::default(),
+            dead_global_indices: IndexSet::default(),
+            needed_canonicals: IndexSet::default(),
             func_wir_indices: Vec::new(),
         }
     }

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -4,7 +4,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::name::{ModuleSource, StructName};
 use crate::project::Project;
@@ -129,7 +129,7 @@ impl<'a> WirContext<'a> {
     /// Create a new `WirContext` from a Project.
     pub fn new(project: &'a Project) -> Self {
         // Collect string literals from all TIR modules (deduped)
-        let mut seen: IndexSet<&str> = IndexSet::new();
+        let mut seen: IndexSet<&str> = IndexSet::default();
         let mut string_literals = Vec::new();
         for tir_module in project.tir_modules.values() {
             for s in &tir_module.string_literals {
@@ -140,7 +140,7 @@ impl<'a> WirContext<'a> {
         }
 
         // Collect bytes literals from all TIR modules (deduped)
-        let mut seen_bytes: IndexSet<&[u8]> = IndexSet::new();
+        let mut seen_bytes: IndexSet<&[u8]> = IndexSet::default();
         let mut bytes_literals = Vec::new();
         for tir_module in project.tir_modules.values() {
             for b in &tir_module.bytes_literals {
@@ -153,36 +153,36 @@ impl<'a> WirContext<'a> {
         Self {
             project,
             types: Vec::new(),
-            type_map: IndexMap::new(),
+            type_map: IndexMap::default(),
             rec_groups: Vec::new(),
-            struct_type_map: IndexMap::new(),
-            array_type_map: IndexMap::new(),
-            array_type_by_name: IndexMap::new(),
-            tuple_type_map: IndexMap::new(),
-            variant_type_map: IndexMap::new(),
-            variant_case_info: IndexMap::new(),
+            struct_type_map: IndexMap::default(),
+            array_type_map: IndexMap::default(),
+            array_type_by_name: IndexMap::default(),
+            tuple_type_map: IndexMap::default(),
+            variant_type_map: IndexMap::default(),
+            variant_case_info: IndexMap::default(),
             functions: Vec::new(),
-            func_map: IndexMap::new(),
+            func_map: IndexMap::default(),
             func_type_ids: Vec::new(),
             imports: Vec::new(),
             import_func_count: 0,
-            import_func_map: IndexMap::new(),
+            import_func_map: IndexMap::default(),
             globals: Vec::new(),
-            global_map: IndexMap::new(),
+            global_map: IndexMap::default(),
             exports: Vec::new(),
             data: Vec::new(),
-            string_literal_map: IndexMap::new(),
-            bytes_literal_map: IndexMap::new(),
+            string_literal_map: IndexMap::default(),
+            bytes_literal_map: IndexMap::default(),
             names: WirNames::default(),
-            canonical_closure_types: IndexMap::new(),
-            closure_wrapper_funcs: IndexMap::new(),
+            canonical_closure_types: IndexMap::default(),
+            closure_wrapper_funcs: IndexMap::default(),
             canonical_closure_counter: 0,
             string_literals,
             bytes_literals,
-            wasm_module_sources: IndexMap::new(),
-            available_wasi_funcs: IndexSet::new(),
+            wasm_module_sources: IndexMap::default(),
+            available_wasi_funcs: IndexSet::default(),
             pending_bodies: Vec::new(),
-            needed_canonicals: IndexMap::new(),
+            needed_canonicals: IndexMap::default(),
         }
     }
 
@@ -731,15 +731,15 @@ impl<'a> WirContext<'a> {
 
         // Extract functions and globals from #![wasm_module("...")] sources
         // into separate WasmModuleInfo structures.
-        let mut wasm_modules: IndexMap<String, crate::wir::WasmModuleInfo> = IndexMap::new();
-        let mut dead_type_indices: IndexSet<u32> = IndexSet::new();
-        let mut dead_func_indices: IndexSet<u32> = IndexSet::new();
-        let mut dead_global_indices: IndexSet<u32> = IndexSet::new();
+        let mut wasm_modules: IndexMap<String, crate::wir::WasmModuleInfo> = IndexMap::default();
+        let mut dead_type_indices: IndexSet<u32> = IndexSet::default();
+        let mut dead_func_indices: IndexSet<u32> = IndexSet::default();
+        let mut dead_global_indices: IndexSet<u32> = IndexSet::default();
 
         for (source_prefix, wasm_mod_name) in &self.wasm_module_sources {
             let mut mod_functions = Vec::new();
             let mut mod_globals = Vec::new();
-            let mut mod_global_name_to_index = IndexMap::new();
+            let mut mod_global_name_to_index = IndexMap::default();
 
             // Find functions belonging to this wasm module (keep in list, mark as dead)
             for (i, func) in functions.iter().enumerate() {
@@ -761,7 +761,7 @@ impl<'a> WirContext<'a> {
                 let body = func.body.clone().unwrap_or_default();
 
                 // Collect referenced globals
-                let mut referenced_globals = IndexMap::new();
+                let mut referenced_globals = IndexMap::default();
                 collect_referenced_globals(&body, &mut referenced_globals);
 
                 for (global_fq, ()) in &referenced_globals {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -3,6 +3,7 @@
 //! This is the core of the `tir_to_wir` phase, translating each TIR function body
 //! into a sequence of WIR instructions.
 
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::tir::{
     CallArg, FunctionRef, PrimitiveType, ResolvedType, TirBinaryOp, TirBlock, TirExpr, TirExprKind,
     TirFunction, TirLiteralPattern, TirMatchArm, TirPattern, TirStmt, TirStmtKind, TirUnaryOp,
@@ -12,7 +13,6 @@ use crate::wir::{
     CanonicalIntrinsic, CmFuturePayload, CmScalarType, WirFuncId, WirInstr, WirName, WirType,
     WirTypeDef, WirTypeId,
 };
-use crate::hashmap::{IndexMap, IndexSet};
 
 use super::context::WirContext;
 

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -12,7 +12,7 @@ use crate::wir::{
     CanonicalIntrinsic, CmFuturePayload, CmScalarType, WirFuncId, WirInstr, WirName, WirType,
     WirTypeDef, WirTypeId,
 };
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use super::context::WirContext;
 
@@ -237,7 +237,7 @@ pub fn translate_function_bodies(ctx: &mut WirContext<'_>) {
 
         if let Some(ref body) = tir_func.body {
             // Build local name map from params
-            let mut local_names = IndexMap::new();
+            let mut local_names = IndexMap::default();
             for param in &tir_func.params {
                 local_names.insert(param.local_index, param.name.clone());
             }
@@ -255,7 +255,7 @@ pub fn translate_function_bodies(ctx: &mut WirContext<'_>) {
                     match_counter: 0,
                     local_counter: 0,
                     local_names,
-                    immutable_locals: IndexSet::new(),
+                    immutable_locals: IndexSet::default(),
                 };
                 translator.translate_block(body)
             };
@@ -419,7 +419,7 @@ impl FunctionTranslator<'_, '_> {
     /// Fresh values are newly created and don't alias existing data,
     /// so they can be used directly without copying.
     fn is_fresh_value(expr: &TirExpr) -> bool {
-        Self::is_fresh_in_context(expr, &IndexSet::new())
+        Self::is_fresh_in_context(expr, &IndexSet::default())
     }
 
     /// Check if an expression is fresh, considering locals known to hold fresh values.

--- a/wado-compiler/src/wir_build/types.rs
+++ b/wado-compiler/src/wir_build/types.rs
@@ -12,7 +12,7 @@ use crate::wir::{
     WirStructType, WirType, WirTypeDef, WirVariantCase, WirVariantType,
 };
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use super::context::WirContext;
 
@@ -67,7 +67,7 @@ fn sort_types_topologically<'a>(
     let variant_names: IndexSet<String> = variants.iter().map(|v| v.name.clone()).collect();
     let all_names: IndexSet<String> = struct_names.union(&variant_names).cloned().collect();
 
-    let mut deps: IndexMap<String, Vec<String>> = IndexMap::new();
+    let mut deps: IndexMap<String, Vec<String>> = IndexMap::default();
 
     for s in structs {
         let mut type_deps = Vec::new();
@@ -93,12 +93,12 @@ fn sort_types_topologically<'a>(
         deps.insert(v.name.clone(), type_deps);
     }
 
-    let mut in_degree: IndexMap<String, usize> = IndexMap::new();
+    let mut in_degree: IndexMap<String, usize> = IndexMap::default();
     for name in &all_names {
         in_degree.insert(name.clone(), deps.get(name).map(Vec::len).unwrap_or(0));
     }
 
-    let mut dependents: IndexMap<String, Vec<String>> = IndexMap::new();
+    let mut dependents: IndexMap<String, Vec<String>> = IndexMap::default();
     for (name, type_deps) in &deps {
         for dep in type_deps {
             dependents
@@ -1043,7 +1043,7 @@ fn register_canonical_closure_types(ctx: &mut WirContext<'_>) {
 
     // Collect all unique function signatures from all modules
     let mut fn_sigs: Vec<(Vec<WirType>, Vec<WirType>)> = Vec::new();
-    let mut seen_keys: indexmap::IndexSet<String> = indexmap::IndexSet::new();
+    let mut seen_keys: crate::hashmap::IndexSet<String> = crate::hashmap::IndexSet::default();
 
     for tir_mod in ctx.project.tir_modules.values() {
         let type_table = &*tir_mod.type_table.borrow();

--- a/wado-compiler/src/wir_optimize.rs
+++ b/wado-compiler/src/wir_optimize.rs
@@ -19,7 +19,7 @@
 //! - **Cleanup**: removes redundant `RefAsNonNull`, `Nop`, and dead code after
 //!   `Unreachable`, normalizing WIR so that codegen can emit it as-is.
 
-use indexmap::{IndexMap, IndexSet};
+use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::optimize::OptLevel;
 use crate::wir::{
@@ -157,11 +157,11 @@ struct VariantReplacement {
     /// Local name holding the discriminant value.
     disc_local: String,
     /// `case_wir_type_idx` → discriminant value (i32).
-    case_disc_values: indexmap::IndexMap<u32, i32>,
+    case_disc_values: crate::hashmap::IndexMap<u32, i32>,
     /// `(case_wir_type_idx, field_name_in_case_struct)` → sroa local name.
-    field_to_local: indexmap::IndexMap<(u32, String), String>,
+    field_to_local: crate::hashmap::IndexMap<(u32, String), String>,
     /// SROA locals that hold ref types (need `ref.as_non_null` when read).
-    ref_locals: indexmap::IndexSet<String>,
+    ref_locals: crate::hashmap::IndexSet<String>,
 }
 
 /// Returns true if a `WirType` is a valid Wasm value type for multi-value returns.
@@ -212,7 +212,7 @@ fn wir_types_equal(a: &WirType, b: &WirType) -> bool {
 
 /// Collect all `func_ids` that must NOT be SROA'd (exports, element tables, `RefFunc`).
 fn collect_pinned_func_ids(module: &WirModule) -> IndexSet<u32> {
-    let mut pinned = IndexSet::new();
+    let mut pinned = IndexSet::default();
 
     // Exported functions
     for export in &module.exports {
@@ -366,7 +366,7 @@ fn try_variant_sroa_candidate(
     let mut max_payload_count: usize = 0;
 
     // Build a mapping of case_wir_type_idx for this variant from variant_case_info
-    let mut case_idx_to_type_idx: indexmap::IndexMap<u32, u32> = indexmap::IndexMap::new();
+    let mut case_idx_to_type_idx: crate::hashmap::IndexMap<u32, u32> = crate::hashmap::IndexMap::default();
     for (&case_wir_idx, &(parent_variant_idx, case_index)) in &module.variant_case_info {
         if parent_variant_idx == variant_type_idx {
             case_idx_to_type_idx.insert(case_index, case_wir_idx);
@@ -436,7 +436,7 @@ fn try_variant_sroa_candidate(
     }
 
     // Collect ALL case type indices (including unit cases) for return validation
-    let mut all_case_type_indices: IndexSet<u32> = IndexSet::new();
+    let mut all_case_type_indices: IndexSet<u32> = IndexSet::default();
     for &opt in &case_type_indices {
         if let Some(idx) = opt {
             all_case_type_indices.insert(idx);
@@ -730,7 +730,7 @@ fn validate_call_sites(
         .collect();
 
     // Scan all function bodies for calls to candidate functions
-    let mut invalid: IndexSet<u32> = IndexSet::new();
+    let mut invalid: IndexSet<u32> = IndexSet::default();
 
     for func in &module.functions {
         if let Some(body) = &func.body {
@@ -1213,7 +1213,7 @@ fn check_uses_in_subtree(instr: &WirInstr, local_name: &str) -> bool {
 /// Phase 3: apply SROA transformations to confirmed candidates.
 fn apply_sroa(module: &mut WirModule, confirmed: &[(u32, SroaCandidate)]) {
     // Build a lookup from func_id_index → candidate info
-    let candidate_map: indexmap::IndexMap<u32, &SroaCandidate> =
+    let candidate_map: crate::hashmap::IndexMap<u32, &SroaCandidate> =
         confirmed.iter().map(|(id, c)| (*id, c)).collect();
 
     // Step A: Create new func types and rewrite function signatures + bodies.
@@ -1732,15 +1732,15 @@ fn default_value_for_type(ty: &WirType) -> WirInstr {
 ///    `StructGet { RefCast { LocalGet(T) } }` with `LocalGet`.
 fn rewrite_call_sites(
     instrs: &mut Vec<WirInstr>,
-    candidate_map: &indexmap::IndexMap<u32, &SroaCandidate>,
+    candidate_map: &crate::hashmap::IndexMap<u32, &SroaCandidate>,
     types: &[WirTypeDef],
 ) {
     // Collect replacements: temp_name → (field_name → fresh_local_name)
-    let mut replacements: indexmap::IndexMap<String, indexmap::IndexMap<String, String>> =
-        indexmap::IndexMap::new();
+    let mut replacements: crate::hashmap::IndexMap<String, crate::hashmap::IndexMap<String, String>> =
+        crate::hashmap::IndexMap::default();
     // Variant replacements: temp_name → VariantReplacement
-    let mut variant_replacements: indexmap::IndexMap<String, VariantReplacement> =
-        indexmap::IndexMap::new();
+    let mut variant_replacements: crate::hashmap::IndexMap<String, VariantReplacement> =
+        crate::hashmap::IndexMap::default();
 
     // First pass: find call sites and prepare MultiValueLocalBind + replacement map
     let mut result = Vec::with_capacity(instrs.len());
@@ -1773,7 +1773,7 @@ fn rewrite_call_sites(
         let candidate = candidate_map[&func_id_idx];
 
         // Generate fresh local names for each field and declare them
-        let mut field_map: indexmap::IndexMap<String, String> = indexmap::IndexMap::new();
+        let mut field_map: crate::hashmap::IndexMap<String, String> = crate::hashmap::IndexMap::default();
         let mut locals: Vec<Option<String>> = Vec::with_capacity(candidate.field_count);
         for (fi, field_name) in candidate.field_names.iter().enumerate() {
             let fresh = format!("__sroa_{temp_name}_{field_name}");
@@ -1789,9 +1789,9 @@ fn rewrite_call_sites(
         if let Some(vi) = &candidate.variant_info {
             // Variant candidate: build VariantReplacement
             let disc_local = field_map["discriminant"].clone();
-            let mut case_disc_values: indexmap::IndexMap<u32, i32> = indexmap::IndexMap::new();
-            let mut field_to_local: indexmap::IndexMap<(u32, String), String> =
-                indexmap::IndexMap::new();
+            let mut case_disc_values: crate::hashmap::IndexMap<u32, i32> = crate::hashmap::IndexMap::default();
+            let mut field_to_local: crate::hashmap::IndexMap<(u32, String), String> =
+                crate::hashmap::IndexMap::default();
 
             for (disc_val, case_type_opt) in vi.case_type_indices.iter().enumerate() {
                 if let Some(case_type_idx) = case_type_opt {
@@ -1822,7 +1822,7 @@ fn rewrite_call_sites(
             }
 
             // Track which SROA locals hold ref types (need ref.as_non_null when read)
-            let mut ref_locals = indexmap::IndexSet::new();
+            let mut ref_locals = crate::hashmap::IndexSet::default();
             for (fi, ft) in candidate.field_types.iter().enumerate() {
                 if matches!(ft, WirType::Ref { .. } | WirType::AbstractRef { .. })
                     && let Some(local_name) = field_map.get(&candidate.field_names[fi])
@@ -1888,7 +1888,7 @@ fn rewrite_call_sites(
 /// Recurse into nested instruction bodies for call site rewriting.
 fn recurse_rewrite_call_sites(
     instr: &mut WirInstr,
-    candidate_map: &indexmap::IndexMap<u32, &SroaCandidate>,
+    candidate_map: &crate::hashmap::IndexMap<u32, &SroaCandidate>,
     types: &[WirTypeDef],
 ) {
     match instr {
@@ -1922,7 +1922,7 @@ fn recurse_rewrite_call_sites(
 /// has eliminated the struct, the copy is redundant.
 fn replace_struct_gets(
     instr: &mut WirInstr,
-    replacements: &indexmap::IndexMap<String, indexmap::IndexMap<String, String>>,
+    replacements: &crate::hashmap::IndexMap<String, crate::hashmap::IndexMap<String, String>>,
 ) {
     // Handle ValueCopy(StructGet(LocalGet(temp))) → LocalGet(sroa_fresh).
     // This eliminates the unnecessary shallow copy that was emitted to preserve value
@@ -1964,7 +1964,7 @@ fn replace_struct_gets(
 
 /// Produce a `LocalGet` for an SROA local, wrapping with `RefAsNonNull` if the local
 /// holds a nullable ref type (variant SROA payload locals use nullable types for padding).
-fn sroa_local_get(local_name: &str, ref_locals: &indexmap::IndexSet<String>) -> WirInstr {
+fn sroa_local_get(local_name: &str, ref_locals: &crate::hashmap::IndexSet<String>) -> WirInstr {
     let get = WirInstr::LocalGet {
         name: local_name.to_string(),
     };
@@ -1983,7 +1983,7 @@ fn sroa_local_get(local_name: &str, ref_locals: &indexmap::IndexSet<String>) -> 
 /// 3. `ValueCopy { StructGet { field, expr: RefCast { type_id, expr: LocalGet(temp) } } }` → same
 fn replace_variant_accesses(
     instr: &mut WirInstr,
-    variant_replacements: &indexmap::IndexMap<String, VariantReplacement>,
+    variant_replacements: &crate::hashmap::IndexMap<String, VariantReplacement>,
 ) {
     // Pattern 3: ValueCopy wrapping StructGet(RefCast(LocalGet(temp)))
     if let WirInstr::ValueCopy { expr, .. } = instr
@@ -2053,7 +2053,7 @@ fn replace_variant_accesses(
 fn is_candidate_call_set(
     instr: &WirInstr,
     expected_name: &str,
-    candidate_map: &indexmap::IndexMap<u32, &SroaCandidate>,
+    candidate_map: &crate::hashmap::IndexMap<u32, &SroaCandidate>,
 ) -> bool {
     let WirInstr::LocalSet { name, value } = instr else {
         return false;
@@ -2069,7 +2069,7 @@ fn is_candidate_call_set(
 /// Handles calls wrapped in `ValueCopy` or trivial inlined `Block`.
 fn extract_candidate_call_info(
     instr: &WirInstr,
-    candidate_map: &indexmap::IndexMap<u32, &SroaCandidate>,
+    candidate_map: &crate::hashmap::IndexMap<u32, &SroaCandidate>,
 ) -> Option<(u32, String)> {
     let WirInstr::LocalSet { name, value } = instr else {
         return None;
@@ -2181,10 +2181,10 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
     let pinned = collect_pinned_func_ids(module);
 
     // Phase 1: identify candidate (func_id, param_index) pairs.
-    let mut candidates: IndexSet<(u32, usize)> = IndexSet::new();
+    let mut candidates: IndexSet<(u32, usize)> = IndexSet::default();
     // Map from (func_id, param_idx) → (struct_type_id_index, inner WirType, field_name).
-    let mut candidate_info: indexmap::IndexMap<(u32, usize), (u32, WirType, String)> =
-        indexmap::IndexMap::new();
+    let mut candidate_info: crate::hashmap::IndexMap<(u32, usize), (u32, WirType, String)> =
+        crate::hashmap::IndexMap::default();
 
     for (i, func) in module.functions.iter().enumerate() {
         let func_id_index = crate::wir_build::DEFINED_FUNC_BASE + u32::try_from(i).unwrap();
@@ -2229,7 +2229,7 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
 
     // Phase 2: validate uses — eliminate candidates whose parameter escapes.
     loop {
-        let mut invalid: IndexSet<(u32, usize)> = IndexSet::new();
+        let mut invalid: IndexSet<(u32, usize)> = IndexSet::default();
 
         for &(func_id_index, param_idx) in &candidates {
             let func_array_idx = (func_id_index - crate::wir_build::DEFINED_FUNC_BASE) as usize;
@@ -2301,7 +2301,7 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
 
     // Step B: rewrite call sites in ALL function bodies.
     // Build lookup: func_id_index → set of SROA'd param indices.
-    let mut sroa_params: indexmap::IndexMap<u32, IndexSet<usize>> = indexmap::IndexMap::new();
+    let mut sroa_params: crate::hashmap::IndexMap<u32, IndexSet<usize>> = crate::hashmap::IndexMap::default();
     for &(func_id_index, param_idx) in &candidates {
         sroa_params
             .entry(func_id_index)
@@ -2310,8 +2310,8 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
     }
 
     // Build (func_id, param_idx) → (WirTypeId of the struct type, field name).
-    let mut param_struct_info: indexmap::IndexMap<(u32, usize), (WirTypeId, String)> =
-        indexmap::IndexMap::new();
+    let mut param_struct_info: crate::hashmap::IndexMap<(u32, usize), (WirTypeId, String)> =
+        crate::hashmap::IndexMap::default();
     for &(func_id_index, param_idx) in &candidates {
         let (ref struct_type_idx, _, ref field_name) = candidate_info[&(func_id_index, param_idx)];
         if let Some(WirTypeDef::Struct(st)) = module.types.get(*struct_type_idx as usize) {
@@ -2323,8 +2323,8 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
     // Build per-function map of param names → struct type that was unwrapped.
     // This tells us what struct type each scalar param was derived from (so we
     // know whether a bare `LocalGet(param)` at a call site needs a StructGet).
-    let mut func_scalar_param_struct: indexmap::IndexMap<u32, indexmap::IndexMap<String, u32>> =
-        indexmap::IndexMap::new();
+    let mut func_scalar_param_struct: crate::hashmap::IndexMap<u32, crate::hashmap::IndexMap<String, u32>> =
+        crate::hashmap::IndexMap::default();
     for &(func_id_index, param_idx) in &candidates {
         let func_array_idx = (func_id_index - crate::wir_build::DEFINED_FUNC_BASE) as usize;
         let param_name = module.functions[func_array_idx].param_names[param_idx].clone();
@@ -2539,9 +2539,9 @@ fn rewrite_single_field_param_reads(instr: &mut WirInstr, param_name: &str, expe
 /// - Other expressions → `StructGet(expr, field_name)` (extract scalar from existing ref)
 fn rewrite_single_field_args_at_call_sites(
     instr: &mut WirInstr,
-    sroa_params: &indexmap::IndexMap<u32, IndexSet<usize>>,
-    param_struct_info: &indexmap::IndexMap<(u32, usize), (WirTypeId, String)>,
-    scalar_param_structs: &indexmap::IndexMap<String, u32>,
+    sroa_params: &crate::hashmap::IndexMap<u32, IndexSet<usize>>,
+    param_struct_info: &crate::hashmap::IndexMap<(u32, usize), (WirTypeId, String)>,
+    scalar_param_structs: &crate::hashmap::IndexMap<String, u32>,
 ) {
     // Recurse first (bottom-up)
     instr.for_each_boxed_child_mut(&mut |child| {
@@ -2637,7 +2637,7 @@ fn elide_dead_single_field_struct_locals(module: &mut WirModule) {
 /// One pass: collect candidates, validate, rewrite. Returns `true` if anything changed.
 fn elide_struct_locals_one_pass(body: &mut [WirInstr]) -> bool {
     // Step 1: collect LocalSet(name, StructNew { [inner] }) at any depth.
-    let mut all_defs: IndexMap<String, WirInstr> = IndexMap::new();
+    let mut all_defs: IndexMap<String, WirInstr> = IndexMap::default();
     for instr in body.iter() {
         collect_struct_single_field_defs(instr, &mut all_defs);
     }
@@ -4282,7 +4282,7 @@ fn forward_struct_field_constants(module: &mut WirModule) {
 /// Collect locals whose references escape (address taken, embedded in structs,
 /// or passed to function calls). These are unsafe for field forwarding.
 fn collect_aliased_locals(body: &[WirInstr]) -> IndexSet<String> {
-    let mut aliased = IndexSet::new();
+    let mut aliased = IndexSet::default();
     for instr in body {
         collect_aliased_in_instr(instr, &mut aliased);
     }
@@ -4343,7 +4343,7 @@ struct FieldKnowledge<'a> {
 impl<'a> FieldKnowledge<'a> {
     fn new(types: &'a [WirTypeDef], aliased: &'a IndexSet<String>) -> Self {
         Self {
-            fields: IndexMap::new(),
+            fields: IndexMap::default(),
             types,
             aliased,
         }
@@ -4759,7 +4759,7 @@ fn elim_bounds_in_guarded_loop(body: &mut [WirInstr]) {
 
     // Collect copies: locals that are set to `constraint.var` within the loop body.
     // These are equivalent to `var` for the purpose of bounds checking.
-    let mut equivalent_vars: IndexSet<String> = IndexSet::new();
+    let mut equivalent_vars: IndexSet<String> = IndexSet::default();
     equivalent_vars.insert(constraint.var.clone());
     collect_copies_in_body(body, &constraint.var, &mut equivalent_vars);
 
@@ -4893,7 +4893,7 @@ fn cleanup_wir(module: &mut WirModule) {
 /// Remove `DeclareLocal` instructions for locals that are never referenced
 /// by any `LocalGet`, `LocalSet`, `LocalTee`, or `MultiValueLocalBind`.
 fn eliminate_dead_locals(body: &mut [WirInstr]) {
-    let mut used: IndexSet<String> = IndexSet::new();
+    let mut used: IndexSet<String> = IndexSet::default();
     for instr in body.iter() {
         collect_local_uses(instr, &mut used);
     }

--- a/wado-compiler/src/wir_optimize.rs
+++ b/wado-compiler/src/wir_optimize.rs
@@ -366,7 +366,8 @@ fn try_variant_sroa_candidate(
     let mut max_payload_count: usize = 0;
 
     // Build a mapping of case_wir_type_idx for this variant from variant_case_info
-    let mut case_idx_to_type_idx: crate::hashmap::IndexMap<u32, u32> = crate::hashmap::IndexMap::default();
+    let mut case_idx_to_type_idx: crate::hashmap::IndexMap<u32, u32> =
+        crate::hashmap::IndexMap::default();
     for (&case_wir_idx, &(parent_variant_idx, case_index)) in &module.variant_case_info {
         if parent_variant_idx == variant_type_idx {
             case_idx_to_type_idx.insert(case_index, case_wir_idx);
@@ -1736,8 +1737,10 @@ fn rewrite_call_sites(
     types: &[WirTypeDef],
 ) {
     // Collect replacements: temp_name → (field_name → fresh_local_name)
-    let mut replacements: crate::hashmap::IndexMap<String, crate::hashmap::IndexMap<String, String>> =
-        crate::hashmap::IndexMap::default();
+    let mut replacements: crate::hashmap::IndexMap<
+        String,
+        crate::hashmap::IndexMap<String, String>,
+    > = crate::hashmap::IndexMap::default();
     // Variant replacements: temp_name → VariantReplacement
     let mut variant_replacements: crate::hashmap::IndexMap<String, VariantReplacement> =
         crate::hashmap::IndexMap::default();
@@ -1773,7 +1776,8 @@ fn rewrite_call_sites(
         let candidate = candidate_map[&func_id_idx];
 
         // Generate fresh local names for each field and declare them
-        let mut field_map: crate::hashmap::IndexMap<String, String> = crate::hashmap::IndexMap::default();
+        let mut field_map: crate::hashmap::IndexMap<String, String> =
+            crate::hashmap::IndexMap::default();
         let mut locals: Vec<Option<String>> = Vec::with_capacity(candidate.field_count);
         for (fi, field_name) in candidate.field_names.iter().enumerate() {
             let fresh = format!("__sroa_{temp_name}_{field_name}");
@@ -1789,7 +1793,8 @@ fn rewrite_call_sites(
         if let Some(vi) = &candidate.variant_info {
             // Variant candidate: build VariantReplacement
             let disc_local = field_map["discriminant"].clone();
-            let mut case_disc_values: crate::hashmap::IndexMap<u32, i32> = crate::hashmap::IndexMap::default();
+            let mut case_disc_values: crate::hashmap::IndexMap<u32, i32> =
+                crate::hashmap::IndexMap::default();
             let mut field_to_local: crate::hashmap::IndexMap<(u32, String), String> =
                 crate::hashmap::IndexMap::default();
 
@@ -2301,7 +2306,8 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
 
     // Step B: rewrite call sites in ALL function bodies.
     // Build lookup: func_id_index → set of SROA'd param indices.
-    let mut sroa_params: crate::hashmap::IndexMap<u32, IndexSet<usize>> = crate::hashmap::IndexMap::default();
+    let mut sroa_params: crate::hashmap::IndexMap<u32, IndexSet<usize>> =
+        crate::hashmap::IndexMap::default();
     for &(func_id_index, param_idx) in &candidates {
         sroa_params
             .entry(func_id_index)
@@ -2323,8 +2329,10 @@ fn sroa_single_field_parameters(module: &mut WirModule) {
     // Build per-function map of param names → struct type that was unwrapped.
     // This tells us what struct type each scalar param was derived from (so we
     // know whether a bare `LocalGet(param)` at a call site needs a StructGet).
-    let mut func_scalar_param_struct: crate::hashmap::IndexMap<u32, crate::hashmap::IndexMap<String, u32>> =
-        crate::hashmap::IndexMap::default();
+    let mut func_scalar_param_struct: crate::hashmap::IndexMap<
+        u32,
+        crate::hashmap::IndexMap<String, u32>,
+    > = crate::hashmap::IndexMap::default();
     for &(func_id_index, param_idx) in &candidates {
         let func_array_idx = (func_id_index - crate::wir_build::DEFINED_FUNC_BASE) as usize;
         let param_name = module.functions[func_array_idx].param_names[param_idx].clone();

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -6,7 +6,7 @@
 //! Worlds are keyed by their fully-qualified name (e.g., "wasi:cli/command",
 //! "wasi:http/service") derived from the `#[wasi("...")]` attribute.
 
-use indexmap::IndexMap;
+use crate::hashmap::IndexMap;
 
 use crate::ast::{Type, WorldDecl, WorldExport};
 


### PR DESCRIPTION
## Summary
This PR replaces the default hasher for `IndexMap` and `IndexSet` throughout the codebase with `rustc_hash::FxBuildHasher` for improved performance. A new `hashmap` module provides type aliases that use the faster FxHash hasher instead of the default SipHash.

## Key Changes

- **New `hashmap` module** (`src/hashmap.rs`): Provides `IndexMap<K, V>` and `IndexSet<V>` type aliases that use `FxBuildHasher` instead of the default hasher
- **Updated all imports**: Replaced `use indexmap::{IndexMap, IndexSet}` with `use crate::hashmap::{IndexMap, IndexSet}` across ~40 files
- **Constructor updates**: Changed `IndexMap::new()` and `IndexSet::new()` calls to `IndexMap::default()` and `IndexSet::default()` for consistency with the new type aliases
- **Clippy configuration**: Updated `clippy.toml` to reference the new `crate::hashmap` module instead of the external `indexmap` crate
- **Dependencies**: Added `rustc-hash` dependency to both root and `wado-compiler` `Cargo.toml`

## Notable Implementation Details

- **Performance optimization**: FxHash is significantly faster than SipHash for non-cryptographic use cases like compiler hash tables, with minimal collision risk for typical compiler workloads
- **Deterministic iteration order**: Maintains the deterministic iteration order guarantee from `indexmap` while improving hash computation speed
- **Resolver cache optimization**: Added `known_type_names_cache` field to `Resolver` with `rebuild_known_type_names_cache()` method to provide O(1) type name lookups instead of scanning all module maps
- **Consistent initialization**: All `IndexMap` and `IndexSet` initializations now use `.default()` for consistency with the new type alias pattern

https://claude.ai/code/session_01NPcmKQFMRvjPA7BxrQnSzr