### PR TITLE
Add C zlib Wasm benchmark for compression comparison

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -46,7 +46,7 @@ Compresses and decompresses 100KB of patterned data (bytes `i % 256`) for 10 ite
 
 - **Use case**: Compression library performance, byte array throughput
 - **Operations**: zlib compress/decompress, large byte array manipulation
-- **Comparison**: Wado (`core:zlib`, pure Wado implementation) vs zlib-rs (native Rust)
+- **Comparison**: Wado (`core:zlib`, pure Wado) vs C zlib-1.3.1 (Wasm/wasmtime) vs zlib-rs (native Rust)
 
 ```bash
 make benchmark-zlib
@@ -150,14 +150,23 @@ All implementations produce the same result: 664,579 primes.
 
 All implementations produce the same result: 664,579 primes.
 
-### zlib Compression (100KB x 10 iterations)
+### zlib Compress (100KB x 10 iterations)
 
-| Runtime               | Compress (ms) | Decompress (ms) | Relative |
-| --------------------- | ------------- | --------------- | -------- |
-| zlib-rs (native Rust) | 1.0           | 0.2             | 1.00x    |
-| **Wado** (pure Wado)  | 57            | 886             | 786x     |
+| Runtime               | Time (ms) | Relative |
+| --------------------- | --------- | -------- |
+| zlib-rs (native Rust) | 1.0       | 1.00x    |
+| C (Wasm/wasmtime)     | 5.3       | 5.1x     |
+| **Wado** (pure Wado)  | 59        | 57x      |
 
-Wado's `core:zlib` is a pure Wado implementation compiled to Wasm, so significant overhead is expected compared to native.
+### zlib Decompress (100KB x 10 iterations)
+
+| Runtime               | Time (ms) | Relative  |
+| --------------------- | --------- | --------- |
+| zlib-rs (native Rust) | 0.18      | 1.00x     |
+| C (Wasm/wasmtime)     | 0.97      | 5.4x      |
+| **Wado** (pure Wado)  | 888       | 4,933x    |
+
+zlib-rs runs natively; C zlib-1.3.1 and Wado are both compiled to Wasm and run on wasmtime. Wado's `core:zlib` is a pure Wado implementation, so significant overhead is expected.
 
 ### Float-to-String (500,000 conversions, 6 decimal places)
 
@@ -292,7 +301,7 @@ samply record wado run --profile perfmap benchmark/count_prime/count_prime.wado
 - Times include program initialization overhead
 - Wado CLI is built with `--release` for fair comparison with natively-compiled competitors
 - Wado benchmarks use `MonotonicClock::now()` from `wasi:clocks` for timing
-- zlib benchmark compares Wado's pure Wado zlib against native zlib-rs (Rust)
+- zlib benchmark compares Wado's pure Wado zlib, C zlib-1.3.1 (Wasm/wasmtime), and native zlib-rs (Rust)
 - fts benchmark compares Wado, C (`snprintf`), Rust (`write!`), and Zig (`std.fmt`)
 - Rust benchmarks use `rustc -O` (release optimization)
 - Zig benchmarks use `-OReleaseFast`
@@ -311,5 +320,5 @@ benchmark/
 ├── json_twitter/{json_twitter.wado,serde_json.rs,twitter.json}
 ├── mandelbrot/mandelbrot.{wado,c,js}
 ├── sieve/sieve.{wado,c,js}
-└── zlib/{zlib_bench.wado,zlib_rs.rs}
+└── zlib/{zlib_bench.wado,zlib_rs.rs,zlib_c.c}
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -160,11 +160,11 @@ All implementations produce the same result: 664,579 primes.
 
 ### zlib Decompress (100KB x 10 iterations)
 
-| Runtime               | Time (ms) | Relative  |
-| --------------------- | --------- | --------- |
-| zlib-rs (native Rust) | 0.18      | 1.00x     |
-| C (Wasm/wasmtime)     | 0.97      | 5.4x      |
-| **Wado** (pure Wado)  | 888       | 4,933x    |
+| Runtime               | Time (ms) | Relative |
+| --------------------- | --------- | -------- |
+| zlib-rs (native Rust) | 0.18      | 1.00x    |
+| C (Wasm/wasmtime)     | 0.97      | 5.4x     |
+| **Wado** (pure Wado)  | 888       | 4,933x   |
 
 zlib-rs runs natively; C zlib-1.3.1 and Wado are both compiled to Wasm and run on wasmtime. Wado's `core:zlib` is a pure Wado implementation, so significant overhead is expected.
 

--- a/benchmark/mise.toml
+++ b/benchmark/mise.toml
@@ -83,8 +83,43 @@ set -e
 echo "=== Compiling zlib-rs benchmark ==="
 cargo build --release --manifest-path zlib/Cargo.toml --quiet
 
+echo "=== Compiling C zlib Wasm benchmark ==="
+ZLIB_SRC="../wasm-size/zlib/zlib-1.3.1"
+WASM_CLANG=""
+
+# 1. wasi-sdk: clang with co-located wasi-sysroot
+if command -v clang >/dev/null 2>&1; then
+    SDK_DIR="$(cd "$(dirname "$(command -v clang)")/.." 2>/dev/null && pwd)"
+    if [ -d "$SDK_DIR/share/wasi-sysroot" ]; then
+        WASM_CLANG="clang --target=wasm32-wasi --sysroot=$SDK_DIR/share/wasi-sysroot"
+        WASI_CRT1=""
+        WASI_LIBC="-lc"
+    fi
+fi
+
+# 2. System clang + apt wasi-libc (Ubuntu/Debian)
+if [ -z "$WASM_CLANG" ] && command -v clang >/dev/null 2>&1 && command -v wasm-ld >/dev/null 2>&1 && [ -f "/usr/lib/wasm32-wasi/crt1.o" ]; then
+    WASM_CLANG="clang --target=wasm32-wasi -nostdlib -I/usr/include/wasm32-wasi"
+    WASI_CRT1="/usr/lib/wasm32-wasi/crt1.o"
+    WASI_LIBC="-L/usr/lib/wasm32-wasi -lc"
+fi
+
+if [ -n "$WASM_CLANG" ]; then
+    ZLIB_SRCS="$ZLIB_SRC/adler32.c $ZLIB_SRC/compress.c $ZLIB_SRC/crc32.c $ZLIB_SRC/deflate.c $ZLIB_SRC/inffast.c $ZLIB_SRC/inflate.c $ZLIB_SRC/inftrees.c $ZLIB_SRC/trees.c $ZLIB_SRC/uncompr.c $ZLIB_SRC/zutil.c"
+    eval $WASM_CLANG -O3 -I$ZLIB_SRC -o zlib/zlib_c.wasm zlib/zlib_c.c $ZLIB_SRCS $WASI_CRT1 $WASI_LIBC
+    HAVE_C_WASM=1
+else
+    echo "SKIP: C Wasm (install wasi-sdk or apt install wasi-libc libclang-rt-dev-wasm32)"
+    HAVE_C_WASM=0
+fi
+
 echo "=== zlib-rs (native Rust) ==="
 ./zlib/target/release/zlib_rs_bench
+
+if [ "$HAVE_C_WASM" -eq 1 ]; then
+    echo "=== C zlib (Wasm/wasmtime) ==="
+    wasmtime zlib/zlib_c.wasm
+fi
 
 echo "=== Wado ==="
 cargo run --release --manifest-path ../wado-cli/Cargo.toml --quiet -- run -O2 zlib/zlib_bench.wado
@@ -186,7 +221,7 @@ MISE_JOBS=1 mise run json-catalog
 [tasks.clean]
 description = "Clean benchmark artifacts"
 run = """
-rm -f count_prime/*.wasm mandelbrot/*.wasm sieve/*.wasm
+rm -f count_prime/*.wasm mandelbrot/*.wasm sieve/*.wasm zlib/zlib_c.wasm
 rm -f count_prime/count_prime_c mandelbrot/mandelbrot_c sieve/sieve_c
 rm -f fts/fts_c fts/fts_rs fts/fts_zig fts/fts_zig.o
 rm -rf zlib/target json_twitter/target json_canada/target json_catalog/target

--- a/benchmark/mise.toml
+++ b/benchmark/mise.toml
@@ -2,7 +2,12 @@
 # https://mise.jdx.dev/
 #
 # Run `mise install` to install managed tools.
-# C compiler (cc) is expected from the system.
+# C compiler (cc) is expected from the system for native C benchmarks.
+#
+# Optional: wasi-sdk (clang + wasi-sysroot) for the C zlib Wasm benchmark.
+# Install via wasm-size/ (`mise install` there) or apt (Ubuntu/Debian):
+#   apt install wasi-libc libclang-rt-18-dev-wasm32
+# The zlib task skips the C Wasm step gracefully if neither is available.
 
 [tools]
 node = "latest"

--- a/benchmark/zlib/zlib_c.c
+++ b/benchmark/zlib/zlib_c.c
@@ -1,0 +1,90 @@
+// zlib C benchmark for comparison with Wado and zlib-rs
+//
+// Compresses and decompresses 100KB of patterned data x10 iterations,
+// using the same data pattern as zlib_bench.wado and zlib_rs.rs.
+//
+// Compiled to Wasm with:
+//   clang --target=wasm32-wasi -O3 ...
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "../../wasm-size/zlib/zlib-1.3.1/zlib.h"
+
+static long long now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+int main(void) {
+    int size = 100000;
+    int iterations = 10;
+
+    // Generate 100KB of patterned data: bytes (i % 256)
+    unsigned char *data = (unsigned char *)malloc(size);
+    for (int i = 0; i < size; i++) {
+        data[i] = (unsigned char)(i % 256);
+    }
+
+    printf("zlib %d bytes x %d iterations\n", size, iterations);
+
+    // Benchmark compression (10 iterations)
+    uLong bound = compressBound((uLong)size);
+    unsigned char *compressed = (unsigned char *)malloc(bound);
+    uLong compressed_len = 0;
+
+    long long t0 = now_ns();
+    for (int iter = 0; iter < iterations; iter++) {
+        uLong dest_len = bound;
+        int rc = compress2(compressed, &dest_len, data, (uLong)size, 6);
+        if (rc != Z_OK) {
+            fprintf(stderr, "compress2 failed: %d\n", rc);
+            return 1;
+        }
+        compressed_len = dest_len;
+    }
+    long long t1 = now_ns();
+
+    long long compress_ns = t1 - t0;
+    long long compress_ms = compress_ns / 1000000;
+    long long compress_us_rem = (compress_ns / 1000) % 1000;
+    printf("Compressed: %d -> %lu bytes\n", size, (unsigned long)compressed_len);
+    printf("Compress: %lld.%03lld ms\n", compress_ms, compress_us_rem);
+
+    // Benchmark decompression (10 iterations)
+    unsigned char *decompressed = (unsigned char *)malloc(size);
+
+    long long t2 = now_ns();
+    for (int iter = 0; iter < iterations; iter++) {
+        uLong dest_len = (uLong)size;
+        int rc = uncompress(decompressed, &dest_len, compressed, compressed_len);
+        if (rc != Z_OK) {
+            fprintf(stderr, "uncompress failed: %d\n", rc);
+            return 1;
+        }
+    }
+    long long t3 = now_ns();
+
+    long long decompress_ns = t3 - t2;
+    long long decompress_ms = decompress_ns / 1000000;
+    long long decompress_us_rem = (decompress_ns / 1000) % 1000;
+    printf("Decompress: %lld.%03lld ms\n", decompress_ms, decompress_us_rem);
+
+    // Verify round-trip
+    if (memcmp(data, decompressed, size) != 0) {
+        fprintf(stderr, "ERROR: decompressed data mismatch\n");
+        return 1;
+    }
+
+    long long total_ns = compress_ns + decompress_ns;
+    long long total_ms = total_ns / 1000000;
+    long long total_us_rem = (total_ns / 1000) % 1000;
+    printf("Elapsed: %lld.%03lld ms\n", total_ms, total_us_rem);
+
+    free(data);
+    free(compressed);
+    free(decompressed);
+    return 0;
+}


### PR DESCRIPTION
## Summary
Add a C implementation of the zlib benchmark compiled to WebAssembly, enabling direct performance comparison between Wado's pure Wado zlib implementation, native C zlib-1.3.1 (via Wasm/wasmtime), and native Rust zlib-rs.

## Key Changes

- **New benchmark**: `benchmark/zlib/zlib_c.c` - C zlib benchmark that compresses/decompresses 100KB of patterned data across 10 iterations, matching the test data pattern used by existing Wado and Rust benchmarks
- **Build integration**: Updated `benchmark/mise.toml` to compile the C zlib benchmark to Wasm with automatic detection of wasi-sdk or system wasi-libc installation, gracefully skipping if unavailable
- **Benchmark execution**: Added wasmtime invocation to run the compiled C Wasm benchmark alongside existing benchmarks
- **Documentation**: Updated `benchmark/README.md` to include C zlib results in comparison tables and clarify that both C and Wado implementations run on wasmtime while zlib-rs runs natively

## Implementation Details

- The C benchmark uses `compress2()` with compression level 6 and `uncompress()` from zlib-1.3.1
- Build system attempts two detection paths: wasi-sdk (clang with co-located wasi-sysroot) and system clang + apt wasi-libc
- Timing uses `clock_gettime(CLOCK_MONOTONIC)` for nanosecond precision, consistent with other benchmarks
- Results show C Wasm performance is ~5x slower than native zlib-rs but significantly faster than pure Wado implementation (~57x slower for compression, ~4,933x for decompression)

https://claude.ai/code/session_01RUd8JzX3GcgN9CGbmosyL2