### PR TITLE
Clean up TODO comments, incliding Implementation of env() function to retrieve environment variables

### DIFF
--- a/docs/stdlib-core.md
+++ b/docs/stdlib-core.md
@@ -2126,7 +2126,6 @@ Writes raw bytes to stdout.
 #### `pub fn env(name: String) -> Option<String> with Environment`
 
 Returns the value of an environment variable by name.
-TODO: Implement when for-in loops are supported.
 
 #### `pub fn args() -> Array<String> with Environment`
 

--- a/wado-compiler/lib/core/cli.wado
+++ b/wado-compiler/lib/core/cli.wado
@@ -83,8 +83,16 @@ pub fn print_bytes(data: Array<u8>) with Stdout {
 }
 
 /// Returns the value of an environment variable by name.
-/// TODO: Implement when for-in loops are supported.
-pub fn env(name: String) -> Option<String> with Environment;
+pub fn env(name: String) -> Option<String> with Environment {
+    let vars = Environment::get_environment();
+    for let mut i = 0; i < vars.len(); i += 1 {
+        let pair = vars[i];
+        if pair.0 == name {
+            return Option::<String>::Some(pair.1);
+        }
+    }
+    return null;
+}
 
 /// Returns all command-line arguments.
 pub fn args() -> Array<String> with Environment {

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -185,7 +185,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                         return_type: func.return_type.as_ref().map(|_| "unknown".to_string()),
                         effects: func.effects.clone(),
                         is_builtin,
-                        wasi_import: None, // TODO: extract from attributes
+                        wasi_import: func.attrs.first().and_then(|a| a.wasi_import.clone()),
                     });
 
                     self.symbols

--- a/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
@@ -56,15 +56,15 @@ struct Option<String>::Some {
     payload_0: ref String,
 }
 
+struct Array<Tuple<String,String>> {  // Array<T> with T=Tuple<String,String>
+    mut repr: ref array<Tuple<String,String>>,
+    mut used: i32,
+}
+
 array array<u64> (mut u64);
 
 struct Array<u64> {  // Array<T> with T=u64
     mut repr: ref array<u64>,
-    mut used: i32,
-}
-
-struct Array<Tuple<String,String>> {  // Array<T> with T=Tuple<String,String>
-    mut repr: ref array<Tuple<String,String>>,
     mut used: i32,
 }
 
@@ -142,13 +142,13 @@ type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
 type "functype/String::append_char" = fn(ref String, char);
 
+type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
+
 type "functype/MiniDict<String,String>::has" = fn(ref MiniDict<String,String>, ref String) -> bool;
 
 type "functype/MiniDict<String,String>::get" = fn(ref MiniDict<String,String>, ref String) -> ref Option<String>;
 
 type "functype/MiniDict<String,String>::set" = fn(ref MiniDict<String,String>, ref String, ref String);
-
-type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
 
 type "functype/Array<Tuple<String,String>>^IndexAssign::index_assign" = fn(ref Array<Tuple<String,String>>, i32, ref "tuple/[String, String]");
 
@@ -731,109 +731,6 @@ fn String::append_char(self, c) {
     };
 }
 
-fn MiniDict<String,String>::has(self, key) {
-    let i: i32;
-    let __local_5: i32;
-    let _licm_entries_6: ref Array<Tuple<String,String>>;
-    let _licm_used_7: i32;
-    let _licm_repr_8: ref array<Tuple<String,String>>;
-    __for_2: block {
-        i = 0;
-        _licm_entries_6 = self;
-        _licm_used_7 = _licm_entries_6.used;
-        _licm_repr_8 = _licm_entries_6.repr;
-        block {
-            l44: loop {
-                if (i < _licm_used_7) == 0 {
-                    break __for_2;
-                };
-                if String^Eq::eq(__inline_Array_Tuple_String_String___IndexValue__index_value_1: block -> ref "tuple/[String, String]" {
-                    __local_5 = i;
-                    if __local_5 >= _licm_used_7 {
-                        "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
-                        unreachable;
-                    };
-                    break __inline_Array_Tuple_String_String___IndexValue__index_value_1: builtin::array_get<ref "tuple/[String, String]">(_licm_repr_8, __local_5);
-                }.0, key) {
-                    return 1;
-                };
-                i = i + 1;
-                continue l44;
-            };
-        };
-    };
-    return 0;
-}
-
-fn MiniDict<String,String>::get(self, key) {
-    let i: i32;
-    let __local_5: i32;
-    let __local_7: i32;
-    let _licm_entries_8: ref Array<Tuple<String,String>>;
-    let _licm_used_9: i32;
-    let _licm_repr_10: ref array<Tuple<String,String>>;
-    __for_1: block {
-        i = 0;
-        _licm_entries_8 = self;
-        _licm_used_9 = _licm_entries_8.used;
-        _licm_repr_10 = _licm_entries_8.repr;
-        block {
-            l49: loop {
-                if (i < _licm_used_9) == 0 {
-                    break __for_1;
-                };
-                if String^Eq::eq(__inline_Array_Tuple_String_String___IndexValue__index_value_1: block -> ref "tuple/[String, String]" {
-                    __local_5 = i;
-                    if __local_5 >= _licm_used_9 {
-                        "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
-                        unreachable;
-                    };
-                    break __inline_Array_Tuple_String_String___IndexValue__index_value_1: builtin::array_get<ref "tuple/[String, String]">(_licm_repr_10, __local_5);
-                }.0, key) {
-                    return Option<String>::Some { discriminant: 0, payload_0: ref.as_non_null(__inline_Array_Tuple_String_String___IndexValue__index_value_2: block -> ref "tuple/[String, String]" {
-                        __local_7 = i;
-                        break __inline_Array_Tuple_String_String___IndexValue__index_value_2: builtin::array_get<ref "tuple/[String, String]">(_licm_repr_10, __local_7);
-                    }.1) };
-                };
-                i = i + 1;
-                continue l49;
-            };
-        };
-    };
-    return Option<String> { 1 };
-}
-
-fn MiniDict<String,String>::set(self, key, value) {
-    let i: i32;
-    let __local_6: i32;
-    let _licm_entries_7: ref Array<Tuple<String,String>>;
-    __for_0: block {
-        i = 0;
-        _licm_entries_7 = self;
-        block {
-            l54: loop {
-                if (i < _licm_entries_7.used) == 0 {
-                    break __for_0;
-                };
-                if String^Eq::eq(__inline_Array_Tuple_String_String___IndexValue__index_value_1: block -> ref "tuple/[String, String]" {
-                    __local_6 = i;
-                    if __local_6 >= _licm_entries_7.used {
-                        "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
-                        unreachable;
-                    };
-                    break __inline_Array_Tuple_String_String___IndexValue__index_value_1: builtin::array_get<ref "tuple/[String, String]">(_licm_entries_7.repr, __local_6);
-                }.0, key) {
-                    Array<Tuple<String,String>>^IndexAssign::index_assign(_licm_entries_7, i, "tuple/[String, String]" { 0: ref.as_non_null(key), 1: ref.as_non_null(value) });
-                    return;
-                };
-                i = i + 1;
-                continue l54;
-            };
-        };
-    };
-    Array<Tuple<String,String>>::append(self, "tuple/[String, String]" { 0: ref.as_non_null(key), 1: ref.as_non_null(value) });
-}
-
 fn Array<Tuple<String,String>>::append(self, value) {
     let used: i32;
     let capacity: i32;
@@ -853,6 +750,109 @@ fn Array<Tuple<String,String>>::append(self, value) {
     };
     builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
     self.used = used + 1;
+}
+
+fn MiniDict<String,String>::has(self, key) {
+    let i: i32;
+    let __local_5: i32;
+    let _licm_entries_6: ref Array<Tuple<String,String>>;
+    let _licm_used_7: i32;
+    let _licm_repr_8: ref array<Tuple<String,String>>;
+    __for_2: block {
+        i = 0;
+        _licm_entries_6 = self;
+        _licm_used_7 = _licm_entries_6.used;
+        _licm_repr_8 = _licm_entries_6.repr;
+        block {
+            l45: loop {
+                if (i < _licm_used_7) == 0 {
+                    break __for_2;
+                };
+                if String^Eq::eq(__inline_Array_Tuple_String_String___IndexValue__index_value_1: block -> ref "tuple/[String, String]" {
+                    __local_5 = i;
+                    if __local_5 >= _licm_used_7 {
+                        "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
+                        unreachable;
+                    };
+                    break __inline_Array_Tuple_String_String___IndexValue__index_value_1: builtin::array_get<ref "tuple/[String, String]">(_licm_repr_8, __local_5);
+                }.0, key) {
+                    return 1;
+                };
+                i = i + 1;
+                continue l45;
+            };
+        };
+    };
+    return 0;
+}
+
+fn MiniDict<String,String>::get(self, key) {
+    let i: i32;
+    let __local_5: i32;
+    let __local_7: i32;
+    let _licm_entries_8: ref Array<Tuple<String,String>>;
+    let _licm_used_9: i32;
+    let _licm_repr_10: ref array<Tuple<String,String>>;
+    __for_1: block {
+        i = 0;
+        _licm_entries_8 = self;
+        _licm_used_9 = _licm_entries_8.used;
+        _licm_repr_10 = _licm_entries_8.repr;
+        block {
+            l50: loop {
+                if (i < _licm_used_9) == 0 {
+                    break __for_1;
+                };
+                if String^Eq::eq(__inline_Array_Tuple_String_String___IndexValue__index_value_1: block -> ref "tuple/[String, String]" {
+                    __local_5 = i;
+                    if __local_5 >= _licm_used_9 {
+                        "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
+                        unreachable;
+                    };
+                    break __inline_Array_Tuple_String_String___IndexValue__index_value_1: builtin::array_get<ref "tuple/[String, String]">(_licm_repr_10, __local_5);
+                }.0, key) {
+                    return Option<String>::Some { discriminant: 0, payload_0: ref.as_non_null(__inline_Array_Tuple_String_String___IndexValue__index_value_2: block -> ref "tuple/[String, String]" {
+                        __local_7 = i;
+                        break __inline_Array_Tuple_String_String___IndexValue__index_value_2: builtin::array_get<ref "tuple/[String, String]">(_licm_repr_10, __local_7);
+                    }.1) };
+                };
+                i = i + 1;
+                continue l50;
+            };
+        };
+    };
+    return Option<String> { 1 };
+}
+
+fn MiniDict<String,String>::set(self, key, value) {
+    let i: i32;
+    let __local_6: i32;
+    let _licm_entries_7: ref Array<Tuple<String,String>>;
+    __for_0: block {
+        i = 0;
+        _licm_entries_7 = self;
+        block {
+            l55: loop {
+                if (i < _licm_entries_7.used) == 0 {
+                    break __for_0;
+                };
+                if String^Eq::eq(__inline_Array_Tuple_String_String___IndexValue__index_value_1: block -> ref "tuple/[String, String]" {
+                    __local_6 = i;
+                    if __local_6 >= _licm_entries_7.used {
+                        "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
+                        unreachable;
+                    };
+                    break __inline_Array_Tuple_String_String___IndexValue__index_value_1: builtin::array_get<ref "tuple/[String, String]">(_licm_entries_7.repr, __local_6);
+                }.0, key) {
+                    Array<Tuple<String,String>>^IndexAssign::index_assign(_licm_entries_7, i, "tuple/[String, String]" { 0: ref.as_non_null(key), 1: ref.as_non_null(value) });
+                    return;
+                };
+                i = i + 1;
+                continue l55;
+            };
+        };
+    };
+    Array<Tuple<String,String>>::append(self, "tuple/[String, String]" { 0: ref.as_non_null(key), 1: ref.as_non_null(value) });
 }
 
 fn Array<Tuple<String,String>>^IndexAssign::index_assign(self, index, value) {

--- a/wado-compiler/tests/fixtures.golden/tuple_struct_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_struct_field.wir.wado
@@ -41,14 +41,14 @@ struct [Stream<u8>, StreamWritable<u8>] {
     mut 1: i32,
 }
 
-struct [String, i32] {
-    mut 0: ref String,
-    mut 1: i32,
-}
-
 struct [String, String] {
     mut 0: ref String,
     mut 1: ref String,
+}
+
+struct [String, i32] {
+    mut 0: ref String,
+    mut 1: i32,
 }
 
 variant Option<char> {

--- a/wado-compiler/tests/fixtures.golden/wasi_cli.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_cli.wir.wado
@@ -49,15 +49,15 @@ struct Array<String> {  // Array<T> with T=String
     mut used: i32,
 }
 
+struct Array<Tuple<String,String>> {  // Array<T> with T=Tuple<String,String>
+    mut repr: ref array<Tuple<String,String>>,
+    mut used: i32,
+}
+
 array array<u64> (mut u64);
 
 struct Array<u64> {  // Array<T> with T=u64
     mut repr: ref array<u64>,
-    mut used: i32,
-}
-
-struct Array<Tuple<String,String>> {  // Array<T> with T=Tuple<String,String>
-    mut repr: ref array<Tuple<String,String>>,
     mut used: i32,
 }
 
@@ -91,9 +91,9 @@ type "functype/__cm_adapter__Stdout_write_via_stream" = fn(i32) -> i32;
 
 type "functype/__cm_adapter__Stderr_write_via_stream" = fn(i32) -> i32;
 
-type "functype/__cm_adapter__Environment_get_arguments" = fn() -> ref Array<String>;
-
 type "functype/__cm_adapter__Environment_get_environment" = fn() -> ref Array<Tuple<String,String>>;
+
+type "functype/__cm_adapter__Environment_get_arguments" = fn() -> ref Array<String>;
 
 type "functype/__cm_export__run" = fn();
 
@@ -137,9 +137,9 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String::append_char" = fn(ref String, char);
 
-type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
-
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
+
+type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -230,46 +230,6 @@ fn __cm_adapter__Stderr_write_via_stream(data) {
     return "wasi/wasi:cli/Stderr::write_via_stream"(data, __async_outptr);
 }
 
-fn __cm_adapter__Environment_get_arguments() {
-    let __outptr: i32;
-    let __base: i32;
-    let __count: i32;
-    let __result: ref Array<String>;
-    let __i: i32;
-    let __elem_addr: i32;
-    let __local_7: i32;
-    let __local_8: i32;
-    let __local_9: ref array<u8>;
-    __outptr = "mem/realloc"(0, 0, 4, 8);
-    "wasi/wasi:cli/Environment::get_arguments"(__outptr);
-    __base = builtin::load_i32(__outptr);
-    __count = builtin::load_i32(__outptr + 4);
-    __result = Array<String> { repr: builtin::array_new<ref String>(__count), used: 0 };
-    __i = 0;
-    b1: block {
-        l2: loop {
-            if __i >= __count {
-                break b1;
-            };
-            __elem_addr = __base + (__i * 8);
-            Array<String>::append(__result, __inline_memory_to_gc_string_1: block -> ref String {
-                __local_7 = builtin::load_i32(__elem_addr);
-                __local_8 = builtin::load_i32(__elem_addr + 4);
-                __local_9 = "core:internal/memory_to_gc_array"(__local_7, __local_8);
-                break __inline_memory_to_gc_string_1: String { repr: ref.as_non_null(__local_9), used: __local_8 };
-            });
-            drop("mem/realloc"(builtin::load_i32(__elem_addr), builtin::load_i32(__elem_addr + 4), 1, 0));
-            __i = __i + 1;
-            continue l2;
-        };
-    };
-    if __count > 0 {
-        drop("mem/realloc"(__base, __count * 8, 4, 0));
-    };
-    drop("mem/realloc"(__outptr, 8, 4, 0));
-    return __result;
-}
-
 fn __cm_adapter__Environment_get_environment() {
     let __outptr: i32;
     let __base: i32;
@@ -291,10 +251,10 @@ fn __cm_adapter__Environment_get_environment() {
     __count = builtin::load_i32(__outptr + 4);
     __result = Array<Tuple<String,String>> { repr: builtin::array_new<ref "tuple/[String, String]">(__count), used: 0 };
     __i = 0;
-    b5: block {
-        l6: loop {
+    b1: block {
+        l2: loop {
             if __i >= __count {
-                break b5;
+                break b1;
             };
             __elem_addr = __base + (__i * 16);
             __lifted_result_6 = __inline_memory_to_gc_string_1: block -> ref String {
@@ -313,11 +273,51 @@ fn __cm_adapter__Environment_get_environment() {
             drop("mem/realloc"(builtin::load_i32(__elem_addr + 0), builtin::load_i32((__elem_addr + 0) + 4), 1, 0));
             drop("mem/realloc"(builtin::load_i32(__elem_addr + 8), builtin::load_i32((__elem_addr + 8) + 4), 1, 0));
             __i = __i + 1;
-            continue l6;
+            continue l2;
         };
     };
     if __count > 0 {
         drop("mem/realloc"(__base, __count * 16, 4, 0));
+    };
+    drop("mem/realloc"(__outptr, 8, 4, 0));
+    return __result;
+}
+
+fn __cm_adapter__Environment_get_arguments() {
+    let __outptr: i32;
+    let __base: i32;
+    let __count: i32;
+    let __result: ref Array<String>;
+    let __i: i32;
+    let __elem_addr: i32;
+    let __local_7: i32;
+    let __local_8: i32;
+    let __local_9: ref array<u8>;
+    __outptr = "mem/realloc"(0, 0, 4, 8);
+    "wasi/wasi:cli/Environment::get_arguments"(__outptr);
+    __base = builtin::load_i32(__outptr);
+    __count = builtin::load_i32(__outptr + 4);
+    __result = Array<String> { repr: builtin::array_new<ref String>(__count), used: 0 };
+    __i = 0;
+    b5: block {
+        l6: loop {
+            if __i >= __count {
+                break b5;
+            };
+            __elem_addr = __base + (__i * 8);
+            Array<String>::append(__result, __inline_memory_to_gc_string_1: block -> ref String {
+                __local_7 = builtin::load_i32(__elem_addr);
+                __local_8 = builtin::load_i32(__elem_addr + 4);
+                __local_9 = "core:internal/memory_to_gc_array"(__local_7, __local_8);
+                break __inline_memory_to_gc_string_1: String { repr: ref.as_non_null(__local_9), used: __local_8 };
+            });
+            drop("mem/realloc"(builtin::load_i32(__elem_addr), builtin::load_i32(__elem_addr + 4), 1, 0));
+            __i = __i + 1;
+            continue l6;
+        };
+    };
+    if __count > 0 {
+        drop("mem/realloc"(__base, __count * 8, 4, 0));
     };
     drop("mem/realloc"(__outptr, 8, 4, 0));
     return __result;
@@ -685,27 +685,6 @@ fn String::append_char(self, c) {
     };
 }
 
-fn Array<Tuple<String,String>>::append(self, value) {
-    let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<String,String>>;
-    let __local_6: i32;
-    used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_6 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_6 > 4, __local_6, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
-        builtin::array_copy<ref "tuple/[String, String]">(new_repr, 0, self.repr, 0, used);
-        self.repr = ref.as_non_null(new_repr);
-    };
-    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
-    self.used = used + 1;
-}
-
 fn Array<String>::append(self, value) {
     let used: i32;
     let capacity: i32;
@@ -724,6 +703,27 @@ fn Array<String>::append(self, value) {
         self.repr = ref.as_non_null(new_repr);
     };
     builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,String>>::append(self, value) {
+    let used: i32;
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Tuple<String,String>>;
+    let __local_6: i32;
+    used = self.used;
+    capacity = builtin::array_len(self.repr);
+    if builtin::unlikely(used >= capacity) {
+        new_capacity = __inline_i32_max_0: block -> i32 {
+            __local_6 = capacity * 2;
+            break __inline_i32_max_0: select i32(__local_6 > 4, __local_6, 4);
+        };
+        new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
+        builtin::array_copy<ref "tuple/[String, String]">(new_repr, 0, self.repr, 0, used);
+        self.repr = ref.as_non_null(new_repr);
+    };
+    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
     self.used = used + 1;
 }
 

--- a/wado-compiler/tests/fixtures/closure_mutable_capture.wado
+++ b/wado-compiler/tests/fixtures/closure_mutable_capture.wado
@@ -1,5 +1,5 @@
-// TODO: Mutable closure that mutates a captured variable
-// Requires: &mut || syntax for mutable closures (fn mut type)
+// Mutable closure that mutates a captured variable
+// Uses &mut || syntax for mutable closures (fn mut type).
 // The closure modifies the captured outer variable through the shared environment.
 use { println, Stdout } from "core:cli";
 

--- a/wado-compiler/tests/fixtures/http-request-options.wado
+++ b/wado-compiler/tests/fixtures/http-request-options.wado
@@ -1,9 +1,8 @@
 // HTTP RequestOptions resource test
 // Tests creating and configuring RequestOptions.
 //
-// TODO: Fails because the compiled Wasm imports `wasi:http/RequestOptions::new` etc.,
-// but wasmtime's wasi-http linker does not yet export the request-options resource.
-// This is a wasmtime limitation, not a compiler bug.
+// Fails with a Wasm validation type mismatch in codegen.
+// The compiled Wasm also needs wasmtime to support the request-options resource.
 
 use { Request, Response, ErrorCode, Fields, RequestOptions, Trailers } from "wasi:http";
 

--- a/wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado
+++ b/wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado
@@ -1,4 +1,4 @@
-// TODO test: duplicate fields during JSON deserialization
+// Duplicate fields during JSON deserialization
 // When the same field appears twice in JSON, the last value should win
 // (consistent with JSON RFC 8259 which says names SHOULD be unique,
 // but behavior for duplicates is implementation-defined).

--- a/wado-compiler/tests/fixtures/serde_json_nested_struct.wado
+++ b/wado-compiler/tests/fixtures/serde_json_nested_struct.wado
@@ -1,4 +1,4 @@
-// TODO test: synthesized Serialize/Deserialize for nested structs
+// Synthesized Serialize/Deserialize for nested structs
 // A struct containing another struct field should work with synthesis.
 use { Serialize, Deserialize } from "core:serde";
 use { to_string, from_string } from "core:json";

--- a/wado-compiler/tests/fixtures/serde_json_option_array_fields.wado
+++ b/wado-compiler/tests/fixtures/serde_json_option_array_fields.wado
@@ -1,4 +1,4 @@
-// TODO test: synthesized struct with Option and Array fields roundtrip
+// Synthesized struct with Option and Array fields roundtrip
 // Struct fields of type Option<T> and Array<T> should work with synthesis.
 use { Serialize, Deserialize } from "core:serde";
 use { to_string, from_string } from "core:json";

--- a/wado-compiler/tests/fixtures/serde_json_result.wado
+++ b/wado-compiler/tests/fixtures/serde_json_result.wado
@@ -1,4 +1,4 @@
-// TODO test: Result<T, E> Serialize/Deserialize
+// Result<T, E> Serialize/Deserialize
 // Result should serialize as variant: Ok(v) → {"Ok": v}, Err(e) → {"Err": e}
 use { Serialize, Deserialize } from "core:serde";
 use { to_string, from_string } from "core:json";

--- a/wado-compiler/tests/fixtures/serde_json_treemap.wado
+++ b/wado-compiler/tests/fixtures/serde_json_treemap.wado
@@ -1,4 +1,4 @@
-// TODO test: TreeMap Serialize/Deserialize via begin_map
+// TreeMap Serialize/Deserialize via begin_map
 // TreeMap<String, T> should serialize as JSON objects: {"key1": val1, "key2": val2}
 // Hand-written impl in stdlib (not compiler-synthesized).
 use { Serialize, Deserialize } from "core:serde";

--- a/wado-compiler/tests/fixtures/serde_json_unknown_fields.wado
+++ b/wado-compiler/tests/fixtures/serde_json_unknown_fields.wado
@@ -1,4 +1,4 @@
-// TODO test: unknown fields are silently ignored during deserialization
+// Unknown fields are silently ignored during deserialization
 // Extra fields in JSON that don't match any struct field should be skipped.
 use { Serialize, Deserialize } from "core:serde";
 use { from_string } from "core:json";

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -79,6 +79,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -191,6 +199,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -1035,6 +1047,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -1147,6 +1167,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -1267,7 +1291,25 @@ pub fn print_bytes(data: Array<u8>) with Stdout {
     core::internal::wait_for_subtask(subtask);
 }
 
-pub fn env(name: String) -> Option<String> with Environment;
+pub fn env(name: String) -> Option<String> with Environment {
+    let vars: Array<[String, String]> = __cm_adapter__Environment_get_environment();
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < vars."Array<Tuple<String,String>>::len"()) {
+                break __for_0;
+            }
+            __for_0_body: {
+                let pair: [String, String] = vars."Array<Tuple<String,String>>^IndexValue::index_value"(i);
+                if pair.0."String^Eq::eq"(&name) {
+                    return Option<String>::Some(pair.1);
+                }
+            }
+            i = (i + 1);
+        }
+    }
+    return null;
+}
 
 pub fn args() -> Array<String> with Environment {
     return __cm_adapter__Environment_get_arguments();
@@ -1318,6 +1360,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     *self.0."Stream<u8>^Inspect::inspect"(f);
     f.Formatter::write_str(", ");
     *self.1."StreamWritable<u8>^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
     f.Formatter::write_str("]");
 }
 
@@ -1435,6 +1485,10 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, S
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
 }
 
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
+}
+
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     self."Fn<2,Ordering>^Inspect::inspect"(f);
 }
@@ -1489,6 +1543,17 @@ pub fn "Tuple<i32,i32>^Display::fmt"(self: &[i32, i32], f: &mut Formatter) {
 
 pub fn "Tuple<i32,i32,i32>^Display::fmt"(self: &[i32, i32, i32], f: &mut Formatter) {
     self."Tuple<i32,i32,i32>^Inspect::inspect"(f);
+}
+
+fn "Array<Tuple<String,String>>^IndexValue::index_value"(self: &Array<[String, String]>, index: i32) -> [String, String] {
+    if (index >= self.used) {
+        core::internal::panic("index out of bounds");
+    }
+    return core::builtin::array_get::<[String, String]>(self.repr, index);
+}
+
+pub fn "Array<Tuple<String,String>>::len"(self: &Array<[String, String]>) -> i32 {
+    return self.used;
 }
 
 fn "array_copy<u8>"(dst: builtin::array<u8>, dst_offset: i32, src: builtin::array<u8>, src_offset: i32, len: i32);
@@ -1814,6 +1879,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -1926,6 +1999,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -2038,6 +2115,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -2150,6 +2235,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -2256,6 +2345,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -2368,6 +2465,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -3552,6 +3653,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -3680,6 +3789,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -4616,6 +4729,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -4728,6 +4849,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -6637,6 +6762,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -6749,6 +6882,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7448,6 +7585,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7568,6 +7713,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7754,6 +7903,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7872,6 +8029,10 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, S
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
 }
 
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
+}
+
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     self."Fn<2,Ordering>^Inspect::inspect"(f);
 }
@@ -7982,6 +8143,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     *self.0."Stream<u8>^Inspect::inspect"(f);
     f.Formatter::write_str(", ");
     *self.1."StreamWritable<u8>^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
     f.Formatter::write_str("]");
 }
 
@@ -8101,6 +8270,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8793,6 +8966,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8935,6 +9116,10 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, S
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
 }
 
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
+}
+
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     self."Fn<2,Ordering>^Inspect::inspect"(f);
 }
@@ -8999,6 +9184,32 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) -> i32 {
 fn __cm_adapter__Stderr_write_via_stream(data: i32) -> i32 {
     let __async_outptr: i32 = core::builtin::realloc(0, 0, 1, 2);
     return cm_raw_call wasi:cli/Stderr::write_via_stream(data, __async_outptr);
+}
+
+fn __cm_adapter__Environment_get_environment() -> Array<[String, String]> {
+    let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
+    cm_raw_call wasi:cli/Environment::get_environment(__outptr);
+    let __base: i32 = core::builtin::i32_load(__outptr);
+    let __count: i32 = core::builtin::i32_load((__outptr + 4));
+    let mut __result: Array<[String, String]> = "Array<Tuple<String,String>>::with_capacity"(__count);
+    let mut __i: i32 = 0;
+    loop {
+        if (__i >= __count) {
+            break;
+        }
+        let __elem_addr: i32 = (__base + (__i * 16));
+        let __lifted_result: String = core::internal::memory_to_gc_string(core::builtin::i32_load((__elem_addr + 0)), core::builtin::i32_load(((__elem_addr + 0) + 4)));
+        let __lifted_result: String = core::internal::memory_to_gc_string(core::builtin::i32_load((__elem_addr + 8)), core::builtin::i32_load(((__elem_addr + 8) + 4)));
+        __result."Array<Tuple<String,String>>::append"([__lifted_result, __lifted_result]);
+        core::builtin::realloc(core::builtin::i32_load((__elem_addr + 0)), core::builtin::i32_load(((__elem_addr + 0) + 4)), 1, 0);
+        core::builtin::realloc(core::builtin::i32_load((__elem_addr + 8)), core::builtin::i32_load(((__elem_addr + 8) + 4)), 1, 0);
+        __i = (__i + 1);
+    }
+    if (__count > 0) {
+        core::builtin::realloc(__base, (__count * 16), 4, 0);
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result;
 }
 
 fn __cm_adapter__Environment_get_arguments() -> Array<String> {
@@ -9070,6 +9281,23 @@ pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
 
 pub fn "Array<String>::with_capacity"(capacity: i32) -> Array<String> {
     return Array<String> { repr: core::builtin::array_new::<String>(capacity), used: 0 };
+}
+
+pub fn "Array<Tuple<String,String>>::append"(self: &mut Array<[String, String]>, value: [String, String]) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+        let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
+        core::builtin::array_copy::<[String, String]>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<[String, String]>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
+pub fn "Array<Tuple<String,String>>::with_capacity"(capacity: i32) -> Array<[String, String]> {
+    return Array<Tuple<String,String>> { repr: core::builtin::array_new::<[String, String]>(capacity), used: 0 };
 }
 
 fn "ArrayIter<Point>^Iterator::next"(self: &mut ArrayIter<Point>) -> Option<Point> {
@@ -9235,6 +9463,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -9347,6 +9583,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -9439,6 +9679,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -9551,6 +9799,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -9643,6 +9895,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -9755,6 +10015,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -9847,6 +10111,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -9959,6 +10231,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -10051,6 +10327,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -10163,6 +10447,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -10255,6 +10543,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -10367,6 +10663,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -10459,6 +10759,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -10571,6 +10879,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -10663,6 +10975,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -10775,6 +11095,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -10867,6 +11191,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -10979,6 +11311,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -11071,6 +11407,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -11183,6 +11527,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -11275,6 +11623,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -11387,6 +11743,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -11479,6 +11839,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -11591,6 +11959,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -11719,6 +12091,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -11835,6 +12215,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -12248,6 +12632,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -12364,6 +12756,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -79,6 +79,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -147,6 +155,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -963,6 +975,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -1031,6 +1051,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -1123,7 +1147,25 @@ pub fn print_bytes(data: Array<u8>) with Stdout {
     core::internal::wait_for_subtask(subtask);
 }
 
-pub fn env(name: String) -> Option<String> with Environment;
+pub fn env(name: String) -> Option<String> with Environment {
+    let vars: Array<[String, String]> = __cm_adapter__Environment_get_environment();
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < vars."Array<Tuple<String,String>>::len"()) {
+                break __for_0;
+            }
+            __for_0_body: {
+                let pair: [String, String] = vars."Array<Tuple<String,String>>^IndexValue::index_value"(i);
+                if pair.0."String^Eq::eq"(&name) {
+                    return Option<String>::Some(pair.1);
+                }
+            }
+            i = (i + 1);
+        }
+    }
+    return null;
+}
 
 pub fn args() -> Array<String> with Environment {
     return __cm_adapter__Environment_get_arguments();
@@ -1174,6 +1216,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     *self.0."Stream<u8>^Inspect::inspect"(f);
     f.Formatter::write_str(", ");
     *self.1."StreamWritable<u8>^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
     f.Formatter::write_str("]");
 }
 
@@ -1247,6 +1297,10 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, S
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
 }
 
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
+}
+
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     self."Fn<2,Ordering>^Inspect::inspect"(f);
 }
@@ -1273,6 +1327,17 @@ pub fn "Tuple<f64,f64>^Display::fmt"(self: &[f64, f64], f: &mut Formatter) {
 
 pub fn "Fn<1,i32>^Display::fmt"(self: &fn(i32) -> i32, f: &mut Formatter) {
     self."Fn<1,i32>^Inspect::inspect"(f);
+}
+
+fn "Array<Tuple<String,String>>^IndexValue::index_value"(self: &Array<[String, String]>, index: i32) -> [String, String] {
+    if (index >= self.used) {
+        core::internal::panic("index out of bounds");
+    }
+    return core::builtin::array_get::<[String, String]>(self.repr, index);
+}
+
+pub fn "Array<Tuple<String,String>>::len"(self: &Array<[String, String]>) -> i32 {
+    return self.used;
 }
 
 fn "array_copy<u8>"(dst: builtin::array<u8>, dst_offset: i32, src: builtin::array<u8>, src_offset: i32, len: i32);
@@ -1598,6 +1663,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -1666,6 +1739,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -1750,6 +1827,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -1818,6 +1903,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -1890,6 +1979,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -1958,6 +2055,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -3114,6 +3215,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -3198,6 +3307,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -4106,6 +4219,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -4174,6 +4295,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -6055,6 +6180,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -6123,6 +6256,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -6794,6 +6931,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -6870,6 +7015,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7028,6 +7177,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7100,6 +7257,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7187,6 +7348,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7261,6 +7430,10 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, S
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
 }
 
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
+}
+
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     self."Fn<2,Ordering>^Inspect::inspect"(f);
 }
@@ -7320,6 +7493,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     *self.0."Stream<u8>^Inspect::inspect"(f);
     f.Formatter::write_str(", ");
     *self.1."StreamWritable<u8>^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
     f.Formatter::write_str("]");
 }
 
@@ -7391,6 +7572,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7455,6 +7640,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7523,6 +7716,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7587,6 +7784,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7655,6 +7860,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7719,6 +7928,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7787,6 +8004,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7851,6 +8072,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -7919,6 +8148,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -7983,6 +8216,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8051,6 +8292,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8115,6 +8360,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8183,6 +8436,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8247,6 +8504,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8315,6 +8580,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8379,6 +8648,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8447,6 +8724,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8511,6 +8792,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8579,6 +8868,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8643,6 +8936,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8711,6 +9012,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8775,6 +9080,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -8843,6 +9156,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -8943,6 +9260,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -9015,6 +9340,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
@@ -9380,6 +9709,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -9478,6 +9815,10 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, S
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
 }
 
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
+}
+
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     self."Fn<2,Ordering>^Inspect::inspect"(f);
 }
@@ -9514,6 +9855,32 @@ fn __cm_adapter__Stdout_write_via_stream(data: i32) -> i32 {
 fn __cm_adapter__Stderr_write_via_stream(data: i32) -> i32 {
     let __async_outptr: i32 = core::builtin::realloc(0, 0, 1, 2);
     return cm_raw_call wasi:cli/Stderr::write_via_stream(data, __async_outptr);
+}
+
+fn __cm_adapter__Environment_get_environment() -> Array<[String, String]> {
+    let __outptr: i32 = core::builtin::realloc(0, 0, 4, 8);
+    cm_raw_call wasi:cli/Environment::get_environment(__outptr);
+    let __base: i32 = core::builtin::i32_load(__outptr);
+    let __count: i32 = core::builtin::i32_load((__outptr + 4));
+    let mut __result: Array<[String, String]> = "Array<Tuple<String,String>>::with_capacity"(__count);
+    let mut __i: i32 = 0;
+    loop {
+        if (__i >= __count) {
+            break;
+        }
+        let __elem_addr: i32 = (__base + (__i * 16));
+        let __lifted_result: String = core::internal::memory_to_gc_string(core::builtin::i32_load((__elem_addr + 0)), core::builtin::i32_load(((__elem_addr + 0) + 4)));
+        let __lifted_result: String = core::internal::memory_to_gc_string(core::builtin::i32_load((__elem_addr + 8)), core::builtin::i32_load(((__elem_addr + 8) + 4)));
+        __result."Array<Tuple<String,String>>::append"([__lifted_result, __lifted_result]);
+        core::builtin::realloc(core::builtin::i32_load((__elem_addr + 0)), core::builtin::i32_load(((__elem_addr + 0) + 4)), 1, 0);
+        core::builtin::realloc(core::builtin::i32_load((__elem_addr + 8)), core::builtin::i32_load(((__elem_addr + 8) + 4)), 1, 0);
+        __i = (__i + 1);
+    }
+    if (__count > 0) {
+        core::builtin::realloc(__base, (__count * 16), 4, 0);
+    }
+    core::builtin::realloc(__outptr, 8, 4, 0);
+    return __result;
 }
 
 fn __cm_adapter__Environment_get_arguments() -> Array<String> {
@@ -9585,6 +9952,23 @@ pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
 
 pub fn "Array<String>::with_capacity"(capacity: i32) -> Array<String> {
     return Array<String> { repr: core::builtin::array_new::<String>(capacity), used: 0 };
+}
+
+pub fn "Array<Tuple<String,String>>::append"(self: &mut Array<[String, String]>, value: [String, String]) {
+    let used: i32 = self.used;
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    if core::builtin::unlikely((used >= capacity)) {
+        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+        let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
+        core::builtin::array_copy::<[String, String]>(new_repr, 0, self.repr, 0, used);
+        self.repr = new_repr;
+    }
+    core::builtin::array_set::<[String, String]>(self.repr, used, value);
+    self.used = (used + 1);
+}
+
+pub fn "Array<Tuple<String,String>>::with_capacity"(capacity: i32) -> Array<[String, String]> {
+    return Array<Tuple<String,String>> { repr: core::builtin::array_new::<[String, String]>(capacity), used: 0 };
 }
 
 pub fn "Array<i32>::len"(self: &Array<i32>) -> i32 {
@@ -9961,6 +10345,14 @@ pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(self: &[Stream<u8
     f.Formatter::write_str("]");
 }
 
+pub fn "Tuple<String,String>^Inspect::inspect"(self: &[String, String], f: &mut Formatter) {
+    f.Formatter::write_str("[");
+    *self.0."String^Inspect::inspect"(f);
+    f.Formatter::write_str(", ");
+    *self.1."String^Inspect::inspect"(f);
+    f.Formatter::write_str("]");
+}
+
 pub fn "Fn<2,Ordering>^Inspect::inspect"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {
     f.Formatter::write_str("|&T, &T| -> Ordering");
 }
@@ -10033,6 +10425,10 @@ pub fn "Tuple<Stream<T>,StreamWritable<T>>^Display::fmt"(self: &[Stream<T>, Stre
 
 pub fn "Tuple<Stream<u8>,StreamWritable<u8>>^Display::fmt"(self: &[Stream<u8>, StreamWritable<u8>], f: &mut Formatter) {
     self."Tuple<Stream<u8>,StreamWritable<u8>>^Inspect::inspect"(f);
+}
+
+pub fn "Tuple<String,String>^Display::fmt"(self: &[String, String], f: &mut Formatter) {
+    self."Tuple<String,String>^Inspect::inspect"(f);
 }
 
 pub fn "Fn<2,Ordering>^Display::fmt"(self: &fn(&T, &T) -> Ordering, f: &mut Formatter) {


### PR DESCRIPTION
## Summary
Implements the `env()` function in the standard library to retrieve environment variable values by name. This replaces the previous stub implementation with a working version that queries the environment at runtime.

## Key Changes

- **Implemented `env()` function** (`wado-compiler/lib/core/cli.wado`):
  - Replaced stub declaration with full implementation
  - Uses a for-loop to iterate through environment variables
  - Returns `Option<String>::Some(value)` when variable is found, `null` otherwise
  - Calls `Environment::get_environment()` to retrieve all environment variables as an array of tuples

- **Added support for `Array<Tuple<String,String>>`**:
  - Implemented `Array<Tuple<String,String>>::append()` method for dynamic array growth
  - Implemented `Array<Tuple<String,String>>::with_capacity()` constructor
  - Implemented `Array<Tuple<String,String>>^IndexValue::index_value()` for array indexing
  - Implemented `Array<Tuple<String,String>>::len()` to get array length

- **Added `Inspect` and `Display` trait implementations** for `Tuple<String,String>`:
  - Enables proper formatting and debugging of string tuple pairs
  - Follows the same pattern as existing tuple implementations

- **Added WASI adapter** `__cm_adapter__Environment_get_environment()`:
  - Marshals environment variables from WASI interface into managed arrays
  - Handles memory allocation and cleanup for the returned tuple array

- **Updated documentation** (`docs/stdlib-core.md`):
  - Removed TODO comment indicating the function was not yet implemented

## Implementation Details

The `env()` function now:
1. Calls `Environment::get_environment()` to get all environment variables as `Array<[String, String]>`
2. Iterates through the array using a for-loop with index-based access
3. Compares each tuple's first element (variable name) with the requested name
4. Returns the second element (variable value) when a match is found
5. Returns `null` (None) if no matching variable is found

This implementation enables proper environment variable access in WASI-based applications.

https://claude.ai/code/session_018L47gqDdyxZR134g1S1E8o