### PR TITLE
Implement definite initialization analysis for uninitialized variables

### DIFF
--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -401,7 +401,8 @@ pub struct LetStmt {
     pub is_mut: bool,
     pub is_reactive: bool,
     pub ty: Option<Type>,
-    pub value: Expr,
+    /// Initializer expression, or `None` for uninitialized declarations (`let x: i32;`).
+    pub value: Option<Expr>,
     pub span: Span,
 }
 

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -164,7 +164,7 @@ pub struct Binder<'a, H: CompilerHost> {
     local_names_in_function: IndexSet<String>,
     /// Variables declared without an initializer that have not yet been
     /// definitely assigned on all paths reaching the current point.
-    /// Key: (scope_depth, name) — scope_depth disambiguates shadowed vars.
+    /// Key: (`scope_depth`, name) — `scope_depth` disambiguates shadowed vars.
     possibly_uninit: IndexSet<(u32, String)>,
 }
 
@@ -565,12 +565,12 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
                 // If the target is an uninitialized variable, this is its first
                 // initialization — allow it (skipping the immutability check) and
                 // mark the variable as definitely initialized.
-                if let Expr::Ident(ident) = &assign.target {
-                    if self.is_possibly_uninit(&ident.name) {
-                        self.mark_initialized(&ident.name);
-                        self.bind_expr(&assign.value)?;
-                        return Ok(());
-                    }
+                if let Expr::Ident(ident) = &assign.target
+                    && self.is_possibly_uninit(&ident.name)
+                {
+                    self.mark_initialized(&ident.name);
+                    self.bind_expr(&assign.value)?;
+                    return Ok(());
                 }
 
                 // Normal assignment: check mutability for simple variable assignments

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -67,6 +67,9 @@ pub enum BindError {
 
     /// Assignment to an immutable variable
     AssignToImmutable { name: String, span: Span },
+
+    /// Variable used before it was definitely initialized
+    UseBeforeInit { name: String, span: Span },
 }
 
 impl std::fmt::Display for BindError {
@@ -94,6 +97,13 @@ impl std::fmt::Display for BindError {
                 write!(
                     f,
                     "{}:{}: error: cannot assign to immutable variable '{}'",
+                    span.line, span.column, name
+                )
+            }
+            BindError::UseBeforeInit { name, span } => {
+                write!(
+                    f,
+                    "{}:{}: error: '{}' is used before initialization",
                     span.line, span.column, name
                 )
             }
@@ -129,6 +139,11 @@ impl From<BindError> for crate::compiler_host::Diagnostic {
                 format!("cannot assign to immutable variable '{name}'"),
                 *span,
             ),
+            BindError::UseBeforeInit { name, span } => (
+                Code::UninitializedVariable,
+                format!("'{name}' is used before initialization"),
+                *span,
+            ),
         };
         crate::compiler_host::Diagnostic {
             severity: Severity::Error,
@@ -147,6 +162,10 @@ pub struct Binder<'a, H: CompilerHost> {
     /// All local variable names defined in the current function
     /// Used to distinguish "out of scope" errors from "global reference"
     local_names_in_function: IndexSet<String>,
+    /// Variables declared without an initializer that have not yet been
+    /// definitely assigned on all paths reaching the current point.
+    /// Key: (scope_depth, name) — scope_depth disambiguates shadowed vars.
+    possibly_uninit: IndexSet<(u32, String)>,
 }
 
 impl<'a, H: CompilerHost> Binder<'a, H> {
@@ -157,6 +176,25 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
             logger,
             current_depth: 0,
             local_names_in_function: IndexSet::default(),
+            possibly_uninit: IndexSet::default(),
+        }
+    }
+
+    /// Returns true if the innermost binding for `name` is possibly uninitialized.
+    fn is_possibly_uninit(&self, name: &str) -> bool {
+        if let Some(binding) = self.lookup(name) {
+            self.possibly_uninit
+                .contains(&(binding.scope_depth, name.to_string()))
+        } else {
+            false
+        }
+    }
+
+    /// Mark the innermost binding for `name` as definitely initialized.
+    fn mark_initialized(&mut self, name: &str) {
+        if let Some(binding) = self.lookup(name) {
+            self.possibly_uninit
+                .shift_remove(&(binding.scope_depth, name.to_string()));
         }
     }
 
@@ -200,8 +238,9 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
 
     /// Bind a function's local variables
     fn bind_function(&mut self, func: &Function) -> Result<(), Bail> {
-        // Clear local names for this function
+        // Clear per-function state
         self.local_names_in_function.clear();
+        self.possibly_uninit.clear();
 
         self.enter_scope();
 
@@ -257,16 +296,54 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
 
     /// Bind a let statement
     fn bind_let(&mut self, let_stmt: &LetStmt) -> Result<(), Bail> {
-        // First bind the value expression (uses variables from outer scope)
-        self.bind_expr(&let_stmt.value)?;
+        if let Some(ref value) = let_stmt.value {
+            // Initialized let: bind the initializer first (uses outer scope vars)
+            self.bind_expr(value)?;
+            // Define the variables from the pattern as initialized
+            self.bind_let_pattern(
+                &let_stmt.pattern,
+                let_stmt.is_mut,
+                let_stmt.is_reactive,
+                let_stmt.span,
+            )
+        } else {
+            // Uninitialized let (`let x: T;`): define as possibly uninitialized.
+            // Type annotation is guaranteed by the parser.
+            self.bind_let_pattern_uninit(
+                &let_stmt.pattern,
+                let_stmt.is_mut,
+                let_stmt.is_reactive,
+                let_stmt.span,
+            )
+        }
+    }
 
-        // Then define the variables from the pattern
-        self.bind_let_pattern(
-            &let_stmt.pattern,
-            let_stmt.is_mut,
-            let_stmt.is_reactive,
-            let_stmt.span,
-        )
+    /// Like `bind_let_pattern` but registers variables as possibly uninitialized.
+    fn bind_let_pattern_uninit(
+        &mut self,
+        pattern: &crate::ast::Pattern,
+        is_mut: bool,
+        is_reactive: bool,
+        span: Span,
+    ) -> Result<(), Bail> {
+        match pattern {
+            crate::ast::Pattern::Ident(name) | crate::ast::Pattern::MutIdent(name) => {
+                self.define_uninit(name, is_mut, is_reactive, span)?;
+            }
+            crate::ast::Pattern::Tuple(patterns) => {
+                for p in patterns {
+                    self.bind_let_pattern_uninit(p, is_mut, is_reactive, span)?;
+                }
+            }
+            crate::ast::Pattern::Wildcard => {}
+            crate::ast::Pattern::Struct { fields, .. } => {
+                for field in fields {
+                    self.bind_let_pattern_uninit(&field.pattern, is_mut, is_reactive, span)?;
+                }
+            }
+            crate::ast::Pattern::Literal(_) | crate::ast::Pattern::Variant { .. } => {}
+        }
+        Ok(())
     }
 
     /// Bind a let pattern with mutability and reactivity information
@@ -334,14 +411,30 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         }
 
         self.bind_condition(&if_stmt.condition)?;
+
+        // Snapshot possibly_uninit before diverging branches.
+        let uninit_before = self.possibly_uninit.clone();
+
         self.bind_block(&if_stmt.then_block)?;
+        let uninit_after_then = self.possibly_uninit.clone();
 
         if is_pattern {
             self.exit_scope();
         }
 
         if let Some(ref else_block) = if_stmt.else_block {
+            // Process else with the pre-branch state
+            self.possibly_uninit = uninit_before.clone();
             self.bind_block(else_block)?;
+            let uninit_after_else = self.possibly_uninit.clone();
+            // After if-else: a var is possibly-uninit if uninit in either branch (union)
+            self.possibly_uninit = uninit_after_then;
+            for entry in uninit_after_else {
+                self.possibly_uninit.insert(entry);
+            }
+        } else {
+            // No else branch: restore to before-branch state (branch might not run)
+            self.possibly_uninit = uninit_before;
         }
 
         if if_stmt.init.is_some() {
@@ -360,7 +453,11 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         }
 
         self.bind_condition(&while_stmt.condition)?;
+
+        // Loop body does not guarantee initialization (may execute zero times).
+        let uninit_before = self.possibly_uninit.clone();
         self.bind_block(&while_stmt.body)?;
+        self.possibly_uninit = uninit_before;
 
         if is_pattern {
             self.exit_scope();
@@ -387,8 +484,10 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
             self.bind_expr(update)?;
         }
 
-        // Bind body
+        // Loop body does not guarantee initialization (may execute zero times).
+        let uninit_before = self.possibly_uninit.clone();
         self.bind_block(&for_stmt.body)?;
+        self.possibly_uninit = uninit_before;
 
         self.exit_scope();
         Ok(())
@@ -410,8 +509,10 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
             for_of_stmt.span,
         )?;
 
-        // Bind body
+        // Loop body does not guarantee initialization (may execute zero times).
+        let uninit_before = self.possibly_uninit.clone();
         self.bind_block(&for_of_stmt.body)?;
+        self.possibly_uninit = uninit_before;
 
         self.exit_scope();
         Ok(())
@@ -419,7 +520,12 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
 
     /// Bind a loop statement
     fn bind_loop(&mut self, loop_stmt: &LoopStmt) -> Result<(), Bail> {
-        self.bind_block(&loop_stmt.body)
+        // Loop body does not guarantee initialization (may execute zero times
+        // from the perspective of the enclosing code).
+        let uninit_before = self.possibly_uninit.clone();
+        self.bind_block(&loop_stmt.body)?;
+        self.possibly_uninit = uninit_before;
+        Ok(())
     }
 
     /// Bind an assert statement
@@ -447,11 +553,27 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
                             used_at: ident.span,
                         })?;
                     }
+                } else if self.is_possibly_uninit(&ident.name) {
+                    self.logger.error(BindError::UseBeforeInit {
+                        name: ident.name.clone(),
+                        span: ident.span,
+                    })?;
                 }
             }
 
             Expr::Assign(assign) => {
-                // Check mutability for simple variable assignments
+                // If the target is an uninitialized variable, this is its first
+                // initialization — allow it (skipping the immutability check) and
+                // mark the variable as definitely initialized.
+                if let Expr::Ident(ident) = &assign.target {
+                    if self.is_possibly_uninit(&ident.name) {
+                        self.mark_initialized(&ident.name);
+                        self.bind_expr(&assign.value)?;
+                        return Ok(());
+                    }
+                }
+
+                // Normal assignment: check mutability for simple variable assignments
                 if let Expr::Ident(ident) = &assign.target
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
@@ -612,14 +734,27 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         }
 
         self.bind_condition(&if_expr.condition)?;
+
+        // Snapshot possibly_uninit before diverging branches.
+        let uninit_before = self.possibly_uninit.clone();
+
         self.bind_block(&if_expr.then_block)?;
+        let uninit_after_then = self.possibly_uninit.clone();
 
         if is_pattern {
             self.exit_scope();
         }
 
         if let Some(ref else_block) = if_expr.else_block {
+            self.possibly_uninit = uninit_before.clone();
             self.bind_block(else_block)?;
+            let uninit_after_else = self.possibly_uninit.clone();
+            self.possibly_uninit = uninit_after_then;
+            for entry in uninit_after_else {
+                self.possibly_uninit.insert(entry);
+            }
+        } else {
+            self.possibly_uninit = uninit_before;
         }
 
         if if_expr.init.is_some() {
@@ -649,18 +784,36 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
     /// Bind a match expression
     fn bind_match_expr(&mut self, match_expr: &MatchExpr) -> Result<(), Bail> {
         self.bind_expr(&match_expr.expr)?;
+
+        let uninit_before = self.possibly_uninit.clone();
+        let mut uninit_after_all_arms: Option<IndexSet<(u32, String)>> = None;
+
         for arm in &match_expr.arms {
+            // Process each arm from the pre-match state
+            self.possibly_uninit = uninit_before.clone();
+
             self.enter_scope();
-            // Bind pattern (introduces variables)
             self.bind_pattern(&arm.pattern, arm.span)?;
-            // Bind optional guard
             if let Some(guard) = &arm.guard {
                 self.bind_expr(guard)?;
             }
-            // Bind arm body
             self.bind_expr(&arm.body)?;
             self.exit_scope();
+
+            // Merge: a var is possibly-uninit after the match if possibly-uninit in any arm
+            match uninit_after_all_arms.take() {
+                None => uninit_after_all_arms = Some(self.possibly_uninit.clone()),
+                Some(prev) => {
+                    let mut merged = prev;
+                    for entry in &self.possibly_uninit {
+                        merged.insert(entry.clone());
+                    }
+                    uninit_after_all_arms = Some(merged);
+                }
+            }
         }
+
+        self.possibly_uninit = uninit_after_all_arms.unwrap_or(uninit_before);
         Ok(())
     }
 
@@ -723,9 +876,14 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         self.scopes.push(Scope::new());
     }
 
-    /// Exit the current scope
+    /// Exit the current scope, removing its variables from `possibly_uninit`.
     fn exit_scope(&mut self) {
-        self.scopes.pop();
+        if let Some(scope) = self.scopes.pop() {
+            for (name, binding) in &scope.bindings {
+                self.possibly_uninit
+                    .shift_remove(&(binding.scope_depth, name.clone()));
+            }
+        }
         self.current_depth -= 1;
     }
 
@@ -762,6 +920,21 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
                 scope_depth: self.current_depth,
             },
         );
+        Ok(())
+    }
+
+    /// Like `define`, but also marks the variable as possibly uninitialized.
+    /// Used for `let x: T;` declarations without an initializer.
+    fn define_uninit(
+        &mut self,
+        name: &str,
+        is_mut: bool,
+        is_reactive: bool,
+        span: Span,
+    ) -> Result<(), Bail> {
+        self.define(name, is_mut, is_reactive, span)?;
+        self.possibly_uninit
+            .insert((self.current_depth, name.to_string()));
         Ok(())
     }
 

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -84,6 +84,8 @@ pub enum Code {
     DuplicateDefinition,
     /// Cannot assign to immutable variable
     ImmutableAssignment,
+    /// Variable used before it was definitely initialized
+    UninitializedVariable,
 
     // Type errors
     /// Type mismatch
@@ -136,6 +138,7 @@ impl std::fmt::Display for Code {
             Code::UndefinedVariable => "UNDEFINED_VARIABLE",
             Code::DuplicateDefinition => "DUPLICATE_DEFINITION",
             Code::ImmutableAssignment => "IMMUTABLE_ASSIGNMENT",
+            Code::UninitializedVariable => "UNINITIALIZED_VARIABLE",
             Code::TypeMismatch => "TYPE_MISMATCH",
             Code::UnknownType => "UNKNOWN_TYPE",
             Code::InvalidCast => "INVALID_CAST",

--- a/wado-compiler/src/desugar.rs
+++ b/wado-compiler/src/desugar.rs
@@ -168,7 +168,7 @@ fn desugar_let_stmt(l: &LetStmt) -> LetStmt {
         is_mut: l.is_mut,
         is_reactive: l.is_reactive,
         ty: l.ty.clone(),
-        value: desugar_expr(&l.value),
+        value: l.value.as_ref().map(desugar_expr),
         span: l.span,
     }
 }
@@ -217,7 +217,7 @@ fn desugar_stmt(stmt: &Stmt, ctx: &mut DesugarContext) -> Stmt {
             is_mut: l.is_mut,
             is_reactive: l.is_reactive,
             ty: l.ty.clone(),
-            value: desugar_expr(&l.value),
+            value: l.value.as_ref().map(desugar_expr),
             span: l.span,
         }),
         Stmt::Expr(e) => Stmt::Expr(crate::ast::ExprStmt {
@@ -944,7 +944,7 @@ fn desugar_assert(assert_stmt: &AssertStmt, ctx: &mut DesugarContext) -> Stmt {
             is_mut: false,
             is_reactive: false,
             ty: None,
-            value: expr.clone(),
+            value: Some(expr.clone()),
             span,
         }));
     }
@@ -960,7 +960,7 @@ fn desugar_assert(assert_stmt: &AssertStmt, ctx: &mut DesugarContext) -> Stmt {
         is_mut: false,
         is_reactive: false,
         ty: None,
-        value: reconstructed_condition,
+        value: Some(reconstructed_condition),
         span,
     }));
 

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -1101,8 +1101,9 @@ impl Parser {
             if ty.is_none() {
                 let span = self.peek().span;
                 return Err(ParseError {
-                    message: "type annotation required for variable declaration without initializer"
-                        .to_string(),
+                    message:
+                        "type annotation required for variable declaration without initializer"
+                            .to_string(),
                     span,
                 });
             }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -1091,9 +1091,24 @@ impl Parser {
             None
         };
 
-        self.expect(&TokenKind::Eq)?;
-        let value = self.parse_expr()?;
-        let end_span = value.span();
+        let (value, end_span) = if self.check(&TokenKind::Eq) {
+            self.advance();
+            let v = self.parse_expr()?;
+            let s = v.span();
+            (Some(v), s)
+        } else {
+            // No initializer: type annotation is required
+            if ty.is_none() {
+                let span = self.peek().span;
+                return Err(ParseError {
+                    message: "type annotation required for variable declaration without initializer"
+                        .to_string(),
+                    span,
+                });
+            }
+            // Use current position (before the semicolon) as end span
+            (None, self.peek().span)
+        };
 
         Ok(Stmt::Let(LetStmt {
             pattern,
@@ -1274,7 +1289,7 @@ impl Parser {
             is_mut,
             is_reactive: false,
             ty,
-            value,
+            value: Some(value),
             span: start_span.merge(&end_span),
         })
     }

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1352,10 +1352,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             }
             ast::Expr::If(if_expr) => {
-                if let Some(init) = &if_expr.init {
-                    if let Some(ref v) = init.value {
-                        Self::collect_mutated_vars(v, result);
-                    }
+                if let Some(init) = &if_expr.init
+                    && let Some(ref v) = init.value
+                {
+                    Self::collect_mutated_vars(v, result);
                 }
                 if let ast::Condition::Expr(cond) = &if_expr.condition {
                     Self::collect_mutated_vars(cond, result);
@@ -1400,10 +1400,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             }
             ast::Stmt::If(is) => {
-                if let Some(init) = &is.init {
-                    if let Some(ref v) = init.value {
-                        Self::collect_mutated_vars(v, result);
-                    }
+                if let Some(init) = &is.init
+                    && let Some(ref v) = init.value
+                {
+                    Self::collect_mutated_vars(v, result);
                 }
                 if let ast::Condition::Expr(cond) = &is.condition {
                     Self::collect_mutated_vars(cond, result);

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1353,7 +1353,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             ast::Expr::If(if_expr) => {
                 if let Some(init) = &if_expr.init {
-                    Self::collect_mutated_vars(&init.value, result);
+                    if let Some(ref v) = init.value {
+                        Self::collect_mutated_vars(v, result);
+                    }
                 }
                 if let ast::Condition::Expr(cond) = &if_expr.condition {
                     Self::collect_mutated_vars(cond, result);
@@ -1393,11 +1395,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
         match stmt {
             ast::Stmt::Expr(es) => Self::collect_mutated_vars(&es.expr, result),
             ast::Stmt::Let(ls) => {
-                Self::collect_mutated_vars(&ls.value, result);
+                if let Some(ref v) = ls.value {
+                    Self::collect_mutated_vars(v, result);
+                }
             }
             ast::Stmt::If(is) => {
                 if let Some(init) = &is.init {
-                    Self::collect_mutated_vars(&init.value, result);
+                    if let Some(ref v) = init.value {
+                        Self::collect_mutated_vars(v, result);
+                    }
                 }
                 if let ast::Condition::Expr(cond) = &is.condition {
                     Self::collect_mutated_vars(cond, result);

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -364,7 +364,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// variable is assigned before any use.
     fn resolve_uninit_let(&mut self, let_stmt: &LetStmt, ctx: &mut FunctionContext) -> TirStmt {
         // Type annotation is guaranteed by the parser when there is no initializer.
-        let type_id = self.resolve_type(let_stmt.ty.as_ref().expect("parser ensures type annotation for uninit let"));
+        let type_id = self.resolve_type(
+            let_stmt
+                .ty
+                .as_ref()
+                .expect("parser ensures type annotation for uninit let"),
+        );
 
         match &let_stmt.pattern {
             ast::Pattern::Ident(name) | ast::Pattern::MutIdent(name) => {
@@ -373,8 +378,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let local_index = ctx.add_local(name.clone(), type_id, is_mut);
                 // Unit placeholder: WIR builder sees unit type → skips LocalSet.
                 // The local is pre-declared and Wasm zero-initializes it.
-                let placeholder =
-                    TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, let_stmt.span);
+                let placeholder = TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, let_stmt.span);
                 TirStmt::new(
                     TirStmtKind::Let {
                         name: name.clone(),
@@ -390,13 +394,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             _ => {
                 let _ = self.logger.error(TypeError::InvalidPattern {
-                    message:
-                        "only simple variable names are allowed in uninitialized declarations"
-                            .to_string(),
+                    message: "only simple variable names are allowed in uninitialized declarations"
+                        .to_string(),
                     span: let_stmt.span,
                 });
                 TirStmt::new(
-                    TirStmtKind::Expr(TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, let_stmt.span)),
+                    TirStmtKind::Expr(TirExpr::new(
+                        TirExprKind::Unit,
+                        TypeTable::UNIT,
+                        let_stmt.span,
+                    )),
                     let_stmt.span,
                 )
             }

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -88,12 +88,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
     /// Resolve a let statement
     pub(super) fn resolve_let(&mut self, let_stmt: &LetStmt, ctx: &mut FunctionContext) -> TirStmt {
+        // Handle uninitialized declaration: `let x: T;` (no initializer)
+        if let_stmt.value.is_none() {
+            return self.resolve_uninit_let(let_stmt, ctx);
+        }
+
+        // From here on `value` is guaranteed to be Some.
+        let ast_value = let_stmt.value.as_ref().unwrap();
+
         // Check for tuple literal to array coercion when type annotation is present
         let (value, type_id) = if let Some(annotated_type) = &let_stmt.ty {
             let target_type = self.resolve_type(annotated_type);
 
             // Special case: tuple literal with Tuple type annotation
-            if let ast::Expr::TupleLiteral(tuple_lit) = &let_stmt.value {
+            if let ast::Expr::TupleLiteral(tuple_lit) = ast_value {
                 {
                     let target_resolved = self.type_table.borrow().get(target_type).clone();
                     if let ResolvedType::Tuple(expected_elem_types) = target_resolved {
@@ -129,22 +137,22 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     expected_elem_types.len()
                                 ),
                                 found: format!("tuple with {} elements", tuple_lit.elements.len()),
-                                span: let_stmt.value.span(),
+                                span: ast_value.span(),
                             });
                         }
 
                         let value = TirExpr::new(
                             TirExprKind::TupleLiteral { elements },
                             target_type,
-                            let_stmt.value.span(),
+                            ast_value.span(),
                         );
                         (value, target_type)
                     } else {
-                        let value = self.resolve_expr(&let_stmt.value, ctx, Some(target_type));
+                        let value = self.resolve_expr(ast_value, ctx, Some(target_type));
                         (value, target_type)
                     }
                 }
-            } else if let ast::Expr::StructLiteral(struct_lit) = &let_stmt.value {
+            } else if let ast::Expr::StructLiteral(struct_lit) = ast_value {
                 // Handle implicit struct literal: let p: Point = { x: 1, y: 2 }
                 if struct_lit.name.is_none() {
                     // Check if target type is a struct
@@ -220,7 +228,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         );
                         (value, target_type)
                     } else if let Some(coerced) =
-                        self.try_coerce_struct_to_map(&let_stmt.value, ctx, target_type)
+                        self.try_coerce_struct_to_map(ast_value, ctx, target_type)
                     {
                         (coerced, target_type)
                     } else {
@@ -233,21 +241,21 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             ),
                             span: struct_lit.span,
                         });
-                        let value = self.resolve_expr(&let_stmt.value, ctx, None);
+                        let value = self.resolve_expr(ast_value, ctx, None);
                         (value, target_type)
                     }
                 } else {
                     // Named struct literal - resolve normally
-                    let value = self.resolve_expr(&let_stmt.value, ctx, Some(target_type));
+                    let value = self.resolve_expr(ast_value, ctx, Some(target_type));
                     (value, target_type)
                 }
             } else {
                 // Use expected type for numeric literal coercion
-                let value = self.resolve_expr(&let_stmt.value, ctx, Some(target_type));
+                let value = self.resolve_expr(ast_value, ctx, Some(target_type));
                 (value, target_type)
             }
         } else {
-            let value = self.resolve_expr(&let_stmt.value, ctx, None);
+            let value = self.resolve_expr(ast_value, ctx, None);
             (value.clone(), value.type_id)
         };
 
@@ -270,7 +278,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: self.type_table.borrow().type_name(type_id),
                     found: self.type_table.borrow().type_name(value.type_id),
-                    span: let_stmt.value.span(),
+                    span: ast_value.span(),
                 });
             }
         }
@@ -344,6 +352,53 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 });
                 // Return a dummy statement
                 TirStmt::new(TirStmtKind::Expr(value), let_stmt.span)
+            }
+        }
+    }
+
+    /// Resolve an uninitialized let declaration: `let x: T;`
+    ///
+    /// Emits a `TirStmtKind::Let` with a unit placeholder value so that
+    /// the local is pre-allocated (Wasm zero-initializes locals) without
+    /// emitting a `LocalSet`.  The bind phase has already verified that the
+    /// variable is assigned before any use.
+    fn resolve_uninit_let(&mut self, let_stmt: &LetStmt, ctx: &mut FunctionContext) -> TirStmt {
+        // Type annotation is guaranteed by the parser when there is no initializer.
+        let type_id = self.resolve_type(let_stmt.ty.as_ref().expect("parser ensures type annotation for uninit let"));
+
+        match &let_stmt.pattern {
+            ast::Pattern::Ident(name) | ast::Pattern::MutIdent(name) => {
+                let is_mut =
+                    let_stmt.is_mut || matches!(&let_stmt.pattern, ast::Pattern::MutIdent(_));
+                let local_index = ctx.add_local(name.clone(), type_id, is_mut);
+                // Unit placeholder: WIR builder sees unit type → skips LocalSet.
+                // The local is pre-declared and Wasm zero-initializes it.
+                let placeholder =
+                    TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, let_stmt.span);
+                TirStmt::new(
+                    TirStmtKind::Let {
+                        name: name.clone(),
+                        local_index,
+                        is_mut,
+                        is_reactive: let_stmt.is_reactive,
+                        type_id,
+                        value: placeholder,
+                        skip_value_copy: false,
+                    },
+                    let_stmt.span,
+                )
+            }
+            _ => {
+                let _ = self.logger.error(TypeError::InvalidPattern {
+                    message:
+                        "only simple variable names are allowed in uninitialized declarations"
+                            .to_string(),
+                    span: let_stmt.span,
+                });
+                TirStmt::new(
+                    TirStmtKind::Expr(TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, let_stmt.span)),
+                    let_stmt.span,
+                )
             }
         }
     }
@@ -1332,14 +1387,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
             is_mut: true,
             is_reactive: false,
             ty: None,
-            value: Expr::MethodCall(Box::new(MethodCallExpr {
+            value: Some(Expr::MethodCall(Box::new(MethodCallExpr {
                 receiver: into_iter_receiver,
                 method: "into_iter".to_string(),
                 type_args: vec![],
                 args: vec![],
                 has_trailing_comma: false,
                 span,
-            })),
+            }))),
             span,
         };
         let iter_let_tir = self.resolve_let(&into_iter_let, ctx);

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -1183,8 +1183,10 @@ impl<'a> Unparser<'a> {
             self.unparse_type(ty);
         }
 
-        self.output.push_str(" = ");
-        self.unparse_expr(&l.value);
+        if let Some(ref v) = l.value {
+            self.output.push_str(" = ");
+            self.unparse_expr(v);
+        }
         self.output.push_str(";\n");
     }
 
@@ -1226,8 +1228,10 @@ impl<'a> Unparser<'a> {
                 self.output.push_str(": ");
                 self.unparse_type(ty);
             }
-            self.output.push_str(" = ");
-            self.unparse_expr(&init.value);
+            if let Some(ref v) = init.value {
+                self.output.push_str(" = ");
+                self.unparse_expr(v);
+            }
             self.output.push_str("; ");
         }
 
@@ -1277,8 +1281,10 @@ impl<'a> Unparser<'a> {
                 self.output.push_str(": ");
                 self.unparse_type(ty);
             }
-            self.output.push_str(" = ");
-            self.unparse_expr(&init.value);
+            if let Some(ref v) = init.value {
+                self.output.push_str(" = ");
+                self.unparse_expr(v);
+            }
             self.output.push_str("; ");
         }
 
@@ -1401,8 +1407,10 @@ impl<'a> Unparser<'a> {
                     self.output.push_str(": ");
                     self.unparse_type(ty);
                 }
-                self.output.push_str(" = ");
-                self.unparse_expr(&l.value);
+                if let Some(ref v) = l.value {
+                    self.output.push_str(" = ");
+                    self.unparse_expr(v);
+                }
             }
             Stmt::Expr(e) => {
                 self.unparse_expr(&e.expr);
@@ -1875,8 +1883,10 @@ impl<'a> Unparser<'a> {
                 self.output.push_str(": ");
                 self.unparse_type(ty);
             }
-            self.output.push_str(" = ");
-            self.unparse_expr(&init.value);
+            if let Some(ref v) = init.value {
+                self.output.push_str(" = ");
+                self.unparse_expr(v);
+            }
             self.output.push_str("; ");
         }
 
@@ -2838,8 +2848,10 @@ fn unparse_stmt_into(stmt: &Stmt, output: &mut String) {
                 output.push_str(": ");
                 unparse_type_into(ty, output);
             }
-            output.push_str(" = ");
-            unparse_expr_into(&l.value, output, false);
+            if let Some(ref v) = l.value {
+                output.push_str(" = ");
+                unparse_expr_into(v, output, false);
+            }
             output.push(';');
         }
         Stmt::Expr(e) => {
@@ -3017,8 +3029,10 @@ fn unparse_if_expr_into(i: &IfExpr, output: &mut String) {
             output.push_str(": ");
             unparse_type_into(ty, output);
         }
-        output.push_str(" = ");
-        unparse_expr_into(&init.value, output, false);
+        if let Some(ref v) = init.value {
+            output.push_str(" = ");
+            unparse_expr_into(v, output, false);
+        }
         output.push_str("; ");
     }
     unparse_condition_into(&i.condition, output);

--- a/wado-compiler/tests/fixtures/var_uninit_loop_not_guaranteed_error.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_loop_not_guaranteed_error.wado
@@ -1,0 +1,15 @@
+// Error: assignment inside a loop body does not guarantee initialization,
+// because the loop may execute zero times.
+
+export fn run() {
+    let x: i32;
+    let mut i = 0;
+    while i < 3 {
+        x = i;  // assignment inside loop body — not counted as guaranteed init
+        i = i + 1;
+    }
+    assert x == 2;  // Error: x may be used before initialization
+}
+
+__DATA__
+{"compile_error": "used before initialization"}

--- a/wado-compiler/tests/fixtures/var_uninit_missing_else_error.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_missing_else_error.wado
@@ -1,0 +1,14 @@
+// Error: if without else does not guarantee assignment on all paths
+
+export fn run() {
+    let x: i32;
+    let cond = true;
+    if cond {
+        x = 1;
+        // no else branch: x may not be assigned if cond is false
+    }
+    assert x == 1;  // Error: x may be used before initialization
+}
+
+__DATA__
+{"compile_error": "used before initialization"}

--- a/wado-compiler/tests/fixtures/var_uninit_no_assign_error.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_no_assign_error.wado
@@ -1,0 +1,9 @@
+// Error: variable used without any prior assignment
+
+export fn run() {
+    let x: i32;
+    assert x == 0;  // Error: x is used before initialization
+}
+
+__DATA__
+{"compile_error": "used before initialization"}

--- a/wado-compiler/tests/fixtures/var_uninit_no_type_annotation_error.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_no_type_annotation_error.wado
@@ -1,0 +1,11 @@
+// Error: type annotation is required when there is no initializer.
+// Without an initializer the compiler cannot infer the type.
+
+export fn run() {
+    let x;  // Error: type annotation required for uninitialized variable
+    x = 42;
+    assert x == 42;
+}
+
+__DATA__
+{"compile_error": "type annotation required"}

--- a/wado-compiler/tests/fixtures/var_uninit_partial_match_error.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_partial_match_error.wado
@@ -6,7 +6,7 @@ export fn run() {
     match opt {
         Some(v) => { x = v; },
         None => {},  // x is not assigned in this arm
-    }
+    };
     assert x == 10;  // Error: x may be used before initialization
 }
 

--- a/wado-compiler/tests/fixtures/var_uninit_partial_match_error.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_partial_match_error.wado
@@ -1,0 +1,14 @@
+// Error: not all match arms assign the variable
+
+export fn run() {
+    let x: i32;
+    let opt: Option<i32> = Option::Some(10);
+    match opt {
+        Some(v) => { x = v; },
+        None => {},  // x is not assigned in this arm
+    }
+    assert x == 10;  // Error: x may be used before initialization
+}
+
+__DATA__
+{"compile_error": "used before initialization"}

--- a/wado-compiler/tests/fixtures/var_uninit_valid.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_valid.wado
@@ -1,0 +1,90 @@
+// Valid patterns for uninitialized variable declarations.
+// Rule (from Wasm validation): a local get is valid if a set is guaranteed before it.
+
+// Pattern 1: declare then assign then use in sequence
+test "declare, assign, use" {
+    let x: i32;
+    x = 42;
+    assert x == 42;
+}
+
+// Pattern 2: assign in both branches of if-else, then use
+test "if-else both branches assign" {
+    let result: i32;
+    let cond = true;
+    if cond {
+        result = 1;
+    } else {
+        result = 2;
+    }
+    assert result == 1;
+}
+
+// Pattern 3: assign in all arms of match, then use
+test "match all arms assign" {
+    let x: i32;
+    let opt: Option<i32> = Option::Some(10);
+    match opt {
+        Some(v) => { x = v; },
+        None => { x = 0; },
+    }
+    assert x == 10;
+}
+
+// Pattern 4: let mut — declare then assign, then reassign
+test "mut: declare then assign then reassign" {
+    let mut x: i32;
+    x = 1;
+    x = 2;
+    assert x == 2;
+}
+
+// Pattern 5: nested if-else, all paths assign
+test "nested if-else all paths assign" {
+    let x: i32;
+    let a = true;
+    let b = false;
+    if a {
+        if b {
+            x = 1;
+        } else {
+            x = 2;
+        }
+    } else {
+        x = 3;
+    }
+    assert x == 2;
+}
+
+// Pattern 6: assign before use in a loop body (set happens before the get)
+test "assign before use in loop" {
+    let mut x: i32;
+    let mut i = 0;
+    x = 0;
+    while i < 3 {
+        x = x + 1;
+        i = i + 1;
+    }
+    assert x == 3;
+}
+
+// Pattern 7: different types — f64
+test "f64 uninit then assign" {
+    let y: f64;
+    y = 3.14;
+    assert y > 3.0;
+}
+
+// Pattern 8: bool uninit then assign in if-else
+test "bool uninit assigned in if-else" {
+    let flag: bool;
+    if 1 > 0 {
+        flag = true;
+    } else {
+        flag = false;
+    }
+    assert flag;
+}
+
+__DATA__
+{"test": {}}

--- a/wado-compiler/tests/fixtures/var_uninit_valid.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_valid.wado
@@ -28,7 +28,7 @@ test "match all arms assign" {
     match opt {
         Some(v) => { x = v; },
         None => { x = 0; },
-    }
+    };
     assert x == 10;
 }
 

--- a/wado-compiler/tests/fixtures/var_uninit_valid.wado
+++ b/wado-compiler/tests/fixtures/var_uninit_valid.wado
@@ -1,5 +1,6 @@
 // Valid patterns for uninitialized variable declarations.
 // Rule (from Wasm validation): a local get is valid if a set is guaranteed before it.
+// Type annotation is required when there is no initializer.
 
 // Pattern 1: declare then assign then use in sequence
 test "declare, assign, use" {
@@ -56,11 +57,12 @@ test "nested if-else all paths assign" {
     assert x == 2;
 }
 
-// Pattern 6: assign before use in a loop body (set happens before the get)
-test "assign before use in loop" {
+// Pattern 6: assign *before* the loop, then use inside and after the loop.
+// (Assignment inside a loop body does NOT count as guaranteed initialization.)
+test "assign before loop, use inside loop" {
     let mut x: i32;
     let mut i = 0;
-    x = 0;
+    x = 0;  // guaranteed assignment happens before the loop
     while i < 3 {
         x = x + 1;
         i = i + 1;
@@ -68,7 +70,7 @@ test "assign before use in loop" {
     assert x == 3;
 }
 
-// Pattern 7: different types — f64
+// Pattern 7: f64
 test "f64 uninit then assign" {
     let y: f64;
     y = 3.14;
@@ -84,6 +86,25 @@ test "bool uninit assigned in if-else" {
         flag = false;
     }
     assert flag;
+}
+
+// Pattern 9: String uninit then assign
+test "String uninit then assign" {
+    let s: String;
+    s = "hello";
+    assert s.len() == 5;
+}
+
+// Pattern 10: String uninit assigned in if-else
+test "String uninit assigned in if-else" {
+    let greeting: String;
+    let formal = false;
+    if formal {
+        greeting = "Good day.";
+    } else {
+        greeting = "Hi!";
+    }
+    assert greeting.len() == 3;
 }
 
 __DATA__

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -34,7 +34,10 @@ fn extract_literal(module: &wado_compiler::ast::Module) -> Option<&wado_compiler
     let Stmt::Let(let_stmt) = stmt else {
         return None;
     };
-    let Expr::Literal(lit_expr) = &let_stmt.value else {
+    let Some(value) = &let_stmt.value else {
+        return None;
+    };
+    let Expr::Literal(lit_expr) = value else {
         return None;
     };
     Some(&lit_expr.value)

--- a/wado-compiler/tests/string_templates.rs
+++ b/wado-compiler/tests/string_templates.rs
@@ -30,7 +30,7 @@ fn extract_expr(module: &wado_compiler::ast::Module) -> Option<&wado_compiler::a
     let Stmt::Let(let_stmt) = stmt else {
         return None;
     };
-    Some(&let_stmt.value)
+    let_stmt.value.as_ref()
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR adds support for uninitialized variable declarations (e.g., `let x: i32;`) with definite initialization analysis to ensure variables are assigned before use. The implementation tracks which variables are possibly uninitialized across control flow paths and reports errors when uninitialized variables are accessed.

## Key Changes

- **AST & Parser**: Modified `LetStmt.value` to be `Option<Expr>` to represent declarations without initializers. Parser now requires type annotations for uninitialized declarations and rejects them without one.

- **Binder (Definite Initialization Analysis)**:
  - Added `possibly_uninit` set to track variables declared without initializers that haven't been definitely assigned
  - Implemented `is_possibly_uninit()` and `mark_initialized()` helper methods
  - Added `bind_let_pattern_uninit()` to handle uninitialized variable declarations
  - Enhanced control flow analysis:
    - **If-else**: Variables are considered initialized only if assigned in both branches; missing else branch means variable remains possibly uninitialized
    - **Match**: Variables must be assigned in all arms to be considered initialized
    - **Loops** (while, for, for-of, loop): Loop bodies don't guarantee initialization since loops may execute zero times
  - Assignment to uninitialized variables marks them as initialized and bypasses immutability checks
  - Added `UseBeforeInit` error variant for reporting uninitialized variable usage

- **Resolver**: Added `resolve_uninit_let()` to emit a unit placeholder value for uninitialized declarations, allowing Wasm to pre-allocate and zero-initialize the local without emitting a LocalSet instruction.

- **Code Generation**: Updated unparser and desugar to handle optional initializers in let statements.

- **Error Handling**: Added `UninitializedVariable` diagnostic code for proper error reporting.

- **Tests**: Added comprehensive test fixtures covering valid patterns (sequential assignment, if-else with both branches, match with all arms) and error cases (missing else, partial match, no type annotation, loop bodies, unused variables).

## Implementation Details

The definite initialization analysis uses a snapshot-and-merge approach for control flow:
- Before entering diverging branches (if-else, match arms), the `possibly_uninit` state is saved
- Each branch is processed independently from the saved state
- After branches, states are merged: a variable is possibly uninitialized if it's uninitialized in any branch
- Loop bodies don't affect the outer `possibly_uninit` state since they may not execute

This ensures sound analysis while allowing common patterns like assigning in all branches of an if-else or match expression.

https://claude.ai/code/session_01PaYDTHqoWAwcPERb29M5de