### PR TITLE
Refactor trait resolution context into dedicated TraitEnv and TraitContext

### DIFF
--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -44,8 +44,8 @@ use crate::tir::{
     TirEnum, TirEnumCase, TirFlags, TirFlagsMember, TirModule, TirNewtype, TypeId, TypeTable,
 };
 
-pub use types::TypeError;
 use trait_env::TraitEnv;
+pub use types::TypeError;
 use types::{EnumInfo, FlagsInfo, ModuleTypeMaps, ResourceInfo, StructFieldInfo, VariantInfo};
 
 pub struct Resolver<'a, H: CompilerHost> {
@@ -362,7 +362,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         if self.is_known_type_name(&param.name) {
                             // Concrete type in explicit params (e.g., `impl<i32, T>`): skip
                             if !param.bounds.is_empty() {
-                                self.trait_ctx.type_param_bounds
+                                self.trait_ctx
+                                    .type_param_bounds
                                     .entry(param.name.clone())
                                     .or_insert_with(Vec::new)
                                     .extend(param.bounds.clone());
@@ -374,11 +375,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                 .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), actual_idx);
-                            self.trait_ctx.type_params
+                            self.trait_ctx
+                                .type_params
                                 .insert(param.name.clone(), (actual_idx, type_id));
                         }
                         if !param.bounds.is_empty() {
-                            self.trait_ctx.type_param_bounds
+                            self.trait_ctx
+                                .type_param_bounds
                                 .entry(param.name.clone())
                                 .or_insert_with(Vec::new)
                                 .extend(param.bounds.clone());
@@ -397,7 +400,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.trait_ctx.type_params
+                                    self.trait_ctx
+                                        .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }
@@ -409,7 +413,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         if let Some(ref tn) = trait_name {
                             let target_type_id = self.resolve_type(&impl_block.ty);
                             let type_params: Vec<_> = self
-                                .trait_ctx.type_params
+                                .trait_ctx
+                                .type_params
                                 .iter()
                                 .map(|(name, &(index, type_id))| (name.clone(), index, type_id))
                                 .collect();
@@ -438,7 +443,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
-                            self.trait_ctx.assoc_type_bindings
+                            self.trait_ctx
+                                .assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
 
                             // Register in TypeTable for substitution resolution

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -20,6 +20,8 @@ mod operators;
 mod orchestration;
 mod stmt;
 mod template;
+mod trait_env;
+mod trait_query;
 mod type_resolution;
 pub(crate) mod types;
 mod util;
@@ -43,10 +45,8 @@ use crate::tir::{
 };
 
 pub use types::TypeError;
-use types::{
-    BlanketTraitImplIndex, EnumInfo, FlagsInfo, ModuleTypeMaps, ResourceInfo, StructFieldInfo,
-    TraitDeclIndex, TraitImplIndex, VariantInfo,
-};
+use trait_env::TraitEnv;
+use types::{EnumInfo, FlagsInfo, ModuleTypeMaps, ResourceInfo, StructFieldInfo, VariantInfo};
 
 pub struct Resolver<'a, H: CompilerHost> {
     /// Type table (shared across all modules via Rc<RefCell>)
@@ -86,13 +86,9 @@ pub struct Resolver<'a, H: CompilerHost> {
     current_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
     current_module_items: Vec<Item>,
-    /// Type parameters currently in scope (name -> (index, `TypeId`))
-    /// Set when resolving generic structs or functions
-    current_type_params: IndexMap<String, (u32, TypeId)>,
-    /// Trait bounds on type parameters in scope (name -> full bounds with assoc types)
-    /// Used for resolving trait methods on type params (e.g., `T.cmp()` when T: Ord)
-    /// Full `TraitBound` objects preserve associated type bindings like `I: IntoIterator<Item = u8>`
-    current_type_param_bounds: IndexMap<String, Vec<ast::TraitBound>>,
+    /// Mutable trait resolution context: type params, bounds, associated type bindings, self type.
+    /// Grouped together so scope entry/exit can save/restore the whole context at once.
+    trait_ctx: trait_env::TraitContext,
     /// Generic struct definitions (name -> type param count)
     /// Used to determine if a struct is generic
     generic_struct_names: IndexSet<String>,
@@ -108,11 +104,6 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// Resolved param types for generic methods (`mangled_name` -> `param TypeIds`)
     /// Resolved in the method's own type param scope so `TypeParams` have correct ids.
     generic_method_resolved_param_types: IndexMap<String, Vec<TypeId>>,
-    /// Current associated type bindings in scope (`Self::Name` -> resolved type)
-    /// Set when resolving trait implementations
-    current_associated_type_bindings: IndexMap<String, TypeId>,
-    /// Current `Self` type in scope (the type being implemented in an impl block)
-    current_self_type: Option<TypeId>,
     /// WASI registry for looking up effect return types
     wasi_registry: &'static WasiRegistry,
     /// Builtin registry for looking up builtin function return types
@@ -128,14 +119,9 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// Built lazily on first access per module. Avoids rebuilding `build_module_map`
     /// on every imported method call or field access.
     module_type_maps_cache: IndexMap<ModuleSource, ModuleTypeMaps>,
-    /// Pre-built index: type name → (`module_source`, `item_idx`) for trait impl blocks in `loaded_modules`.
-    /// Shared across all module Resolvers; avoids O(all items) scans in `find_trait_method_for_type`.
-    trait_impl_index: Arc<TraitImplIndex>,
-    /// Pre-built index: trait name → (`module_source`, `item_idx`) for trait declarations in `loaded_modules`.
-    trait_decl_index: Arc<TraitDeclIndex>,
-    /// Pre-built list of blanket trait impl blocks: `impl<T: Trait> OtherTrait for T`.
-    /// Checked as fallback when concrete type lookup in `trait_impl_index` fails.
-    blanket_trait_impl_index: Arc<BlanketTraitImplIndex>,
+    /// Immutable trait knowledge base: impl indices, trait declarations, and blanket impls.
+    /// Built once and shared across all module resolvers via `Arc`.
+    trait_env: Arc<TraitEnv>,
     /// Pre-loaded file contents for `#include_str` / `#include_bytes`.
     /// Key: `[module_source_display, raw_path]`, value: raw bytes.
     included_files: &'a IndexMap<[String; 2], Vec<u8>>,
@@ -159,8 +145,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     ) -> Self {
         let (wasi_registry, _) = WasiRegistry::build_from_stdlib();
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
-        let (trait_impl_index, trait_decl_index, blanket_trait_impl_index) =
-            Self::build_trait_indices(loaded_modules);
+        let trait_env = TraitEnv::build(loaded_modules);
         Self {
             type_table,
             symbols,
@@ -182,24 +167,19 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             logger,
             current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
             current_module_items: Vec::new(),
-            current_type_params: IndexMap::default(),
-            current_type_param_bounds: IndexMap::default(),
+            trait_ctx: trait_env::TraitContext::default(),
             generic_struct_names: IndexSet::default(),
             generic_function_params: IndexMap::default(),
             generic_function_resolved_param_types: IndexMap::default(),
             generic_method_params: IndexMap::default(),
             generic_method_resolved_param_types: IndexMap::default(),
-            current_associated_type_bindings: IndexMap::default(),
-            current_self_type: None,
             wasi_registry,
             builtin_registry,
             current_module_globals: IndexMap::default(),
             imported_globals: IndexMap::default(),
             associated_constants: IndexMap::default(),
             module_type_maps_cache: IndexMap::default(),
-            trait_impl_index,
-            trait_decl_index,
-            blanket_trait_impl_index,
+            trait_env,
             included_files,
             known_type_names_cache: IndexSet::default(),
             indexing_trait_cache: IndexMap::default(),
@@ -369,8 +349,9 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
                     // Register type parameters from impl block's generic type FIRST
                     // e.g., impl IndexValue<i32> for Triple<T> needs T registered
-                    let old_type_params = std::mem::take(&mut self.current_type_params);
-                    let old_type_param_bounds = std::mem::take(&mut self.current_type_param_bounds);
+                    let saved_trait_ctx = self.trait_ctx.clone();
+                    self.trait_ctx.type_params.clear();
+                    self.trait_ctx.type_param_bounds.clear();
 
                     // Register explicit type params from impl<T: Bound> declarations,
                     // skipping concrete types (e.g., `impl<i32, T>` — skip "i32").
@@ -381,23 +362,23 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         if self.is_known_type_name(&param.name) {
                             // Concrete type in explicit params (e.g., `impl<i32, T>`): skip
                             if !param.bounds.is_empty() {
-                                self.current_type_param_bounds
+                                self.trait_ctx.type_param_bounds
                                     .entry(param.name.clone())
                                     .or_insert_with(Vec::new)
                                     .extend(param.bounds.clone());
                             }
                             continue;
                         }
-                        if !self.current_type_params.contains_key(&param.name) {
+                        if !self.trait_ctx.type_params.contains_key(&param.name) {
                             let type_id = self
                                 .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), actual_idx);
-                            self.current_type_params
+                            self.trait_ctx.type_params
                                 .insert(param.name.clone(), (actual_idx, type_id));
                         }
                         if !param.bounds.is_empty() {
-                            self.current_type_param_bounds
+                            self.trait_ctx.type_param_bounds
                                 .entry(param.name.clone())
                                 .or_insert_with(Vec::new)
                                 .extend(param.bounds.clone());
@@ -409,14 +390,14 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         for (i, arg) in generic.args.iter().enumerate() {
                             if let ast::Type::Named(named) = arg {
                                 let name = &named.name;
-                                if !self.current_type_params.contains_key(name)
+                                if !self.trait_ctx.type_params.contains_key(name)
                                     && !self.is_known_type_name(name)
                                 {
                                     let type_id = self
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.current_type_params
+                                    self.trait_ctx.type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }
@@ -428,7 +409,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         if let Some(ref tn) = trait_name {
                             let target_type_id = self.resolve_type(&impl_block.ty);
                             let type_params: Vec<_> = self
-                                .current_type_params
+                                .trait_ctx.type_params
                                 .iter()
                                 .map(|(name, &(index, type_id))| (name.clone(), index, type_id))
                                 .collect();
@@ -442,15 +423,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                     span: impl_block.span,
                                 });
                         }
-                        self.current_type_params = old_type_params;
-                        self.current_type_param_bounds = old_type_param_bounds;
+                        self.trait_ctx = saved_trait_ctx;
                         continue;
                     }
 
                     // Set up associated type bindings for trait implementations
                     // This now works because type params (like T) are registered above
-                    let old_associated_type_bindings =
-                        std::mem::take(&mut self.current_associated_type_bindings);
+                    self.trait_ctx.assoc_type_bindings.clear();
                     if impl_block.trait_type.is_some() {
                         // Resolve the target type for registering associated type resolutions
                         let target_type_id = self.resolve_type(&impl_block.ty);
@@ -459,7 +438,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
-                            self.current_associated_type_bindings
+                            self.trait_ctx.assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
 
                             // Register in TypeTable for substitution resolution
@@ -527,10 +506,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         }
                     }
 
-                    // Restore old associated type bindings, type params, and bounds
-                    self.current_associated_type_bindings = old_associated_type_bindings;
-                    self.current_type_params = old_type_params;
-                    self.current_type_param_bounds = old_type_param_bounds;
+                    // Restore trait context
+                    self.trait_ctx = saved_trait_ctx;
                 }
                 Item::Trait(_trait_decl) => {
                     // Trait declarations are handled in the first pass (signature registration)

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -214,7 +214,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
                     // Check if this is a type parameter static call (T::method where T: Trait)
                     else if let Some(&(_param_idx, type_param_type_id)) =
-                        self.current_type_params.get(prefix)
+                        self.trait_ctx.type_params.get(prefix)
                     {
                         return self.resolve_type_param_static_call(
                             prefix,
@@ -549,13 +549,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
             {
                 // Set up the function's type parameters in scope so we can resolve
                 // type parameter references (like T -> TypeParam { index: 0 })
-                let old_type_params = std::mem::take(&mut self.current_type_params);
+                let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
                 for (i, type_param) in type_params.iter().enumerate() {
                     let type_id = self
                         .type_table
                         .borrow_mut()
                         .make_type_param(type_param.name.clone(), i as u32);
-                    self.current_type_params
+                    self.trait_ctx.type_params
                         .insert(type_param.name.clone(), (i as u32, type_id));
                 }
 
@@ -624,7 +624,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 self.enum_cases = old_enum_cases;
                 self.flags_cases = old_flags_cases;
                 self.resource_types = old_resource_types;
-                self.current_type_params = old_type_params;
+                self.trait_ctx.type_params = old_type_params;
 
                 return resolved;
             }
@@ -1060,18 +1060,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
 
         // Temporarily create TypeParam TypeIds for this method's type params
-        let old_type_params = self.current_type_params.clone();
-        let old_type_param_bounds = self.current_type_param_bounds.clone();
+        let saved_trait_ctx = self.trait_ctx.clone();
         let mut type_param_list: Vec<(String, TypeId)> = vec![];
         for (i, tp) in type_params.iter().enumerate() {
             let type_id = self
                 .type_table
                 .borrow_mut()
                 .make_type_param(tp.name.clone(), i as u32);
-            self.current_type_params
+            self.trait_ctx.type_params
                 .insert(tp.name.clone(), (i as u32, type_id));
             if !tp.bounds.is_empty() {
-                self.current_type_param_bounds
+                self.trait_ctx.type_param_bounds
                     .insert(tp.name.clone(), tp.bounds.clone());
             }
             type_param_list.push((tp.name.clone(), type_id));
@@ -1084,9 +1083,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .map(|p| self.resolve_type(&p.ty))
             .collect();
 
-        // Restore type params
-        self.current_type_params = old_type_params;
-        self.current_type_param_bounds = old_type_param_bounds;
+        self.trait_ctx = saved_trait_ctx;
 
         // Unify resolved param types against actual arg types
         let mut type_param_map: IndexMap<TypeId, TypeId> = IndexMap::default();
@@ -1155,20 +1152,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
 
         // Temporarily register type params so resolve_type can find them
-        let saved = std::mem::take(&mut self.current_type_params);
+        let saved = std::mem::take(&mut self.trait_ctx.type_params);
         for (i, tp) in fn_type_params.iter().enumerate() {
             let idx = i as u32;
             let type_id = self
                 .type_table
                 .borrow_mut()
                 .make_type_param(tp.name.clone(), idx);
-            self.current_type_params
+            self.trait_ctx.type_params
                 .insert(tp.name.clone(), (idx, type_id));
         }
 
         let param_types: Vec<TypeId> = fn_params.iter().map(|p| self.resolve_type(&p.ty)).collect();
 
-        self.current_type_params = saved;
+        self.trait_ctx.type_params = saved;
 
         // Substitute type params with explicit type args
         param_types
@@ -1241,7 +1238,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .iter()
             .any(|&t| self.type_table.borrow().contains_type_param(t));
 
-        if has_unresolved && self.current_type_params.is_empty() {
+        if has_unresolved && self.trait_ctx.type_params.is_empty() {
             return self
                 .type_table
                 .borrow_mut()
@@ -1266,7 +1263,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         call: &ast::CallExpr,
         _ctx: &mut FunctionContext,
     ) -> TirExpr {
-        let bounds = self.current_type_param_bounds.get(type_param_name).cloned();
+        let bounds = self.trait_ctx.type_param_bounds.get(type_param_name).cloned();
 
         if let Some(bounds) = bounds
             && let Some((found_trait, method_info_result)) = {

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -555,7 +555,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         .type_table
                         .borrow_mut()
                         .make_type_param(type_param.name.clone(), i as u32);
-                    self.trait_ctx.type_params
+                    self.trait_ctx
+                        .type_params
                         .insert(type_param.name.clone(), (i as u32, type_id));
                 }
 
@@ -1067,10 +1068,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .type_table
                 .borrow_mut()
                 .make_type_param(tp.name.clone(), i as u32);
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(tp.name.clone(), (i as u32, type_id));
             if !tp.bounds.is_empty() {
-                self.trait_ctx.type_param_bounds
+                self.trait_ctx
+                    .type_param_bounds
                     .insert(tp.name.clone(), tp.bounds.clone());
             }
             type_param_list.push((tp.name.clone(), type_id));
@@ -1159,7 +1162,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .type_table
                 .borrow_mut()
                 .make_type_param(tp.name.clone(), idx);
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(tp.name.clone(), (idx, type_id));
         }
 
@@ -1263,7 +1267,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
         call: &ast::CallExpr,
         _ctx: &mut FunctionContext,
     ) -> TirExpr {
-        let bounds = self.trait_ctx.type_param_bounds.get(type_param_name).cloned();
+        let bounds = self
+            .trait_ctx
+            .type_param_bounds
+            .get(type_param_name)
+            .cloned();
 
         if let Some(bounds) = bounds
             && let Some((found_trait, method_info_result)) = {

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -36,13 +36,13 @@ pub(super) fn extract_comp_features(attrs: &[crate::ast::Attribute]) -> u32 {
 impl<H: CompilerHost> Resolver<'_, H> {
     pub(super) fn resolve_struct(&mut self, struct_decl: &ast::StructDecl) -> TirStruct {
         // Set up type parameters in scope before resolving fields
-        let old_type_params = std::mem::take(&mut self.current_type_params);
+        let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
         for (index, param) in struct_decl.type_params.iter().enumerate() {
             let type_id = self
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), index as u32);
-            self.current_type_params
+            self.trait_ctx.type_params
                 .insert(param.name.clone(), (index as u32, type_id));
         }
 
@@ -86,7 +86,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .collect();
 
         // Restore previous type params scope
-        self.current_type_params = old_type_params;
+        self.trait_ctx.type_params = old_type_params;
 
         let serde_rename_all = struct_decl.attrs.iter().find_map(|a| {
             if a.name == "serde" && a.args.first().is_some_and(|s| s == "rename_all") {
@@ -154,13 +154,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
         variant_decl: &ast::VariantDecl,
     ) -> TirVariantDecl {
         // Set up type parameters in scope before resolving field types
-        let old_type_params = std::mem::take(&mut self.current_type_params);
+        let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
         for (index, param) in variant_decl.type_params.iter().enumerate() {
             let type_id = self
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), index as u32);
-            self.current_type_params
+            self.trait_ctx.type_params
                 .insert(param.name.clone(), (index as u32, type_id));
         }
 
@@ -195,7 +195,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .collect();
 
         // Restore previous type params scope
-        self.current_type_params = old_type_params;
+        self.trait_ctx.type_params = old_type_params;
 
         let comp_features = extract_comp_features(&variant_decl.attrs);
         if comp_features != 0 {
@@ -245,18 +245,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// Resolve a function
     pub(super) fn resolve_function(&mut self, func: &Function) -> Option<TirFunction> {
         // Set up type parameters in scope before resolving types
-        let old_type_params = std::mem::take(&mut self.current_type_params);
-        let old_type_param_bounds = std::mem::take(&mut self.current_type_param_bounds);
+        let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
+        let old_type_param_bounds = std::mem::take(&mut self.trait_ctx.type_param_bounds);
         let mut type_param_list = Vec::new();
         for (index, param) in func.type_params.iter().enumerate() {
             let type_id = self
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), index as u32);
-            self.current_type_params
+            self.trait_ctx.type_params
                 .insert(param.name.clone(), (index as u32, type_id));
             if !param.bounds.is_empty() {
-                self.current_type_param_bounds
+                self.trait_ctx.type_param_bounds
                     .insert(param.name.clone(), param.bounds.clone());
             }
             type_param_list.push((param.name.clone(), type_id));
@@ -350,8 +350,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .collect();
 
         // Restore previous type params scope
-        self.current_type_params = old_type_params;
-        self.current_type_param_bounds = old_type_param_bounds;
+        self.trait_ctx.type_params = old_type_params;
+        self.trait_ctx.type_param_bounds = old_type_param_bounds;
 
         Some(TirFunction {
             name: func.name.clone(),
@@ -463,8 +463,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
         trait_name: Option<&str>,
     ) -> Option<TirFunction> {
         // Set up type parameters in scope before resolving types
-        let old_type_params = std::mem::take(&mut self.current_type_params);
-        let old_type_param_bounds = std::mem::take(&mut self.current_type_param_bounds);
+        let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
+        let old_type_param_bounds = std::mem::take(&mut self.trait_ctx.type_param_bounds);
         let mut type_param_list = Vec::new();
 
         // First, collect type params from impl block's generic type (e.g., impl Box<T>)
@@ -474,12 +474,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
             for (i, arg) in generic.args.iter().enumerate() {
                 if let ast::Type::Named(named) = arg {
                     let name = &named.name;
-                    if !self.current_type_params.contains_key(name) {
+                    if !self.trait_ctx.type_params.contains_key(name) {
                         let type_id = self
                             .type_table
                             .borrow_mut()
                             .make_type_param(name.clone(), i as u32);
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(name.clone(), (i as u32, type_id));
                         // Store impl type param info for later monomorphization
                         impl_type_params.push(crate::tir::TirTypeParam {
@@ -500,7 +500,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
-                self.current_type_params
+                self.trait_ctx.type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = old_type_param_bounds
                     .get(&named.name)
@@ -523,7 +523,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
-                self.current_type_params
+                self.trait_ctx.type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = old_type_param_bounds
                     .get(&named.name)
@@ -545,29 +545,29 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // We need to restore them from old_type_param_bounds temporarily... NO.
         // The caller sets up bounds BEFORE calling resolve_method, so old_type_param_bounds
         // contains the caller's bounds. We should use those as base and add method-level bounds.
-        self.current_type_param_bounds = old_type_param_bounds.clone();
+        self.trait_ctx.type_param_bounds = old_type_param_bounds.clone();
 
         // Then, collect method-level type params
-        let offset = self.current_type_params.len();
+        let offset = self.trait_ctx.type_params.len();
         for (index, param) in func.type_params.iter().enumerate() {
             let idx = (offset + index) as u32;
             let type_id = self
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), idx);
-            self.current_type_params
+            self.trait_ctx.type_params
                 .insert(param.name.clone(), (idx, type_id));
             type_param_list.push((param.name.clone(), type_id));
             if !param.bounds.is_empty() {
-                self.current_type_param_bounds
+                self.trait_ctx.type_param_bounds
                     .insert(param.name.clone(), param.bounds.clone());
             }
         }
 
         // Set up Self type for the impl block
         // This allows `&Self` to resolve correctly in method parameters
-        let old_self_type = self.current_self_type;
-        self.current_self_type = Some(self.resolve_type(impl_type));
+        let old_self_type = self.trait_ctx.self_type;
+        self.trait_ctx.self_type = Some(self.resolve_type(impl_type));
 
         // Resolve return type
         let return_type = func
@@ -659,8 +659,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
 
         // Restore previous type params scope and bounds
-        self.current_type_params = old_type_params;
-        self.current_type_param_bounds = old_type_param_bounds;
+        self.trait_ctx.type_params = old_type_params;
+        self.trait_ctx.type_param_bounds = old_type_param_bounds;
 
         // Store type parameters for generic methods (for call site substitution)
         if !func.type_params.is_empty() {
@@ -671,7 +671,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // Restore Self type
-        self.current_self_type = old_self_type;
+        self.trait_ctx.self_type = old_self_type;
 
         Some(TirFunction {
             name: func.name.clone(), // Will be mangled by caller

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -42,7 +42,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), index as u32);
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(param.name.clone(), (index as u32, type_id));
         }
 
@@ -160,7 +161,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), index as u32);
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(param.name.clone(), (index as u32, type_id));
         }
 
@@ -253,10 +255,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), index as u32);
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(param.name.clone(), (index as u32, type_id));
             if !param.bounds.is_empty() {
-                self.trait_ctx.type_param_bounds
+                self.trait_ctx
+                    .type_param_bounds
                     .insert(param.name.clone(), param.bounds.clone());
             }
             type_param_list.push((param.name.clone(), type_id));
@@ -479,7 +483,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             .type_table
                             .borrow_mut()
                             .make_type_param(name.clone(), i as u32);
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(name.clone(), (i as u32, type_id));
                         // Store impl type param info for later monomorphization
                         impl_type_params.push(crate::tir::TirTypeParam {
@@ -500,7 +505,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
-                self.trait_ctx.type_params
+                self.trait_ctx
+                    .type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = old_type_param_bounds
                     .get(&named.name)
@@ -523,7 +529,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
-                self.trait_ctx.type_params
+                self.trait_ctx
+                    .type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = old_type_param_bounds
                     .get(&named.name)
@@ -555,11 +562,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .type_table
                 .borrow_mut()
                 .make_type_param(param.name.clone(), idx);
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(param.name.clone(), (idx, type_id));
             type_param_list.push((param.name.clone(), type_id));
             if !param.bounds.is_empty() {
-                self.trait_ctx.type_param_bounds
+                self.trait_ctx
+                    .type_param_bounds
                     .insert(param.name.clone(), param.bounds.clone());
             }
         }

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -129,7 +129,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             };
             if let Some(name) = type_param_name
-                && let Some(bounds) = self.current_type_param_bounds.get(&name).cloned()
+                && let Some(bounds) = self.trait_ctx.type_param_bounds.get(&name).cloned()
                 && let Some((found_trait, info)) = {
                     let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();
                     self.find_method_in_trait_bounds(
@@ -1051,19 +1051,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 .any(|p| p.self_kind != ast::SelfKind::None);
                             if method.name == method_name && !has_self {
                                 // Set up type parameters from impl block before resolving
-                                let old_type_params = std::mem::take(&mut self.current_type_params);
+                                let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
 
                                 // Extract type params from impl block type (e.g., impl Array<T>)
                                 if let ast::Type::Generic(generic) = &impl_block.ty {
                                     for (i, arg) in generic.args.iter().enumerate() {
                                         if let ast::Type::Named(named) = arg {
                                             let name = &named.name;
-                                            if !self.current_type_params.contains_key(name) {
+                                            if !self.trait_ctx.type_params.contains_key(name) {
                                                 let type_id = self
                                                     .type_table
                                                     .borrow_mut()
                                                     .make_type_param(name.clone(), i as u32);
-                                                self.current_type_params
+                                                self.trait_ctx.type_params
                                                     .insert(name.clone(), (i as u32, type_id));
                                             }
                                         }
@@ -1077,7 +1077,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     .unwrap_or(TypeTable::UNIT);
 
                                 // Restore type parameters
-                                self.current_type_params = old_type_params;
+                                self.trait_ctx.type_params = old_type_params;
 
                                 return result;
                             }
@@ -1098,16 +1098,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             });
                         if method.name == method_name && !has_self {
                             // Set up type parameters from resource declaration before resolving
-                            let old_type_params = std::mem::take(&mut self.current_type_params);
+                            let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
 
                             for (i, param) in resource.type_params.iter().enumerate() {
                                 let name = &param.name;
-                                if !self.current_type_params.contains_key(name) {
+                                if !self.trait_ctx.type_params.contains_key(name) {
                                     let type_id = self
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.current_type_params
+                                    self.trait_ctx.type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }
@@ -1119,7 +1119,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 .unwrap_or(TypeTable::UNIT);
 
                             // Restore type parameters
-                            self.current_type_params = old_type_params;
+                            self.trait_ctx.type_params = old_type_params;
 
                             return result;
                         }
@@ -1143,19 +1143,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 if method.name == method_name && !has_self {
                                     // Set up type parameters from impl block before resolving
                                     let old_type_params =
-                                        std::mem::take(&mut self.current_type_params);
+                                        std::mem::take(&mut self.trait_ctx.type_params);
 
                                     // Extract type params from impl block type (e.g., impl Array<T>)
                                     if let ast::Type::Generic(generic) = &impl_block.ty {
                                         for (i, arg) in generic.args.iter().enumerate() {
                                             if let ast::Type::Named(named) = arg {
                                                 let name = &named.name;
-                                                if !self.current_type_params.contains_key(name) {
+                                                if !self.trait_ctx.type_params.contains_key(name) {
                                                     let type_id = self
                                                         .type_table
                                                         .borrow_mut()
                                                         .make_type_param(name.clone(), i as u32);
-                                                    self.current_type_params
+                                                    self.trait_ctx.type_params
                                                         .insert(name.clone(), (i as u32, type_id));
                                                 }
                                             }
@@ -1169,7 +1169,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .unwrap_or(TypeTable::UNIT);
 
                                     // Restore type parameters
-                                    self.current_type_params = old_type_params;
+                                    self.trait_ctx.type_params = old_type_params;
 
                                     return result;
                                 }
@@ -1196,16 +1196,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             });
                         if method.name == method_name && !has_self {
                             // Set up type parameters from resource declaration before resolving
-                            let old_type_params = std::mem::take(&mut self.current_type_params);
+                            let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
 
                             for (i, param) in resource.type_params.iter().enumerate() {
                                 let name = &param.name;
-                                if !self.current_type_params.contains_key(name) {
+                                if !self.trait_ctx.type_params.contains_key(name) {
                                     let type_id = self
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.current_type_params
+                                    self.trait_ctx.type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }
@@ -1217,7 +1217,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 .unwrap_or(TypeTable::UNIT);
 
                             // Restore type parameters
-                            self.current_type_params = old_type_params;
+                            self.trait_ctx.type_params = old_type_params;
 
                             return result;
                         }

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -1051,7 +1051,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 .any(|p| p.self_kind != ast::SelfKind::None);
                             if method.name == method_name && !has_self {
                                 // Set up type parameters from impl block before resolving
-                                let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
+                                let old_type_params =
+                                    std::mem::take(&mut self.trait_ctx.type_params);
 
                                 // Extract type params from impl block type (e.g., impl Array<T>)
                                 if let ast::Type::Generic(generic) = &impl_block.ty {
@@ -1063,7 +1064,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                                     .type_table
                                                     .borrow_mut()
                                                     .make_type_param(name.clone(), i as u32);
-                                                self.trait_ctx.type_params
+                                                self.trait_ctx
+                                                    .type_params
                                                     .insert(name.clone(), (i as u32, type_id));
                                             }
                                         }
@@ -1107,7 +1109,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.trait_ctx.type_params
+                                    self.trait_ctx
+                                        .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }
@@ -1155,7 +1158,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                                         .type_table
                                                         .borrow_mut()
                                                         .make_type_param(name.clone(), i as u32);
-                                                    self.trait_ctx.type_params
+                                                    self.trait_ctx
+                                                        .type_params
                                                         .insert(name.clone(), (i as u32, type_id));
                                                 }
                                             }
@@ -1205,7 +1209,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.trait_ctx.type_params
+                                    self.trait_ctx
+                                        .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -1,4 +1,4 @@
-//! Method and trait lookup, trait implementation search, bounds checking.
+//! Method lookup, operator resolution, and indexing trait dispatch.
 
 use crate::hashmap::{IndexMap, IndexSet};
 
@@ -6,7 +6,7 @@ use crate::ast::{self, BinaryOp, Expr, Item, Literal, Type, UnaryOp};
 use crate::compiler_host::CompilerHost;
 use crate::name::{LocalMethodName, MethodName, ModuleSource};
 use crate::tir::{
-    CallArg, FunctionRef, PrimitiveType, ResolvedType, TirExpr, TirExprKind, TirUnaryOp, TypeId,
+    CallArg, FunctionRef, ResolvedType, TirExpr, TirExprKind, TirUnaryOp, TypeId,
     TypeTable,
 };
 use crate::token::Span;
@@ -14,7 +14,7 @@ use crate::token::Span;
 use super::Resolver;
 use super::types::{
     ArithmeticTraitInfo, FunctionContext, IndexAssignTraitInfo, IndexMutTraitInfo, IndexTraitInfo,
-    IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo, TypeError,
+    IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo,
 };
 
 /// Lightweight reference to an impl block, avoiding deep clones.
@@ -56,7 +56,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// Returns lightweight `ImplBlockRef` values instead of cloning impl block data.
     fn collect_trait_impl_refs(&self, type_name: &str) -> Vec<ImplBlockRef> {
         let mut refs = Vec::new();
-        if let Some(entries) = self.trait_impl_index.get(type_name) {
+        if let Some(entries) = self.trait_env.impl_index.get(type_name) {
             for (module_src, item_idx) in entries {
                 let module = &self.loaded_modules[module_src];
                 if let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -81,7 +81,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     fn collect_trait_impl_refs_multi(&self, type_names: &[String]) -> Vec<ImplBlockRef> {
         let mut refs = Vec::new();
         for name in type_names {
-            if let Some(entries) = self.trait_impl_index.get(name.as_str()) {
+            if let Some(entries) = self.trait_env.impl_index.get(name.as_str()) {
                 for (module_src, item_idx) in entries {
                     let module = &self.loaded_modules[module_src];
                     if let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -429,7 +429,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 if method.name == method_name {
                                     // Set up type params for generic impls (e.g., impl Array<T>)
                                     let old_type_params =
-                                        std::mem::take(&mut self.current_type_params);
+                                        std::mem::take(&mut self.trait_ctx.type_params);
                                     let mut impl_offset = 0u32;
                                     if let Some(ref type_args) = receiver_type_args
                                         && let Type::Generic(generic) = &impl_block.ty
@@ -439,7 +439,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                             if let Type::Named(named) = arg
                                                 && i < type_args.len()
                                             {
-                                                self.current_type_params.insert(
+                                                self.trait_ctx.type_params.insert(
                                                     named.name.clone(),
                                                     (i as u32, type_args[i]),
                                                 );
@@ -457,7 +457,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                                 index,
                                             },
                                         );
-                                        self.current_type_params.insert(
+                                        self.trait_ctx.type_params.insert(
                                             type_param.name.clone(),
                                             (index, type_param_id),
                                         );
@@ -524,7 +524,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     );
                                     self.module_type_maps_cache
                                         .insert(module_source.clone(), cached);
-                                    self.current_type_params = old_type_params;
+                                    self.trait_ctx.type_params = old_type_params;
 
                                     return Some(MethodInfo {
                                         return_type,
@@ -561,7 +561,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 if method.name == method_name {
                                     // Set up type params for generic impls (e.g., impl Array<T>)
                                     let old_type_params =
-                                        std::mem::take(&mut self.current_type_params);
+                                        std::mem::take(&mut self.trait_ctx.type_params);
                                     let mut impl_offset = 0u32;
                                     if let Some(ref type_args) = receiver_type_args
                                         && let Type::Generic(generic) = &impl_block.ty
@@ -571,7 +571,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                             if let Type::Named(named) = arg
                                                 && i < type_args.len()
                                             {
-                                                self.current_type_params.insert(
+                                                self.trait_ctx.type_params.insert(
                                                     named.name.clone(),
                                                     (i as u32, type_args[i]),
                                                 );
@@ -589,7 +589,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                                 index,
                                             },
                                         );
-                                        self.current_type_params.insert(
+                                        self.trait_ctx.type_params.insert(
                                             type_param.name.clone(),
                                             (index, type_param_id),
                                         );
@@ -613,7 +613,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .map(|p| p.is_mut)
                                         .collect();
 
-                                    self.current_type_params = old_type_params;
+                                    self.trait_ctx.type_params = old_type_params;
 
                                     return Some(MethodInfo {
                                         return_type,
@@ -709,11 +709,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
 
             // Set up type params for generic resources (e.g., resource Stream<T>)
-            let old_type_params = std::mem::take(&mut self.current_type_params);
+            let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
             if let Some(type_args) = receiver_type_args {
                 for (i, param) in resource.type_params.iter().enumerate() {
                     if i < type_args.len() {
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(param.name.clone(), (i as u32, type_args[i]));
                     }
                 }
@@ -732,7 +732,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .map(|p| p.is_mut)
                 .collect();
 
-            self.current_type_params = old_type_params;
+            self.trait_ctx.type_params = old_type_params;
 
             // Extract CM canonical name from #[cm("...")] attribute
             let cm_name = method
@@ -1299,7 +1299,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the receiver
         // type satisfies the bound.  e.g., `impl<I: Iterator> IntoIterator for I` matches
         // any concrete type that implements Iterator.
-        for (module_src, item_idx) in self.blanket_trait_impl_index.as_ref() {
+        for (module_src, item_idx) in &self.trait_env.blanket_impl_index {
             let module = &self.loaded_modules[module_src];
             if let Item::Impl(impl_block) = &module.items[*item_idx]
                 && impl_block.trait_type.is_some()
@@ -1396,13 +1396,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .collect();
             let impl_module_source = self.impl_block_module_source(impl_ref);
 
+            // Save trait context for this impl block scope
+            let saved_trait_ctx = self.trait_ctx.clone();
+            self.trait_ctx.type_params.clear();
+            self.trait_ctx.assoc_type_bindings.clear();
+
             // Set up type parameters for resolving generic associated types
-            let old_type_params = std::mem::take(&mut self.current_type_params);
             if let Some(type_args) = receiver_type_args {
                 for (name, idx) in &type_param_entries {
                     let i = *idx as usize;
                     if i < type_args.len() {
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(name.clone(), (*idx, type_args[i]));
                     }
                 }
@@ -1410,26 +1414,24 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
             // For blanket impls where impl_ty is a free type parameter
             if let Some(ref name) = blanket_name
-                && !self.current_type_params.contains_key(name)
+                && !self.trait_ctx.type_params.contains_key(name)
                 && !self.is_known_type_name(name)
             {
                 if let Some(recv_id) = receiver_type_id {
-                    self.current_type_params.insert(name.clone(), (0, recv_id));
+                    self.trait_ctx.type_params.insert(name.clone(), (0, recv_id));
                 } else {
                     let type_id = self
                         .type_table
                         .borrow_mut()
                         .make_type_param(name.clone(), 0);
-                    self.current_type_params.insert(name.clone(), (0, type_id));
+                    self.trait_ctx.type_params.insert(name.clone(), (0, type_id));
                 }
             }
 
             // Set up associated type bindings for resolving Self::* types
-            let old_associated_type_bindings =
-                std::mem::take(&mut self.current_associated_type_bindings);
             for (name, ty) in &assoc_bindings {
                 let type_id = self.resolve_type(ty);
-                self.current_associated_type_bindings
+                self.trait_ctx.assoc_type_bindings
                     .insert(name.clone(), type_id);
             }
 
@@ -1468,7 +1470,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let trait_name = self.get_type_name(&trait_type_for_name);
 
                 // Set up method-level type params (e.g., V in deserialize_any<V: Visitor>)
-                let impl_offset = self.current_type_params.len() as u32;
+                let impl_offset = self.trait_ctx.type_params.len() as u32;
                 for (i, type_param) in method_type_params.iter().enumerate() {
                     let index = impl_offset + i as u32;
                     let type_param_id =
@@ -1478,10 +1480,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 name: type_param.name.clone(),
                                 index,
                             });
-                    self.current_type_params
+                    self.trait_ctx.type_params
                         .insert(type_param.name.clone(), (index, type_param_id));
                     if !type_param.bounds.is_empty() {
-                        self.current_type_param_bounds
+                        self.trait_ctx.type_param_bounds
                             .insert(type_param.name.clone(), type_param.bounds.clone());
                     }
                 }
@@ -1493,8 +1495,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                 // Remove method-level type params from scope
                 for type_param in &method_type_params {
-                    self.current_type_params.shift_remove(&type_param.name);
-                    self.current_type_param_bounds
+                    self.trait_ctx.type_params.shift_remove(&type_param.name);
+                    self.trait_ctx.type_param_bounds
                         .shift_remove(&type_param.name);
                 }
                 let param_types = self.extract_param_types(&params);
@@ -1561,9 +1563,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             }
 
-            // Restore associated type bindings and type params
-            self.current_associated_type_bindings = old_associated_type_bindings;
-            self.current_type_params = old_type_params;
+            // Restore trait context
+            self.trait_ctx = saved_trait_ctx;
         }
 
         // Remove duplicates
@@ -1574,26 +1575,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         found_traits.into_iter().next()
     }
 
-    /// Find a trait declaration by name across all modules.
-    /// Returns the trait's methods (cloned) if found.
-    pub(super) fn find_trait_decl_methods(&self, trait_name: &str) -> Option<Vec<ast::Function>> {
-        // Fast O(1) lookup via pre-built index instead of scanning all modules.
-        if let Some((module_src, item_idx)) = self.trait_decl_index.get(trait_name) {
-            let module = &self.loaded_modules[module_src];
-            if let Item::Trait(trait_decl) = &module.items[*item_idx] {
-                return Some(trait_decl.methods.clone());
-            }
-        }
-        // Check current module items (not covered by the index).
-        for item in &self.current_module_items {
-            if let Item::Trait(trait_decl) = item
-                && trait_decl.name == trait_name
-            {
-                return Some(trait_decl.methods.clone());
-            }
-        }
-        None
-    }
 
     /// Find Index trait implementation for a type
     pub(super) fn find_index_trait_impl(
@@ -2040,711 +2021,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         None
     }
 
-    /// Check if a type implements a specific trait (for trait bound checking)
-    pub(super) fn type_implements_trait(&self, type_id: TypeId, trait_name: &str) -> bool {
-        let resolved = self.type_table.borrow().get(type_id).clone();
-
-        // Type parameters satisfy bounds declared on them (e.g., T: Describable
-        // means T implements Describable within the scope of that declaration)
-        if let ResolvedType::TypeParam { name, .. } = &resolved {
-            if let Some(bounds) = self.current_type_param_bounds.get(name) {
-                return bounds.iter().any(|b| b.name == trait_name);
-            }
-            return false;
-        }
-
-        // Primitives have built-in implementations for certain traits
-        if let ResolvedType::Primitive(prim) = &resolved {
-            match trait_name {
-                // All primitives implement Eq and Ord
-                "Eq" | "Ord" => return true,
-                // Numeric primitives implement arithmetic traits
-                "Add" | "Sub" | "Mul" | "Div" | "Rem"
-                    if !matches!(prim, PrimitiveType::Bool | PrimitiveType::Char) =>
-                {
-                    return true;
-                }
-                _ => {}
-            }
-            // For other traits, check the type name
-            let type_name = format!("{prim:?}").to_lowercase();
-            return self.find_trait_impl_for_type(&type_name, trait_name);
-        }
-
-        // All enums automatically implement Eq and Ord
-        if let ResolvedType::Enum { .. } = &resolved {
-            match trait_name {
-                "Eq" | "Ord" => return true,
-                _ => {}
-            }
-        }
-
-        // Get the type name and type args for looking up implementations
-        let (type_name, type_args) = match &resolved {
-            ResolvedType::Struct { name, .. }
-            | ResolvedType::Enum { name, .. }
-            | ResolvedType::Variant { name, .. } => (name.clone(), None),
-            ResolvedType::GenericInstance {
-                name, type_args, ..
-            } => (
-                name.clone(),
-                if type_args.is_empty() {
-                    None
-                } else {
-                    Some(type_args.clone())
-                },
-            ),
-            ResolvedType::Ref(inner) => {
-                // Check for a specific impl Trait for &T first (e.g., impl Inspect for &T)
-                let inner_id = *inner;
-                if self.find_trait_impl_for_type_with_args("&", trait_name, Some(&[inner_id])) {
-                    return true;
-                }
-                return self.type_implements_trait(inner_id, trait_name);
-            }
-            ResolvedType::MutRef(inner) => {
-                let inner_id = *inner;
-                if self.find_trait_impl_for_type_with_args("&mut", trait_name, Some(&[inner_id])) {
-                    return true;
-                }
-                return self.type_implements_trait(inner_id, trait_name);
-            }
-            ResolvedType::Tuple(elems) => {
-                // Tuples implement a trait when all elements implement it
-                let elems = elems.clone();
-                return elems
-                    .iter()
-                    .all(|e| self.type_implements_trait(*e, trait_name));
-            }
-            ResolvedType::AssocTypeProjection { bounds, .. } => {
-                // An associated type projection T::Assoc implements a trait if
-                // the trait declaration for Assoc declares that bound.
-                // e.g., I::Iter: Iterator when IntoIterator::Iter: Iterator
-                return bounds.iter().any(|b| b == trait_name);
-            }
-            ResolvedType::Newtype { base_type, .. } => {
-                // Newtypes inherit trait implementations from their base type.
-                let base_id = *base_type;
-                return self.type_implements_trait(base_id, trait_name);
-            }
-            _ => return false,
-        };
-
-        self.find_trait_impl_for_type_with_args(&type_name, trait_name, type_args.as_deref())
-    }
-
-    /// Helper to check if there's an impl block for a type implementing a trait
-    pub(super) fn find_trait_impl_for_type(&self, type_name: &str, trait_name: &str) -> bool {
-        self.find_trait_impl_for_type_with_args(type_name, trait_name, None)
-    }
-
-    /// Check if there's a trait impl for a type, with optional type args for bounds checking.
-    /// For `impl<T: Eq> Eq for Array<T>`, when checking `Array<Foo>`, passes `[Foo]` as `type_args`.
-    pub(super) fn find_trait_impl_for_type_with_args(
-        &self,
-        type_name: &str,
-        trait_name: &str,
-        type_args: Option<&[TypeId]>,
-    ) -> bool {
-        // Use pre-built index for O(1) lookup by type name.
-        if let Some(entries) = self.trait_impl_index.get(type_name) {
-            for (module_src, item_idx) in entries {
-                let module = &self.loaded_modules[module_src];
-                if let Item::Impl(impl_block) = &module.items[*item_idx]
-                    && let Some(trait_type) = &impl_block.trait_type
-                {
-                    let impl_trait_name = self.get_type_name(trait_type);
-                    if impl_trait_name == trait_name
-                        && self.check_impl_block_bounds(impl_block, type_args)
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        // Also check current module items (not covered by the index).
-        for item in &self.current_module_items {
-            if let Item::Impl(impl_block) = item
-                && let Some(trait_type) = &impl_block.trait_type
-                && Self::get_type_name_static(&impl_block.ty) == type_name
-            {
-                let impl_trait_name = self.get_type_name(trait_type);
-                if impl_trait_name == trait_name
-                    && self.check_impl_block_bounds(impl_block, type_args)
-                {
-                    return true;
-                }
-            }
-        }
-
-        // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the
-        // concrete type satisfies the bound.
-        for (module_src, item_idx) in self.blanket_trait_impl_index.as_ref() {
-            let module = &self.loaded_modules[module_src];
-            if let Item::Impl(impl_block) = &module.items[*item_idx]
-                && let Some(trait_type) = &impl_block.trait_type
-            {
-                let impl_trait_name = self.get_type_name(trait_type);
-                if impl_trait_name == trait_name {
-                    let impl_type_name = Self::get_type_name_static(&impl_block.ty);
-                    let matching_param = impl_block
-                        .type_params
-                        .iter()
-                        .find(|tp| tp.name == impl_type_name);
-                    if let Some(param) = matching_param {
-                        let bounds_satisfied = param
-                            .bounds
-                            .iter()
-                            .all(|bound| self.find_trait_impl_for_type(type_name, &bound.name));
-                        if bounds_satisfied {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-
-        false
-    }
-
-    /// Compute `assoc_type_bindings` for an `AssocTypeProjection` by resolving `Self::X`
-    /// references in the trait bound's associated type constraints.
-    ///
-    /// Example: `IntoIterator::Iter` has bound `Iterator<Item = Self::Item>`.
-    /// With `I: IntoIterator<Item = u8>` and `self_type = I`, `Self::Item = I::Item = u8`.
-    /// Result: `[("Item", u8_typeid)]`, stored in the `I::Iter` projection.
-    ///
-    /// This enables `I::Iter::Item` to resolve to `u8` when `Iterator::next` is called.
-    fn compute_assoc_type_bindings_from_trait_bounds(
-        &mut self,
-        self_type_id: TypeId,
-        self_type_param_name: Option<&str>,
-        assoc_bounds: &[crate::ast::TraitBound],
-    ) -> Vec<(String, TypeId)> {
-        let mut bindings = Vec::new();
-        let Some(type_param_name) = self_type_param_name else {
-            // Also handle AssocTypeProjection self_type: propagate bindings from its bindings
-            let resolved = self.type_table.borrow().get(self_type_id).clone();
-            if let ResolvedType::AssocTypeProjection {
-                assoc_type_bindings,
-                ..
-            } = resolved
-            {
-                // Reuse existing bindings from the source projection
-                return assoc_type_bindings;
-            }
-            return bindings;
-        };
-        // For each bound, check its associated type constraints and resolve Self::X
-        for bound in assoc_bounds {
-            for assoc in &bound.assoc_types.clone() {
-                if let crate::ast::Type::NamespacedGeneric(ns) = &assoc.ty
-                    && ns.namespace == "Self"
-                {
-                    // Self::ns.name → type_param_name::ns.name
-                    // Look in current_type_param_bounds[type_param_name] for direct binding
-                    if let Some(param_bounds) =
-                        self.current_type_param_bounds.get(type_param_name).cloned()
-                    {
-                        for pb in &param_bounds {
-                            for ab in &pb.assoc_types {
-                                if ab.name == ns.name {
-                                    let resolved_ty = self.resolve_type(&ab.ty.clone());
-                                    bindings.push((assoc.name.clone(), resolved_ty));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        bindings
-    }
-
-    /// Find a method in the trait declarations given by the bound names.
-    /// For example, if T: Ord, look up the "cmp" method in the Ord trait declaration.
-    /// Returns (`trait_name`, `MethodInfo`) with the method's return type, `self_kind`, and `param_types`,
-    /// where Self is substituted with the `TypeParam`'s type.
-    pub(super) fn find_method_in_trait_bounds(
-        &mut self,
-        bounds: &[String],
-        method_name: &str,
-        self_type_id: TypeId,
-    ) -> Option<(String, MethodInfo)> {
-        // Collect trait declarations from all modules
-        for trait_name in bounds {
-            // Search all loaded modules for the trait declaration
-            let mut found_trait_method: Option<(
-                ast::Function,
-                Vec<ast::AssociatedTypeDecl>,
-                ModuleSource,
-            )> = None;
-
-            for (module_src, module) in self.loaded_modules {
-                for item in &module.items {
-                    if let Item::Trait(trait_decl) = item
-                        && trait_decl.name == *trait_name
-                    {
-                        for method in &trait_decl.methods {
-                            if method.name == method_name {
-                                found_trait_method = Some((
-                                    method.clone(),
-                                    trait_decl.associated_types.clone(),
-                                    module_src.clone(),
-                                ));
-                                break;
-                            }
-                        }
-                    }
-                }
-                if found_trait_method.is_some() {
-                    break;
-                }
-            }
-
-            // Also check current module items
-            if found_trait_method.is_none() {
-                for item in &self.current_module_items {
-                    if let Item::Trait(trait_decl) = item
-                        && trait_decl.name == *trait_name
-                    {
-                        for method in &trait_decl.methods {
-                            if method.name == method_name {
-                                found_trait_method = Some((
-                                    method.clone(),
-                                    trait_decl.associated_types.clone(),
-                                    self.current_module_source.clone(),
-                                ));
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if let Some((method, trait_assoc_types, _module_source)) = found_trait_method {
-                // Resolve the method signature with Self = self_type_id (the TypeParam)
-                let old_self_type = self.current_self_type;
-                self.current_self_type = Some(self_type_id);
-
-                // Set up associated type bindings as projections so that
-                // Self::AssocType resolves to AssocTypeProjection(self_type_id, "AssocType").
-                // We also compute assoc_type_bindings to propagate concrete types through
-                // associated type chains. For example:
-                //   self_type = I (TypeParam with bound IntoIterator<Item = u8>)
-                //   Assoc = "Iter" with bound Iterator<Item = Self::Item>
-                //   Self::Item = I::Item = u8
-                //   → I::Iter.assoc_type_bindings = [("Item", u8)]
-                // This allows I::Iter::Item to resolve to u8 when Iterator::next is called.
-                let old_bindings = std::mem::take(&mut self.current_associated_type_bindings);
-                // Determine the TypeParam name for Self, if self_type is a TypeParam.
-                let self_type_param_name = {
-                    let resolved = self.type_table.borrow().get(self_type_id).clone();
-                    if let ResolvedType::TypeParam { name, .. } = resolved {
-                        Some(name)
-                    } else {
-                        None
-                    }
-                };
-                for assoc_decl in &trait_assoc_types {
-                    // Check if self_type has a direct assoc_type_binding for this name.
-                    // This handles the case: self_type = I::Iter which has ("Item", u8_typeid).
-                    let directly_bound = {
-                        let resolved = self.type_table.borrow().get(self_type_id).clone();
-                        if let ResolvedType::AssocTypeProjection {
-                            assoc_type_bindings,
-                            ..
-                        } = resolved
-                        {
-                            assoc_type_bindings
-                                .iter()
-                                .find(|(name, _)| *name == assoc_decl.name)
-                                .map(|(_, type_id)| *type_id)
-                        } else {
-                            None
-                        }
-                    };
-                    let projection = directly_bound.unwrap_or_else(|| {
-                        let bound_names: Vec<String> =
-                            assoc_decl.bounds.iter().map(|b| b.name.clone()).collect();
-                        // Compute assoc_type_bindings by resolving Self::X references in the
-                        // assoc type's bounds. e.g., Iterator<Item = Self::Item> with Self = I
-                        // and I: IntoIterator<Item = u8> gives [("Item", u8)].
-                        let atb = self.compute_assoc_type_bindings_from_trait_bounds(
-                            self_type_id,
-                            self_type_param_name.as_deref(),
-                            &assoc_decl.bounds,
-                        );
-                        self.type_table.borrow_mut().make_assoc_type_projection(
-                            self_type_id,
-                            assoc_decl.name.clone(),
-                            bound_names,
-                            atb,
-                        )
-                    });
-                    self.current_associated_type_bindings
-                        .insert(assoc_decl.name.clone(), projection);
-                }
-
-                // Register the method's own type parameters so that they resolve to
-                // TypeParam{index: N} instead of UNKNOWN. This is needed for generic methods
-                // like `fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, ...>`
-                // where `T` must be a proper TypeParam to allow substitution at the call site.
-                // We use index 0, 1, ... because find_method_in_trait_bounds is only called
-                // for TypeParam/AssocTypeProjection receivers, where impl_offset = 0.
-                let old_type_params_for_method = self.current_type_params.clone();
-                let old_type_param_bounds_for_method = self.current_type_param_bounds.clone();
-                for (index, param) in method.type_params.iter().enumerate() {
-                    let type_id = self
-                        .type_table
-                        .borrow_mut()
-                        .make_type_param(param.name.clone(), index as u32);
-                    self.current_type_params
-                        .insert(param.name.clone(), (index as u32, type_id));
-                    if !param.bounds.is_empty() {
-                        self.current_type_param_bounds
-                            .insert(param.name.clone(), param.bounds.clone());
-                    }
-                }
-
-                let return_type = method
-                    .return_type
-                    .as_ref()
-                    .map(|t| self.resolve_type(t))
-                    .unwrap_or(TypeTable::UNIT);
-                let self_kind = method
-                    .params
-                    .first()
-                    .map(|p| p.self_kind)
-                    .unwrap_or(ast::SelfKind::None);
-                let param_types = self.extract_param_types(&method.params);
-                let param_is_mut: Vec<bool> = method
-                    .params
-                    .iter()
-                    .filter(|p| p.name != "self")
-                    .map(|p| p.is_mut)
-                    .collect();
-
-                self.current_type_params = old_type_params_for_method;
-                self.current_type_param_bounds = old_type_param_bounds_for_method;
-                self.current_associated_type_bindings = old_bindings;
-                self.current_self_type = old_self_type;
-
-                return Some((
-                    trait_name.clone(),
-                    MethodInfo {
-                        return_type,
-                        self_kind,
-                        param_types,
-                        param_is_mut,
-                        inherited_from_base: None,
-                        cm_name: None,
-                    },
-                ));
-            }
-        }
-
-        None
-    }
-
-    /// Check if an impl block's type parameter bounds are satisfied by the given type args.
-    /// For `impl<T: Ord> Array<T>`, checks that the concrete type substituted for T implements Ord.
-    pub(super) fn check_impl_block_bounds(
-        &self,
-        impl_block: &ast::ImplBlock,
-        type_args: Option<&[TypeId]>,
-    ) -> bool {
-        // No type params with bounds → always OK
-        if impl_block.type_params.iter().all(|p| p.bounds.is_empty()) {
-            return true;
-        }
-
-        let Some(type_args) = type_args else {
-            // No type args to check (non-generic receiver) → skip bounds check
-            return true;
-        };
-
-        // Build name → bounds map from impl block type params (trait names only)
-        let bounds_map: IndexMap<&str, Vec<String>> = impl_block
-            .type_params
-            .iter()
-            .filter(|p| !p.bounds.is_empty())
-            .map(|p| {
-                (
-                    p.name.as_str(),
-                    p.bounds.iter().map(|b| b.name.clone()).collect(),
-                )
-            })
-            .collect();
-
-        // Match type params to receiver type args via generic type arg positions
-        let inner_type_name: Option<&str> =
-            if let ast::Type::Reference(boxed) | ast::Type::MutReference(boxed) = &impl_block.ty {
-                if let ast::Type::Named(inner) = boxed.as_ref() {
-                    Some(&inner.name)
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-        if let ast::Type::Generic(generic) = &impl_block.ty {
-            for (i, arg) in generic.args.iter().enumerate() {
-                if let ast::Type::Named(named) = arg
-                    && let Some(bounds) = bounds_map.get(named.name.as_str())
-                    && let Some(&type_arg) = type_args.get(i)
-                {
-                    // If the type arg is itself a type parameter (e.g., T in a generic context),
-                    // skip the bounds check. Within a bounded impl block, type params are assumed
-                    // to satisfy bounds; concrete types are checked at call sites.
-                    if matches!(
-                        self.type_table.borrow().get(type_arg),
-                        ResolvedType::TypeParam { .. }
-                    ) {
-                        continue;
-                    }
-                    for bound in bounds {
-                        if !self.type_implements_trait(type_arg, bound) {
-                            return false;
-                        }
-                    }
-                }
-            }
-        } else if let Some(inner_name) = inner_type_name {
-            // Handle `impl<T: Bound> Trait for &T` / `impl<T: Bound> Trait for &mut T`:
-            // type_args[0] is the inner type T.
-            if let Some(bounds) = bounds_map.get(inner_name)
-                && let Some(&type_arg) = type_args.first()
-                && !matches!(
-                    self.type_table.borrow().get(type_arg),
-                    ResolvedType::TypeParam { .. }
-                )
-            {
-                for bound in bounds {
-                    if !self.type_implements_trait(type_arg, bound) {
-                        return false;
-                    }
-                }
-            }
-        }
-
-        true
-    }
-
-    /// Check trait bounds on a generic function's type arguments.
-    /// Looks up the function's type params and validates bounds against the provided type args.
-    pub(super) fn check_function_type_arg_bounds(
-        &mut self,
-        callee_module: &ModuleSource,
-        func_name: &str,
-        type_args: &[TypeId],
-        span: Span,
-    ) {
-        // Look up function's type params from AST
-        let type_params = self.lookup_function_type_params(callee_module, func_name);
-        for (i, param) in type_params.iter().enumerate() {
-            if let Some(&type_arg) = type_args.get(i) {
-                for bound in &param.bounds {
-                    if self.type_implements_trait(type_arg, &bound.name) {
-                        // Register associated type resolutions so the monomorphizer can
-                        // substitute e.g. I::Iter → ArrayIter<u8> when I = Array<u8>.
-                        self.register_assoc_types_for_concrete_type_and_trait(
-                            type_arg,
-                            &bound.name.clone(),
-                        );
-                    } else {
-                        let type_name = self.type_id_to_string(type_arg);
-                        let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
-                            type_name,
-                            trait_name: bound.name.clone(),
-                            param_name: param.name.clone(),
-                            span,
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    /// Register associated type resolutions for a concrete type instantiating a trait.
-    /// For example, when `Array<u8>` implements `IntoIterator`, registers:
-    /// - (Array<u8>, "Item") → u8
-    /// - (Array<u8>, "Iter") → `ArrayIter`<u8>
-    /// This enables the monomorphizer to resolve `I::Iter` → `ArrayIter<u8>` when `I = Array<u8>`.
-    pub(super) fn register_assoc_types_for_concrete_type_and_trait(
-        &mut self,
-        concrete_type_id: TypeId,
-        trait_name: &str,
-    ) {
-        // Get the base type name and concrete type args for impl block lookup.
-        // For newtypes, follow the chain to the underlying type to find the trait impl,
-        // but registration (below) still uses concrete_type_id so the monomorphizer can
-        // resolve e.g. `MyBytes::Iter` when `MyBytes` is a newtype over `Array<u8>`.
-        let (type_name, concrete_type_args) = {
-            let tt = self.type_table.borrow();
-            let effective_id = tt.get_ultimate_base_type(concrete_type_id);
-            match tt.get(effective_id).clone() {
-                ResolvedType::GenericInstance {
-                    name, type_args, ..
-                } => (name, type_args),
-                ResolvedType::Struct { name, .. } => (name, vec![]),
-                ResolvedType::BuiltinArray(elem) => ("Array".to_string(), vec![elem]),
-                _ => return,
-            }
-        };
-
-        // Collect matching impl block info (avoids borrow conflicts during resolution)
-        struct ImplInfo {
-            type_params: Vec<ast::GenericParam>,
-            impl_ty_param_names: Vec<String>,
-            assoc_types: Vec<ast::AssociatedTypeBinding>,
-        }
-        let impl_infos: Vec<ImplInfo> = {
-            let mut result = vec![];
-            if let Some(entries) = self.trait_impl_index.get(&type_name) {
-                let entries = entries.clone();
-                for (module_src, item_idx) in entries {
-                    let module = &self.loaded_modules[&module_src];
-                    if let Item::Impl(impl_block) = &module.items[item_idx]
-                        && let Some(trait_type) = &impl_block.trait_type
-                        && self.get_type_name(trait_type) == trait_name
-                        && !impl_block.associated_types.is_empty()
-                    {
-                        let impl_ty_param_names: Vec<String> = match &impl_block.ty {
-                            ast::Type::Generic(g) => g
-                                .args
-                                .iter()
-                                .filter_map(|arg| {
-                                    if let ast::Type::Named(named) = arg {
-                                        Some(named.name.clone())
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect(),
-                            _ => vec![],
-                        };
-                        result.push(ImplInfo {
-                            type_params: impl_block.type_params.clone(),
-                            impl_ty_param_names,
-                            assoc_types: impl_block.associated_types.clone(),
-                        });
-                    }
-                }
-            }
-            result
-        };
-
-        for info in impl_infos {
-            let old_type_params = self.current_type_params.clone();
-            let old_type_param_bounds = self.current_type_param_bounds.clone();
-
-            // Bind impl type params to concrete type args.
-            // For `impl<T> IntoIterator for Array<T>` with Array<u8>:
-            // impl_ty_param_names = ["T"], concrete_type_args = [u8_typeid]
-            // → set current_type_params["T"] = (0, u8_typeid)
-            for (i, tp_name) in info.impl_ty_param_names.iter().enumerate() {
-                if let Some(&concrete_arg) = concrete_type_args.get(i) {
-                    self.current_type_params
-                        .insert(tp_name.clone(), (i as u32, concrete_arg));
-                }
-            }
-            // Add bounds from type param declarations
-            for param in &info.type_params {
-                if !param.bounds.is_empty() {
-                    self.current_type_param_bounds
-                        .entry(param.name.clone())
-                        .or_insert_with(Vec::new)
-                        .extend(param.bounds.clone());
-                }
-            }
-
-            // Resolve and register each associated type in this substituted context
-            for binding in &info.assoc_types {
-                let resolved_id = self.resolve_type(&binding.ty);
-                if !self.type_table.borrow().contains_type_param(resolved_id) {
-                    self.type_table.borrow_mut().register_assoc_type_resolution(
-                        concrete_type_id,
-                        binding.name.clone(),
-                        resolved_id,
-                    );
-                }
-            }
-
-            self.current_type_params = old_type_params;
-            self.current_type_param_bounds = old_type_param_bounds;
-        }
-
-        // Also check blanket impls: `impl<I: Trait> OtherTrait for I`.
-        // For example, `impl<I: Iterator> IntoIterator for I` applies to StrUtf8ByteIter.
-        struct BlanketImplInfo {
-            blanket_param_name: String,
-            blanket_param_bounds: Vec<ast::TraitBound>,
-            assoc_types: Vec<ast::AssociatedTypeBinding>,
-        }
-        let blanket_infos: Vec<BlanketImplInfo> = {
-            let mut result = vec![];
-            for (module_src, item_idx) in self.blanket_trait_impl_index.as_ref() {
-                let module = &self.loaded_modules[module_src];
-                if let Item::Impl(impl_block) = &module.items[*item_idx]
-                    && let Some(trait_type) = &impl_block.trait_type
-                    && self.get_type_name(trait_type) == trait_name
-                    && !impl_block.associated_types.is_empty()
-                {
-                    let impl_type_name = Self::get_type_name_static(&impl_block.ty);
-                    if let Some(blanket_param) = impl_block
-                        .type_params
-                        .iter()
-                        .find(|tp| tp.name == impl_type_name && !tp.bounds.is_empty())
-                    {
-                        // Check if the concrete type satisfies the blanket param's bounds
-                        let bounds_ok = blanket_param
-                            .bounds
-                            .iter()
-                            .all(|bound| self.type_implements_trait(concrete_type_id, &bound.name));
-                        if bounds_ok {
-                            result.push(BlanketImplInfo {
-                                blanket_param_name: blanket_param.name.clone(),
-                                blanket_param_bounds: blanket_param.bounds.clone(),
-                                assoc_types: impl_block.associated_types.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-            result
-        };
-
-        for info in blanket_infos {
-            let old_type_params = self.current_type_params.clone();
-            let old_type_param_bounds = self.current_type_param_bounds.clone();
-
-            // Bind the blanket type param to the concrete type
-            // For `impl<I: Iterator> IntoIterator for I` with StrUtf8ByteIter:
-            // → set current_type_params["I"] = (0, StrUtf8ByteIter_typeid)
-            self.current_type_params
-                .insert(info.blanket_param_name.clone(), (0, concrete_type_id));
-            self.current_type_param_bounds
-                .insert(info.blanket_param_name.clone(), info.blanket_param_bounds);
-
-            // Resolve and register each associated type
-            for binding in &info.assoc_types {
-                let resolved_id = self.resolve_type(&binding.ty);
-                if !self.type_table.borrow().contains_type_param(resolved_id) {
-                    self.type_table.borrow_mut().register_assoc_type_resolution(
-                        concrete_type_id,
-                        binding.name.clone(),
-                        resolved_id,
-                    );
-                }
-            }
-
-            self.current_type_params = old_type_params;
-            self.current_type_param_bounds = old_type_param_bounds;
-        }
-    }
 
     /// Look up the type parameters of a static method from its AST definition.
     /// Searches impl blocks in loaded modules for `impl StructName { fn method_name<...> }`.
@@ -2945,22 +2221,22 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let impl_source = self.impl_block_module_source(impl_ref);
 
                 // Set up associated type bindings
-                let old_bindings = std::mem::take(&mut self.current_associated_type_bindings);
+                let old_bindings = std::mem::take(&mut self.trait_ctx.assoc_type_bindings);
                 for (name, ty) in &assoc_bindings {
                     let type_id = self.resolve_type_with_param_mapping(ty, &type_param_mapping);
-                    self.current_associated_type_bindings
+                    self.trait_ctx.assoc_type_bindings
                         .insert(name.clone(), type_id);
                 }
 
                 // Get the associated type (Output or Input)
                 let assoc_type = self
-                    .current_associated_type_bindings
+                    .trait_ctx.assoc_type_bindings
                     .get(assoc_type_name)
                     .copied()
                     .unwrap_or(TypeTable::UNKNOWN);
 
                 // Restore associated type bindings
-                self.current_associated_type_bindings = old_bindings;
+                self.trait_ctx.assoc_type_bindings = old_bindings;
 
                 let result = Some((assoc_type, self_kind, trait_name, impl_source));
                 self.indexing_trait_cache.insert(cache_key, result.clone());
@@ -2972,117 +2248,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         None
     }
 
-    /// Build a mapping from type parameter names to concrete type IDs.
-    /// For `impl Trait for Container<T>` with concrete type `Container<i32>`,
-    /// returns `{"T" -> i32's TypeId}`.
-    ///
-    /// When `declared_type_params` is non-empty, only names in that set are
-    /// treated as type parameters. This prevents concrete types (e.g., `String` in
-    /// `impl Trait for Map<String, V>`) from being incorrectly mapped.
-    /// When empty, all `Named` types are assumed to be type parameters (legacy behavior).
-    pub(super) fn build_type_param_mapping(
-        impl_ty: &Type,
-        concrete_type_args: &[TypeId],
-        declared_type_params: &IndexSet<String>,
-    ) -> IndexMap<String, TypeId> {
-        let mut mapping = IndexMap::default();
-
-        // Extract type parameter names from impl_ty, tracking positions
-        // Position tracking is needed to map type params to the correct concrete arg
-        if let Type::Generic(g) = impl_ty {
-            for (concrete_idx, arg) in g.args.iter().enumerate() {
-                if let Type::Named(n) = arg {
-                    let is_type_param = if declared_type_params.is_empty() {
-                        true // legacy: treat all Named as type params
-                    } else {
-                        declared_type_params.contains(&n.name)
-                    };
-                    if is_type_param && let Some(&type_id) = concrete_type_args.get(concrete_idx) {
-                        mapping.insert(n.name.clone(), type_id);
-                    }
-                }
-            }
-        }
-
-        mapping
-    }
-
-    /// Check that concrete type args at non-type-parameter positions match the impl type.
-    /// e.g., `impl KeyValueLiteral for TreeMap<String, V>` with `TreeMap<i32, String>` should fail
-    /// because position 0 expects String but got i32.
-    fn verify_impl_type_compatibility(
-        impl_ty: &Type,
-        concrete_type_args: &[TypeId],
-        declared_type_params: &IndexSet<String>,
-        type_table: &std::cell::RefCell<TypeTable>,
-    ) -> bool {
-        if declared_type_params.is_empty() {
-            return true; // No filtering available, assume compatible
-        }
-        let Type::Generic(g) = impl_ty else {
-            return true;
-        };
-        let tt = type_table.borrow();
-        for (i, arg) in g.args.iter().enumerate() {
-            let Some(&concrete_id) = concrete_type_args.get(i) else {
-                continue;
-            };
-            if !Self::impl_type_matches_concrete(arg, concrete_id, declared_type_params, &tt) {
-                return false;
-            }
-        }
-        true
-    }
-
-    /// Recursively check whether an impl type argument matches a concrete type ID.
-    /// - `Type::Named` that is a declared type param → always matches (free type param)
-    /// - `Type::Named` not in type params → concrete name must equal `type_table.type_name()`
-    /// - `Type::Generic` → concrete must be a `GenericInstance` with same outer name; inner args checked recursively
-    /// - Other types → not validated (return true)
-    fn impl_type_matches_concrete(
-        impl_ty: &Type,
-        concrete_id: TypeId,
-        declared_type_params: &IndexSet<String>,
-        type_table: &TypeTable,
-    ) -> bool {
-        match impl_ty {
-            Type::Named(n) => {
-                if declared_type_params.contains(&n.name) {
-                    true // free type param — matches anything
-                } else {
-                    type_table.type_name(concrete_id) == n.name
-                }
-            }
-            Type::Generic(g) => {
-                let resolved = type_table.get(concrete_id).clone();
-                match resolved {
-                    ResolvedType::GenericInstance {
-                        name, type_args, ..
-                    } => {
-                        if name != g.name {
-                            return false;
-                        }
-                        for (i, inner) in g.args.iter().enumerate() {
-                            let Some(&inner_id) = type_args.get(i) else {
-                                return false;
-                            };
-                            if !Self::impl_type_matches_concrete(
-                                inner,
-                                inner_id,
-                                declared_type_params,
-                                type_table,
-                            ) {
-                                return false;
-                            }
-                        }
-                        true
-                    }
-                    _ => false,
-                }
-            }
-            _ => true,
-        }
-    }
 
     /// Resolve a type, substituting type parameters using the provided mapping.
     pub(super) fn resolve_type_with_param_mapping(

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -6,8 +6,7 @@ use crate::ast::{self, BinaryOp, Expr, Item, Literal, Type, UnaryOp};
 use crate::compiler_host::CompilerHost;
 use crate::name::{LocalMethodName, MethodName, ModuleSource};
 use crate::tir::{
-    CallArg, FunctionRef, ResolvedType, TirExpr, TirExprKind, TirUnaryOp, TypeId,
-    TypeTable,
+    CallArg, FunctionRef, ResolvedType, TirExpr, TirExprKind, TirUnaryOp, TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -713,7 +712,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
             if let Some(type_args) = receiver_type_args {
                 for (i, param) in resource.type_params.iter().enumerate() {
                     if i < type_args.len() {
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(param.name.clone(), (i as u32, type_args[i]));
                     }
                 }
@@ -1406,7 +1406,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 for (name, idx) in &type_param_entries {
                     let i = *idx as usize;
                     if i < type_args.len() {
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(name.clone(), (*idx, type_args[i]));
                     }
                 }
@@ -1418,20 +1419,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 && !self.is_known_type_name(name)
             {
                 if let Some(recv_id) = receiver_type_id {
-                    self.trait_ctx.type_params.insert(name.clone(), (0, recv_id));
+                    self.trait_ctx
+                        .type_params
+                        .insert(name.clone(), (0, recv_id));
                 } else {
                     let type_id = self
                         .type_table
                         .borrow_mut()
                         .make_type_param(name.clone(), 0);
-                    self.trait_ctx.type_params.insert(name.clone(), (0, type_id));
+                    self.trait_ctx
+                        .type_params
+                        .insert(name.clone(), (0, type_id));
                 }
             }
 
             // Set up associated type bindings for resolving Self::* types
             for (name, ty) in &assoc_bindings {
                 let type_id = self.resolve_type(ty);
-                self.trait_ctx.assoc_type_bindings
+                self.trait_ctx
+                    .assoc_type_bindings
                     .insert(name.clone(), type_id);
             }
 
@@ -1480,10 +1486,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 name: type_param.name.clone(),
                                 index,
                             });
-                    self.trait_ctx.type_params
+                    self.trait_ctx
+                        .type_params
                         .insert(type_param.name.clone(), (index, type_param_id));
                     if !type_param.bounds.is_empty() {
-                        self.trait_ctx.type_param_bounds
+                        self.trait_ctx
+                            .type_param_bounds
                             .insert(type_param.name.clone(), type_param.bounds.clone());
                     }
                 }
@@ -1496,7 +1504,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // Remove method-level type params from scope
                 for type_param in &method_type_params {
                     self.trait_ctx.type_params.shift_remove(&type_param.name);
-                    self.trait_ctx.type_param_bounds
+                    self.trait_ctx
+                        .type_param_bounds
                         .shift_remove(&type_param.name);
                 }
                 let param_types = self.extract_param_types(&params);
@@ -1574,7 +1583,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // but we'll handle that later with explicit disambiguation syntax)
         found_traits.into_iter().next()
     }
-
 
     /// Find Index trait implementation for a type
     pub(super) fn find_index_trait_impl(
@@ -2021,7 +2029,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         None
     }
 
-
     /// Look up the type parameters of a static method from its AST definition.
     /// Searches impl blocks in loaded modules for `impl StructName { fn method_name<...> }`.
     pub(super) fn lookup_static_method_type_params(
@@ -2224,13 +2231,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let old_bindings = std::mem::take(&mut self.trait_ctx.assoc_type_bindings);
                 for (name, ty) in &assoc_bindings {
                     let type_id = self.resolve_type_with_param_mapping(ty, &type_param_mapping);
-                    self.trait_ctx.assoc_type_bindings
+                    self.trait_ctx
+                        .assoc_type_bindings
                         .insert(name.clone(), type_id);
                 }
 
                 // Get the associated type (Output or Input)
                 let assoc_type = self
-                    .trait_ctx.assoc_type_bindings
+                    .trait_ctx
+                    .assoc_type_bindings
                     .get(assoc_type_name)
                     .copied()
                     .unwrap_or(TypeTable::UNKNOWN);
@@ -2247,7 +2256,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         self.indexing_trait_cache.insert(cache_key, None);
         None
     }
-
 
     /// Resolve a type, substituting type parameters using the provided mapping.
     pub(super) fn resolve_type_with_param_mapping(

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -1,19 +1,15 @@
 //! Single module type/signature collection and name resolution helpers.
 
-use crate::hashmap::IndexMap;
-
 use crate::ast::{self, Item, Module, Type};
 use crate::compiler_host::CompilerHost;
-use crate::name::ModuleSource;
 use crate::tir::{TypeId, TypeTable};
 
 use super::Resolver;
 use super::types::{
-    BlanketTraitImplIndex, EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, StructFieldInfo,
-    TraitDeclIndex, TraitImplIndex, VariantCaseData, VariantInfo,
+    EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, StructFieldInfo, VariantCaseData,
+    VariantInfo,
 };
 use crate::name::MethodName;
-use std::sync::Arc;
 
 impl<H: CompilerHost> Resolver<'_, H> {
     pub(super) fn collect_types(&mut self, module: &Module) {
@@ -62,13 +58,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
             match item {
                 Item::Struct(struct_decl) => {
                     // Set up type parameters in scope for resolving field types
-                    let old_type_params = std::mem::take(&mut self.current_type_params);
+                    let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
                     for (index, param) in struct_decl.type_params.iter().enumerate() {
                         let type_id = self
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), index as u32);
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(param.name.clone(), (index as u32, type_id));
                     }
 
@@ -111,7 +107,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     );
 
                     // Restore type params scope
-                    self.current_type_params = old_type_params;
+                    self.trait_ctx.type_params = old_type_params;
                 }
                 Item::Type(newtype_decl) => {
                     // Resolve the base type
@@ -126,14 +122,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
                 Item::Variant(variant_decl) => {
                     // Set up type parameters in scope for resolving field types
-                    let old_type_params = std::mem::take(&mut self.current_type_params);
+                    let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
                     let mut type_param_type_ids = Vec::new();
                     for (index, param) in variant_decl.type_params.iter().enumerate() {
                         let type_id = self
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), index as u32);
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(param.name.clone(), (index as u32, type_id));
                         type_param_type_ids.push(type_id);
                     }
@@ -180,7 +176,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
 
                     // Restore type params scope
-                    self.current_type_params = old_type_params;
+                    self.trait_ctx.type_params = old_type_params;
                 }
                 Item::Enum(enum_decl) => {
                     // Collect enum cases (no field types, just names and indices)
@@ -249,17 +245,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 Item::Function(func) => {
                     // Set up the function's own type parameters before resolving the return type,
                     // so that associated type projections like `V::Output` can be resolved.
-                    let old_type_params = std::mem::take(&mut self.current_type_params);
-                    let old_type_param_bounds = std::mem::take(&mut self.current_type_param_bounds);
+                    let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
+                    let old_type_param_bounds = std::mem::take(&mut self.trait_ctx.type_param_bounds);
                     for (i, param) in func.type_params.iter().enumerate() {
                         let type_id = self
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), i as u32);
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(param.name.clone(), (i as u32, type_id));
                         if !param.bounds.is_empty() {
-                            self.current_type_param_bounds
+                            self.trait_ctx.type_param_bounds
                                 .insert(param.name.clone(), param.bounds.clone());
                         }
                     }
@@ -268,15 +264,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         .as_ref()
                         .map(|t| self.resolve_type(t))
                         .unwrap_or(TypeTable::UNIT);
-                    self.current_type_params = old_type_params;
-                    self.current_type_param_bounds = old_type_param_bounds;
+                    self.trait_ctx.type_params = old_type_params;
+                    self.trait_ctx.type_param_bounds = old_type_param_bounds;
                     self.function_return_types
                         .insert(func.name.clone(), return_type);
                 }
                 Item::Impl(impl_block) => {
                     // Set up type parameters from impl block before resolving method signatures
-                    let old_type_params = std::mem::take(&mut self.current_type_params);
-                    let old_type_param_bounds = std::mem::take(&mut self.current_type_param_bounds);
+                    let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
+                    let old_type_param_bounds = std::mem::take(&mut self.trait_ctx.type_param_bounds);
 
                     // First, collect explicit type params from impl<T>, skipping concrete types
                     // (e.g., `impl<i32, T> IndexValue<i32> for Triple<T>` — skip "i32").
@@ -289,10 +285,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), actual_idx);
-                        self.current_type_params
+                        self.trait_ctx.type_params
                             .insert(param.name.clone(), (actual_idx, type_id));
                         if !param.bounds.is_empty() {
-                            self.current_type_param_bounds
+                            self.trait_ctx.type_param_bounds
                                 .insert(param.name.clone(), param.bounds.clone());
                         }
                         actual_idx += 1;
@@ -305,7 +301,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         for (i, arg) in generic.args.iter().enumerate() {
                             if let ast::Type::Named(named) = arg {
                                 let name = &named.name;
-                                if !self.current_type_params.contains_key(name)
+                                if !self.trait_ctx.type_params.contains_key(name)
                                     && !self.is_known_type_name(name)
                                 {
                                     let index = (offset + i) as u32;
@@ -313,7 +309,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), index);
-                                    self.current_type_params
+                                    self.trait_ctx.type_params
                                         .insert(name.clone(), (index, type_id));
                                 }
                             }
@@ -322,11 +318,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                     // Set up associated type bindings for trait implementations
                     let old_associated_type_bindings =
-                        std::mem::take(&mut self.current_associated_type_bindings);
+                        std::mem::take(&mut self.trait_ctx.assoc_type_bindings);
                     if impl_block.trait_type.is_some() {
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
-                            self.current_associated_type_bindings
+                            self.trait_ctx.assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
                         }
                     }
@@ -342,17 +338,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         // Set up method-level type parameters so that `V::Output`-style
                         // associated type projections can be resolved in the return type.
                         let mut method_type_param_names: Vec<String> = Vec::new();
-                        let offset = self.current_type_params.len();
+                        let offset = self.trait_ctx.type_params.len();
                         for (i, param) in method.type_params.iter().enumerate() {
                             let idx = (offset + i) as u32;
                             let type_id = self
                                 .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), idx);
-                            self.current_type_params
+                            self.trait_ctx.type_params
                                 .insert(param.name.clone(), (idx, type_id));
                             if !param.bounds.is_empty() {
-                                self.current_type_param_bounds
+                                self.trait_ctx.type_param_bounds
                                     .insert(param.name.clone(), param.bounds.clone());
                             }
                             method_type_param_names.push(param.name.clone());
@@ -366,8 +362,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                         // Remove method-level type params from scope
                         for name in &method_type_param_names {
-                            self.current_type_params.shift_remove(name);
-                            self.current_type_param_bounds.shift_remove(name);
+                            self.trait_ctx.type_params.shift_remove(name);
+                            self.trait_ctx.type_param_bounds.shift_remove(name);
                         }
 
                         let mangled_name = MethodName::format_local(
@@ -379,9 +375,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
 
                     // Restore type parameters, bounds, and associated type bindings
-                    self.current_type_params = old_type_params;
-                    self.current_type_param_bounds = old_type_param_bounds;
-                    self.current_associated_type_bindings = old_associated_type_bindings;
+                    self.trait_ctx.type_params = old_type_params;
+                    self.trait_ctx.type_param_bounds = old_type_param_bounds;
+                    self.trait_ctx.assoc_type_bindings = old_associated_type_bindings;
                 }
                 _ => {}
             }
@@ -396,53 +392,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
             Type::MutReference(_) => "&mut".to_string(),
             _ => "Unknown".to_string(),
         }
-    }
-
-    /// Build trait impl and trait declaration indices from all loaded modules.
-    /// Called once in `resolve_all_modules` before per-module resolution begins.
-    /// The indices enable O(1) trait lookup by type/trait name instead of scanning all modules.
-    pub(super) fn build_trait_indices(
-        modules: &IndexMap<ModuleSource, Module>,
-    ) -> (
-        Arc<TraitImplIndex>,
-        Arc<TraitDeclIndex>,
-        Arc<BlanketTraitImplIndex>,
-    ) {
-        let mut impl_index: TraitImplIndex = IndexMap::default();
-        let mut decl_index: TraitDeclIndex = IndexMap::default();
-        let mut blanket_index: BlanketTraitImplIndex = Vec::new();
-        for (module_source, module) in modules {
-            for (item_idx, item) in module.items.iter().enumerate() {
-                match item {
-                    Item::Impl(impl_block) if impl_block.trait_type.is_some() => {
-                        let type_name = Self::get_type_name_static(&impl_block.ty);
-                        // Detect blanket impls: impl_ty is a type parameter from type_params
-                        let is_blanket = impl_block
-                            .type_params
-                            .iter()
-                            .any(|tp| tp.name == type_name && !tp.bounds.is_empty());
-                        if is_blanket {
-                            blanket_index.push((module_source.clone(), item_idx));
-                        }
-                        impl_index
-                            .entry(type_name)
-                            .or_default()
-                            .push((module_source.clone(), item_idx));
-                    }
-                    Item::Trait(trait_decl) => {
-                        decl_index
-                            .entry(trait_decl.name.clone())
-                            .or_insert((module_source.clone(), item_idx));
-                    }
-                    _ => {}
-                }
-            }
-        }
-        (
-            Arc::new(impl_index),
-            Arc::new(decl_index),
-            Arc::new(blanket_index),
-        )
     }
 
     pub(super) fn get_type_name(&self, ty: &Type) -> String {

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -64,7 +64,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), index as u32);
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(param.name.clone(), (index as u32, type_id));
                     }
 
@@ -129,7 +130,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), index as u32);
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(param.name.clone(), (index as u32, type_id));
                         type_param_type_ids.push(type_id);
                     }
@@ -246,16 +248,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     // Set up the function's own type parameters before resolving the return type,
                     // so that associated type projections like `V::Output` can be resolved.
                     let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
-                    let old_type_param_bounds = std::mem::take(&mut self.trait_ctx.type_param_bounds);
+                    let old_type_param_bounds =
+                        std::mem::take(&mut self.trait_ctx.type_param_bounds);
                     for (i, param) in func.type_params.iter().enumerate() {
                         let type_id = self
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), i as u32);
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(param.name.clone(), (i as u32, type_id));
                         if !param.bounds.is_empty() {
-                            self.trait_ctx.type_param_bounds
+                            self.trait_ctx
+                                .type_param_bounds
                                 .insert(param.name.clone(), param.bounds.clone());
                         }
                     }
@@ -272,7 +277,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 Item::Impl(impl_block) => {
                     // Set up type parameters from impl block before resolving method signatures
                     let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
-                    let old_type_param_bounds = std::mem::take(&mut self.trait_ctx.type_param_bounds);
+                    let old_type_param_bounds =
+                        std::mem::take(&mut self.trait_ctx.type_param_bounds);
 
                     // First, collect explicit type params from impl<T>, skipping concrete types
                     // (e.g., `impl<i32, T> IndexValue<i32> for Triple<T>` — skip "i32").
@@ -285,10 +291,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             .type_table
                             .borrow_mut()
                             .make_type_param(param.name.clone(), actual_idx);
-                        self.trait_ctx.type_params
+                        self.trait_ctx
+                            .type_params
                             .insert(param.name.clone(), (actual_idx, type_id));
                         if !param.bounds.is_empty() {
-                            self.trait_ctx.type_param_bounds
+                            self.trait_ctx
+                                .type_param_bounds
                                 .insert(param.name.clone(), param.bounds.clone());
                         }
                         actual_idx += 1;
@@ -309,7 +317,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), index);
-                                    self.trait_ctx.type_params
+                                    self.trait_ctx
+                                        .type_params
                                         .insert(name.clone(), (index, type_id));
                                 }
                             }
@@ -322,7 +331,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     if impl_block.trait_type.is_some() {
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
-                            self.trait_ctx.assoc_type_bindings
+                            self.trait_ctx
+                                .assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
                         }
                     }
@@ -345,10 +355,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), idx);
-                            self.trait_ctx.type_params
+                            self.trait_ctx
+                                .type_params
                                 .insert(param.name.clone(), (idx, type_id));
                             if !param.bounds.is_empty() {
-                                self.trait_ctx.type_param_bounds
+                                self.trait_ctx
+                                    .type_param_bounds
                                     .insert(param.name.clone(), param.bounds.clone());
                             }
                             method_type_param_names.push(param.name.clone());

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -424,8 +424,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Build trait lookup indices once for all modules.
         // This allows find_trait_method_for_type and find_indexing_trait_impl to do O(1)
         // lookups by type name instead of scanning all items in all modules per method call.
-        let (trait_impl_index, trait_decl_index, blanket_trait_impl_index) =
-            Self::build_trait_indices(modules);
+        let trait_env = super::trait_env::TraitEnv::build(modules);
 
         // Second pass: resolve each module with per-module function_return_types and imports
         for module_source in &sorted_sources {
@@ -545,24 +544,19 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 logger,
                 current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"), // Set in resolve_module
                 current_module_items: Vec::new(), // Set in resolve_module
-                current_type_params: IndexMap::default(),
-                current_type_param_bounds: IndexMap::default(),
+                trait_ctx: super::trait_env::TraitContext::default(),
                 generic_struct_names: IndexSet::default(),
                 generic_function_params: IndexMap::default(),
                 generic_function_resolved_param_types: IndexMap::default(),
                 generic_method_params: IndexMap::default(),
                 generic_method_resolved_param_types: IndexMap::default(),
-                current_associated_type_bindings: IndexMap::default(),
-                current_self_type: None,
                 wasi_registry,
                 builtin_registry: &builtin_registry,
                 current_module_globals: IndexMap::default(),
                 imported_globals: IndexMap::default(),
                 associated_constants: IndexMap::default(),
                 module_type_maps_cache: IndexMap::default(),
-                trait_impl_index: Arc::clone(&trait_impl_index),
-                trait_decl_index: Arc::clone(&trait_decl_index),
-                blanket_trait_impl_index: Arc::clone(&blanket_trait_impl_index),
+                trait_env: Arc::clone(&trait_env),
                 included_files,
                 known_type_names_cache: IndexSet::default(),
                 indexing_trait_cache: IndexMap::default(),

--- a/wado-compiler/src/resolver/trait_env.rs
+++ b/wado-compiler/src/resolver/trait_env.rs
@@ -1,0 +1,116 @@
+//! Global trait knowledge base: trait declarations, impl blocks, and blanket impls.
+//!
+//! `TraitEnv` is built once before resolution begins and is immutable thereafter.
+//! It provides O(1) lookup of trait implementations by type name and trait name,
+//! replacing linear scans across all modules.
+
+use std::sync::Arc;
+
+use crate::ast::{self, Item, Module};
+use crate::hashmap::IndexMap;
+use crate::name::ModuleSource;
+use crate::tir::TypeId;
+
+/// Pre-built index: type name → list of (`ModuleSource`, item index) for trait impl blocks.
+/// Built once from all loaded modules to avoid O(all items) scans per method call.
+pub(super) type TraitImplIndex = IndexMap<String, Vec<(ModuleSource, usize)>>;
+
+/// Pre-built index: trait name → (`ModuleSource`, item index) for trait declarations.
+pub(super) type TraitDeclIndex = IndexMap<String, (ModuleSource, usize)>;
+
+/// Pre-built list of blanket trait impls: `impl<T: Trait> OtherTrait for T`.
+/// These are impl blocks where the impl type is a free type parameter with trait bounds.
+/// Stored separately because they can't be indexed by concrete type name.
+pub(super) type BlanketTraitImplIndex = Vec<(ModuleSource, usize)>;
+
+/// Immutable global knowledge base for trait resolution.
+///
+/// Contains pre-built indices for fast lookup of trait implementations,
+/// trait declarations, and blanket impls. Built once before resolution
+/// begins and shared (via `Arc`) across all module resolvers.
+pub(super) struct TraitEnv {
+    /// Type name → impl blocks that implement traits for that type.
+    pub(super) impl_index: TraitImplIndex,
+    /// Trait name → trait declaration location.
+    pub(super) decl_index: TraitDeclIndex,
+    /// Blanket impls (`impl<T: Bound> Trait for T`), checked as fallback.
+    pub(super) blanket_impl_index: BlanketTraitImplIndex,
+}
+
+impl TraitEnv {
+    /// Build trait indices from all loaded modules.
+    ///
+    /// Called once in `resolve_all_modules` before per-module resolution begins.
+    /// The indices enable O(1) trait lookup by type/trait name instead of scanning all modules.
+    pub(super) fn build(modules: &IndexMap<ModuleSource, Module>) -> Arc<Self> {
+        let mut impl_index: TraitImplIndex = IndexMap::default();
+        let mut decl_index: TraitDeclIndex = IndexMap::default();
+        let mut blanket_impl_index: BlanketTraitImplIndex = Vec::new();
+
+        for (module_source, module) in modules {
+            for (item_idx, item) in module.items.iter().enumerate() {
+                match item {
+                    Item::Impl(impl_block) if impl_block.trait_type.is_some() => {
+                        let type_name = get_type_name_static(&impl_block.ty);
+                        // Detect blanket impls: impl_ty is a type parameter from type_params
+                        let is_blanket = impl_block
+                            .type_params
+                            .iter()
+                            .any(|tp| tp.name == type_name && !tp.bounds.is_empty());
+                        if is_blanket {
+                            blanket_impl_index.push((module_source.clone(), item_idx));
+                        }
+                        impl_index
+                            .entry(type_name)
+                            .or_default()
+                            .push((module_source.clone(), item_idx));
+                    }
+                    Item::Trait(trait_decl) => {
+                        decl_index
+                            .entry(trait_decl.name.clone())
+                            .or_insert((module_source.clone(), item_idx));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Arc::new(Self {
+            impl_index,
+            decl_index,
+            blanket_impl_index,
+        })
+    }
+}
+
+/// Mutable trait resolution context scoped to the current resolution site.
+///
+/// Groups all state that changes when entering/leaving generic scopes
+/// (impl blocks, trait method lookups, etc). By cloning this struct before
+/// entering a scope and restoring it afterward, we avoid scattered save/restore
+/// patterns and make the scope boundary explicit.
+#[derive(Clone, Default)]
+pub(super) struct TraitContext {
+    /// Type parameters currently in scope (name → (index, `TypeId`)).
+    /// Set when resolving generic structs, functions, or impl blocks.
+    pub(super) type_params: IndexMap<String, (u32, TypeId)>,
+    /// Trait bounds on type parameters in scope (name → full bounds with assoc types).
+    /// Used for resolving trait methods on type params (e.g., `T.cmp()` when T: Ord).
+    pub(super) type_param_bounds: IndexMap<String, Vec<ast::TraitBound>>,
+    /// Associated type bindings in scope (`Self::Name` → resolved type).
+    /// Set when resolving trait implementations.
+    pub(super) assoc_type_bindings: IndexMap<String, TypeId>,
+    /// Current `Self` type in scope (the type being implemented in an impl block).
+    pub(super) self_type: Option<TypeId>,
+}
+
+/// Extract a type name from an AST type without needing a Resolver instance.
+fn get_type_name_static(ty: &ast::Type) -> String {
+    match ty {
+        ast::Type::Named(named) => named.name.clone(),
+        ast::Type::Generic(generic) => generic.name.clone(),
+        ast::Type::Reference(_) => "&".to_string(),
+        ast::Type::MutReference(_) => "&mut".to_string(),
+        _ => "Unknown".to_string(),
+    }
+}

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -238,8 +238,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 {
                     // Self::ns.name → type_param_name::ns.name
                     // Look in current_type_param_bounds[type_param_name] for direct binding
-                    if let Some(param_bounds) =
-                        self.trait_ctx.type_param_bounds.get(type_param_name).cloned()
+                    if let Some(param_bounds) = self
+                        .trait_ctx
+                        .type_param_bounds
+                        .get(type_param_name)
+                        .cloned()
                     {
                         for pb in &param_bounds {
                             for ab in &pb.assoc_types {
@@ -373,7 +376,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             atb,
                         )
                     });
-                    self.trait_ctx.assoc_type_bindings
+                    self.trait_ctx
+                        .assoc_type_bindings
                         .insert(assoc_decl.name.clone(), projection);
                 }
 
@@ -388,10 +392,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         .type_table
                         .borrow_mut()
                         .make_type_param(param.name.clone(), index as u32);
-                    self.trait_ctx.type_params
+                    self.trait_ctx
+                        .type_params
                         .insert(param.name.clone(), (index as u32, type_id));
                     if !param.bounds.is_empty() {
-                        self.trait_ctx.type_param_bounds
+                        self.trait_ctx
+                            .type_param_bounds
                             .insert(param.name.clone(), param.bounds.clone());
                     }
                 }
@@ -631,14 +637,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
             // → set current_type_params["T"] = (0, u8_typeid)
             for (i, tp_name) in info.impl_ty_param_names.iter().enumerate() {
                 if let Some(&concrete_arg) = concrete_type_args.get(i) {
-                    self.trait_ctx.type_params
+                    self.trait_ctx
+                        .type_params
                         .insert(tp_name.clone(), (i as u32, concrete_arg));
                 }
             }
             // Add bounds from type param declarations
             for param in &info.type_params {
                 if !param.bounds.is_empty() {
-                    self.trait_ctx.type_param_bounds
+                    self.trait_ctx
+                        .type_param_bounds
                         .entry(param.name.clone())
                         .or_insert_with(Vec::new)
                         .extend(param.bounds.clone());
@@ -706,9 +714,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
             // Bind the blanket type param to the concrete type
             // For `impl<I: Iterator> IntoIterator for I` with StrUtf8ByteIter:
             // → set current_type_params["I"] = (0, StrUtf8ByteIter_typeid)
-            self.trait_ctx.type_params
+            self.trait_ctx
+                .type_params
                 .insert(info.blanket_param_name.clone(), (0, concrete_type_id));
-            self.trait_ctx.type_param_bounds
+            self.trait_ctx
+                .type_param_bounds
                 .insert(info.blanket_param_name.clone(), info.blanket_param_bounds);
 
             // Resolve and register each associated type

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1,0 +1,841 @@
+//! Trait query functions: checking trait implementations, bounds validation,
+//! and associated type resolution.
+
+use crate::hashmap::{IndexMap, IndexSet};
+
+use crate::ast::{self, Item, Type};
+use crate::compiler_host::CompilerHost;
+use crate::name::ModuleSource;
+use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
+use crate::token::Span;
+
+use super::Resolver;
+use super::types::{MethodInfo, TypeError};
+
+impl<H: CompilerHost> Resolver<'_, H> {
+    /// Find a trait declaration by name across all modules.
+    /// Returns the trait's methods (cloned) if found.
+    pub(super) fn find_trait_decl_methods(&self, trait_name: &str) -> Option<Vec<ast::Function>> {
+        // Fast O(1) lookup via pre-built index instead of scanning all modules.
+        if let Some((module_src, item_idx)) = self.trait_env.decl_index.get(trait_name) {
+            let module = &self.loaded_modules[module_src];
+            if let Item::Trait(trait_decl) = &module.items[*item_idx] {
+                return Some(trait_decl.methods.clone());
+            }
+        }
+        // Check current module items (not covered by the index).
+        for item in &self.current_module_items {
+            if let Item::Trait(trait_decl) = item
+                && trait_decl.name == trait_name
+            {
+                return Some(trait_decl.methods.clone());
+            }
+        }
+        None
+    }
+
+    /// Check if a type implements a specific trait (for trait bound checking)
+    pub(super) fn type_implements_trait(&self, type_id: TypeId, trait_name: &str) -> bool {
+        let resolved = self.type_table.borrow().get(type_id).clone();
+
+        // Type parameters satisfy bounds declared on them (e.g., T: Describable
+        // means T implements Describable within the scope of that declaration)
+        if let ResolvedType::TypeParam { name, .. } = &resolved {
+            if let Some(bounds) = self.trait_ctx.type_param_bounds.get(name) {
+                return bounds.iter().any(|b| b.name == trait_name);
+            }
+            return false;
+        }
+
+        // Primitives have built-in implementations for certain traits
+        if let ResolvedType::Primitive(prim) = &resolved {
+            match trait_name {
+                // All primitives implement Eq and Ord
+                "Eq" | "Ord" => return true,
+                // Numeric primitives implement arithmetic traits
+                "Add" | "Sub" | "Mul" | "Div" | "Rem"
+                    if !matches!(prim, PrimitiveType::Bool | PrimitiveType::Char) =>
+                {
+                    return true;
+                }
+                _ => {}
+            }
+            // For other traits, check the type name
+            let type_name = format!("{prim:?}").to_lowercase();
+            return self.find_trait_impl_for_type(&type_name, trait_name);
+        }
+
+        // All enums automatically implement Eq and Ord
+        if let ResolvedType::Enum { .. } = &resolved {
+            match trait_name {
+                "Eq" | "Ord" => return true,
+                _ => {}
+            }
+        }
+
+        // Get the type name and type args for looking up implementations
+        let (type_name, type_args) = match &resolved {
+            ResolvedType::Struct { name, .. }
+            | ResolvedType::Enum { name, .. }
+            | ResolvedType::Variant { name, .. } => (name.clone(), None),
+            ResolvedType::GenericInstance {
+                name, type_args, ..
+            } => (
+                name.clone(),
+                if type_args.is_empty() {
+                    None
+                } else {
+                    Some(type_args.clone())
+                },
+            ),
+            ResolvedType::Ref(inner) => {
+                // Check for a specific impl Trait for &T first (e.g., impl Inspect for &T)
+                let inner_id = *inner;
+                if self.find_trait_impl_for_type_with_args("&", trait_name, Some(&[inner_id])) {
+                    return true;
+                }
+                return self.type_implements_trait(inner_id, trait_name);
+            }
+            ResolvedType::MutRef(inner) => {
+                let inner_id = *inner;
+                if self.find_trait_impl_for_type_with_args("&mut", trait_name, Some(&[inner_id])) {
+                    return true;
+                }
+                return self.type_implements_trait(inner_id, trait_name);
+            }
+            ResolvedType::Tuple(elems) => {
+                // Tuples implement a trait when all elements implement it
+                let elems = elems.clone();
+                return elems
+                    .iter()
+                    .all(|e| self.type_implements_trait(*e, trait_name));
+            }
+            ResolvedType::AssocTypeProjection { bounds, .. } => {
+                // An associated type projection T::Assoc implements a trait if
+                // the trait declaration for Assoc declares that bound.
+                // e.g., I::Iter: Iterator when IntoIterator::Iter: Iterator
+                return bounds.iter().any(|b| b == trait_name);
+            }
+            ResolvedType::Newtype { base_type, .. } => {
+                // Newtypes inherit trait implementations from their base type.
+                let base_id = *base_type;
+                return self.type_implements_trait(base_id, trait_name);
+            }
+            _ => return false,
+        };
+
+        self.find_trait_impl_for_type_with_args(&type_name, trait_name, type_args.as_deref())
+    }
+
+    /// Helper to check if there's an impl block for a type implementing a trait
+    pub(super) fn find_trait_impl_for_type(&self, type_name: &str, trait_name: &str) -> bool {
+        self.find_trait_impl_for_type_with_args(type_name, trait_name, None)
+    }
+
+    /// Check if there's a trait impl for a type, with optional type args for bounds checking.
+    /// For `impl<T: Eq> Eq for Array<T>`, when checking `Array<Foo>`, passes `[Foo]` as `type_args`.
+    pub(super) fn find_trait_impl_for_type_with_args(
+        &self,
+        type_name: &str,
+        trait_name: &str,
+        type_args: Option<&[TypeId]>,
+    ) -> bool {
+        // Use pre-built index for O(1) lookup by type name.
+        if let Some(entries) = self.trait_env.impl_index.get(type_name) {
+            for (module_src, item_idx) in entries {
+                let module = &self.loaded_modules[module_src];
+                if let Item::Impl(impl_block) = &module.items[*item_idx]
+                    && let Some(trait_type) = &impl_block.trait_type
+                {
+                    let impl_trait_name = self.get_type_name(trait_type);
+                    if impl_trait_name == trait_name
+                        && self.check_impl_block_bounds(impl_block, type_args)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Also check current module items (not covered by the index).
+        for item in &self.current_module_items {
+            if let Item::Impl(impl_block) = item
+                && let Some(trait_type) = &impl_block.trait_type
+                && Self::get_type_name_static(&impl_block.ty) == type_name
+            {
+                let impl_trait_name = self.get_type_name(trait_type);
+                if impl_trait_name == trait_name
+                    && self.check_impl_block_bounds(impl_block, type_args)
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the
+        // concrete type satisfies the bound.
+        for (module_src, item_idx) in &self.trait_env.blanket_impl_index {
+            let module = &self.loaded_modules[module_src];
+            if let Item::Impl(impl_block) = &module.items[*item_idx]
+                && let Some(trait_type) = &impl_block.trait_type
+            {
+                let impl_trait_name = self.get_type_name(trait_type);
+                if impl_trait_name == trait_name {
+                    let impl_type_name = Self::get_type_name_static(&impl_block.ty);
+                    let matching_param = impl_block
+                        .type_params
+                        .iter()
+                        .find(|tp| tp.name == impl_type_name);
+                    if let Some(param) = matching_param {
+                        let bounds_satisfied = param
+                            .bounds
+                            .iter()
+                            .all(|bound| self.find_trait_impl_for_type(type_name, &bound.name));
+                        if bounds_satisfied {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Compute `assoc_type_bindings` for an `AssocTypeProjection` by resolving `Self::X`
+    /// references in the trait bound's associated type constraints.
+    ///
+    /// Example: `IntoIterator::Iter` has bound `Iterator<Item = Self::Item>`.
+    /// With `I: IntoIterator<Item = u8>` and `self_type = I`, `Self::Item = I::Item = u8`.
+    /// Result: `[("Item", u8_typeid)]`, stored in the `I::Iter` projection.
+    ///
+    /// This enables `I::Iter::Item` to resolve to `u8` when `Iterator::next` is called.
+    fn compute_assoc_type_bindings_from_trait_bounds(
+        &mut self,
+        self_type_id: TypeId,
+        self_type_param_name: Option<&str>,
+        assoc_bounds: &[crate::ast::TraitBound],
+    ) -> Vec<(String, TypeId)> {
+        let mut bindings = Vec::new();
+        let Some(type_param_name) = self_type_param_name else {
+            // Also handle AssocTypeProjection self_type: propagate bindings from its bindings
+            let resolved = self.type_table.borrow().get(self_type_id).clone();
+            if let ResolvedType::AssocTypeProjection {
+                assoc_type_bindings,
+                ..
+            } = resolved
+            {
+                // Reuse existing bindings from the source projection
+                return assoc_type_bindings;
+            }
+            return bindings;
+        };
+        // For each bound, check its associated type constraints and resolve Self::X
+        for bound in assoc_bounds {
+            for assoc in &bound.assoc_types.clone() {
+                if let crate::ast::Type::NamespacedGeneric(ns) = &assoc.ty
+                    && ns.namespace == "Self"
+                {
+                    // Self::ns.name → type_param_name::ns.name
+                    // Look in current_type_param_bounds[type_param_name] for direct binding
+                    if let Some(param_bounds) =
+                        self.trait_ctx.type_param_bounds.get(type_param_name).cloned()
+                    {
+                        for pb in &param_bounds {
+                            for ab in &pb.assoc_types {
+                                if ab.name == ns.name {
+                                    let resolved_ty = self.resolve_type(&ab.ty.clone());
+                                    bindings.push((assoc.name.clone(), resolved_ty));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        bindings
+    }
+
+    /// Find a method in the trait declarations given by the bound names.
+    /// For example, if T: Ord, look up the "cmp" method in the Ord trait declaration.
+    /// Returns (`trait_name`, `MethodInfo`) with the method's return type, `self_kind`, and `param_types`,
+    /// where Self is substituted with the `TypeParam`'s type.
+    pub(super) fn find_method_in_trait_bounds(
+        &mut self,
+        bounds: &[String],
+        method_name: &str,
+        self_type_id: TypeId,
+    ) -> Option<(String, MethodInfo)> {
+        // Collect trait declarations from all modules
+        for trait_name in bounds {
+            // Search all loaded modules for the trait declaration
+            let mut found_trait_method: Option<(
+                ast::Function,
+                Vec<ast::AssociatedTypeDecl>,
+                ModuleSource,
+            )> = None;
+
+            for (module_src, module) in self.loaded_modules {
+                for item in &module.items {
+                    if let Item::Trait(trait_decl) = item
+                        && trait_decl.name == *trait_name
+                    {
+                        for method in &trait_decl.methods {
+                            if method.name == method_name {
+                                found_trait_method = Some((
+                                    method.clone(),
+                                    trait_decl.associated_types.clone(),
+                                    module_src.clone(),
+                                ));
+                                break;
+                            }
+                        }
+                    }
+                }
+                if found_trait_method.is_some() {
+                    break;
+                }
+            }
+
+            // Also check current module items
+            if found_trait_method.is_none() {
+                for item in &self.current_module_items {
+                    if let Item::Trait(trait_decl) = item
+                        && trait_decl.name == *trait_name
+                    {
+                        for method in &trait_decl.methods {
+                            if method.name == method_name {
+                                found_trait_method = Some((
+                                    method.clone(),
+                                    trait_decl.associated_types.clone(),
+                                    self.current_module_source.clone(),
+                                ));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some((method, trait_assoc_types, _module_source)) = found_trait_method {
+                // Save the entire trait context; we'll modify self_type, assoc_type_bindings,
+                // type_params, and type_param_bounds during this resolution scope.
+                let saved_trait_ctx = self.trait_ctx.clone();
+                self.trait_ctx.self_type = Some(self_type_id);
+                self.trait_ctx.assoc_type_bindings.clear();
+
+                // Set up associated type bindings as projections so that
+                // Self::AssocType resolves to AssocTypeProjection(self_type_id, "AssocType").
+                // We also compute assoc_type_bindings to propagate concrete types through
+                // associated type chains.
+                // Determine the TypeParam name for Self, if self_type is a TypeParam.
+                let self_type_param_name = {
+                    let resolved = self.type_table.borrow().get(self_type_id).clone();
+                    if let ResolvedType::TypeParam { name, .. } = resolved {
+                        Some(name)
+                    } else {
+                        None
+                    }
+                };
+                for assoc_decl in &trait_assoc_types {
+                    // Check if self_type has a direct assoc_type_binding for this name.
+                    // This handles the case: self_type = I::Iter which has ("Item", u8_typeid).
+                    let directly_bound = {
+                        let resolved = self.type_table.borrow().get(self_type_id).clone();
+                        if let ResolvedType::AssocTypeProjection {
+                            assoc_type_bindings,
+                            ..
+                        } = resolved
+                        {
+                            assoc_type_bindings
+                                .iter()
+                                .find(|(name, _)| *name == assoc_decl.name)
+                                .map(|(_, type_id)| *type_id)
+                        } else {
+                            None
+                        }
+                    };
+                    let projection = directly_bound.unwrap_or_else(|| {
+                        let bound_names: Vec<String> =
+                            assoc_decl.bounds.iter().map(|b| b.name.clone()).collect();
+                        // Compute assoc_type_bindings by resolving Self::X references in the
+                        // assoc type's bounds. e.g., Iterator<Item = Self::Item> with Self = I
+                        // and I: IntoIterator<Item = u8> gives [("Item", u8)].
+                        let atb = self.compute_assoc_type_bindings_from_trait_bounds(
+                            self_type_id,
+                            self_type_param_name.as_deref(),
+                            &assoc_decl.bounds,
+                        );
+                        self.type_table.borrow_mut().make_assoc_type_projection(
+                            self_type_id,
+                            assoc_decl.name.clone(),
+                            bound_names,
+                            atb,
+                        )
+                    });
+                    self.trait_ctx.assoc_type_bindings
+                        .insert(assoc_decl.name.clone(), projection);
+                }
+
+                // Register the method's own type parameters so that they resolve to
+                // TypeParam{index: N} instead of UNKNOWN. This is needed for generic methods
+                // like `fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, ...>`
+                // where `T` must be a proper TypeParam to allow substitution at the call site.
+                // We use index 0, 1, ... because find_method_in_trait_bounds is only called
+                // for TypeParam/AssocTypeProjection receivers, where impl_offset = 0.
+                for (index, param) in method.type_params.iter().enumerate() {
+                    let type_id = self
+                        .type_table
+                        .borrow_mut()
+                        .make_type_param(param.name.clone(), index as u32);
+                    self.trait_ctx.type_params
+                        .insert(param.name.clone(), (index as u32, type_id));
+                    if !param.bounds.is_empty() {
+                        self.trait_ctx.type_param_bounds
+                            .insert(param.name.clone(), param.bounds.clone());
+                    }
+                }
+
+                let return_type = method
+                    .return_type
+                    .as_ref()
+                    .map(|t| self.resolve_type(t))
+                    .unwrap_or(TypeTable::UNIT);
+                let self_kind = method
+                    .params
+                    .first()
+                    .map(|p| p.self_kind)
+                    .unwrap_or(ast::SelfKind::None);
+                let param_types = self.extract_param_types(&method.params);
+                let param_is_mut: Vec<bool> = method
+                    .params
+                    .iter()
+                    .filter(|p| p.name != "self")
+                    .map(|p| p.is_mut)
+                    .collect();
+
+                self.trait_ctx = saved_trait_ctx;
+
+                return Some((
+                    trait_name.clone(),
+                    MethodInfo {
+                        return_type,
+                        self_kind,
+                        param_types,
+                        param_is_mut,
+                        inherited_from_base: None,
+                        cm_name: None,
+                    },
+                ));
+            }
+        }
+
+        None
+    }
+
+    /// Check if an impl block's type parameter bounds are satisfied by the given type args.
+    /// For `impl<T: Ord> Array<T>`, checks that the concrete type substituted for T implements Ord.
+    pub(super) fn check_impl_block_bounds(
+        &self,
+        impl_block: &ast::ImplBlock,
+        type_args: Option<&[TypeId]>,
+    ) -> bool {
+        // No type params with bounds → always OK
+        if impl_block.type_params.iter().all(|p| p.bounds.is_empty()) {
+            return true;
+        }
+
+        let Some(type_args) = type_args else {
+            // No type args to check (non-generic receiver) → skip bounds check
+            return true;
+        };
+
+        // Build name → bounds map from impl block type params (trait names only)
+        let bounds_map: IndexMap<&str, Vec<String>> = impl_block
+            .type_params
+            .iter()
+            .filter(|p| !p.bounds.is_empty())
+            .map(|p| {
+                (
+                    p.name.as_str(),
+                    p.bounds.iter().map(|b| b.name.clone()).collect(),
+                )
+            })
+            .collect();
+
+        // Match type params to receiver type args via generic type arg positions
+        let inner_type_name: Option<&str> =
+            if let ast::Type::Reference(boxed) | ast::Type::MutReference(boxed) = &impl_block.ty {
+                if let ast::Type::Named(inner) = boxed.as_ref() {
+                    Some(&inner.name)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+        if let ast::Type::Generic(generic) = &impl_block.ty {
+            for (i, arg) in generic.args.iter().enumerate() {
+                if let ast::Type::Named(named) = arg
+                    && let Some(bounds) = bounds_map.get(named.name.as_str())
+                    && let Some(&type_arg) = type_args.get(i)
+                {
+                    // If the type arg is itself a type parameter (e.g., T in a generic context),
+                    // skip the bounds check. Within a bounded impl block, type params are assumed
+                    // to satisfy bounds; concrete types are checked at call sites.
+                    if matches!(
+                        self.type_table.borrow().get(type_arg),
+                        ResolvedType::TypeParam { .. }
+                    ) {
+                        continue;
+                    }
+                    for bound in bounds {
+                        if !self.type_implements_trait(type_arg, bound) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        } else if let Some(inner_name) = inner_type_name {
+            // Handle `impl<T: Bound> Trait for &T` / `impl<T: Bound> Trait for &mut T`:
+            // type_args[0] is the inner type T.
+            if let Some(bounds) = bounds_map.get(inner_name)
+                && let Some(&type_arg) = type_args.first()
+                && !matches!(
+                    self.type_table.borrow().get(type_arg),
+                    ResolvedType::TypeParam { .. }
+                )
+            {
+                for bound in bounds {
+                    if !self.type_implements_trait(type_arg, bound) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Check trait bounds on a generic function's type arguments.
+    /// Looks up the function's type params and validates bounds against the provided type args.
+    pub(super) fn check_function_type_arg_bounds(
+        &mut self,
+        callee_module: &ModuleSource,
+        func_name: &str,
+        type_args: &[TypeId],
+        span: Span,
+    ) {
+        // Look up function's type params from AST
+        let type_params = self.lookup_function_type_params(callee_module, func_name);
+        for (i, param) in type_params.iter().enumerate() {
+            if let Some(&type_arg) = type_args.get(i) {
+                for bound in &param.bounds {
+                    if self.type_implements_trait(type_arg, &bound.name) {
+                        // Register associated type resolutions so the monomorphizer can
+                        // substitute e.g. I::Iter → ArrayIter<u8> when I = Array<u8>.
+                        self.register_assoc_types_for_concrete_type_and_trait(
+                            type_arg,
+                            &bound.name.clone(),
+                        );
+                    } else {
+                        let type_name = self.type_id_to_string(type_arg);
+                        let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
+                            type_name,
+                            trait_name: bound.name.clone(),
+                            param_name: param.name.clone(),
+                            span,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Register associated type resolutions for a concrete type instantiating a trait.
+    /// For example, when `Array<u8>` implements `IntoIterator`, registers:
+    /// - (Array<u8>, "Item") → u8
+    /// - (Array<u8>, "Iter") → `ArrayIter`<u8>
+    /// This enables the monomorphizer to resolve `I::Iter` → `ArrayIter<u8>` when `I = Array<u8>`.
+    pub(super) fn register_assoc_types_for_concrete_type_and_trait(
+        &mut self,
+        concrete_type_id: TypeId,
+        trait_name: &str,
+    ) {
+        // Get the base type name and concrete type args for impl block lookup.
+        // For newtypes, follow the chain to the underlying type to find the trait impl,
+        // but registration (below) still uses concrete_type_id so the monomorphizer can
+        // resolve e.g. `MyBytes::Iter` when `MyBytes` is a newtype over `Array<u8>`.
+        let (type_name, concrete_type_args) = {
+            let tt = self.type_table.borrow();
+            let effective_id = tt.get_ultimate_base_type(concrete_type_id);
+            match tt.get(effective_id).clone() {
+                ResolvedType::GenericInstance {
+                    name, type_args, ..
+                } => (name, type_args),
+                ResolvedType::Struct { name, .. } => (name, vec![]),
+                ResolvedType::BuiltinArray(elem) => ("Array".to_string(), vec![elem]),
+                _ => return,
+            }
+        };
+
+        // Collect matching impl block info (avoids borrow conflicts during resolution)
+        struct ImplInfo {
+            type_params: Vec<ast::GenericParam>,
+            impl_ty_param_names: Vec<String>,
+            assoc_types: Vec<ast::AssociatedTypeBinding>,
+        }
+        let impl_infos: Vec<ImplInfo> = {
+            let mut result = vec![];
+            if let Some(entries) = self.trait_env.impl_index.get(&type_name) {
+                let entries = entries.clone();
+                for (module_src, item_idx) in entries {
+                    let module = &self.loaded_modules[&module_src];
+                    if let Item::Impl(impl_block) = &module.items[item_idx]
+                        && let Some(trait_type) = &impl_block.trait_type
+                        && self.get_type_name(trait_type) == trait_name
+                        && !impl_block.associated_types.is_empty()
+                    {
+                        let impl_ty_param_names: Vec<String> = match &impl_block.ty {
+                            ast::Type::Generic(g) => g
+                                .args
+                                .iter()
+                                .filter_map(|arg| {
+                                    if let ast::Type::Named(named) = arg {
+                                        Some(named.name.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect(),
+                            _ => vec![],
+                        };
+                        result.push(ImplInfo {
+                            type_params: impl_block.type_params.clone(),
+                            impl_ty_param_names,
+                            assoc_types: impl_block.associated_types.clone(),
+                        });
+                    }
+                }
+            }
+            result
+        };
+
+        for info in impl_infos {
+            let saved_trait_ctx = self.trait_ctx.clone();
+
+            // Bind impl type params to concrete type args.
+            // For `impl<T> IntoIterator for Array<T>` with Array<u8>:
+            // impl_ty_param_names = ["T"], concrete_type_args = [u8_typeid]
+            // → set current_type_params["T"] = (0, u8_typeid)
+            for (i, tp_name) in info.impl_ty_param_names.iter().enumerate() {
+                if let Some(&concrete_arg) = concrete_type_args.get(i) {
+                    self.trait_ctx.type_params
+                        .insert(tp_name.clone(), (i as u32, concrete_arg));
+                }
+            }
+            // Add bounds from type param declarations
+            for param in &info.type_params {
+                if !param.bounds.is_empty() {
+                    self.trait_ctx.type_param_bounds
+                        .entry(param.name.clone())
+                        .or_insert_with(Vec::new)
+                        .extend(param.bounds.clone());
+                }
+            }
+
+            // Resolve and register each associated type in this substituted context
+            for binding in &info.assoc_types {
+                let resolved_id = self.resolve_type(&binding.ty);
+                if !self.type_table.borrow().contains_type_param(resolved_id) {
+                    self.type_table.borrow_mut().register_assoc_type_resolution(
+                        concrete_type_id,
+                        binding.name.clone(),
+                        resolved_id,
+                    );
+                }
+            }
+
+            self.trait_ctx = saved_trait_ctx;
+        }
+
+        // Also check blanket impls: `impl<I: Trait> OtherTrait for I`.
+        // For example, `impl<I: Iterator> IntoIterator for I` applies to StrUtf8ByteIter.
+        struct BlanketImplInfo {
+            blanket_param_name: String,
+            blanket_param_bounds: Vec<ast::TraitBound>,
+            assoc_types: Vec<ast::AssociatedTypeBinding>,
+        }
+        let blanket_infos: Vec<BlanketImplInfo> = {
+            let mut result = vec![];
+            for (module_src, item_idx) in &self.trait_env.blanket_impl_index {
+                let module = &self.loaded_modules[module_src];
+                if let Item::Impl(impl_block) = &module.items[*item_idx]
+                    && let Some(trait_type) = &impl_block.trait_type
+                    && self.get_type_name(trait_type) == trait_name
+                    && !impl_block.associated_types.is_empty()
+                {
+                    let impl_type_name = Self::get_type_name_static(&impl_block.ty);
+                    if let Some(blanket_param) = impl_block
+                        .type_params
+                        .iter()
+                        .find(|tp| tp.name == impl_type_name && !tp.bounds.is_empty())
+                    {
+                        // Check if the concrete type satisfies the blanket param's bounds
+                        let bounds_ok = blanket_param
+                            .bounds
+                            .iter()
+                            .all(|bound| self.type_implements_trait(concrete_type_id, &bound.name));
+                        if bounds_ok {
+                            result.push(BlanketImplInfo {
+                                blanket_param_name: blanket_param.name.clone(),
+                                blanket_param_bounds: blanket_param.bounds.clone(),
+                                assoc_types: impl_block.associated_types.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            result
+        };
+
+        for info in blanket_infos {
+            let saved_trait_ctx = self.trait_ctx.clone();
+
+            // Bind the blanket type param to the concrete type
+            // For `impl<I: Iterator> IntoIterator for I` with StrUtf8ByteIter:
+            // → set current_type_params["I"] = (0, StrUtf8ByteIter_typeid)
+            self.trait_ctx.type_params
+                .insert(info.blanket_param_name.clone(), (0, concrete_type_id));
+            self.trait_ctx.type_param_bounds
+                .insert(info.blanket_param_name.clone(), info.blanket_param_bounds);
+
+            // Resolve and register each associated type
+            for binding in &info.assoc_types {
+                let resolved_id = self.resolve_type(&binding.ty);
+                if !self.type_table.borrow().contains_type_param(resolved_id) {
+                    self.type_table.borrow_mut().register_assoc_type_resolution(
+                        concrete_type_id,
+                        binding.name.clone(),
+                        resolved_id,
+                    );
+                }
+            }
+
+            self.trait_ctx = saved_trait_ctx;
+        }
+    }
+
+    /// Build a mapping from type parameter names to concrete type IDs.
+    /// For `impl Trait for Container<T>` with concrete type `Container<i32>`,
+    /// returns `{"T" -> i32's TypeId}`.
+    ///
+    /// When `declared_type_params` is non-empty, only names in that set are
+    /// treated as type parameters. This prevents concrete types (e.g., `String` in
+    /// `impl Trait for Map<String, V>`) from being incorrectly mapped.
+    /// When empty, all `Named` types are assumed to be type parameters (legacy behavior).
+    pub(super) fn build_type_param_mapping(
+        impl_ty: &Type,
+        concrete_type_args: &[TypeId],
+        declared_type_params: &IndexSet<String>,
+    ) -> IndexMap<String, TypeId> {
+        let mut mapping = IndexMap::default();
+
+        // Extract type parameter names from impl_ty, tracking positions
+        // Position tracking is needed to map type params to the correct concrete arg
+        if let Type::Generic(g) = impl_ty {
+            for (concrete_idx, arg) in g.args.iter().enumerate() {
+                if let Type::Named(n) = arg {
+                    let is_type_param = if declared_type_params.is_empty() {
+                        true // legacy: treat all Named as type params
+                    } else {
+                        declared_type_params.contains(&n.name)
+                    };
+                    if is_type_param && let Some(&type_id) = concrete_type_args.get(concrete_idx) {
+                        mapping.insert(n.name.clone(), type_id);
+                    }
+                }
+            }
+        }
+
+        mapping
+    }
+
+    /// Check that concrete type args at non-type-parameter positions match the impl type.
+    /// e.g., `impl KeyValueLiteral for TreeMap<String, V>` with `TreeMap<i32, String>` should fail
+    /// because position 0 expects String but got i32.
+    pub(super) fn verify_impl_type_compatibility(
+        impl_ty: &Type,
+        concrete_type_args: &[TypeId],
+        declared_type_params: &IndexSet<String>,
+        type_table: &std::cell::RefCell<TypeTable>,
+    ) -> bool {
+        if declared_type_params.is_empty() {
+            return true; // No filtering available, assume compatible
+        }
+        let Type::Generic(g) = impl_ty else {
+            return true;
+        };
+        let tt = type_table.borrow();
+        for (i, arg) in g.args.iter().enumerate() {
+            let Some(&concrete_id) = concrete_type_args.get(i) else {
+                continue;
+            };
+            if !Self::impl_type_matches_concrete(arg, concrete_id, declared_type_params, &tt) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Recursively check whether an impl type argument matches a concrete type ID.
+    /// - `Type::Named` that is a declared type param → always matches (free type param)
+    /// - `Type::Named` not in type params → concrete name must equal `type_table.type_name()`
+    /// - `Type::Generic` → concrete must be a `GenericInstance` with same outer name; inner args checked recursively
+    /// - Other types → not validated (return true)
+    pub(super) fn impl_type_matches_concrete(
+        impl_ty: &Type,
+        concrete_id: TypeId,
+        declared_type_params: &IndexSet<String>,
+        type_table: &TypeTable,
+    ) -> bool {
+        match impl_ty {
+            Type::Named(n) => {
+                if declared_type_params.contains(&n.name) {
+                    true // free type param — matches anything
+                } else {
+                    type_table.type_name(concrete_id) == n.name
+                }
+            }
+            Type::Generic(g) => {
+                let resolved = type_table.get(concrete_id).clone();
+                match resolved {
+                    ResolvedType::GenericInstance {
+                        name, type_args, ..
+                    } => {
+                        if name != g.name {
+                            return false;
+                        }
+                        for (i, inner) in g.args.iter().enumerate() {
+                            let Some(&inner_id) = type_args.get(i) else {
+                                return false;
+                            };
+                            if !Self::impl_type_matches_concrete(
+                                inner,
+                                inner_id,
+                                declared_type_params,
+                                type_table,
+                            ) {
+                                return false;
+                            }
+                        }
+                        true
+                    }
+                    _ => false,
+                }
+            }
+            _ => true,
+        }
+    }
+}

--- a/wado-compiler/src/resolver/type_resolution.rs
+++ b/wado-compiler/src/resolver/type_resolution.rs
@@ -55,7 +55,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Handle Self::AssociatedType
         if namespaced.namespace.as_str() == "Self" {
             // Look up the associated type binding
-            if let Some(&type_id) = self.current_associated_type_bindings.get(&namespaced.name) {
+            if let Some(&type_id) = self.trait_ctx.assoc_type_bindings.get(&namespaced.name) {
                 return type_id;
             }
             // If not found, it's an unknown associated type
@@ -67,7 +67,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // Handle T::AssociatedType where T is a type parameter in scope
-        if let Some(&(_, param_type_id)) = self.current_type_params.get(&namespaced.namespace) {
+        if let Some(&(_, param_type_id)) = self.trait_ctx.type_params.get(&namespaced.namespace) {
             // If the param is bound to a concrete type (not a TypeParam), look up the assoc
             // type from the TypeTable directly. This handles cases like blanket impl resolution
             // where we temporarily bind e.g. I = StrUtf8ByteIter (concrete struct), and
@@ -143,7 +143,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     pub(super) fn resolve_named_type(&mut self, name: &str, _span: Span) -> TypeId {
         // Handle `Self` type reference in impl blocks
         if name == "Self" {
-            if let Some(self_type) = self.current_self_type {
+            if let Some(self_type) = self.trait_ctx.self_type {
                 return self_type;
             }
             // Self used outside of impl block - return Unknown
@@ -151,7 +151,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // First check if it's a type parameter in scope
-        if let Some(&(_, type_id)) = self.current_type_params.get(name) {
+        if let Some(&(_, type_id)) = self.trait_ctx.type_params.get(name) {
             return type_id;
         }
 
@@ -367,7 +367,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         param_name: &str,
         assoc_name: &str,
     ) -> Option<TypeId> {
-        let bounds = self.current_type_param_bounds.get(param_name)?.clone();
+        let bounds = self.trait_ctx.type_param_bounds.get(param_name)?.clone();
         for bound in &bounds {
             for assoc in &bound.assoc_types {
                 if assoc.name == assoc_name {

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -679,18 +679,6 @@ pub(super) enum VarRef {
     },
 }
 
-/// Pre-built index: type name → list of (`ModuleSource`, item index) for trait impl blocks.
-/// Built once from all loaded modules to avoid O(all items) scans per method call.
-pub(super) type TraitImplIndex = IndexMap<String, Vec<(ModuleSource, usize)>>;
-
-/// Pre-built index: trait name → (`ModuleSource`, item index) for trait declarations.
-pub(super) type TraitDeclIndex = IndexMap<String, (ModuleSource, usize)>;
-
-/// Pre-built list of blanket trait impls: `impl<T: Trait> OtherTrait for T`.
-/// These are impl blocks where the impl type is a free type parameter with trait bounds.
-/// Stored separately because they can't be indexed by concrete type name.
-pub(super) type BlanketTraitImplIndex = Vec<(ModuleSource, usize)>;
-
 /// Result of finding a trait method for a type via `find_trait_method_for_type`.
 pub(super) struct TraitMethodMatch {
     pub(super) trait_name: String,


### PR DESCRIPTION
## Summary

This PR refactors the trait resolution system to improve code organization and maintainability by extracting trait-related state and logic into dedicated modules. The changes consolidate scattered trait resolution code and create a clearer separation of concerns between global trait knowledge and mutable resolution context.

## Key Changes

- **New `trait_env.rs` module**: Introduces `TraitEnv` struct to encapsulate global, immutable trait knowledge:
  - `impl_index`: Maps type names to impl blocks implementing traits for that type
  - `decl_index`: Maps trait names to trait declarations
  - `blanket_impl_index`: Stores blanket impl blocks (`impl<T: Bound> Trait for T`)
  - Replaces scattered `trait_impl_index`, `trait_decl_index`, and `blanket_trait_impl_index` fields

- **New `trait_query.rs` module**: Extracts trait query functions from `method_lookup.rs`:
  - `find_trait_decl_methods()`: Locate trait declarations by name
  - `type_implements_trait()`: Check if a type implements a specific trait
  - `find_trait_impl_for_type()` and variants: Trait implementation lookup
  - `find_method_in_trait_bounds()`: Resolve methods on type parameters with trait bounds
  - `compute_assoc_type_bindings_from_trait_bounds()`: Associated type resolution

- **New `TraitContext` struct**: Groups mutable trait resolution state:
  - `type_params`: Type parameters currently in scope
  - `type_param_bounds`: Trait bounds on type parameters
  - `assoc_type_bindings`: Associated type bindings for Self::* resolution
  - `self_type`: Current Self type during trait method resolution
  - Replaces `current_type_params` and `current_type_param_bounds` fields
  - Enables atomic save/restore of entire trait context via `clone()`

- **Updated `method_lookup.rs`**: 
  - Removes ~700 lines of trait query code (moved to `trait_query.rs`)
  - Updates all trait index accesses to use `self.trait_env`
  - Replaces individual field saves/restores with `self.trait_ctx.clone()` for cleaner scope management

- **Updated module resolution**: Adjusts type parameter scope management in `module.rs`, `item.rs`, `method_call.rs`, and `call.rs` to use `self.trait_ctx.type_params`

## Implementation Details

- `TraitEnv` is built once in `orchestration.rs` before per-module resolution and shared via `Arc`
- `TraitContext` is cloned when entering impl block scopes to enable clean restoration on exit
- All trait index lookups now go through `self.trait_env` for consistency
- Associated type binding computation properly handles nested projections (e.g., `I::Iter::Item`)
- Type parameter bounds are preserved through trait method resolution to support generic method calls on type parameters

https://claude.ai/code/session_01RqckxnPLT4NURG7DP2W4px