### PR TITLE
Add conversion traits research and WEP for From/TryFrom/? operator

### DIFF
--- a/docs/research-from-into-framework.md
+++ b/docs/research-from-into-framework.md
@@ -1,0 +1,594 @@
+# Research: From/Into Conversion Trait Framework
+
+Survey of type conversion trait designs, with Rust's `From`/`Into` as the central case study.
+Background for a potential Wado WEP on structured type conversions.
+
+## Motivation
+
+Wado currently supports:
+
+- **`as` casts** — explicit primitive-to-primitive and newtype conversions
+- **Literal coercion** — numeric/string literals adapt to the target type context
+- **`null` → `Option<T>`** coercion
+- **Builder traits** — `SequenceLiteralBuilder`, `KeyValueLiteralBuilder` for collection literals
+- **`FromIterator`** — collecting iterators into collections
+
+There is no general-purpose mechanism for converting between arbitrary user-defined types.
+A structured conversion framework would enable:
+
+1. Ergonomic APIs that accept related types (e.g., `String` where `&str` suffices)
+2. Error type composition (prerequisite for the `?` operator)
+3. Newtype interop beyond `as` casts
+4. Standardized patterns for library authors
+
+---
+
+## Rust — From / Into / TryFrom / TryInto
+
+### Design
+
+Rust's conversion framework (RFC 529, stabilized in Rust 1.0) consists of four traits in
+`std::convert`:
+
+```rust
+trait From<T> {
+    fn from(value: T) -> Self;
+}
+
+trait Into<T> {
+    fn into(self) -> T;
+}
+
+trait TryFrom<T> {
+    type Error;
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
+trait TryInto<T> {
+    type Error;
+    fn try_into(self) -> Result<T, Self::Error>;
+}
+```
+
+Key relationships:
+
+- **Blanket impl**: `impl<T, U> Into<U> for T where U: From<T>` — implementing `From`
+  automatically provides `Into`.
+- **Reflexive impl**: `impl<T> From<T> for T` — every type can convert from itself. This
+  enables `fn new(s: impl Into<String>)` to accept both `String` and `&str`.
+- **Try variants** (stabilized in Rust 1.34): fallible conversions returning `Result`.
+
+In addition, Rust has borrowing conversion traits:
+
+- **`AsRef<T>`**: cheap reference-to-reference conversion (e.g., `String` → `&str`)
+- **`AsMut<T>`**: mutable reference-to-reference conversion
+- **`Borrow<T>`**: like `AsRef` but with a hash/eq consistency contract
+
+### Usage Patterns
+
+**Pattern 1: Flexible function parameters**
+
+```rust
+fn greet(name: impl Into<String>) {
+    let name: String = name.into();
+    println!("Hello, {}!", name);
+}
+greet("world");         // &str → String via From
+greet(String::from("world")); // String → String via reflexive From
+```
+
+**Pattern 2: Error type composition with `?`**
+
+```rust
+impl From<io::Error> for AppError { ... }
+impl From<ParseIntError> for AppError { ... }
+
+fn process() -> Result<(), AppError> {
+    let data = std::fs::read_to_string("file.txt")?;  // io::Error → AppError
+    let n: i32 = data.trim().parse()?;                 // ParseIntError → AppError
+    Ok(())
+}
+```
+
+The `?` operator calls `From::from()` to convert the error type, making `From` the backbone
+of Rust's error handling ergonomics.
+
+**Pattern 3: Newtype wrapping**
+
+```rust
+struct UserId(u64);
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self { UserId(id) }
+}
+let id: UserId = 42u64.into();
+```
+
+### Pros
+
+1. **Standardization**: all Rust libraries agree on a single conversion protocol. No ad hoc
+   `from_foo()` methods proliferating across crates.
+
+2. **Composability with `?`**: `From` impls compose with the `?` operator, enabling clean
+   error propagation without manual matching.
+
+3. **Generic API ergonomics**: `impl Into<T>` as a parameter bound lets functions accept
+   multiple input types while remaining type-safe.
+
+4. **Zero-cost abstraction**: monomorphized at compile time — no dynamic dispatch overhead.
+
+5. **Discoverability**: a well-known trait that IDE tooling can index. "What can I convert
+   this type to/from?" becomes answerable via trait impls.
+
+6. **Separation of fallible/infallible**: `From` guarantees infallible conversion, while
+   `TryFrom` makes fallibility explicit in the type system.
+
+### Cons
+
+1. **Type inference failures with `.into()`**
+
+   The target type of `Into` is on the trait (`Into<T>`), not the method. Turbofish cannot
+   be used: `.into::<String>()` is a compile error. The caller must provide type context
+   through variable annotations or other means.
+
+   ```rust
+   // Fails: cannot infer type
+   let x = some_value.into();
+   // Must write:
+   let x: String = some_value.into();
+   // Or use From directly:
+   let x = String::from(some_value);
+   ```
+
+   This asymmetry is a frequent source of confusion. `From::from()` is often preferred for
+   readability precisely because the target type is visible at the call site.
+
+2. **Readability and code navigation**
+
+   `.into()` hides the target type, making it harder to understand code without IDE support.
+   "Go to definition" on `.into()` leads to the blanket impl, not the actual conversion
+   logic. This is a well-known complaint in medium-to-large Rust codebases.
+
+3. **Hidden performance costs**
+
+   The compiler has no knowledge of the performance characteristics of a given `impl From`.
+   It might require allocation, syscalls, or I/O. Making conversions syntactically cheap
+   (`.into()`) can mask expensive operations.
+
+4. **Orphan rule complications**
+
+   Before Rust 1.41, if neither the source nor target type was local, you couldn't implement
+   `From`. This forced some users to implement `Into` directly, which doesn't provide the
+   reverse `From` impl — creating an asymmetric situation. The orphan rules still limit
+   cross-crate conversion definitions.
+
+5. **Trait family confusion**
+
+   Users must choose between `From`/`Into`, `AsRef`/`AsMut`, `Borrow`, `Deref`, and `ToOwned`.
+   The distinctions are subtle:
+
+   | Trait      | Semantics                          | When to use                    |
+   |------------|------------------------------------|--------------------------------|
+   | `From<T>`  | Owned → owned (consuming)          | Type construction              |
+   | `AsRef<T>` | Borrowed → borrowed (cheap)        | Read-only access               |
+   | `Borrow<T>`| Like AsRef + hash/eq contract      | HashMap keys                   |
+   | `Deref`    | Smart pointer transparency         | Wrapper types                  |
+   | `ToOwned`  | Borrowed → owned (cloning)         | `&str` → `String`             |
+
+   This proliferation is a common complaint. New Rust users struggle to know which trait to
+   implement for their conversion.
+
+6. **Not dyn-compatible (not object-safe)**
+
+   `From` cannot be used as a trait object (`dyn From<T>`), limiting its use in dynamic
+   dispatch scenarios.
+
+7. **Effect system limitations**
+
+   `From`/`Into` cannot be made async or fallible (beyond `TryFrom`). In an effect-generic
+   future, you'd need separate `AsyncFrom`, `StreamFrom`, etc. — an exponential explosion
+   of trait variants.
+
+8. **Semantic guarantees are conventions only**
+
+   The documentation states conversions should be "infallible," "value-preserving," and
+   "obvious" — but the compiler cannot enforce these. Misuse (e.g., lossy conversions via
+   `From`) is possible and occurs in practice.
+
+### Community Opinions
+
+The Rust community is broadly positive about `From`/`Into` as a framework, but has specific
+recurring complaints:
+
+- **Reddit/forums**: ".into() is write-only code" is a common refrain. Experienced users
+  often prefer `Type::from(x)` for clarity.
+
+- **"What is wrong with auto .into?"** (internals.rust-lang.org, 2022): A highly-discussed
+  thread proposing automatic `.into()` calls. Arguments against centered on hidden performance
+  costs and type inference complications. Even the author of the `auto_into` proc-macro crate
+  concluded it was "an anti-pattern."
+
+- **"Implicit into() on return"** (internals.rust-lang.org, 2022): Proposed that return
+  statements automatically apply `.into()` when types mismatch. Received pushback on
+  explicitness grounds.
+
+- **Effective Rust** (David Drysdale): Recommends preferring `From`/`Into` over `as` casts,
+  and `TryFrom`/`TryInto` over potentially lossy `as`. Notes the "inner function" pattern
+  to avoid generic code bloat.
+
+---
+
+## Scala — Implicit Conversions → given/using (Scala 3)
+
+### Design
+
+Scala 2 had `implicit def` for automatic type conversions:
+
+```scala
+implicit def intToString(x: Int): String = x.toString
+val s: String = 42  // compiler inserts intToString(42)
+```
+
+Scala 3 replaced this with the `Conversion` type class and `given`/`using` keywords:
+
+```scala
+given Conversion[Int, String] = _.toString
+```
+
+### What Went Wrong
+
+Scala's implicit conversions are widely considered the language's biggest design mistake:
+
+1. **Invisible behavior**: Conversions happen silently with no syntactic marker. Reading code
+   reveals no hint that a conversion is occurring.
+
+2. **Non-total conversions**: Nothing prevents defining a conversion from `String` to `Int`
+   that throws `NumberFormatException` at runtime. The type system says it's safe; it isn't.
+
+3. **Import-triggered surprises**: Importing a module can silently change the behavior of
+   existing code by bringing new implicit conversions into scope.
+
+4. **Poor error messages**: When implicit resolution fails, the compiler reports generic type
+   mismatches rather than explaining which conversion was expected.
+
+5. **IDE masking**: IDEs automatically suppress compiler warnings about implicit conversions,
+   undermining the language's own safety mechanisms.
+
+6. **Debugging difficulty**: In large codebases, tracking which implicit conversion is being
+   applied at a given call site requires deep understanding of the implicit scope rules.
+
+### Lessons for Wado
+
+- **Implicit conversions without syntactic markers are harmful.** Scala 3 effectively admits
+  this by deprecating the old approach.
+- **Conversions should be explicitly requested at the call site** — either through `.into()`,
+  `as`, or at minimum through a visible trait bound in the function signature.
+- **Non-total conversions need a separate type** (like Rust's `TryFrom` returning `Result`).
+
+---
+
+## Swift — ExpressibleBy Protocols
+
+### Design
+
+Swift uses protocol conformance for literal-to-type conversion:
+
+```swift
+protocol ExpressibleByStringLiteral {
+    init(stringLiteral value: String)
+}
+
+struct UserID: ExpressibleByStringLiteral {
+    let raw: String
+    init(stringLiteral value: String) { self.raw = value }
+}
+
+let id: UserID = "abc123"  // compiler calls init(stringLiteral:)
+```
+
+For non-literal conversions, Swift relies on explicit initializers:
+
+```swift
+let x = Double(42)  // explicit, not implicit
+let s = String(describing: someValue)
+```
+
+### Strengths
+
+- **Literals are ergonomic**: Custom types feel native when they can be expressed as literals.
+- **Non-literal conversions are explicit**: No hidden `.into()` — you call an initializer.
+- **Progressive disclosure**: Simple code stays simple; conversion machinery only appears
+  when needed.
+
+### Weaknesses
+
+- **Limited scope**: Only works for literals, not arbitrary value-to-value conversion.
+- **No general conversion trait**: Swift has no equivalent of `From`/`Into` for non-literal
+  contexts.
+
+### Relevance to Wado
+
+Wado's existing `SequenceLiteralBuilder` and `KeyValueLiteralBuilder` are conceptually similar
+to Swift's `ExpressibleBy` protocols — they handle literal-to-type conversion. A `From`/`Into`
+framework would complement this by handling non-literal conversions.
+
+---
+
+## C++ — Implicit Conversion Operators
+
+### Design
+
+C++ allows implicit conversions through converting constructors and conversion operators:
+
+```cpp
+class MyString {
+    MyString(const char* s);        // implicit converting constructor
+    operator int() const;           // implicit conversion to int
+    explicit operator bool() const; // explicit only
+};
+```
+
+### Problems (Well-documented)
+
+1. **Silent, surprising conversions**: `MyString s = "hello"; int n = s;` compiles silently.
+2. **Ambiguity in overload resolution**: Multiple implicit conversion paths create compilation
+   errors or, worse, select the wrong overload.
+3. **The `explicit` keyword** was added precisely because implicit conversions caused too many
+   bugs. Modern C++ style guidelines recommend making all single-argument constructors
+   `explicit` by default.
+4. **Performance**: Temporary objects created by implicit conversions are a hidden cost.
+
+Google's C++ style guide and many corporate guidelines forbid implicit conversions entirely.
+
+### Lessons for Wado
+
+C++ is the strongest cautionary tale: **implicit conversions without opt-in at the call site
+are a proven source of bugs.** The `explicit` keyword was a retroactive fix for a design
+mistake.
+
+---
+
+## Go — Explicit Conversions Only
+
+### Design
+
+Go has no implicit conversions whatsoever. Even `int32` → `int64` requires an explicit cast:
+
+```go
+var x int32 = 42
+var y int64 = int64(x)  // must be explicit
+```
+
+### Rationale
+
+Go's designers explicitly chose this to avoid the "complexity and confusion" that implicit
+conversions cause in C/C++. The FAQ states: "The convenience of automatic conversion between
+numeric types in C is outweighed by the confusion it causes."
+
+### Strengths
+
+- **No surprises**: Code does exactly what it says.
+- **Simple mental model**: No conversion rules to memorize.
+
+### Weaknesses
+
+- **Verbose**: Numeric code becomes cluttered with casts.
+- **No generic conversion protocol**: No way to express "any type convertible to X" as a
+  bound.
+
+---
+
+## Haskell — Type Classes
+
+### Design
+
+Haskell uses type classes for conversion, but there is no single unified `From`/`Into`:
+
+```haskell
+class Num a where
+    fromInteger :: Integer -> a
+
+class Real a => Integral a where ...
+fromIntegral :: (Integral a, Num b) => a -> b
+```
+
+Conversions are always explicit function calls, but polymorphic literals (like `42`) are
+implicitly converted via `fromInteger`.
+
+### Strengths
+
+- **Polymorphic literals**: `42` works as any `Num` type without explicit casts.
+- **Type class coherence**: Global uniqueness of instances prevents ambiguity.
+
+### Weaknesses
+
+- **No unified conversion trait**: `fromIntegral`, `toInteger`, `fromRational` are all
+  separate functions with no shared structure.
+- **Partial functions**: `fromIntegral` can overflow silently (no `TryFrom` equivalent in
+  base).
+
+---
+
+## Python — Dunder Methods
+
+### Design
+
+Python uses special methods for type conversion:
+
+```python
+class Celsius:
+    def __init__(self, value): self.value = value
+    def __float__(self): return self.value
+    def __int__(self): return int(self.value)
+    def __str__(self): return f"{self.value}°C"
+```
+
+Conversions are explicit at the call site: `float(celsius)`, `int(celsius)`, `str(celsius)`.
+
+### Strengths
+
+- **Explicit call sites**: `float(x)` is clear about what's happening.
+- **Standardized protocol**: Well-known dunder methods that all Python developers understand.
+
+### Weaknesses
+
+- **No static type checking**: Wrong dunder method signatures are discovered at runtime.
+- **Limited to built-in types**: No way to define `__mytype__` for custom-to-custom conversion.
+
+---
+
+## Zig — @as and Explicit Philosophy
+
+### Design
+
+Zig uses `@as` for explicit type coercion and has a very limited set of implicit coercions
+(mainly for comptime-known values):
+
+```zig
+const x: u32 = @as(u32, some_u16);
+```
+
+### Philosophy
+
+Zig follows Go's approach of minimal implicit behavior, preferring explicit conversions. The
+language deliberately avoids traits/interfaces for conversion, relying on explicit function
+calls.
+
+---
+
+## Kotlin — Extension Functions and Smart Casts
+
+### Design
+
+Kotlin uses explicit conversion methods (`toInt()`, `toString()`, etc.) and extension
+functions for custom conversions:
+
+```kotlin
+fun String.toUserId(): UserId = UserId(this)
+val id = "abc123".toUserId()
+```
+
+Smart casts narrow types after `is` checks but don't perform value conversion.
+
+### Strengths
+
+- **Discoverable**: `.to*()` methods are visible in autocomplete.
+- **Explicit**: No hidden conversions.
+- **Extensible**: Extension functions allow adding conversions without modifying types.
+
+### Weaknesses
+
+- **No generic bound**: Cannot express "any type convertible to X" in a generic context.
+- **Naming convention only**: No compiler-enforced trait/interface for conversions.
+
+---
+
+## Cross-Language Summary
+
+| Language  | Mechanism              | Implicit? | Generic bound? | Fallible variant? |
+|-----------|------------------------|-----------|----------------|-------------------|
+| Rust      | `From`/`Into` traits   | No (explicit `.into()`) | Yes (`impl Into<T>`) | `TryFrom`/`TryInto` |
+| Scala 2   | `implicit def`         | Yes       | Via implicits   | No (runtime exn) |
+| Scala 3   | `Conversion` typeclass | Semi (requires import) | Yes | No |
+| Swift     | `ExpressibleBy` + init | Literals only | No | `init?` (failable) |
+| C++       | Converting constructors | Yes (unless `explicit`) | No | No |
+| Go        | Explicit cast syntax   | No        | No              | No |
+| Haskell   | Per-domain type classes | No        | Yes             | Partial |
+| Python    | Dunder methods         | No        | No (dynamic)    | Exceptions |
+| Zig       | `@as`                  | No        | No              | No |
+| Kotlin    | `.to*()` extensions    | No        | No              | Nullable return |
+
+---
+
+## Key Takeaways for Wado
+
+### What works well in Rust's design
+
+1. **Trait-based conversion is the right abstraction level.** It enables generic bounds,
+   compiler verification, and ecosystem-wide standardization.
+
+2. **The `From`→`Into` blanket impl is elegant.** Users implement `From` (natural direction),
+   get `Into` for free (ergonomic direction). This duality is genuinely useful.
+
+3. **Separating infallible (`From`) and fallible (`TryFrom`) is valuable.** It encodes
+   conversion safety in the type system.
+
+4. **Integration with `?` is the killer feature.** The `From` trait's greatest value is
+   enabling automatic error type conversion via `?`. Without this use case, `From`/`Into`
+   would be merely convenient; with it, they're essential.
+
+### What to improve or reconsider
+
+1. **The `.into()` inference problem needs addressing.** The inability to turbofish `.into()`
+   is a fundamental ergonomic issue. Possible solutions:
+   - Make the target type a method parameter: `fn into<T>(self) -> T`
+   - Prefer `Type::from(x)` style (which Wado can optimize for)
+   - Provide syntax sugar that makes the target type visible
+
+2. **The trait family is too large.** Rust has `From`, `Into`, `TryFrom`, `TryInto`, `AsRef`,
+   `AsMut`, `Borrow`, `BorrowMut`, `ToOwned`, `Deref`, `DerefMut` — all related to "getting
+   one type from another." Wado should aim for fewer, more orthogonal traits.
+
+3. **Wado's GC simplifies the picture.** Rust needs `AsRef`/`Borrow`/`Deref` because of
+   ownership and borrowing semantics. With GC-based memory management, Wado doesn't need
+   most of these. The core need is:
+   - **Value conversion** (consuming): `From<T>` / `Into<T>`
+   - **Fallible conversion**: `TryFrom<T>` / `TryInto<T>`
+   - Reference-based conversions (`AsRef`) may be less critical.
+
+4. **Implicit vs. explicit is a spectrum.** The consensus across languages is:
+   - Fully implicit (Scala 2, C++) → proven harmful
+   - Fully explicit (Go) → safe but verbose
+   - Explicit with trait-based generic bounds (Rust) → good middle ground
+   - **Call-site-visible but minimal-syntax** → optimal target for Wado
+
+5. **Wado already has literal coercion.** Wado's existing `SequenceLiteralBuilder` and
+   numeric literal coercion handle the "literal → type" case (like Swift's `ExpressibleBy`).
+   A `From`/`Into` framework would handle the "value → value" case, complementing what exists.
+
+6. **The `?` operator dependency.** If Wado plans to implement the `?` operator (listed as
+   "not yet implemented" in the spec), `From` is a prerequisite. The design of `From` and `?`
+   should be co-designed.
+
+7. **Effect interaction.** Wado has an effect system. A conversion trait should consider
+   whether conversions can have effects (e.g., a conversion that requires I/O). This is
+   something Rust cannot express.
+
+---
+
+## Open Questions for Wado
+
+1. **Should Wado have both `From` and `Into`, or just one?** The blanket impl trick works
+   but adds complexity. An alternative: a single `Convert<From, To>` trait, or just `From`
+   with compiler-provided `.into()` sugar.
+
+2. **Should `.into()` be a method or syntax sugar?** If it's syntax sugar (e.g., `expr as T`
+   calling `From::from`), the turbofish problem disappears.
+
+3. **How does this interact with newtypes?** Currently newtypes use `as` for conversion.
+   Should `From` be auto-derived for newtypes, or should `as` remain the only mechanism?
+
+4. **Should conversions support effects?** e.g., `fn from(value: T) -> Self with FileSystem`
+
+5. **What about the `?` operator?** If Wado implements `?`, the error conversion mechanism
+   needs to be designed together with `From`.
+
+6. **How many conversion traits?** Possible minimal set:
+   - `From<T>` — infallible value conversion
+   - `TryFrom<T>` — fallible value conversion (returns `Result`)
+   - Compiler-provided `.into()` sugar that calls `From::from()`
+
+## References
+
+- [RFC 529: Conversion Traits](https://rust-lang.github.io/rfcs/0529-conversion-traits.html)
+- [RFC 401: Coercions](https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md)
+- [Effective Rust — Item 5: Understand Type Conversions](https://effective-rust.com/casts.html)
+- ["What is wrong with auto .into?"](https://internals.rust-lang.org/t/what-is-wrong-with-auto-into/17319) — Rust Internals
+- ["Implicit into() on return"](https://internals.rust-lang.org/t/language-tidy-up-feature-2-implicit-into-on-return/17872) — Rust Internals
+- ["Traits as Implicit Conversions"](https://slightknack.dev/passerine/traits-as/) — Isaac Clayton
+- [Scala 3 Implicit Redesign](https://www.baeldung.com/scala/scala-3-implicit-redesign) — Baeldung
+- ["Can We Wean Scala Off Implicit Conversions?"](https://contributors.scala-lang.org/t/can-we-wean-scala-off-implicit-conversions/4388) — Scala Contributors
+- [Scala Best Practices: Avoid Implicit Conversions](https://nrinaudo.github.io/scala-best-practices/unsafe/implicit_conversions.html)
+- [Swift ExpressibleBy Protocols Internals](https://swiftrocks.com/swift-expressibleby-protocols-how-they-work-internally-in-the-compiler)
+- [Rust API Design: AsRef, Into, Cow](https://www.philipdaniels.com/blog/2019/rust-api-design/)
+- ["From & Into Confusion — Why Do We Need Both?"](https://users.rust-lang.org/t/from-into-confusion-why-do-we-need-both/80181) — Rust Users Forum
+- [Implicit Numeric Widening Proposal](https://internals.rust-lang.org/t/implicit-numeric-widening-coercion-proposal/23660) — Rust Internals

--- a/docs/research-from-into-framework.md
+++ b/docs/research-from-into-framework.md
@@ -283,7 +283,9 @@ given Conversion[Int, String] = _.toString
 
 ### What Went Wrong
 
-Scala's implicit conversions are widely considered the language's biggest design mistake:
+Scala's implicit conversions are widely considered the language's biggest design mistake.
+Martin Odersky himself called them "evil." The `implicit` keyword was overloaded for three
+distinct features (arguments, conversions, extensions), confusing beginners and experts alike:
 
 1. **Invisible behavior**: Conversions happen silently with no syntactic marker. Reading code
    reveals no hint that a conversion is occurring.
@@ -382,9 +384,12 @@ class MyString {
 3. **The `explicit` keyword** was added precisely because implicit conversions caused too many
    bugs. Modern C++ style guidelines recommend making all single-argument constructors
    `explicit` by default.
-4. **Performance**: Temporary objects created by implicit conversions are a hidden cost.
+4. **The Safe Bool Problem**: `operator bool()` allows implicit conversion to `int` via
+   standard promotion, enabling nonsensical code like `obj << 1` or `int n = myStream`.
+   Before C++11, the workaround `operator void*()` allowed `delete std::cout` to compile.
+5. **Performance**: Temporary objects created by implicit conversions are a hidden cost.
 
-Google's C++ style guide and many corporate guidelines forbid implicit conversions entirely.
+Google's C++ style guide and the C++ Core Guidelines forbid implicit conversions by default.
 
 ### Lessons for Wado
 
@@ -483,22 +488,39 @@ Conversions are explicit at the call site: `float(celsius)`, `int(celsius)`, `st
 
 ---
 
-## Zig — @as and Explicit Philosophy
+## Zig — Separated Conversion Builtins
 
 ### Design
 
-Zig uses `@as` for explicit type coercion and has a very limited set of implicit coercions
-(mainly for comptime-known values):
+Zig uses distinct builtins for different conversion kinds:
+
+- **`@as(T, x)`** — safe, lossless coercion (e.g., `u8` → `u32`)
+- **`@truncate(x)`** — explicit bit-dropping (narrowing with silent data loss)
+- **`@intCast(x)`** — checked narrowing (panics on overflow in safe builds)
 
 ```zig
-const x: u32 = @as(u32, some_u16);
+const x: u32 = @as(u32, some_u16);      // safe widening
+const y: u8 = @truncate(some_u32);       // explicit: drops high bits
+const z: u8 = @intCast(some_u32);        // checked: panics if > 255
 ```
 
-### Philosophy
+### Strengths
 
-Zig follows Go's approach of minimal implicit behavior, preferring explicit conversions. The
-language deliberately avoids traits/interfaces for conversion, relying on explicit function
-calls.
+- Each conversion kind has its own named builtin — code is greppable and auditable.
+- `@as` only works for guaranteed-safe coercions; unsafe casts require a different builtin.
+- Forces the programmer to choose explicitly: silent data loss vs. checked conversion.
+- Follows Zig's "no hidden control flow" and "favor reading over writing" principles.
+
+### Weaknesses
+
+- Verbose for arithmetic mixing different integer sizes.
+- No user-defined conversion mechanism (no traits/protocols).
+
+### Relevance to Wado
+
+Zig's approach of **naming each conversion kind separately** is worth considering. Rather than
+one `From` trait for all conversions, Wado could distinguish lossless widening (automatic),
+checked narrowing (explicit), and semantic conversion (trait-based).
 
 ---
 
@@ -624,6 +646,20 @@ Smart casts narrow types after `is` checks but don't perform value conversion.
    - `TryFrom<T>` — fallible value conversion (returns `Result`)
    - Compiler-provided `.into()` sugar that calls `From::from()`
 
+## Cross-Cutting Themes
+
+| Theme | Languages | Lesson |
+|-------|-----------|--------|
+| Implicit conversions cause bugs | C++, Scala 2, JavaScript | Every language with broad implicit conversion has regretted or constrained it |
+| Separate infallible from fallible | Rust, Haskell (Witch lib), Zig | Community converges on distinguishing "always works" from "might fail" |
+| Explicit is safer but verbose | Go, OCaml, Zig | Full explicitness trades ergonomics for clarity |
+| Literal coercion is the sweet spot | Go (untyped consts), Swift (ExpressibleBy), Zig (comptime), Wado | Literals molding to the target type is universally accepted as safe and ergonomic |
+| Smart/flow-sensitive casts | Kotlin | Compiler-driven narrowing after type checks is well-loved and low-risk |
+| Trait-based conversion (user-extensible) | Rust, Haskell, Swift | Gives users the mechanism without the implicit danger |
+| Name each conversion kind | Zig (`@as`/`@truncate`/`@intCast`) | Separating safe widening, checked narrowing, and lossy truncation aids auditability |
+
+---
+
 ## References
 
 - [RFC 529: Conversion Traits](https://rust-lang.github.io/rfcs/0529-conversion-traits.html)
@@ -639,3 +675,9 @@ Smart casts narrow types after `is` checks but don't perform value conversion.
 - [Rust API Design: AsRef, Into, Cow](https://www.philipdaniels.com/blog/2019/rust-api-design/)
 - ["From & Into Confusion — Why Do We Need Both?"](https://users.rust-lang.org/t/from-into-confusion-why-do-we-need-both/80181) — Rust Users Forum
 - [Implicit Numeric Widening Proposal](https://internals.rust-lang.org/t/implicit-numeric-widening-coercion-proposal/23660) — Rust Internals
+- [Cast Haskell Values with Witch](https://taylor.fausak.me/2021/07/13/witch/) — Rust-inspired From/TryFrom for Haskell
+- [Swift Evolution SE-0115: Rename ExpressibleBy Protocols](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0115-literal-syntax-protocols.md)
+- [C++ Explicit Conversion Operators (N2333)](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2333.html)
+- [Zig's Integer Casting for C Programmers](https://www.lagerdata.com/articles/an-intro-to-zigs-integer-casting-for-c-programmers)
+- [Kotlin Type Checks and Casts](https://kotlinlang.org/docs/typecasts.html)
+- ["Does From Only Exist Because of the Orphan Rule?"](https://users.rust-lang.org/t/does-from-only-exist-because-of-the-orphan-rule/98264) — Rust Users Forum

--- a/docs/research-from-into-framework.md
+++ b/docs/research-from-into-framework.md
@@ -194,6 +194,33 @@ let id: UserId = 42u64.into();
    "obvious" — but the compiler cannot enforce these. Misuse (e.g., lossy conversions via
    `From`) is possible and occurs in practice.
 
+9. **Monomorphization / compile-time cost**
+
+   Using `impl Into<T>` as a function parameter causes monomorphization — each unique caller
+   type generates a new copy of the function body. The `momo` crate exists specifically to
+   mitigate this by splitting `impl Into<T>` functions into a thin generic wrapper + non-generic
+   inner function. The standard library itself uses this "inner function" pattern.
+
+10. **Error handling boilerplate**
+
+    Writing `impl From<IoError> for MyError`, `impl From<ParseError> for MyError`, etc. for
+    every error type is tedious. This is why crates like `thiserror` and `anyhow` exist — they
+    automate what should arguably be a language-level solution. The coherence rules compound
+    this: you cannot write a blanket `impl<E: Error> From<E> for MyError` because it conflicts
+    with the reflexive `impl<T> From<T> for T` in std.
+
+11. **`TryFrom` / `FromStr` design wart**
+
+    `FromStr` predates `TryFrom` and serves the same purpose as `TryFrom<&str>`. Both exist
+    in the standard library with no clear migration path. This illustrates the risk of
+    introducing conversion traits incrementally without a unified design.
+
+12. **IDE support degrades with `.into()`**
+
+    rust-analyzer cannot determine the resulting type after `.into()` in some contexts,
+    breaking autocompletion. "Go to definition" navigates to the blanket impl in std, not the
+    actual `From` implementation.
+
 ### Community Opinions
 
 The Rust community is broadly positive about `From`/`Into` as a framework, but has specific
@@ -203,17 +230,37 @@ recurring complaints:
   often prefer `Type::from(x)` for clarity.
 
 - **"What is wrong with auto .into?"** (internals.rust-lang.org, 2022): A highly-discussed
-  thread proposing automatic `.into()` calls. Arguments against centered on hidden performance
-  costs and type inference complications. Even the author of the `auto_into` proc-macro crate
-  concluded it was "an anti-pattern."
+  thread proposing automatic `.into()` calls. Key arguments from participants:
+  - *ekuber*: "The compiler has no knowledge on the performance characteristics of a given
+    `impl From`. It might require allocation, it might require invoking syscalls, it might
+    even require IO."
+  - *afetisov*: Implicit conversions would break generic functions — `opt.unwrap_or_else(|| 3)`
+    would become ambiguous if `3` could auto-convert to multiple types.
+  - *Multiple participants*: cite C++ and Scala as warnings about implicit conversion pitfalls.
+  - Even the author of the `auto_into` proc-macro crate concluded it was "an anti-pattern."
 
 - **"Implicit into() on return"** (internals.rust-lang.org, 2022): Proposed that return
-  statements automatically apply `.into()` when types mismatch. Received pushback on
-  explicitness grounds.
+  statements automatically apply `.into()` when types mismatch. Key opposition:
+  - *SkiFire13*: "A hidden function call makes readability worse because now you have to ask
+    yourself if there's some kind of hidden conversion going on."
+  - *scottmcm*: Would be a breaking change — `fn foo() -> u8 { 0 }` would no longer compile
+    because `0` could `.into()` multiple types.
+  - *mjbshaw*: Some conversions like `&[T]` to `Arc<[T]>` "require cloning all the elements"
+    — hiding that is dangerous.
+
+- **The `?` operator inconsistency**: The `?` operator already performs an implicit
+  `From::from()` on errors. If Rust already hides `From` conversions inside `?`, why not
+  elsewhere? The counterargument: `?` is visually explicit (you see the `?` character) and
+  confined to error propagation, a well-understood pattern.
 
 - **Effective Rust** (David Drysdale): Recommends preferring `From`/`Into` over `as` casts,
   and `TryFrom`/`TryInto` over potentially lossy `as`. Notes the "inner function" pattern
   to avoid generic code bloat.
+
+- **Community sentiment summary**: Pragmatists want less boilerplate (auto-`.into()`,
+  operators, implicit conversions in limited contexts). Purists value explicitness (hidden
+  conversions hide performance costs, break type inference). The Rust language team has
+  consistently sided with explicitness, with `?` as the sole exception.
 
 ---
 

--- a/docs/research-from-into-framework.md
+++ b/docs/research-from-into-framework.md
@@ -646,6 +646,39 @@ Smart casts narrow types after `is` checks but don't perform value conversion.
    - `TryFrom<T>` — fallible value conversion (returns `Result`)
    - Compiler-provided `.into()` sugar that calls `From::from()`
 
+## Relevant Rust RFCs
+
+### RFC 529: Conversion Traits (Accepted, Rust 1.0)
+
+The foundational RFC establishing `From`, `Into`, `AsRef`, `AsMut`. Motivated by the
+proliferation of ad hoc conversion traits (`FromStr`, `AsSlice`, `FromError`). Established
+the principle that conversions are distinguished by cost (free reference vs. owned allocation)
+and consumption (borrowing vs. moving). Also proposed a `To` trait for reference-to-value
+conversions, which was deferred and never implemented.
+
+### RFC 1542: TryFrom / TryInto (Stabilized in Rust 1.34)
+
+Added fallible conversion traits. Motivated by C FFI interop and platform-dependent integer
+sizes. The blanket impl `impl<T, U> TryFrom<U> for T where U: Into<T>` causes coherence
+conflicts when users try to implement `TryFrom` for their own types — a well-known pain point.
+
+### RFC 1210: Specialization (Accepted, Never Stabilized)
+
+Would allow overlapping trait implementations with a "most specific wins" rule. Relevant
+because it would enable specialized, more efficient `From` implementations alongside blanket
+impls. However, **specialization is unsound** as demonstrated by Ralf Jung. `min_specialization`
+is used internally by the standard library but remains unstable. As of 2025, stabilization
+is not being actively pursued.
+
+### No Active RFC to Redesign From/Into
+
+There is no active RFC proposing fundamental changes to the `From`/`Into` design. The traits
+are deeply embedded in the ecosystem. Improvements focus on surrounding infrastructure (trait
+solver, coherence rules) rather than the traits themselves. This means Wado has a unique
+opportunity to learn from Rust's design without being constrained by backward compatibility.
+
+---
+
 ## Cross-Cutting Themes
 
 | Theme | Languages | Lesson |
@@ -681,3 +714,11 @@ Smart casts narrow types after `is` checks but don't perform value conversion.
 - [Zig's Integer Casting for C Programmers](https://www.lagerdata.com/articles/an-intro-to-zigs-integer-casting-for-c-programmers)
 - [Kotlin Type Checks and Casts](https://kotlinlang.org/docs/typecasts.html)
 - ["Does From Only Exist Because of the Orphan Rule?"](https://users.rust-lang.org/t/does-from-only-exist-because-of-the-orphan-rule/98264) — Rust Users Forum
+- [RFC 1542: TryFrom](https://rust-lang.github.io/rfcs/1542-try-from.html)
+- [RFC 1210: Specialization](https://rust-lang.github.io/rfcs/1210-impl-specialization.html)
+- [Specialization Is Unsound (PR #71420)](https://github.com/rust-lang/rust/pull/71420) — Ralf Jung
+- [Monomorphization Bloat](https://www.alilleybrinker.com/blog/monomorphization-bloat/) — Andrew Lilley Brinker
+- [Defaults Affect Inference](https://faultlore.com/blah/defaults-affect-inference/) — Faultlore
+- [Winning the Fight Against Coherence](https://ohadravid.github.io/posts/2023-05-coherence-and-errors/) — Ohad Ravid
+- [Haskell Coercible for Newtype Conversions](https://wiki.haskell.org/GHC/Coercible) — HaskellWiki
+- [Equivalent of Rust's From/Into in Haskell?](https://discourse.haskell.org/t/equivalent-of-rusts-from-into-trait-in-haskell/8679) — Haskell Discourse

--- a/docs/research-from-into-framework.md
+++ b/docs/research-from-into-framework.md
@@ -166,13 +166,13 @@ let id: UserId = 42u64.into();
    Users must choose between `From`/`Into`, `AsRef`/`AsMut`, `Borrow`, `Deref`, and `ToOwned`.
    The distinctions are subtle:
 
-   | Trait      | Semantics                          | When to use                    |
-   |------------|------------------------------------|--------------------------------|
-   | `From<T>`  | Owned → owned (consuming)          | Type construction              |
-   | `AsRef<T>` | Borrowed → borrowed (cheap)        | Read-only access               |
-   | `Borrow<T>`| Like AsRef + hash/eq contract      | HashMap keys                   |
-   | `Deref`    | Smart pointer transparency         | Wrapper types                  |
-   | `ToOwned`  | Borrowed → owned (cloning)         | `&str` → `String`             |
+   | Trait       | Semantics                     | When to use       |
+   | ----------- | ----------------------------- | ----------------- |
+   | `From<T>`   | Owned → owned (consuming)     | Type construction |
+   | `AsRef<T>`  | Borrowed → borrowed (cheap)   | Read-only access  |
+   | `Borrow<T>` | Like AsRef + hash/eq contract | HashMap keys      |
+   | `Deref`     | Smart pointer transparency    | Wrapper types     |
+   | `ToOwned`   | Borrowed → owned (cloning)    | `&str` → `String` |
 
    This proliferation is a common complaint. New Rust users struggle to know which trait to
    implement for their conversion.
@@ -231,21 +231,21 @@ recurring complaints:
 
 - **"What is wrong with auto .into?"** (internals.rust-lang.org, 2022): A highly-discussed
   thread proposing automatic `.into()` calls. Key arguments from participants:
-  - *ekuber*: "The compiler has no knowledge on the performance characteristics of a given
+  - _ekuber_: "The compiler has no knowledge on the performance characteristics of a given
     `impl From`. It might require allocation, it might require invoking syscalls, it might
     even require IO."
-  - *afetisov*: Implicit conversions would break generic functions — `opt.unwrap_or_else(|| 3)`
+  - _afetisov_: Implicit conversions would break generic functions — `opt.unwrap_or_else(|| 3)`
     would become ambiguous if `3` could auto-convert to multiple types.
-  - *Multiple participants*: cite C++ and Scala as warnings about implicit conversion pitfalls.
+  - _Multiple participants_: cite C++ and Scala as warnings about implicit conversion pitfalls.
   - Even the author of the `auto_into` proc-macro crate concluded it was "an anti-pattern."
 
 - **"Implicit into() on return"** (internals.rust-lang.org, 2022): Proposed that return
   statements automatically apply `.into()` when types mismatch. Key opposition:
-  - *SkiFire13*: "A hidden function call makes readability worse because now you have to ask
+  - _SkiFire13_: "A hidden function call makes readability worse because now you have to ask
     yourself if there's some kind of hidden conversion going on."
-  - *scottmcm*: Would be a breaking change — `fn foo() -> u8 { 0 }` would no longer compile
+  - _scottmcm_: Would be a breaking change — `fn foo() -> u8 { 0 }` would no longer compile
     because `0` could `.into()` multiple types.
-  - *mjbshaw*: Some conversions like `&[T]` to `Arc<[T]>` "require cloning all the elements"
+  - _mjbshaw_: Some conversions like `&[T]` to `Arc<[T]>` "require cloning all the elements"
     — hiding that is dangerous.
 
 - **The `?` operator inconsistency**: The `?` operator already performs an implicit
@@ -553,18 +553,18 @@ Smart casts narrow types after `is` checks but don't perform value conversion.
 
 ## Cross-Language Summary
 
-| Language  | Mechanism              | Implicit? | Generic bound? | Fallible variant? |
-|-----------|------------------------|-----------|----------------|-------------------|
-| Rust      | `From`/`Into` traits   | No (explicit `.into()`) | Yes (`impl Into<T>`) | `TryFrom`/`TryInto` |
-| Scala 2   | `implicit def`         | Yes       | Via implicits   | No (runtime exn) |
-| Scala 3   | `Conversion` typeclass | Semi (requires import) | Yes | No |
-| Swift     | `ExpressibleBy` + init | Literals only | No | `init?` (failable) |
-| C++       | Converting constructors | Yes (unless `explicit`) | No | No |
-| Go        | Explicit cast syntax   | No        | No              | No |
-| Haskell   | Per-domain type classes | No        | Yes             | Partial |
-| Python    | Dunder methods         | No        | No (dynamic)    | Exceptions |
-| Zig       | `@as`                  | No        | No              | No |
-| Kotlin    | `.to*()` extensions    | No        | No              | Nullable return |
+| Language | Mechanism               | Implicit?               | Generic bound?       | Fallible variant?   |
+| -------- | ----------------------- | ----------------------- | -------------------- | ------------------- |
+| Rust     | `From`/`Into` traits    | No (explicit `.into()`) | Yes (`impl Into<T>`) | `TryFrom`/`TryInto` |
+| Scala 2  | `implicit def`          | Yes                     | Via implicits        | No (runtime exn)    |
+| Scala 3  | `Conversion` typeclass  | Semi (requires import)  | Yes                  | No                  |
+| Swift    | `ExpressibleBy` + init  | Literals only           | No                   | `init?` (failable)  |
+| C++      | Converting constructors | Yes (unless `explicit`) | No                   | No                  |
+| Go       | Explicit cast syntax    | No                      | No                   | No                  |
+| Haskell  | Per-domain type classes | No                      | Yes                  | Partial             |
+| Python   | Dunder methods          | No                      | No (dynamic)         | Exceptions          |
+| Zig      | `@as`                   | No                      | No                   | No                  |
+| Kotlin   | `.to*()` extensions     | No                      | No                   | Nullable return     |
 
 ---
 
@@ -681,15 +681,15 @@ opportunity to learn from Rust's design without being constrained by backward co
 
 ## Cross-Cutting Themes
 
-| Theme | Languages | Lesson |
-|-------|-----------|--------|
-| Implicit conversions cause bugs | C++, Scala 2, JavaScript | Every language with broad implicit conversion has regretted or constrained it |
-| Separate infallible from fallible | Rust, Haskell (Witch lib), Zig | Community converges on distinguishing "always works" from "might fail" |
-| Explicit is safer but verbose | Go, OCaml, Zig | Full explicitness trades ergonomics for clarity |
-| Literal coercion is the sweet spot | Go (untyped consts), Swift (ExpressibleBy), Zig (comptime), Wado | Literals molding to the target type is universally accepted as safe and ergonomic |
-| Smart/flow-sensitive casts | Kotlin | Compiler-driven narrowing after type checks is well-loved and low-risk |
-| Trait-based conversion (user-extensible) | Rust, Haskell, Swift | Gives users the mechanism without the implicit danger |
-| Name each conversion kind | Zig (`@as`/`@truncate`/`@intCast`) | Separating safe widening, checked narrowing, and lossy truncation aids auditability |
+| Theme                                    | Languages                                                        | Lesson                                                                              |
+| ---------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Implicit conversions cause bugs          | C++, Scala 2, JavaScript                                         | Every language with broad implicit conversion has regretted or constrained it       |
+| Separate infallible from fallible        | Rust, Haskell (Witch lib), Zig                                   | Community converges on distinguishing "always works" from "might fail"              |
+| Explicit is safer but verbose            | Go, OCaml, Zig                                                   | Full explicitness trades ergonomics for clarity                                     |
+| Literal coercion is the sweet spot       | Go (untyped consts), Swift (ExpressibleBy), Zig (comptime), Wado | Literals molding to the target type is universally accepted as safe and ergonomic   |
+| Smart/flow-sensitive casts               | Kotlin                                                           | Compiler-driven narrowing after type checks is well-loved and low-risk              |
+| Trait-based conversion (user-extensible) | Rust, Haskell, Swift                                             | Gives users the mechanism without the implicit danger                               |
+| Name each conversion kind                | Zig (`@as`/`@truncate`/`@intCast`)                               | Separating safe widening, checked narrowing, and lossy truncation aids auditability |
 
 ---
 

--- a/docs/wep-2026-03-16-conversion-traits.md
+++ b/docs/wep-2026-03-16-conversion-traits.md
@@ -1,0 +1,328 @@
+# WEP: Conversion Traits (From, TryFrom, ? operator)
+
+## Context
+
+Wado currently has two conversion mechanisms:
+
+- **`as` casts** — explicit primitive-to-primitive (e.g., `i32` → `f64`, `char` → `i32`) and newtype casts (e.g., `Meters` → `f64`)
+- **Literal coercion** — numeric and string literals adapt to the target type context (e.g., `let x: i64 = 42`)
+
+There is no general-purpose mechanism for converting between user-defined types, and the `?` operator (already reserved in the spec) has no implementation. The two key motivations for this WEP are:
+
+1. **Error type composition**: Enable the `?` operator for ergonomic error propagation with automatic error conversion
+2. **Structured conversions**: Provide a standardized protocol for user-defined type conversions
+
+### Language Survey
+
+See [Research: From/Into Conversion Trait Framework](./research-from-into-framework.md) for the full survey. Key findings:
+
+| Approach | Languages | Outcome |
+|----------|-----------|---------|
+| Implicit conversions | C++, Scala 2 | Universally regretted; causes bugs, hides costs |
+| Fully explicit | Go, Zig | Safe but verbose; no generic conversion protocol |
+| Trait-based, call-site-explicit | Rust | Good balance; `From`/`?` integration is the standout success |
+| Literal coercion only | Swift | Elegant for literals, insufficient for value-to-value |
+
+Rust's `From`/`Into` framework is the primary reference design. Its strengths: standardized conversion protocol, `?` operator integration, separation of infallible/fallible. Its weaknesses:
+
+- **`.into()` hides the target type** — turbofish doesn't work, IDE "go to definition" leads to blanket impl
+- **`Into<T>` exists mainly for orphan rule workarounds** — fixed in Rust 1.41
+- **`impl Into<T>` parameters cause monomorphization bloat** — the `momo` crate exists to mitigate this
+- **Too many conversion traits** — `From`, `Into`, `TryFrom`, `TryInto`, `AsRef`, `AsMut`, `Borrow`, `Deref`, `ToOwned` confuse users
+
+### Design Goals
+
+1. Support the `?` operator with `From`-based error conversion
+2. Keep target types visible at every call site
+3. Minimize the number of conversion traits (Wado's GC eliminates the need for `AsRef`/`Borrow`/`Deref`)
+4. Support compiler-generated impls for variants and newtypes
+5. No implicit conversions beyond existing literal coercion
+
+## Decision
+
+### 1. `From<T>` Trait
+
+Infallible conversion trait in `core:prelude`:
+
+```wado
+#[comp_feature("from")]
+pub trait From<T> {
+    fn from(value: T) -> Self;
+}
+```
+
+Usage is always explicit via `Type::from(value)`:
+
+```wado
+impl From<i32> for String {
+    fn from(value: i32) -> String {
+        return `{value}`;
+    }
+}
+
+let s = String::from(42);  // "42"
+```
+
+The `#[comp_feature("from")]` attribute registers `From` in the compiler's `TypeTable`, enabling the `?` operator to look up `From` impls for error conversion.
+
+**Reflexive impl**: The compiler provides `impl From<T> for T` for all types (identity conversion). This is needed for `?` to work when the error type already matches.
+
+### 2. `TryFrom<T>` Trait
+
+Fallible conversion trait returning `Result`:
+
+```wado
+pub trait TryFrom<T> {
+    type Error;
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+```
+
+```wado
+impl TryFrom<i64> for u8 {
+    type Error = String;
+    fn try_from(value: i64) -> Result<u8, String> {
+        if value < 0 || value > 255 {
+            return Result::<u8, String>::Err(`{value} out of range for u8`);
+        }
+        return Result::<u8, String>::Ok(value as u8);
+    }
+}
+
+let n = u8::try_from(42 as i64)?;  // Ok(42)
+let n = u8::try_from(999 as i64)?; // Err("999 out of range for u8")
+```
+
+### 3. `?` Operator
+
+The `?` postfix operator (already reserved in the spec's operator table) provides early return for `Result` and `Option`.
+
+**On `Result<T, E>`**: Unwrap `Ok(v)` → `v`, or convert the error and return early:
+
+```wado
+// Desugars to:
+// match expr {
+//     Ok(v) => v,
+//     Err(e) => { return Result::Err(From::from(e)); },
+// }
+
+fn process() -> Result<i32, AppError> {
+    let data = read_file("input.txt")?;   // IoError → AppError via From
+    let n = parse_int(data)?;              // ParseError → AppError via From
+    return Result::<i32, AppError>::Ok(n);
+}
+```
+
+The error conversion `From::from(e)` is the key integration point: `?` calls `From` to convert the inner error type to the enclosing function's error type.
+
+**On `Option<T>`**: Unwrap `Some(v)` → `v`, or return `null` (which is `Option::None`):
+
+```wado
+// Desugars to:
+// match expr {
+//     Some(v) => v,
+//     None => { return null; },
+// }
+
+fn find_user_name(id: i32) -> Option<String> {
+    let user = find_user(id)?;        // None → return null
+    let profile = user.profile()?;    // None → return null
+    return Option::<String>::Some(profile.name);
+}
+```
+
+**Requirements**:
+- The enclosing function must return `Result<T, E>` (for `Result` operand) or `Option<T>` (for `Option` operand)
+- Using `?` on `Result` in a function returning `Option`, or vice versa, is a compile error
+- `?` cannot be used inside closures that don't return `Result`/`Option` themselves
+
+**Effect interaction**: The `?` operator performs early return but does not introduce effects. The function's `with` clause is unaffected.
+
+### 4. No `Into<T>` Trait
+
+Wado does not provide an `Into<T>` trait. The reasons:
+
+1. **`.into()` hides the target type.** Code like `let x = value.into()` requires type context to understand. `String::from(value)` is always clear.
+
+2. **Orphan rules make `Into` unnecessary.** Rust needed `Into` because pre-1.41 orphan rules prevented `impl From<ForeignType> for LocalType` in some cases. Wado uses Rust 1.41+ style orphan rules where having a local type in *any* trait parameter position suffices. With `From<LocalType> for ForeignType` allowed, there's no need for `Into`.
+
+3. **`impl Into<T>` parameters cause monomorphization bloat.** Each unique caller type generates a copy of the function body. The Rust ecosystem created the `momo` crate specifically to work around this problem.
+
+Users write `Type::from(value)` at call sites. This is slightly more verbose than `.into()` but always makes the target type visible.
+
+### 5. No `as` Extension for `From`
+
+The `as` operator retains its current semantics:
+
+- **Primitive casts**: `42 as f64`, `'A' as i32`
+- **Newtype casts**: `meters as f64`, `value as Meters`
+
+`as` does **not** call `From::from()`. The semantic distinction:
+
+| Mechanism | Semantics | Cost |
+|-----------|-----------|------|
+| `as` | Bit reinterpretation / cast | Zero-cost, always succeeds |
+| `From::from()` | Semantic conversion | May allocate, always succeeds |
+| `TryFrom::try_from()` | Fallible conversion | May allocate, may fail |
+
+This keeps `as` simple and predictable. Developers know `x as T` is always a trivial operation.
+
+### 6. Variant `From` Auto-Derive
+
+Variant types can opt into compiler-generated `From` impls using the existing auto-derive syntax:
+
+```wado
+variant AppError {
+    Io(IoError),
+    Parse(ParseError),
+    Validation(String),
+}
+
+impl From<IoError> for AppError;      // generates: AppError::Io(value)
+impl From<ParseError> for AppError;   // generates: AppError::Parse(value)
+impl From<String> for AppError;       // generates: AppError::Validation(value)
+```
+
+Each `impl From<T> for Variant;` (with no body) instructs the compiler to generate:
+
+```wado
+impl From<IoError> for AppError {
+    fn from(value: IoError) -> AppError {
+        return AppError::Io(value);
+    }
+}
+```
+
+This follows the existing pattern used by `impl Serialize for Type;` and `impl Deserialize for Type;`.
+
+**Ambiguity rule**: If multiple variant cases have the same payload type, the compiler rejects the auto-derive with a clear error message. The user must write the `From` impl manually.
+
+This pattern is especially powerful with `?`:
+
+```wado
+fn process() -> Result<String, AppError> {
+    let data = read_file("input.txt")?;   // IoError → AppError::Io via From
+    let parsed = parse(data)?;            // ParseError → AppError::Parse via From
+    return Result::<String, AppError>::Ok(parsed);
+}
+```
+
+### 7. Newtype `From` Auto-Generation
+
+The compiler automatically generates bidirectional `From` impls for newtypes:
+
+```wado
+type UserId = u64;
+// compiler auto-generates:
+// impl From<u64> for UserId { fn from(value: u64) -> UserId { return value as UserId; } }
+// impl From<UserId> for u64 { fn from(value: UserId) -> u64 { return value as u64; } }
+```
+
+This means both `as` and `From::from()` work for newtypes:
+
+```wado
+let id: UserId = 42;                    // literal coercion (existing)
+let id2 = 42 as UserId;                 // as cast (existing)
+let id3 = UserId::from(42 as u64);      // From (new, auto-generated)
+let raw = u64::from(id);                // From (new, auto-generated)
+```
+
+The auto-generated `From` impls enable newtypes to participate in generic code:
+
+```wado
+fn print_id<T: From<u64>>(raw: u64) {
+    let id = T::from(raw);
+    println(`{id}`);
+}
+print_id::<UserId>(42);
+```
+
+### 8. Standard Library `From` Impls
+
+The standard library provides `From` impls for common lossless conversions:
+
+**Numeric widenings** (infallible, lossless):
+
+| From | To |
+|------|----|
+| `i8` | `i16`, `i32`, `i64` |
+| `i16` | `i32`, `i64` |
+| `i32` | `i64` |
+| `u8` | `u16`, `u32`, `u64`, `i16`, `i32`, `i64` |
+| `u16` | `u32`, `u64`, `i32`, `i64` |
+| `u32` | `u64`, `i64` |
+| `f32` | `f64` |
+
+**Other conversions**:
+
+- `impl From<char> for String` — single character to string
+- `impl From<bool> for i32` — `false` → `0`, `true` → `1`
+
+**`TryFrom` impls** for narrowing conversions:
+
+- `impl TryFrom<i64> for i32` — checked narrowing
+- `impl TryFrom<i32> for u32` — checked sign conversion
+- (and similar for other narrowing/sign combinations)
+
+### 9. Interaction with Existing Features
+
+| Feature | Status | Interaction |
+|---------|--------|-------------|
+| `as` casts | Unchanged | `as` = bit cast; `From` = semantic conversion |
+| Literal coercion | Unchanged | Literals still coerce to target type without `From` |
+| `null` → `Option::None` | Unchanged | Syntactic sugar, not a `From` call |
+| Template strings | Unchanged | `\`{x}\`` uses `Display`, not `From` |
+| Newtype `as` | Unchanged | `as` still works; `From` is additionally auto-generated |
+
+## Consequences
+
+### Benefits
+
+- **Ergonomic error handling**: `?` with automatic `From` conversion eliminates manual `match` on `Result` for error propagation
+- **Explicit target types**: No `.into()` means the target type is always visible at the call site
+- **Minimal trait surface**: Two traits (`From`, `TryFrom`) instead of Rust's ten+ conversion traits
+- **Variant error composition**: `impl From<E> for AppError;` auto-derive + `?` makes error handling concise
+- **GC-simplified design**: No need for `AsRef`, `Borrow`, `Deref`, `ToOwned` — Wado's GC handles reference semantics
+
+### Trade-offs
+
+- **More verbose than `.into()`**: `String::from(value)` is longer than `value.into()`. This is intentional — explicitness over brevity.
+- **No generic "accepts any convertible type" parameter**: Without `impl Into<T>`, functions cannot accept multiple types via a single parameter. Users call `Type::from(value)` at the call site instead. This avoids monomorphization bloat but requires the caller to be explicit.
+
+## Future Considerations
+
+### `into T` Operator
+
+If the community finds `Type::from(value)` too verbose in practice, an `into T` postfix operator could be added:
+
+```wado
+let s = 42 into String;          // equivalent to String::from(42)
+let id = raw_id into UserId;     // equivalent to UserId::from(raw_id)
+```
+
+This preserves target type visibility (unlike `.into()`) while being more concise than `Type::from(value)`. It is explicitly out of scope for the initial release — we start with `From::from()` and evaluate community feedback.
+
+### `from T` Parameter Modifier
+
+A parameter modifier that performs conversion at the call site without monomorphization:
+
+```wado
+fn greet(name: String from &str) with Stdout {
+    println(`Hello, {name}!`);
+}
+greet("world");  // compiler inserts String::from("world") at call site
+```
+
+This is reserved as a future possibility but not included in this proposal.
+
+## References
+
+- [Research: From/Into Conversion Trait Framework](./research-from-into-framework.md) — background research for this WEP
+- [RFC 529: Conversion Traits](https://rust-lang.github.io/rfcs/0529-conversion-traits.html)
+- [RFC 1542: TryFrom](https://rust-lang.github.io/rfcs/1542-try-from.html)
+- [WEP: Literal Type Conversion Rules](./wep-2026-01-12-literal-type-conversion.md)
+- [WEP: Newtype Semantics](./wep-2026-01-29-newtype-semantics.md)
+- [WEP: Trait Bounds Enforcement](./wep-2026-02-07-trait-bounds.md)
+- [WEP: Variant Payload Design](./wep-2026-01-25-variant-payload-design.md)
+- [WEP: Operator Overloading](./wep-2026-01-18-operator-overloading.md)
+- [WEP: Default Trait](./wep-2026-03-04-default-trait.md)

--- a/docs/wep-2026-03-16-conversion-traits.md
+++ b/docs/wep-2026-03-16-conversion-traits.md
@@ -16,12 +16,12 @@ There is no general-purpose mechanism for converting between user-defined types,
 
 See [Research: From/Into Conversion Trait Framework](./research-from-into-framework.md) for the full survey. Key findings:
 
-| Approach | Languages | Outcome |
-|----------|-----------|---------|
-| Implicit conversions | C++, Scala 2 | Universally regretted; causes bugs, hides costs |
-| Fully explicit | Go, Zig | Safe but verbose; no generic conversion protocol |
-| Trait-based, call-site-explicit | Rust | Good balance; `From`/`?` integration is the standout success |
-| Literal coercion only | Swift | Elegant for literals, insufficient for value-to-value |
+| Approach                        | Languages    | Outcome                                                      |
+| ------------------------------- | ------------ | ------------------------------------------------------------ |
+| Implicit conversions            | C++, Scala 2 | Universally regretted; causes bugs, hides costs              |
+| Fully explicit                  | Go, Zig      | Safe but verbose; no generic conversion protocol             |
+| Trait-based, call-site-explicit | Rust         | Good balance; `From`/`?` integration is the standout success |
+| Literal coercion only           | Swift        | Elegant for literals, insufficient for value-to-value        |
 
 Rust's `From`/`Into` framework is the primary reference design. Its strengths: standardized conversion protocol, `?` operator integration, separation of infallible/fallible. Its weaknesses:
 
@@ -132,6 +132,7 @@ fn find_user_name(id: i32) -> Option<String> {
 ```
 
 **Requirements**:
+
 - The enclosing function must return `Result<T, E>` (for `Result` operand) or `Option<T>` (for `Option` operand)
 - Using `?` on `Result` in a function returning `Option`, or vice versa, is a compile error
 - `?` cannot be used inside closures that don't return `Result`/`Option` themselves
@@ -144,7 +145,7 @@ Wado does not provide an `Into<T>` trait. The reasons:
 
 1. **`.into()` hides the target type.** Code like `let x = value.into()` requires type context to understand. `String::from(value)` is always clear.
 
-2. **Orphan rules make `Into` unnecessary.** Rust needed `Into` because pre-1.41 orphan rules prevented `impl From<ForeignType> for LocalType` in some cases. Wado uses Rust 1.41+ style orphan rules where having a local type in *any* trait parameter position suffices. With `From<LocalType> for ForeignType` allowed, there's no need for `Into`.
+2. **Orphan rules make `Into` unnecessary.** Rust needed `Into` because pre-1.41 orphan rules prevented `impl From<ForeignType> for LocalType` in some cases. Wado uses Rust 1.41+ style orphan rules where having a local type in _any_ trait parameter position suffices. With `From<LocalType> for ForeignType` allowed, there's no need for `Into`.
 
 3. **`impl Into<T>` parameters cause monomorphization bloat.** Each unique caller type generates a copy of the function body. The Rust ecosystem created the `momo` crate specifically to work around this problem.
 
@@ -159,11 +160,11 @@ The `as` operator retains its current semantics:
 
 `as` does **not** call `From::from()`. The semantic distinction:
 
-| Mechanism | Semantics | Cost |
-|-----------|-----------|------|
-| `as` | Bit reinterpretation / cast | Zero-cost, always succeeds |
-| `From::from()` | Semantic conversion | May allocate, always succeeds |
-| `TryFrom::try_from()` | Fallible conversion | May allocate, may fail |
+| Mechanism             | Semantics                   | Cost                          |
+| --------------------- | --------------------------- | ----------------------------- |
+| `as`                  | Bit reinterpretation / cast | Zero-cost, always succeeds    |
+| `From::from()`        | Semantic conversion         | May allocate, always succeeds |
+| `TryFrom::try_from()` | Fallible conversion         | May allocate, may fail        |
 
 This keeps `as` simple and predictable. Developers know `x as T` is always a trivial operation.
 
@@ -243,15 +244,15 @@ The standard library provides `From` impls for common lossless conversions:
 
 **Numeric widenings** (infallible, lossless):
 
-| From | To |
-|------|----|
-| `i8` | `i16`, `i32`, `i64` |
-| `i16` | `i32`, `i64` |
-| `i32` | `i64` |
-| `u8` | `u16`, `u32`, `u64`, `i16`, `i32`, `i64` |
-| `u16` | `u32`, `u64`, `i32`, `i64` |
-| `u32` | `u64`, `i64` |
-| `f32` | `f64` |
+| From  | To                                       |
+| ----- | ---------------------------------------- |
+| `i8`  | `i16`, `i32`, `i64`                      |
+| `i16` | `i32`, `i64`                             |
+| `i32` | `i64`                                    |
+| `u8`  | `u16`, `u32`, `u64`, `i16`, `i32`, `i64` |
+| `u16` | `u32`, `u64`, `i32`, `i64`               |
+| `u32` | `u64`, `i64`                             |
+| `f32` | `f64`                                    |
 
 **Other conversions**:
 
@@ -266,13 +267,13 @@ The standard library provides `From` impls for common lossless conversions:
 
 ### 9. Interaction with Existing Features
 
-| Feature | Status | Interaction |
-|---------|--------|-------------|
-| `as` casts | Unchanged | `as` = bit cast; `From` = semantic conversion |
-| Literal coercion | Unchanged | Literals still coerce to target type without `From` |
-| `null` → `Option::None` | Unchanged | Syntactic sugar, not a `From` call |
-| Template strings | Unchanged | `\`{x}\`` uses `Display`, not `From` |
-| Newtype `as` | Unchanged | `as` still works; `From` is additionally auto-generated |
+| Feature                 | Status    | Interaction                                             |
+| ----------------------- | --------- | ------------------------------------------------------- |
+| `as` casts              | Unchanged | `as` = bit cast; `From` = semantic conversion           |
+| Literal coercion        | Unchanged | Literals still coerce to target type without `From`     |
+| `null` → `Option::None` | Unchanged | Syntactic sugar, not a `From` call                      |
+| Template strings        | Unchanged | `\`{x}\``uses`Display`, not`From`                       |
+| Newtype `as`            | Unchanged | `as` still works; `From` is additionally auto-generated |
 
 ## Consequences
 

--- a/docs/wep.md
+++ b/docs/wep.md
@@ -74,3 +74,5 @@ Filename: `docs/wep-YYYY-MM-DD-{feature-name}.md`
 - [Gale — Grammar Adaptive LL Engine](./wep-2026-03-02-gale.md)
 - [Range Object](./wep-2026-03-03-range-object.md)
 - [Default Trait](./wep-2026-03-04-default-trait.md)
+- [Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md)
+- [Conversion Traits (From, TryFrom, ? operator)](./wep-2026-03-16-conversion-traits.md)


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for a proposed conversion traits framework for Wado, including both background research and a formal WEP (Wado Enhancement Proposal).

## Changes

### New Files

- **`docs/research-from-into-framework.md`** — Extensive cross-language survey of type conversion designs
  - Analyzes Rust's `From`/`Into`/`TryFrom`/`TryInto` framework in depth, including design rationale, pros/cons, and community feedback
  - Surveys conversion mechanisms in Scala, Swift, C++, Go, Haskell, Python, Zig, and Kotlin
  - Identifies key takeaways and open questions for Wado's design
  - Documents relevant Rust RFCs (529, 1542, 1210) and cross-cutting themes across languages

- **`docs/wep-2026-03-16-conversion-traits.md`** — Formal WEP proposing Wado's conversion trait framework
  - Specifies `From<T>` trait for infallible conversions
  - Specifies `TryFrom<T>` trait for fallible conversions returning `Result`
  - Defines `?` operator semantics for early return on `Result` and `Option`
  - Explicitly excludes `Into<T>` trait to keep target types visible at call sites
  - Proposes auto-derive `From` impls for variant types and newtypes
  - Defines standard library `From` impls for numeric widenings and common conversions
  - Discusses interaction with existing features (`as` casts, literal coercion, etc.)
  - Outlines future possibilities (`into T` operator, `from T` parameter modifier)

### Modified Files

- **`docs/wep.md`** — Updated WEP index to include the new conversion traits WEP

## Design Highlights

The proposal takes a middle ground between Rust's design and lessons from other languages:

- **Explicit call sites**: No implicit conversions beyond existing literal coercion; `From::from(value)` always makes the target type visible
- **Minimal trait surface**: Two traits (`From`, `TryFrom`) instead of Rust's ten+ conversion-related traits, leveraging Wado's GC to eliminate the need for `AsRef`, `Borrow`, `Deref`, etc.
- **`?` operator integration**: Error type composition via `From` enables ergonomic error propagation
- **Compiler-generated impls**: Auto-derive for variant and newtype conversions reduces boilerplate
- **No `Into<T>`**: Avoids the `.into()` inference problem and monomorphization bloat from `impl Into<T>` parameters

The research document provides the rationale for these choices, drawing on Rust's experience and cautionary tales from C++ and Scala 2.

https://claude.ai/code/session_01RYYDRje9mqwDEbyZH94zHm