### PR TITLE
Comment out wasm-tools dependency in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@
 dprint = "latest"
 
 # WebAssembly toolchain for parsing, printing, and validating Wasm
-"github:bytecodealliance/wasm-tools" = "latest"
+# "github:bytecodealliance/wasm-tools" = "latest"  # install manually when needed
 
 # WebAssembly runtime with WASI P3 support (matches Cargo.toml wasmtime = "42")
 wasmtime = "42"


### PR DESCRIPTION
## Summary
Disabled the automatic installation of the `wasm-tools` dependency by commenting it out in the mise.toml configuration file, with a note to install manually when needed.

## Changes
- Commented out the `github:bytecodealliance/wasm-tools` dependency line
- Added an inline comment indicating manual installation is required when the tool is needed

## Rationale
This change allows the project to avoid automatically installing wasm-tools during environment setup, while keeping the configuration available for manual installation when required. This may help reduce initial setup time or avoid unnecessary dependencies in certain workflows.

https://claude.ai/code/session_0182Arvk6NuvaDbgTmjdyvs5