### PR TITLE
Optimize JSON string deserialization with two-phase parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ wado-compiler/tests/fixtures/testdata/test_output.txt
 # plan files
 plan.md
 PLAN.md
+profile.json

--- a/wado-compiler/lib/core/json.wado
+++ b/wado-compiler/lib/core/json.wado
@@ -403,7 +403,39 @@ impl JsonDeserializer {
         }
         self.pos += 1;
 
-        let mut result = String::with_capacity(32);
+        // Phase 1: scan ahead to find the end of the escape-free prefix.
+        // This lets us pre-size the allocation exactly, avoiding repeated grow() calls.
+        let prefix_start = self.pos;
+        let mut scan_pos = self.pos;
+        while scan_pos < self.input.len() {
+            let sb = self.input.get_byte(scan_pos) as i32;
+            if sb == '"' as i32 || sb == '\\' as i32 {
+                break;
+            }
+            scan_pos += 1;
+        }
+        let prefix_len = scan_pos - prefix_start;
+
+        // Fast path: no escapes — allocate exactly the right size and copy raw bytes.
+        if scan_pos < self.input.len() && self.input.get_byte(scan_pos) as i32 == '"' as i32 {
+            let mut result = String::with_capacity(prefix_len);
+            let start = result.internal_reserve_uninit(prefix_len);
+            for let mut i = 0; i < prefix_len; i += 1 {
+                result.set_byte(start + i, self.input.get_byte(prefix_start + i));
+            }
+            self.pos = scan_pos + 1;
+            return Result::<String, DeserializeError>::Ok(result);
+        }
+
+        // Slow path: has escape sequences (or hit EOF).
+        // Pre-copy the escape-free prefix with a well-sized allocation, then handle escapes.
+        let mut result = String::with_capacity(prefix_len + 32);
+        let start = result.internal_reserve_uninit(prefix_len);
+        for let mut i = 0; i < prefix_len; i += 1 {
+            result.set_byte(start + i, self.input.get_byte(prefix_start + i));
+        }
+        self.pos = scan_pos;
+
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
             if b == '"' as i32 {

--- a/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
@@ -1846,258 +1846,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b171: block {
         l172: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b171;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b171;
+            };
+            scan_pos = scan_pos + 1;
+            continue l172;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l179: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l179;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l182: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l182;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b184: block {
+        l185: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b184;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l172;
+            continue l185;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2129,15 +2248,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l197: loop {
+            l210: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2170,7 +2289,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l197;
+                continue l210;
             };
         };
     };
@@ -2240,11 +2359,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b208: block {
-        l209: loop {
+    b221: block {
+        l222: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b208;
+                break b221;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2258,9 +2377,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b208;
+                break b221;
             };
-            continue l209;
+            continue l222;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2281,11 +2400,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b215: block {
-            l216: loop {
+        b228: block {
+            l229: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b215;
+                    break b228;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2299,9 +2418,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b215;
+                    break b228;
                 };
-                continue l216;
+                continue l229;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2342,11 +2461,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b226: block {
-                l227: loop {
+            b239: block {
+                l240: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b226;
+                        break b239;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2360,9 +2479,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b226;
+                        break b239;
                     };
-                    continue l227;
+                    continue l240;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2456,11 +2575,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b236: block {
-        l237: loop {
+    b249: block {
+        l250: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b236;
+                break b249;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -2487,12 +2606,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b245: block {
-                        l246: loop {
+                    b258: block {
+                        l259: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b258;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -2509,9 +2628,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b258;
                             };
-                            continue l246;
+                            continue l259;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2542,12 +2661,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b256: block {
-                            l257: loop {
+                        b269: block {
+                            l270: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b256;
+                                    break b269;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -2563,9 +2682,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b256;
+                                    break b269;
                                 };
-                                continue l257;
+                                continue l270;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2602,9 +2721,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b236;
+                break b249;
             };
-            continue l237;
+            continue l250;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2630,11 +2749,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b267: block {
-        l268: loop {
+    b280: block {
+        l281: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b267;
+                break b280;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2663,7 +2782,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l268;
+            continue l281;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2766,7 +2885,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l283: loop {
+            l296: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -2808,7 +2927,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l283;
+                continue l296;
             };
         };
         self.pos = _hfs_pos_49;
@@ -2833,7 +2952,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l292: loop {
+            l305: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -2913,7 +3032,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l292;
+                continue l305;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3024,13 +3143,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b310: block {
-        l311: loop {
+    b323: block {
+        l324: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b310;
+                break b323;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3038,14 +3157,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b310;
+                break b323;
             };
             if b == 92 {
                 has_escape = 1;
-                break b310;
+                break b323;
             };
             self.de.pos = self.de.pos + 1;
-            continue l311;
+            continue l324;
         };
     };
     if has_escape == 0 {
@@ -3165,13 +3284,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l331: loop {
+            l344: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l331;
+                continue l344;
             };
         };
     };
@@ -3304,8 +3423,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b354: block {
-        l355: loop {
+    b367: block {
+        l368: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3330,9 +3449,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b354;
+                break b367;
             };
-            continue l355;
+            continue l368;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
@@ -2311,258 +2311,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b213: block {
         l214: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b213;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b213;
+            };
+            scan_pos = scan_pos + 1;
+            continue l214;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l221: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l221;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l224: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l224;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b226: block {
+        l227: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b226;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l214;
+            continue l227;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2594,15 +2713,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l239: loop {
+            l252: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2635,7 +2754,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l239;
+                continue l252;
             };
         };
     };
@@ -2705,11 +2824,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b250: block {
-        l251: loop {
+    b263: block {
+        l264: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b250;
+                break b263;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2723,9 +2842,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b250;
+                break b263;
             };
-            continue l251;
+            continue l264;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2746,11 +2865,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b257: block {
-            l258: loop {
+        b270: block {
+            l271: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b257;
+                    break b270;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2764,9 +2883,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b257;
+                    break b270;
                 };
-                continue l258;
+                continue l271;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2807,11 +2926,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b268: block {
-                l269: loop {
+            b281: block {
+                l282: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b268;
+                        break b281;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2825,9 +2944,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b268;
+                        break b281;
                     };
-                    continue l269;
+                    continue l282;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2921,11 +3040,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b278: block {
-        l279: loop {
+    b291: block {
+        l292: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b278;
+                break b291;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -2952,12 +3071,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b287: block {
-                        l288: loop {
+                    b300: block {
+                        l301: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b287;
+                                break b300;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -2974,9 +3093,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b287;
+                                break b300;
                             };
-                            continue l288;
+                            continue l301;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3007,12 +3126,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b298: block {
-                            l299: loop {
+                        b311: block {
+                            l312: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b298;
+                                    break b311;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -3028,9 +3147,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b298;
+                                    break b311;
                                 };
-                                continue l299;
+                                continue l312;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3067,9 +3186,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b278;
+                break b291;
             };
-            continue l279;
+            continue l292;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3095,11 +3214,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b309: block {
-        l310: loop {
+    b322: block {
+        l323: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b309;
+                break b322;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3128,7 +3247,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l310;
+            continue l323;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3231,7 +3350,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l325: loop {
+            l338: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3273,7 +3392,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l325;
+                continue l338;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3298,7 +3417,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l334: loop {
+            l347: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3378,7 +3497,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l334;
+                continue l347;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3489,13 +3608,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b352: block {
-        l353: loop {
+    b365: block {
+        l366: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b352;
+                break b365;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3503,14 +3622,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b352;
+                break b365;
             };
             if b == 92 {
                 has_escape = 1;
-                break b352;
+                break b365;
             };
             self.de.pos = self.de.pos + 1;
-            continue l353;
+            continue l366;
         };
     };
     if has_escape == 0 {
@@ -3692,13 +3811,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l379: loop {
+            l392: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l379;
+                continue l392;
             };
         };
     };
@@ -3831,8 +3950,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b402: block {
-        l403: loop {
+    b415: block {
+        l416: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3857,9 +3976,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b402;
+                break b415;
             };
-            continue l403;
+            continue l416;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error.wir.wado
@@ -2096,258 +2096,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b171: block {
         l172: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b171;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b171;
+            };
+            scan_pos = scan_pos + 1;
+            continue l172;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l179: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l179;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l182: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l182;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b184: block {
+        l185: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b184;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l172;
+            continue l185;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2379,15 +2498,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l197: loop {
+            l210: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2420,7 +2539,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l197;
+                continue l210;
             };
         };
     };
@@ -2490,11 +2609,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b208: block {
-        l209: loop {
+    b221: block {
+        l222: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b208;
+                break b221;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2508,9 +2627,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b208;
+                break b221;
             };
-            continue l209;
+            continue l222;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2531,11 +2650,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b215: block {
-            l216: loop {
+        b228: block {
+            l229: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b215;
+                    break b228;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2549,9 +2668,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b215;
+                    break b228;
                 };
-                continue l216;
+                continue l229;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2592,11 +2711,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b226: block {
-                l227: loop {
+            b239: block {
+                l240: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b226;
+                        break b239;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2610,9 +2729,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b226;
+                        break b239;
                     };
-                    continue l227;
+                    continue l240;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2706,11 +2825,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b236: block {
-        l237: loop {
+    b249: block {
+        l250: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b236;
+                break b249;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -2737,12 +2856,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b245: block {
-                        l246: loop {
+                    b258: block {
+                        l259: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b258;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -2759,9 +2878,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b258;
                             };
-                            continue l246;
+                            continue l259;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2792,12 +2911,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b256: block {
-                            l257: loop {
+                        b269: block {
+                            l270: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b256;
+                                    break b269;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -2813,9 +2932,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b256;
+                                    break b269;
                                 };
-                                continue l257;
+                                continue l270;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2852,9 +2971,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b236;
+                break b249;
             };
-            continue l237;
+            continue l250;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2880,11 +2999,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b267: block {
-        l268: loop {
+    b280: block {
+        l281: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b267;
+                break b280;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2913,7 +3032,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l268;
+            continue l281;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3016,7 +3135,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l283: loop {
+            l296: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3058,7 +3177,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l283;
+                continue l296;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3083,7 +3202,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l292: loop {
+            l305: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3163,7 +3282,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l292;
+                continue l305;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3274,13 +3393,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b310: block {
-        l311: loop {
+    b323: block {
+        l324: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b310;
+                break b323;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3288,14 +3407,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b310;
+                break b323;
             };
             if b == 92 {
                 has_escape = 1;
-                break b310;
+                break b323;
             };
             self.de.pos = self.de.pos + 1;
-            continue l311;
+            continue l324;
         };
     };
     if has_escape == 0 {
@@ -3415,13 +3534,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l331: loop {
+            l344: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l331;
+                continue l344;
             };
         };
     };
@@ -3554,8 +3673,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b354: block {
-        l355: loop {
+    b367: block {
+        l368: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3580,9 +3699,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b354;
+                break b367;
             };
-            continue l355;
+            continue l368;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
@@ -4521,258 +4521,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b368: block {
         l369: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b368;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b368;
+            };
+            scan_pos = scan_pos + 1;
+            continue l369;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l376: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l376;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l379: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l379;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b381: block {
+        l382: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b381;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l369;
+            continue l382;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -4804,15 +4923,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l394: loop {
+            l407: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -4845,7 +4964,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l394;
+                continue l407;
             };
         };
     };
@@ -4915,11 +5034,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b405: block {
-        l406: loop {
+    b418: block {
+        l419: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b405;
+                break b418;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -4933,9 +5052,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b405;
+                break b418;
             };
-            continue l406;
+            continue l419;
         };
     };
     self.pos = _hfs_pos_36;
@@ -4956,11 +5075,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b412: block {
-            l413: loop {
+        b425: block {
+            l426: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b412;
+                    break b425;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -4974,9 +5093,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b412;
+                    break b425;
                 };
-                continue l413;
+                continue l426;
             };
         };
         self.pos = _hfs_pos_37;
@@ -5017,11 +5136,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b423: block {
-                l424: loop {
+            b436: block {
+                l437: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b423;
+                        break b436;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -5035,9 +5154,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b423;
+                        break b436;
                     };
-                    continue l424;
+                    continue l437;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -5131,11 +5250,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b433: block {
-        l434: loop {
+    b446: block {
+        l447: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b433;
+                break b446;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -5162,12 +5281,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b442: block {
-                        l443: loop {
+                    b455: block {
+                        l456: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b442;
+                                break b455;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -5184,9 +5303,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b442;
+                                break b455;
                             };
-                            continue l443;
+                            continue l456;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -5217,12 +5336,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b453: block {
-                            l454: loop {
+                        b466: block {
+                            l467: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b453;
+                                    break b466;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -5238,9 +5357,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b453;
+                                    break b466;
                                 };
-                                continue l454;
+                                continue l467;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -5277,9 +5396,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b433;
+                break b446;
             };
-            continue l434;
+            continue l447;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5374,11 +5493,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b469: block {
-        l470: loop {
+    b482: block {
+        l483: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b469;
+                break b482;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
@@ -5405,12 +5524,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b478: block {
-                        l479: loop {
+                    b491: block {
+                        l492: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b478;
+                                break b491;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
@@ -5427,9 +5546,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b478;
+                                break b491;
                             };
-                            continue l479;
+                            continue l492;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -5460,12 +5579,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b489: block {
-                            l490: loop {
+                        b502: block {
+                            l503: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b489;
+                                    break b502;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
@@ -5481,9 +5600,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b489;
+                                    break b502;
                                 };
-                                continue l490;
+                                continue l503;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -5509,9 +5628,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 return Result<i64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b469;
+                break b482;
             };
-            continue l470;
+            continue l483;
         };
     };
     self.pos = _hfs_pos_49;
@@ -5537,11 +5656,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b498: block {
-        l499: loop {
+    b511: block {
+        l512: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b498;
+                break b511;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -5570,7 +5689,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l499;
+            continue l512;
         };
     };
     self.pos = _hfs_pos_14;
@@ -5673,7 +5792,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l514: loop {
+            l527: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -5715,7 +5834,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l514;
+                continue l527;
             };
         };
         self.pos = _hfs_pos_49;
@@ -5740,7 +5859,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l523: loop {
+            l536: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -5820,7 +5939,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l523;
+                continue l536;
             };
         };
         self.pos = _hfs_pos_50;
@@ -5931,13 +6050,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b541: block {
-        l542: loop {
+    b554: block {
+        l555: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b541;
+                break b554;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -5945,14 +6064,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b541;
+                break b554;
             };
             if b == 92 {
                 has_escape = 1;
-                break b541;
+                break b554;
             };
             self.de.pos = self.de.pos + 1;
-            continue l542;
+            continue l555;
         };
     };
     if has_escape == 0 {
@@ -6242,13 +6361,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l580: loop {
+            l593: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l580;
+                continue l593;
             };
         };
     };
@@ -6337,10 +6456,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b590: block {
-            l591: loop {
+        b603: block {
+            l604: loop {
                 if (i_8 >= 0) == 0 {
-                    break b590;
+                    break b603;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -6349,7 +6468,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l591;
+                continue l604;
             };
         };
         __for_1: block {
@@ -6357,14 +6476,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l594: loop {
+                l607: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l594;
+                    continue l607;
                 };
             };
         };
@@ -6374,10 +6493,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b596: block {
-            l597: loop {
+        b609: block {
+            l610: loop {
                 if (i_10 >= 0) == 0 {
-                    break b596;
+                    break b609;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -6386,7 +6505,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l597;
+                continue l610;
             };
         };
         __for_2: block {
@@ -6394,14 +6513,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l600: loop {
+                l613: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l600;
+                    continue l613;
                 };
             };
         };
@@ -6503,8 +6622,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b619: block {
-        l620: loop {
+    b632: block {
+        l633: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -6529,9 +6648,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b619;
+                break b632;
             };
-            continue l620;
+            continue l633;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_duplicate_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_duplicate_fields.wir.wado
@@ -2245,258 +2245,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b205: block {
         l206: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b205;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b205;
+            };
+            scan_pos = scan_pos + 1;
+            continue l206;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l213: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l213;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l216: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l216;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b218: block {
+        l219: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b218;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l206;
+            continue l219;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2528,15 +2647,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l231: loop {
+            l244: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2569,7 +2688,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l231;
+                continue l244;
             };
         };
     };
@@ -2639,11 +2758,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b242: block {
-        l243: loop {
+    b255: block {
+        l256: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b242;
+                break b255;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2657,9 +2776,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b242;
+                break b255;
             };
-            continue l243;
+            continue l256;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2680,11 +2799,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b249: block {
-            l250: loop {
+        b262: block {
+            l263: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b249;
+                    break b262;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2698,9 +2817,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b249;
+                    break b262;
                 };
-                continue l250;
+                continue l263;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2741,11 +2860,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b260: block {
-                l261: loop {
+            b273: block {
+                l274: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b260;
+                        break b273;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2759,9 +2878,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b260;
+                        break b273;
                     };
-                    continue l261;
+                    continue l274;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2871,11 +2990,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b270: block {
-        l271: loop {
+    b283: block {
+        l284: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b270;
+                break b283;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -2893,9 +3012,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b270;
+                break b283;
             };
-            continue l271;
+            continue l284;
         };
     };
     self.pos = _hfs_pos_57;
@@ -2917,11 +3036,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b278: block {
-            l279: loop {
+        b291: block {
+            l292: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b278;
+                    break b291;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -2940,9 +3059,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b278;
+                    break b291;
                 };
-                continue l279;
+                continue l292;
             };
         };
         self.pos = _hfs_pos_58;
@@ -2984,11 +3103,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b290: block {
-                l291: loop {
+            b303: block {
+                l304: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b290;
+                        break b303;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -3003,9 +3122,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b290;
+                        break b303;
                     };
-                    continue l291;
+                    continue l304;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3055,11 +3174,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b301: block {
-        l302: loop {
+    b314: block {
+        l315: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b301;
+                break b314;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3088,7 +3207,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l302;
+            continue l315;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3191,7 +3310,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l317: loop {
+            l330: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3233,7 +3352,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l317;
+                continue l330;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3258,7 +3377,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l326: loop {
+            l339: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3338,7 +3457,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l326;
+                continue l339;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3449,13 +3568,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b344: block {
-        l345: loop {
+    b357: block {
+        l358: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b344;
+                break b357;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3463,14 +3582,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b344;
+                break b357;
             };
             if b == 92 {
                 has_escape = 1;
-                break b344;
+                break b357;
             };
             self.de.pos = self.de.pos + 1;
-            continue l345;
+            continue l358;
         };
     };
     if has_escape == 0 {
@@ -3540,13 +3659,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l360: loop {
+            l373: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l360;
+                continue l373;
             };
         };
     };
@@ -3635,10 +3754,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b370: block {
-            l371: loop {
+        b383: block {
+            l384: loop {
                 if (i_8 >= 0) == 0 {
-                    break b370;
+                    break b383;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3647,7 +3766,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l371;
+                continue l384;
             };
         };
         __for_1: block {
@@ -3655,14 +3774,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l374: loop {
+                l387: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l374;
+                    continue l387;
                 };
             };
         };
@@ -3672,10 +3791,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b376: block {
-            l377: loop {
+        b389: block {
+            l390: loop {
                 if (i_10 >= 0) == 0 {
-                    break b376;
+                    break b389;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3684,7 +3803,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l377;
+                continue l390;
             };
         };
         __for_2: block {
@@ -3692,14 +3811,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l380: loop {
+                l393: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l380;
+                    continue l393;
                 };
             };
         };

--- a/wado-compiler/tests/fixtures.golden/serde_json_int_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_int_types.wir.wado
@@ -2547,258 +2547,377 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b228: block {
         l229: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b228;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b228;
+            };
+            scan_pos = scan_pos + 1;
+            continue l229;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l236: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l236;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l239: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l239;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b241: block {
+        l242: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b241;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l229;
+            continue l242;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2830,15 +2949,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l254: loop {
+            l267: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2871,7 +2990,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l254;
+                continue l267;
             };
         };
     };
@@ -2896,14 +3015,14 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
     let __local_6: i32;
     let _licm_used_7: i32;
     let _licm_repr_8: ref array<u8>;
-    __for_2: block {
+    __for_4: block {
         i = 0;
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l264: loop {
+            l277: loop {
                 if (i < _licm_used_7) == 0 {
-                    break __for_2;
+                    break __for_4;
                 };
                 b = __inline_String__get_byte_1: block -> u8 {
                     __local_6 = i;
@@ -2921,7 +3040,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
                     return 1;
                 };
                 i = i + 1;
-                continue l264;
+                continue l277;
             };
         };
     };
@@ -2977,10 +3096,10 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
     };
     result = 0_i64;
     _licm_repr_26 = raw.repr;
-    b274: block {
-        l275: loop {
+    b287: block {
+        l288: loop {
             if (idx < len) == 0 {
-                break b274;
+                break b287;
             };
             b = __inline_String__get_byte_6: block -> u8 {
                 __local_23 = idx;
@@ -2999,7 +3118,7 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l275;
+            continue l288;
         };
     };
     if neg {
@@ -3065,10 +3184,10 @@ fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {  // from cor
     len = raw.used;
     result = 0_i64;
     _licm_repr_30 = raw.repr;
-    b286: block {
-        l287: loop {
+    b299: block {
+        l300: loop {
             if (idx < len) == 0 {
-                break b286;
+                break b299;
             };
             b = __inline_String__get_byte_9: block -> u8 {
                 __local_27 = idx;
@@ -3087,7 +3206,7 @@ fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l287;
+            continue l300;
         };
     };
     return Result<u64,DeserializeError>::Ok { discriminant: 0, payload_0: result };
@@ -3178,11 +3297,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b296: block {
-        l297: loop {
+    b309: block {
+        l310: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b296;
+                break b309;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
@@ -3209,12 +3328,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b305: block {
-                        l306: loop {
+                    b318: block {
+                        l319: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b305;
+                                break b318;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
@@ -3231,9 +3350,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b305;
+                                break b318;
                             };
-                            continue l306;
+                            continue l319;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3264,12 +3383,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b316: block {
-                            l317: loop {
+                        b329: block {
+                            l330: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b316;
+                                    break b329;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
@@ -3285,9 +3404,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b316;
+                                    break b329;
                                 };
-                                continue l317;
+                                continue l330;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3313,9 +3432,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 return Result<i64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b296;
+                break b309;
             };
-            continue l297;
+            continue l310;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3400,11 +3519,11 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b329: block {
-        l330: loop {
+    b342: block {
+        l343: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b329;
+                break b342;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_26 = _hfs_pos_49;
@@ -3431,12 +3550,12 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b338: block {
-                        l339: loop {
+                    b351: block {
+                        l352: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b338;
+                                break b351;
                             };
                             b2 = __inline_String__get_byte_9: block -> u8 {
                                 __local_29 = _hfs_pos_47;
@@ -3453,9 +3572,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b338;
+                                break b351;
                             };
-                            continue l339;
+                            continue l352;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3486,12 +3605,12 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b349: block {
-                            l350: loop {
+                        b362: block {
+                            l363: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b349;
+                                    break b362;
                                 };
                                 b3 = __inline_String__get_byte_15: block -> u8 {
                                     __local_38 = _hfs_pos_48;
@@ -3507,9 +3626,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b349;
+                                    break b362;
                                 };
-                                continue l350;
+                                continue l363;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3537,9 +3656,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                 return Result<u64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b329;
+                break b342;
             };
-            continue l330;
+            continue l343;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3635,13 +3754,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l366: loop {
+            l379: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l366;
+                continue l379;
             };
         };
     };
@@ -3774,8 +3893,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b389: block {
-        l390: loop {
+    b402: block {
+        l403: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3800,9 +3919,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b389;
+                break b402;
             };
-            continue l390;
+            continue l403;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_large_int.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_large_int.wir.wado
@@ -2768,258 +2768,377 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b257: block {
         l258: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b257;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b257;
+            };
+            scan_pos = scan_pos + 1;
+            continue l258;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l265: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l265;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l268: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l268;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b270: block {
+        l271: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b270;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l258;
+            continue l271;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -3051,15 +3170,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l283: loop {
+            l296: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -3092,7 +3211,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l283;
+                continue l296;
             };
         };
     };
@@ -3117,14 +3236,14 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
     let __local_6: i32;
     let _licm_used_7: i32;
     let _licm_repr_8: ref array<u8>;
-    __for_2: block {
+    __for_4: block {
         i = 0;
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l293: loop {
+            l306: loop {
                 if (i < _licm_used_7) == 0 {
-                    break __for_2;
+                    break __for_4;
                 };
                 b = __inline_String__get_byte_1: block -> u8 {
                     __local_6 = i;
@@ -3142,7 +3261,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
                     return 1;
                 };
                 i = i + 1;
-                continue l293;
+                continue l306;
             };
         };
     };
@@ -3198,10 +3317,10 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
     };
     result = 0_i64;
     _licm_repr_26 = raw.repr;
-    b303: block {
-        l304: loop {
+    b316: block {
+        l317: loop {
             if (idx < len) == 0 {
-                break b303;
+                break b316;
             };
             b = __inline_String__get_byte_6: block -> u8 {
                 __local_23 = idx;
@@ -3220,7 +3339,7 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l304;
+            continue l317;
         };
     };
     if neg {
@@ -3286,10 +3405,10 @@ fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {  // from cor
     len = raw.used;
     result = 0_i64;
     _licm_repr_30 = raw.repr;
-    b315: block {
-        l316: loop {
+    b328: block {
+        l329: loop {
             if (idx < len) == 0 {
-                break b315;
+                break b328;
             };
             b = __inline_String__get_byte_9: block -> u8 {
                 __local_27 = idx;
@@ -3308,7 +3427,7 @@ fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l316;
+            continue l329;
         };
     };
     return Result<u64,DeserializeError>::Ok { discriminant: 0, payload_0: result };
@@ -3399,11 +3518,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b325: block {
-        l326: loop {
+    b338: block {
+        l339: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b325;
+                break b338;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
@@ -3430,12 +3549,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b334: block {
-                        l335: loop {
+                    b347: block {
+                        l348: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b334;
+                                break b347;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
@@ -3452,9 +3571,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b334;
+                                break b347;
                             };
-                            continue l335;
+                            continue l348;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3485,12 +3604,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b345: block {
-                            l346: loop {
+                        b358: block {
+                            l359: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b345;
+                                    break b358;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
@@ -3506,9 +3625,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b345;
+                                    break b358;
                                 };
-                                continue l346;
+                                continue l359;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3534,9 +3653,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 return Result<i64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b325;
+                break b338;
             };
-            continue l326;
+            continue l339;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3621,11 +3740,11 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b358: block {
-        l359: loop {
+    b371: block {
+        l372: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b358;
+                break b371;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_26 = _hfs_pos_49;
@@ -3652,12 +3771,12 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b367: block {
-                        l368: loop {
+                    b380: block {
+                        l381: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b367;
+                                break b380;
                             };
                             b2 = __inline_String__get_byte_9: block -> u8 {
                                 __local_29 = _hfs_pos_47;
@@ -3674,9 +3793,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b367;
+                                break b380;
                             };
-                            continue l368;
+                            continue l381;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3707,12 +3826,12 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b378: block {
-                            l379: loop {
+                        b391: block {
+                            l392: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b378;
+                                    break b391;
                                 };
                                 b3 = __inline_String__get_byte_15: block -> u8 {
                                     __local_38 = _hfs_pos_48;
@@ -3728,9 +3847,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b378;
+                                    break b391;
                                 };
-                                continue l379;
+                                continue l392;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3758,9 +3877,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                 return Result<u64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b358;
+                break b371;
             };
-            continue l359;
+            continue l372;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3856,13 +3975,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l395: loop {
+            l408: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l395;
+                continue l408;
             };
         };
     };
@@ -3995,8 +4114,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b418: block {
-        l419: loop {
+    b431: block {
+        l432: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -4021,9 +4140,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b418;
+                break b431;
             };
-            continue l419;
+            continue l432;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_multi_type_deser.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_multi_type_deser.wir.wado
@@ -1060,258 +1060,377 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b112: block {
         l113: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b112;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b112;
+            };
+            scan_pos = scan_pos + 1;
+            continue l113;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l120: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l120;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l123: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l123;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b125: block {
+        l126: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b125;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l113;
+            continue l126;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -1343,15 +1462,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l138: loop {
+            l151: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -1384,7 +1503,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l138;
+                continue l151;
             };
         };
     };
@@ -1489,11 +1608,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b152: block {
-        l153: loop {
+    b165: block {
+        l166: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b152;
+                break b165;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -1520,12 +1639,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b161: block {
-                        l162: loop {
+                    b174: block {
+                        l175: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b161;
+                                break b174;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -1542,9 +1661,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b161;
+                                break b174;
                             };
-                            continue l162;
+                            continue l175;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -1575,12 +1694,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b172: block {
-                            l173: loop {
+                        b185: block {
+                            l186: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b172;
+                                    break b185;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -1596,9 +1715,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b172;
+                                    break b185;
                                 };
-                                continue l173;
+                                continue l186;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -1635,9 +1754,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b152;
+                break b165;
             };
-            continue l153;
+            continue l166;
         };
     };
     self.pos = _hfs_pos_51;
@@ -1654,13 +1773,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l184: loop {
+            l197: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l184;
+                continue l197;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
@@ -2986,258 +2986,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b271: block {
         l272: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b271;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b271;
+            };
+            scan_pos = scan_pos + 1;
+            continue l272;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l279: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l279;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l282: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l282;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b284: block {
+        l285: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b284;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l272;
+            continue l285;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -3269,15 +3388,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l297: loop {
+            l310: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -3310,7 +3429,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l297;
+                continue l310;
             };
         };
     };
@@ -3380,11 +3499,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b308: block {
-        l309: loop {
+    b321: block {
+        l322: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b308;
+                break b321;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -3398,9 +3517,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b308;
+                break b321;
             };
-            continue l309;
+            continue l322;
         };
     };
     self.pos = _hfs_pos_36;
@@ -3421,11 +3540,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b315: block {
-            l316: loop {
+        b328: block {
+            l329: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b315;
+                    break b328;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -3439,9 +3558,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b315;
+                    break b328;
                 };
-                continue l316;
+                continue l329;
             };
         };
         self.pos = _hfs_pos_37;
@@ -3482,11 +3601,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b326: block {
-                l327: loop {
+            b339: block {
+                l340: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b326;
+                        break b339;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -3500,9 +3619,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b326;
+                        break b339;
                     };
-                    continue l327;
+                    continue l340;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3612,11 +3731,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b336: block {
-        l337: loop {
+    b349: block {
+        l350: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b336;
+                break b349;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -3634,9 +3753,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b336;
+                break b349;
             };
-            continue l337;
+            continue l350;
         };
     };
     self.pos = _hfs_pos_57;
@@ -3658,11 +3777,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b344: block {
-            l345: loop {
+        b357: block {
+            l358: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b344;
+                    break b357;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -3681,9 +3800,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b344;
+                    break b357;
                 };
-                continue l345;
+                continue l358;
             };
         };
         self.pos = _hfs_pos_58;
@@ -3725,11 +3844,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b356: block {
-                l357: loop {
+            b369: block {
+                l370: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b356;
+                        break b369;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -3744,9 +3863,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b356;
+                        break b369;
                     };
-                    continue l357;
+                    continue l370;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3796,11 +3915,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b367: block {
-        l368: loop {
+    b380: block {
+        l381: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b367;
+                break b380;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3829,7 +3948,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l368;
+            continue l381;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3932,7 +4051,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l383: loop {
+            l396: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3974,7 +4093,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l383;
+                continue l396;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3999,7 +4118,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l392: loop {
+            l405: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -4079,7 +4198,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l392;
+                continue l405;
             };
         };
         self.pos = _hfs_pos_50;
@@ -4190,13 +4309,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b410: block {
-        l411: loop {
+    b423: block {
+        l424: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b410;
+                break b423;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -4204,14 +4323,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b410;
+                break b423;
             };
             if b == 92 {
                 has_escape = 1;
-                break b410;
+                break b423;
             };
             self.de.pos = self.de.pos + 1;
-            continue l411;
+            continue l424;
         };
     };
     if has_escape == 0 {
@@ -4281,13 +4400,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l426: loop {
+            l439: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l426;
+                continue l439;
             };
         };
     };
@@ -4376,10 +4495,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b436: block {
-            l437: loop {
+        b449: block {
+            l450: loop {
                 if (i_8 >= 0) == 0 {
-                    break b436;
+                    break b449;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4388,7 +4507,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l437;
+                continue l450;
             };
         };
         __for_1: block {
@@ -4396,14 +4515,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l440: loop {
+                l453: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l440;
+                    continue l453;
                 };
             };
         };
@@ -4413,10 +4532,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b442: block {
-            l443: loop {
+        b455: block {
+            l456: loop {
                 if (i_10 >= 0) == 0 {
-                    break b442;
+                    break b455;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4425,7 +4544,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l443;
+                continue l456;
             };
         };
         __for_2: block {
@@ -4433,14 +4552,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l446: loop {
+                l459: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l446;
+                    continue l459;
                 };
             };
         };
@@ -4542,8 +4661,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b465: block {
-        l466: loop {
+    b478: block {
+        l479: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -4568,9 +4687,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b465;
+                break b478;
             };
-            continue l466;
+            continue l479;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
@@ -2534,258 +2534,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b215: block {
         l216: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b215;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b215;
+            };
+            scan_pos = scan_pos + 1;
+            continue l216;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l223: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l223;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l226: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l226;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b228: block {
+        l229: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b228;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l216;
+            continue l229;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2817,15 +2936,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l241: loop {
+            l254: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2858,7 +2977,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l241;
+                continue l254;
             };
         };
     };
@@ -2928,11 +3047,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b252: block {
-        l253: loop {
+    b265: block {
+        l266: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b252;
+                break b265;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2946,9 +3065,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b252;
+                break b265;
             };
-            continue l253;
+            continue l266;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2969,11 +3088,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b259: block {
-            l260: loop {
+        b272: block {
+            l273: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b259;
+                    break b272;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2987,9 +3106,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b259;
+                    break b272;
                 };
-                continue l260;
+                continue l273;
             };
         };
         self.pos = _hfs_pos_37;
@@ -3030,11 +3149,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b270: block {
-                l271: loop {
+            b283: block {
+                l284: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b270;
+                        break b283;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -3048,9 +3167,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b270;
+                        break b283;
                     };
-                    continue l271;
+                    continue l284;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3144,11 +3263,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b280: block {
-        l281: loop {
+    b293: block {
+        l294: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b280;
+                break b293;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -3175,12 +3294,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b289: block {
-                        l290: loop {
+                    b302: block {
+                        l303: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b289;
+                                break b302;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -3197,9 +3316,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b289;
+                                break b302;
                             };
-                            continue l290;
+                            continue l303;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3230,12 +3349,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b300: block {
-                            l301: loop {
+                        b313: block {
+                            l314: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b300;
+                                    break b313;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -3251,9 +3370,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b300;
+                                    break b313;
                                 };
-                                continue l301;
+                                continue l314;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3290,9 +3409,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b280;
+                break b293;
             };
-            continue l281;
+            continue l294;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3318,11 +3437,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b311: block {
-        l312: loop {
+    b324: block {
+        l325: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b311;
+                break b324;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3351,7 +3470,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l312;
+            continue l325;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3454,7 +3573,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l327: loop {
+            l340: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3496,7 +3615,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l327;
+                continue l340;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3521,7 +3640,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l336: loop {
+            l349: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3601,7 +3720,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l336;
+                continue l349;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3712,13 +3831,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b354: block {
-        l355: loop {
+    b367: block {
+        l368: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b354;
+                break b367;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3726,14 +3845,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b354;
+                break b367;
             };
             if b == 92 {
                 has_escape = 1;
-                break b354;
+                break b367;
             };
             self.de.pos = self.de.pos + 1;
-            continue l355;
+            continue l368;
         };
     };
     if has_escape == 0 {
@@ -3865,13 +3984,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l376: loop {
+            l389: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l376;
+                continue l389;
             };
         };
     };
@@ -4004,8 +4123,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b399: block {
-        l400: loop {
+    b412: block {
+        l413: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -4030,9 +4149,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b399;
+                break b412;
             };
-            continue l400;
+            continue l413;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
@@ -4754,258 +4754,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b331: block {
         l332: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b331;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b331;
+            };
+            scan_pos = scan_pos + 1;
+            continue l332;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l339: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l339;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l342: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l342;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b344: block {
+        l345: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b344;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l332;
+            continue l345;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -5037,15 +5156,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l357: loop {
+            l370: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -5078,7 +5197,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l357;
+                continue l370;
             };
         };
     };
@@ -5183,11 +5302,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b371: block {
-        l372: loop {
+    b384: block {
+        l385: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b371;
+                break b384;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -5214,12 +5333,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b380: block {
-                        l381: loop {
+                    b393: block {
+                        l394: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b380;
+                                break b393;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -5236,9 +5355,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b380;
+                                break b393;
                             };
-                            continue l381;
+                            continue l394;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -5269,12 +5388,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b391: block {
-                            l392: loop {
+                        b404: block {
+                            l405: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b391;
+                                    break b404;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -5290,9 +5409,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b391;
+                                    break b404;
                                 };
-                                continue l392;
+                                continue l405;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -5329,9 +5448,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b371;
+                break b384;
             };
-            continue l372;
+            continue l385;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5443,11 +5562,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b407: block {
-        l408: loop {
+    b420: block {
+        l421: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b407;
+                break b420;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -5465,9 +5584,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b407;
+                break b420;
             };
-            continue l408;
+            continue l421;
         };
     };
     self.pos = _hfs_pos_57;
@@ -5489,11 +5608,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b415: block {
-            l416: loop {
+        b428: block {
+            l429: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b415;
+                    break b428;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -5512,9 +5631,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b415;
+                    break b428;
                 };
-                continue l416;
+                continue l429;
             };
         };
         self.pos = _hfs_pos_58;
@@ -5556,11 +5675,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b427: block {
-                l428: loop {
+            b440: block {
+                l441: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b427;
+                        break b440;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -5575,9 +5694,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b427;
+                        break b440;
                     };
-                    continue l428;
+                    continue l441;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -5691,13 +5810,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l446: loop {
+            l459: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l446;
+                continue l459;
             };
         };
     };
@@ -5786,10 +5905,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b456: block {
-            l457: loop {
+        b469: block {
+            l470: loop {
                 if (i_8 >= 0) == 0 {
-                    break b456;
+                    break b469;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -5798,7 +5917,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l457;
+                continue l470;
             };
         };
         __for_1: block {
@@ -5806,14 +5925,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l460: loop {
+                l473: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l460;
+                    continue l473;
                 };
             };
         };
@@ -5823,10 +5942,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b462: block {
-            l463: loop {
+        b475: block {
+            l476: loop {
                 if (i_10 >= 0) == 0 {
-                    break b462;
+                    break b475;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -5835,7 +5954,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l463;
+                continue l476;
             };
         };
         __for_2: block {
@@ -5843,14 +5962,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l466: loop {
+                l479: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l466;
+                    continue l479;
                 };
             };
         };
@@ -5952,8 +6071,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b485: block {
-        l486: loop {
+    b498: block {
+        l499: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -5978,9 +6097,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b485;
+                break b498;
             };
-            continue l486;
+            continue l499;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_rename.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_rename.wir.wado
@@ -1876,258 +1876,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b171: block {
         l172: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b171;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b171;
+            };
+            scan_pos = scan_pos + 1;
+            continue l172;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l179: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l179;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l182: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l182;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b184: block {
+        l185: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b184;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l172;
+            continue l185;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2159,15 +2278,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l197: loop {
+            l210: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2200,7 +2319,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l197;
+                continue l210;
             };
         };
     };
@@ -2270,11 +2389,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b208: block {
-        l209: loop {
+    b221: block {
+        l222: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b208;
+                break b221;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2288,9 +2407,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b208;
+                break b221;
             };
-            continue l209;
+            continue l222;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2311,11 +2430,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b215: block {
-            l216: loop {
+        b228: block {
+            l229: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b215;
+                    break b228;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2329,9 +2448,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b215;
+                    break b228;
                 };
-                continue l216;
+                continue l229;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2372,11 +2491,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b226: block {
-                l227: loop {
+            b239: block {
+                l240: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b226;
+                        break b239;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2390,9 +2509,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b226;
+                        break b239;
                     };
-                    continue l227;
+                    continue l240;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2486,11 +2605,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b236: block {
-        l237: loop {
+    b249: block {
+        l250: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b236;
+                break b249;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -2517,12 +2636,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b245: block {
-                        l246: loop {
+                    b258: block {
+                        l259: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b258;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -2539,9 +2658,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b258;
                             };
-                            continue l246;
+                            continue l259;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2572,12 +2691,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b256: block {
-                            l257: loop {
+                        b269: block {
+                            l270: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b256;
+                                    break b269;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -2593,9 +2712,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b256;
+                                    break b269;
                                 };
-                                continue l257;
+                                continue l270;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2632,9 +2751,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b236;
+                break b249;
             };
-            continue l237;
+            continue l250;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2660,11 +2779,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b267: block {
-        l268: loop {
+    b280: block {
+        l281: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b267;
+                break b280;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2693,7 +2812,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l268;
+            continue l281;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2796,7 +2915,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l283: loop {
+            l296: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -2838,7 +2957,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l283;
+                continue l296;
             };
         };
         self.pos = _hfs_pos_49;
@@ -2863,7 +2982,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l292: loop {
+            l305: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -2943,7 +3062,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l292;
+                continue l305;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3054,13 +3173,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b310: block {
-        l311: loop {
+    b323: block {
+        l324: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b310;
+                break b323;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3068,14 +3187,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b310;
+                break b323;
             };
             if b == 92 {
                 has_escape = 1;
-                break b310;
+                break b323;
             };
             self.de.pos = self.de.pos + 1;
-            continue l311;
+            continue l324;
         };
     };
     if has_escape == 0 {
@@ -3145,13 +3264,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l326: loop {
+            l339: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l326;
+                continue l339;
             };
         };
     };
@@ -3284,8 +3403,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b349: block {
-        l350: loop {
+    b362: block {
+        l363: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3310,9 +3429,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b349;
+                break b362;
             };
-            continue l350;
+            continue l363;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_rename_all.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_rename_all.wir.wado
@@ -2452,258 +2452,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b258: block {
         l259: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b258;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b258;
+            };
+            scan_pos = scan_pos + 1;
+            continue l259;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l266: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l266;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l269: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l269;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b271: block {
+        l272: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b271;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l259;
+            continue l272;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2735,15 +2854,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l284: loop {
+            l297: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2776,7 +2895,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l284;
+                continue l297;
             };
         };
     };
@@ -2801,14 +2920,14 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
     let __local_6: i32;
     let _licm_used_7: i32;
     let _licm_repr_8: ref array<u8>;
-    __for_2: block {
+    __for_4: block {
         i = 0;
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l294: loop {
+            l307: loop {
                 if (i < _licm_used_7) == 0 {
-                    break __for_2;
+                    break __for_4;
                 };
                 b = __inline_String__get_byte_1: block -> u8 {
                     __local_6 = i;
@@ -2826,7 +2945,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
                     return 1;
                 };
                 i = i + 1;
-                continue l294;
+                continue l307;
             };
         };
     };
@@ -2882,10 +3001,10 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
     };
     result = 0_i64;
     _licm_repr_26 = raw.repr;
-    b304: block {
-        l305: loop {
+    b317: block {
+        l318: loop {
             if (idx < len) == 0 {
-                break b304;
+                break b317;
             };
             b = __inline_String__get_byte_6: block -> u8 {
                 __local_23 = idx;
@@ -2904,7 +3023,7 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l305;
+            continue l318;
         };
     };
     if neg {
@@ -2964,11 +3083,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b312: block {
-        l313: loop {
+    b325: block {
+        l326: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b312;
+                break b325;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2982,9 +3101,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b312;
+                break b325;
             };
-            continue l313;
+            continue l326;
         };
     };
     self.pos = _hfs_pos_36;
@@ -3005,11 +3124,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b319: block {
-            l320: loop {
+        b332: block {
+            l333: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b319;
+                    break b332;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -3023,9 +3142,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b319;
+                    break b332;
                 };
-                continue l320;
+                continue l333;
             };
         };
         self.pos = _hfs_pos_37;
@@ -3066,11 +3185,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b330: block {
-                l331: loop {
+            b343: block {
+                l344: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b330;
+                        break b343;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -3084,9 +3203,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b330;
+                        break b343;
                     };
-                    continue l331;
+                    continue l344;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3180,11 +3299,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b340: block {
-        l341: loop {
+    b353: block {
+        l354: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b340;
+                break b353;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -3211,12 +3330,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b349: block {
-                        l350: loop {
+                    b362: block {
+                        l363: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b349;
+                                break b362;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -3233,9 +3352,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b349;
+                                break b362;
                             };
-                            continue l350;
+                            continue l363;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3266,12 +3385,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b360: block {
-                            l361: loop {
+                        b373: block {
+                            l374: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b360;
+                                    break b373;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -3287,9 +3406,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b360;
+                                    break b373;
                                 };
-                                continue l361;
+                                continue l374;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3326,9 +3445,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b340;
+                break b353;
             };
-            continue l341;
+            continue l354;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3423,11 +3542,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b376: block {
-        l377: loop {
+    b389: block {
+        l390: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b376;
+                break b389;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
@@ -3454,12 +3573,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b385: block {
-                        l386: loop {
+                    b398: block {
+                        l399: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b385;
+                                break b398;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
@@ -3476,9 +3595,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b385;
+                                break b398;
                             };
-                            continue l386;
+                            continue l399;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3509,12 +3628,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b396: block {
-                            l397: loop {
+                        b409: block {
+                            l410: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b396;
+                                    break b409;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
@@ -3530,9 +3649,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b396;
+                                    break b409;
                                 };
-                                continue l397;
+                                continue l410;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3558,9 +3677,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 return Result<i64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b376;
+                break b389;
             };
-            continue l377;
+            continue l390;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3586,11 +3705,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b405: block {
-        l406: loop {
+    b418: block {
+        l419: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b405;
+                break b418;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3619,7 +3738,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l406;
+            continue l419;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3722,7 +3841,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l421: loop {
+            l434: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3764,7 +3883,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l421;
+                continue l434;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3789,7 +3908,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l430: loop {
+            l443: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3869,7 +3988,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l430;
+                continue l443;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3980,13 +4099,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b448: block {
-        l449: loop {
+    b461: block {
+        l462: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b448;
+                break b461;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3994,14 +4113,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b448;
+                break b461;
             };
             if b == 92 {
                 has_escape = 1;
-                break b448;
+                break b461;
             };
             self.de.pos = self.de.pos + 1;
-            continue l449;
+            continue l462;
         };
     };
     if has_escape == 0 {
@@ -4162,13 +4281,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l473: loop {
+            l486: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l473;
+                continue l486;
             };
         };
     };
@@ -4301,8 +4420,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b496: block {
-        l497: loop {
+    b509: block {
+        l510: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -4327,9 +4446,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b496;
+                break b509;
             };
-            continue l497;
+            continue l510;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_result.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_result.wir.wado
@@ -1774,258 +1774,377 @@ fn "core:json/JsonDeserializer::expect_char"(self, c) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b162: block {
         l163: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b162;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b162;
+            };
+            scan_pos = scan_pos + 1;
+            continue l163;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l170: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l170;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l173: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l173;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b175: block {
+        l176: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b175;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l163;
+            continue l176;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2057,15 +2176,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l188: loop {
+            l201: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2098,7 +2217,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l188;
+                continue l201;
             };
         };
     };
@@ -2203,11 +2322,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b202: block {
-        l203: loop {
+    b215: block {
+        l216: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b202;
+                break b215;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -2234,12 +2353,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b211: block {
-                        l212: loop {
+                    b224: block {
+                        l225: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b211;
+                                break b224;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -2256,9 +2375,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b211;
+                                break b224;
                             };
-                            continue l212;
+                            continue l225;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2289,12 +2408,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b222: block {
-                            l223: loop {
+                        b235: block {
+                            l236: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b222;
+                                    break b235;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -2310,9 +2429,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b222;
+                                    break b235;
                                 };
-                                continue l223;
+                                continue l236;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2349,9 +2468,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b202;
+                break b215;
             };
-            continue l203;
+            continue l216;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2442,13 +2561,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l242: loop {
+            l255: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l242;
+                continue l255;
             };
         };
     };
@@ -2581,8 +2700,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b265: block {
-        l266: loop {
+    b278: block {
+        l279: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -2607,9 +2726,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b265;
+                break b278;
             };
-            continue l266;
+            continue l279;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
@@ -10936,258 +10936,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b851: block {
         l852: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b851;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b851;
+            };
+            scan_pos = scan_pos + 1;
+            continue l852;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l859: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l859;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l862: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l862;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b864: block {
+        l865: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b864;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l852;
+            continue l865;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -11219,15 +11338,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l877: loop {
+            l890: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -11260,7 +11379,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l877;
+                continue l890;
             };
         };
     };
@@ -11330,11 +11449,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b888: block {
-        l889: loop {
+    b901: block {
+        l902: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b888;
+                break b901;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -11348,9 +11467,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b888;
+                break b901;
             };
-            continue l889;
+            continue l902;
         };
     };
     self.pos = _hfs_pos_36;
@@ -11371,11 +11490,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b895: block {
-            l896: loop {
+        b908: block {
+            l909: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b895;
+                    break b908;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -11389,9 +11508,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b895;
+                    break b908;
                 };
-                continue l896;
+                continue l909;
             };
         };
         self.pos = _hfs_pos_37;
@@ -11432,11 +11551,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b906: block {
-                l907: loop {
+            b919: block {
+                l920: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b906;
+                        break b919;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -11450,9 +11569,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b906;
+                        break b919;
                     };
-                    continue l907;
+                    continue l920;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -11546,11 +11665,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b916: block {
-        l917: loop {
+    b929: block {
+        l930: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b916;
+                break b929;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -11577,12 +11696,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b925: block {
-                        l926: loop {
+                    b938: block {
+                        l939: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b925;
+                                break b938;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -11599,9 +11718,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b925;
+                                break b938;
                             };
-                            continue l926;
+                            continue l939;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -11632,12 +11751,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b936: block {
-                            l937: loop {
+                        b949: block {
+                            l950: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b936;
+                                    break b949;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -11653,9 +11772,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b936;
+                                    break b949;
                                 };
-                                continue l937;
+                                continue l950;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -11692,9 +11811,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b916;
+                break b929;
             };
-            continue l917;
+            continue l930;
         };
     };
     self.pos = _hfs_pos_51;
@@ -11806,11 +11925,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b952: block {
-        l953: loop {
+    b965: block {
+        l966: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b952;
+                break b965;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -11828,9 +11947,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b952;
+                break b965;
             };
-            continue l953;
+            continue l966;
         };
     };
     self.pos = _hfs_pos_57;
@@ -11852,11 +11971,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b960: block {
-            l961: loop {
+        b973: block {
+            l974: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b960;
+                    break b973;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -11875,9 +11994,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b960;
+                    break b973;
                 };
-                continue l961;
+                continue l974;
             };
         };
         self.pos = _hfs_pos_58;
@@ -11919,11 +12038,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b972: block {
-                l973: loop {
+            b985: block {
+                l986: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b972;
+                        break b985;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -11938,9 +12057,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b972;
+                        break b985;
                     };
-                    continue l973;
+                    continue l986;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -11990,11 +12109,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b983: block {
-        l984: loop {
+    b996: block {
+        l997: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b983;
+                break b996;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -12023,7 +12142,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l984;
+            continue l997;
         };
     };
     self.pos = _hfs_pos_14;
@@ -12126,7 +12245,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l999: loop {
+            l1012: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -12168,7 +12287,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l999;
+                continue l1012;
             };
         };
         self.pos = _hfs_pos_49;
@@ -12193,7 +12312,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l1008: loop {
+            l1021: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -12273,7 +12392,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l1008;
+                continue l1021;
             };
         };
         self.pos = _hfs_pos_50;
@@ -12443,13 +12562,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b1033: block {
-        l1034: loop {
+    b1046: block {
+        l1047: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b1033;
+                break b1046;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -12457,14 +12576,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b1033;
+                break b1046;
             };
             if b == 92 {
                 has_escape = 1;
-                break b1033;
+                break b1046;
             };
             self.de.pos = self.de.pos + 1;
-            continue l1034;
+            continue l1047;
         };
     };
     if has_escape == 0 {
@@ -12731,13 +12850,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l1069: loop {
+            l1082: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l1069;
+                continue l1082;
             };
         };
     };
@@ -12826,10 +12945,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b1079: block {
-            l1080: loop {
+        b1092: block {
+            l1093: loop {
                 if (i_8 >= 0) == 0 {
-                    break b1079;
+                    break b1092;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -12838,7 +12957,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l1080;
+                continue l1093;
             };
         };
         __for_1: block {
@@ -12846,14 +12965,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l1083: loop {
+                l1096: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l1083;
+                    continue l1096;
                 };
             };
         };
@@ -12863,10 +12982,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b1085: block {
-            l1086: loop {
+        b1098: block {
+            l1099: loop {
                 if (i_10 >= 0) == 0 {
-                    break b1085;
+                    break b1098;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -12875,7 +12994,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l1086;
+                continue l1099;
             };
         };
         __for_2: block {
@@ -12883,14 +13002,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l1089: loop {
+                l1102: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l1089;
+                    continue l1102;
                 };
             };
         };
@@ -12992,8 +13111,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b1108: block {
-        l1109: loop {
+    b1121: block {
+        l1122: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -13018,9 +13137,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b1108;
+                break b1121;
             };
-            continue l1109;
+            continue l1122;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_scientific_notation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_scientific_notation.wir.wado
@@ -4444,258 +4444,377 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b365: block {
         l366: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b365;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b365;
+            };
+            scan_pos = scan_pos + 1;
+            continue l366;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l373: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l373;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l376: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l376;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b378: block {
+        l379: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b378;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l366;
+            continue l379;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -4727,15 +4846,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l391: loop {
+            l404: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -4768,7 +4887,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l391;
+                continue l404;
             };
         };
     };
@@ -4793,14 +4912,14 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
     let __local_6: i32;
     let _licm_used_7: i32;
     let _licm_repr_8: ref array<u8>;
-    __for_2: block {
+    __for_4: block {
         i = 0;
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l401: loop {
+            l414: loop {
                 if (i < _licm_used_7) == 0 {
-                    break __for_2;
+                    break __for_4;
                 };
                 b = __inline_String__get_byte_1: block -> u8 {
                     __local_6 = i;
@@ -4818,7 +4937,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(self, raw) {  // from core:json
                     return 1;
                 };
                 i = i + 1;
-                continue l401;
+                continue l414;
             };
         };
     };
@@ -4874,10 +4993,10 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
     };
     result = 0_i64;
     _licm_repr_26 = raw.repr;
-    b411: block {
-        l412: loop {
+    b424: block {
+        l425: loop {
             if (idx < len) == 0 {
-                break b411;
+                break b424;
             };
             b = __inline_String__get_byte_6: block -> u8 {
                 __local_23 = idx;
@@ -4896,7 +5015,7 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l412;
+            continue l425;
         };
     };
     if neg {
@@ -4962,10 +5081,10 @@ fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {  // from cor
     len = raw.used;
     result = 0_i64;
     _licm_repr_30 = raw.repr;
-    b423: block {
-        l424: loop {
+    b436: block {
+        l437: loop {
             if (idx < len) == 0 {
-                break b423;
+                break b436;
             };
             b = __inline_String__get_byte_9: block -> u8 {
                 __local_27 = idx;
@@ -4984,7 +5103,7 @@ fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {  // from cor
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l424;
+            continue l437;
         };
     };
     return Result<u64,DeserializeError>::Ok { discriminant: 0, payload_0: result };
@@ -5076,11 +5195,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b433: block {
-        l434: loop {
+    b446: block {
+        l447: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b433;
+                break b446;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -5107,12 +5226,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b442: block {
-                        l443: loop {
+                    b455: block {
+                        l456: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b442;
+                                break b455;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -5129,9 +5248,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b442;
+                                break b455;
                             };
-                            continue l443;
+                            continue l456;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -5162,12 +5281,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b453: block {
-                            l454: loop {
+                        b466: block {
+                            l467: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b453;
+                                    break b466;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -5183,9 +5302,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b453;
+                                    break b466;
                                 };
-                                continue l454;
+                                continue l467;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -5222,9 +5341,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b433;
+                break b446;
             };
-            continue l434;
+            continue l447;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5319,11 +5438,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b469: block {
-        l470: loop {
+    b482: block {
+        l483: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b469;
+                break b482;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
@@ -5350,12 +5469,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b478: block {
-                        l479: loop {
+                    b491: block {
+                        l492: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b478;
+                                break b491;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
@@ -5372,9 +5491,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b478;
+                                break b491;
                             };
-                            continue l479;
+                            continue l492;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -5405,12 +5524,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b489: block {
-                            l490: loop {
+                        b502: block {
+                            l503: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b489;
+                                    break b502;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
@@ -5426,9 +5545,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b489;
+                                    break b502;
                                 };
-                                continue l490;
+                                continue l503;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -5454,9 +5573,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 return Result<i64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b469;
+                break b482;
             };
-            continue l470;
+            continue l483;
         };
     };
     self.pos = _hfs_pos_49;
@@ -5541,11 +5660,11 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b502: block {
-        l503: loop {
+    b515: block {
+        l516: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b502;
+                break b515;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_26 = _hfs_pos_49;
@@ -5572,12 +5691,12 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b511: block {
-                        l512: loop {
+                    b524: block {
+                        l525: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b511;
+                                break b524;
                             };
                             b2 = __inline_String__get_byte_9: block -> u8 {
                                 __local_29 = _hfs_pos_47;
@@ -5594,9 +5713,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b511;
+                                break b524;
                             };
-                            continue l512;
+                            continue l525;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -5627,12 +5746,12 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b522: block {
-                            l523: loop {
+                        b535: block {
+                            l536: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b522;
+                                    break b535;
                                 };
                                 b3 = __inline_String__get_byte_15: block -> u8 {
                                     __local_38 = _hfs_pos_48;
@@ -5648,9 +5767,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b522;
+                                    break b535;
                                 };
-                                continue l523;
+                                continue l536;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -5678,9 +5797,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {  // from core:json
                 return Result<u64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b502;
+                break b515;
             };
-            continue l503;
+            continue l516;
         };
     };
     self.pos = _hfs_pos_49;
@@ -5789,11 +5908,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b535: block {
-        l536: loop {
+    b548: block {
+        l549: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b535;
+                break b548;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -5811,9 +5930,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b535;
+                break b548;
             };
-            continue l536;
+            continue l549;
         };
     };
     self.pos = _hfs_pos_57;
@@ -5835,11 +5954,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b543: block {
-            l544: loop {
+        b556: block {
+            l557: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b543;
+                    break b556;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -5858,9 +5977,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b543;
+                    break b556;
                 };
-                continue l544;
+                continue l557;
             };
         };
         self.pos = _hfs_pos_58;
@@ -5902,11 +6021,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b555: block {
-                l556: loop {
+            b568: block {
+                l569: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b555;
+                        break b568;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -5921,9 +6040,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b555;
+                        break b568;
                     };
-                    continue l556;
+                    continue l569;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -6101,13 +6220,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l581: loop {
+            l594: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l581;
+                continue l594;
             };
         };
     };
@@ -6196,10 +6315,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b591: block {
-            l592: loop {
+        b604: block {
+            l605: loop {
                 if (i_8 >= 0) == 0 {
-                    break b591;
+                    break b604;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -6208,7 +6327,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l592;
+                continue l605;
             };
         };
         __for_1: block {
@@ -6216,14 +6335,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l595: loop {
+                l608: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l595;
+                    continue l608;
                 };
             };
         };
@@ -6233,10 +6352,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b597: block {
-            l598: loop {
+        b610: block {
+            l611: loop {
                 if (i_10 >= 0) == 0 {
-                    break b597;
+                    break b610;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -6245,7 +6364,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l598;
+                continue l611;
             };
         };
         __for_2: block {
@@ -6253,14 +6372,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l601: loop {
+                l614: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l601;
+                    continue l614;
                 };
             };
         };

--- a/wado-compiler/tests/fixtures.golden/serde_json_string_escape.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_string_escape.wir.wado
@@ -1401,258 +1401,377 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b82: block {
         l83: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b82;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b82;
+            };
+            scan_pos = scan_pos + 1;
+            continue l83;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l90: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l90;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l93: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l93;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b95: block {
+        l96: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b95;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l83;
+            continue l96;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -1684,15 +1803,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l108: loop {
+            l121: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -1725,7 +1844,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l108;
+                continue l121;
             };
         };
     };
@@ -1751,13 +1870,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l118: loop {
+            l131: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l118;
+                continue l131;
             };
         };
     };
@@ -1890,8 +2009,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b141: block {
-        l142: loop {
+    b154: block {
+        l155: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -1916,9 +2035,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b141;
+                break b154;
             };
-            continue l142;
+            continue l155;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.wir.wado
@@ -1317,258 +1317,377 @@ fn "core:json/JsonDeserializer::expect_char"(self, c) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b96: block {
         l97: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b96;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b96;
+            };
+            scan_pos = scan_pos + 1;
+            continue l97;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l104: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l104;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l107: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l107;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b109: block {
+        l110: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b109;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l97;
+            continue l110;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -1600,15 +1719,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l122: loop {
+            l135: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -1641,7 +1760,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l122;
+                continue l135;
             };
         };
     };
@@ -1741,13 +1860,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l140: loop {
+            l153: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l140;
+                continue l153;
             };
         };
     };
@@ -1880,8 +1999,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b163: block {
-        l164: loop {
+    b176: block {
+        l177: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -1906,9 +2025,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b163;
+                break b176;
             };
-            continue l164;
+            continue l177;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
@@ -2675,258 +2675,377 @@ fn "core:json/JsonDeserializer::expect_char"(self, c) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b241: block {
         l242: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b241;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b241;
+            };
+            scan_pos = scan_pos + 1;
+            continue l242;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l249: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l249;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l252: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l252;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b254: block {
+        l255: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b254;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l242;
+            continue l255;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2958,15 +3077,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l267: loop {
+            l280: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2999,7 +3118,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l267;
+                continue l280;
             };
         };
     };
@@ -3120,11 +3239,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b281: block {
-        l282: loop {
+    b294: block {
+        l295: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b281;
+                break b294;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -3142,9 +3261,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b281;
+                break b294;
             };
-            continue l282;
+            continue l295;
         };
     };
     self.pos = _hfs_pos_57;
@@ -3166,11 +3285,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b289: block {
-            l290: loop {
+        b302: block {
+            l303: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b289;
+                    break b302;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -3189,9 +3308,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b289;
+                    break b302;
                 };
-                continue l290;
+                continue l303;
             };
         };
         self.pos = _hfs_pos_58;
@@ -3233,11 +3352,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b301: block {
-                l302: loop {
+            b314: block {
+                l315: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b301;
+                        break b314;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -3252,9 +3371,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b301;
+                        break b314;
                     };
-                    continue l302;
+                    continue l315;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3369,13 +3488,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l321: loop {
+            l334: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l321;
+                continue l334;
             };
         };
     };
@@ -3464,10 +3583,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b331: block {
-            l332: loop {
+        b344: block {
+            l345: loop {
                 if (i_8 >= 0) == 0 {
-                    break b331;
+                    break b344;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3476,7 +3595,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l332;
+                continue l345;
             };
         };
         __for_1: block {
@@ -3484,14 +3603,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l335: loop {
+                l348: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l335;
+                    continue l348;
                 };
             };
         };
@@ -3501,10 +3620,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b337: block {
-            l338: loop {
+        b350: block {
+            l351: loop {
                 if (i_10 >= 0) == 0 {
-                    break b337;
+                    break b350;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3513,7 +3632,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l338;
+                continue l351;
             };
         };
         __for_2: block {
@@ -3521,14 +3640,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l341: loop {
+                l354: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l341;
+                    continue l354;
                 };
             };
         };
@@ -3630,8 +3749,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b360: block {
-        l361: loop {
+    b373: block {
+        l374: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3656,9 +3775,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b360;
+                break b373;
             };
-            continue l361;
+            continue l374;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
@@ -5222,258 +5222,377 @@ fn "core:json/JsonDeserializer::expect_char"(self, c) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b407: block {
         l408: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b407;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b407;
+            };
+            scan_pos = scan_pos + 1;
+            continue l408;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l415: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l415;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l418: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l418;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b420: block {
+        l421: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b420;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l408;
+            continue l421;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -5505,15 +5624,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l433: loop {
+            l446: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -5546,7 +5665,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l433;
+                continue l446;
             };
         };
     };
@@ -5651,11 +5770,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b447: block {
-        l448: loop {
+    b460: block {
+        l461: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b447;
+                break b460;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -5682,12 +5801,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b456: block {
-                        l457: loop {
+                    b469: block {
+                        l470: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b456;
+                                break b469;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -5704,9 +5823,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b456;
+                                break b469;
                             };
-                            continue l457;
+                            continue l470;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -5737,12 +5856,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b467: block {
-                            l468: loop {
+                        b480: block {
+                            l481: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b467;
+                                    break b480;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -5758,9 +5877,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b467;
+                                    break b480;
                                 };
-                                continue l468;
+                                continue l481;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -5797,9 +5916,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b447;
+                break b460;
             };
-            continue l448;
+            continue l461;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5889,13 +6008,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l487: loop {
+            l500: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l487;
+                continue l500;
             };
         };
     };
@@ -6028,8 +6147,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b510: block {
-        l511: loop {
+    b523: block {
+        l524: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -6054,9 +6173,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b510;
+                break b523;
             };
-            continue l511;
+            continue l524;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
@@ -2736,258 +2736,377 @@ fn "core:json/JsonDeserializer::expect_char"(self, c) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b230: block {
         l231: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b230;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b230;
+            };
+            scan_pos = scan_pos + 1;
+            continue l231;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l238: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l238;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l241: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l241;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b243: block {
+        l244: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b243;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l231;
+            continue l244;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -3019,15 +3138,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l256: loop {
+            l269: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -3060,7 +3179,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l256;
+                continue l269;
             };
         };
     };
@@ -3165,11 +3284,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b270: block {
-        l271: loop {
+    b283: block {
+        l284: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b270;
+                break b283;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -3196,12 +3315,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b279: block {
-                        l280: loop {
+                    b292: block {
+                        l293: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b279;
+                                break b292;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -3218,9 +3337,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b279;
+                                break b292;
                             };
-                            continue l280;
+                            continue l293;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3251,12 +3370,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b290: block {
-                            l291: loop {
+                        b303: block {
+                            l304: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b290;
+                                    break b303;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -3272,9 +3391,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b290;
+                                    break b303;
                                 };
-                                continue l291;
+                                continue l304;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3311,9 +3430,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b270;
+                break b283;
             };
-            continue l271;
+            continue l284;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3341,13 +3460,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l303: loop {
+            l316: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l303;
+                continue l316;
             };
         };
     };
@@ -3436,10 +3555,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b313: block {
-            l314: loop {
+        b326: block {
+            l327: loop {
                 if (i_8 >= 0) == 0 {
-                    break b313;
+                    break b326;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3448,7 +3567,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l314;
+                continue l327;
             };
         };
         __for_1: block {
@@ -3456,14 +3575,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l317: loop {
+                l330: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l317;
+                    continue l330;
                 };
             };
         };
@@ -3473,10 +3592,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b319: block {
-            l320: loop {
+        b332: block {
+            l333: loop {
                 if (i_10 >= 0) == 0 {
-                    break b319;
+                    break b332;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3485,7 +3604,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l320;
+                continue l333;
             };
         };
         __for_2: block {
@@ -3493,14 +3612,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l323: loop {
+                l336: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l323;
+                    continue l336;
                 };
             };
         };
@@ -3602,8 +3721,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b342: block {
-        l343: loop {
+    b355: block {
+        l356: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3628,9 +3747,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b342;
+                break b355;
             };
-            continue l343;
+            continue l356;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_unknown_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_unknown_fields.wir.wado
@@ -2485,258 +2485,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b213: block {
         l214: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b213;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b213;
+            };
+            scan_pos = scan_pos + 1;
+            continue l214;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l221: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l221;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l224: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l224;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b226: block {
+        l227: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b226;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l214;
+            continue l227;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -2768,15 +2887,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l239: loop {
+            l252: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -2809,7 +2928,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l239;
+                continue l252;
             };
         };
     };
@@ -2879,11 +2998,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b250: block {
-        l251: loop {
+    b263: block {
+        l264: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b250;
+                break b263;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2897,9 +3016,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b250;
+                break b263;
             };
-            continue l251;
+            continue l264;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2920,11 +3039,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b257: block {
-            l258: loop {
+        b270: block {
+            l271: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b257;
+                    break b270;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2938,9 +3057,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b257;
+                    break b270;
                 };
-                continue l258;
+                continue l271;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2981,11 +3100,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b268: block {
-                l269: loop {
+            b281: block {
+                l282: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b268;
+                        break b281;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2999,9 +3118,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b268;
+                        break b281;
                     };
-                    continue l269;
+                    continue l282;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3111,11 +3230,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b278: block {
-        l279: loop {
+    b291: block {
+        l292: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b278;
+                break b291;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -3133,9 +3252,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b278;
+                break b291;
             };
-            continue l279;
+            continue l292;
         };
     };
     self.pos = _hfs_pos_57;
@@ -3157,11 +3276,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b286: block {
-            l287: loop {
+        b299: block {
+            l300: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b286;
+                    break b299;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -3180,9 +3299,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b286;
+                    break b299;
                 };
-                continue l287;
+                continue l300;
             };
         };
         self.pos = _hfs_pos_58;
@@ -3224,11 +3343,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b298: block {
-                l299: loop {
+            b311: block {
+                l312: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b298;
+                        break b311;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -3243,9 +3362,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b298;
+                        break b311;
                     };
-                    continue l299;
+                    continue l312;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3295,11 +3414,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b309: block {
-        l310: loop {
+    b322: block {
+        l323: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b309;
+                break b322;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3328,7 +3447,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l310;
+            continue l323;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3431,7 +3550,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l325: loop {
+            l338: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3473,7 +3592,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l325;
+                continue l338;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3498,7 +3617,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l334: loop {
+            l347: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3578,7 +3697,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l334;
+                continue l347;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3689,13 +3808,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b352: block {
-        l353: loop {
+    b365: block {
+        l366: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b352;
+                break b365;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3703,14 +3822,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b352;
+                break b365;
             };
             if b == 92 {
                 has_escape = 1;
-                break b352;
+                break b365;
             };
             self.de.pos = self.de.pos + 1;
-            continue l353;
+            continue l366;
         };
     };
     if has_escape == 0 {
@@ -3780,13 +3899,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l368: loop {
+            l381: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l368;
+                continue l381;
             };
         };
     };
@@ -3875,10 +3994,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b378: block {
-            l379: loop {
+        b391: block {
+            l392: loop {
                 if (i_8 >= 0) == 0 {
-                    break b378;
+                    break b391;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3887,7 +4006,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l379;
+                continue l392;
             };
         };
         __for_1: block {
@@ -3895,14 +4014,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l382: loop {
+                l395: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l382;
+                    continue l395;
                 };
             };
         };
@@ -3912,10 +4031,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b384: block {
-            l385: loop {
+        b397: block {
+            l398: loop {
                 if (i_10 >= 0) == 0 {
-                    break b384;
+                    break b397;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3924,7 +4043,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l385;
+                continue l398;
             };
         };
         __for_2: block {
@@ -3932,14 +4051,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l388: loop {
+                l401: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l388;
+                    continue l401;
                 };
             };
         };

--- a/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
@@ -3935,258 +3935,377 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
 }
 
 fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
-    let result: ref String;
+    let prefix_start: i32;
+    let scan_pos: i32;
+    let sb: i32;
+    let prefix_len: i32;
+    let result_5: ref String;
+    let start_6: i32;
+    let i_7: i32;
+    let result_8: ref String;
+    let start_9: i32;
+    let i_10: i32;
     let b: i32;
     let esc: i32;
     let r: ref Result<char,DeserializeError>;
-    let c_5: char;
+    let c_14: char;
     let e: ref "core:serde/DeserializeError";
     let seq_len: i32;
-    let b0_8: u32;
-    let b1_9: u32;
-    let code_10: u32;
-    let c_11: char;
-    let b0_12: u32;
-    let b1_13: u32;
-    let b2_14: u32;
-    let code_15: u32;
-    let c_16: char;
     let b0_17: u32;
     let b1_18: u32;
-    let b2_19: u32;
+    let code_19: u32;
+    let c_20: char;
+    let b0_21: u32;
+    let b1_22: u32;
+    let b2_23: u32;
+    let code_24: u32;
+    let c_25: char;
+    let b0_26: u32;
+    let b1_27: u32;
+    let b2_28: u32;
     let b3: u32;
-    let code_21: u32;
-    let c_22: char;
-    let __local_23: ref String;
-    let __local_24: ref Formatter;
+    let code_30: u32;
+    let c_31: char;
+    let __local_32: ref String;
+    let __local_33: ref Formatter;
     let __pattern_temp_0: ref Result<char,DeserializeError>;
     let __pattern_temp_1: ref Result<char,DeserializeError>;
-    let __local_30: ref String;
-    let __local_31: i64;
-    let __local_32: ref String;
-    let __local_33: i32;
-    let __local_34: ref String;
-    let __local_35: i64;
-    let __local_37: ref String;
-    let __local_38: ref String;
-    let __local_39: i32;
-    let __local_40: ref String;
-    let __local_41: i64;
-    let __local_42: ref String;
-    let __local_43: i32;
-    let __local_45: ref String;
-    let __local_46: ref String;
-    let __local_47: i64;
+    let __local_39: ref String;
+    let __local_40: i64;
+    let __local_41: ref String;
+    let __local_42: i32;
+    let __local_43: ref String;
+    let __local_44: i64;
+    let __local_47: i32;
     let __local_48: ref String;
-    let __local_49: i64;
-    let __local_50: ref String;
-    let __local_51: i32;
-    let __local_52: ref String;
-    let __local_53: i32;
-    let __local_54: ref String;
-    let __local_55: i32;
-    let __local_56: ref String;
+    let __local_49: ref String;
+    let __local_50: i32;
+    let index_53: i32;
+    let value_54: u8;
+    let __local_56: i32;
     let __local_57: i32;
-    let __local_58: ref String;
-    let __local_59: i32;
-    let __local_60: ref String;
-    let __local_61: i32;
-    let __local_62: i64;
-    let _hfs_pos_63: i32;
+    let index_59: i32;
+    let value_60: u8;
+    let __local_62: i32;
+    let __local_63: ref String;
+    let __local_64: ref String;
+    let __local_65: i32;
+    let __local_66: ref String;
+    let __local_67: i64;
+    let __local_68: ref String;
+    let __local_69: i32;
+    let __local_71: ref String;
+    let __local_72: ref String;
+    let __local_73: i64;
+    let __local_74: ref String;
+    let __local_75: i64;
+    let __local_76: ref String;
+    let __local_77: i32;
+    let __local_78: ref String;
+    let __local_79: i32;
+    let __local_80: ref String;
+    let __local_81: i32;
+    let __local_82: ref String;
+    let __local_83: i32;
+    let __local_84: ref String;
+    let __local_85: i32;
+    let __local_86: ref String;
+    let __local_87: i32;
+    let __local_88: i64;
+    let _licm_input_89: ref String;
+    let _licm_used_90: i32;
+    let _licm_repr_91: ref array<u8>;
+    let _licm_input_92: ref String;
+    let _licm_repr_93: ref array<u8>;
+    let _licm_repr_94: ref array<u8>;
+    let _licm_input_95: ref String;
+    let _licm_repr_96: ref array<u8>;
+    let _licm_repr_97: ref array<u8>;
+    let _hfs_pos_98: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_30 = self.input;
-        break __inline_String__len_0: __local_30.used;
+        __local_39 = self.input;
+        break __inline_String__len_0: __local_39.used;
     } {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde/DeserializeError" {
-            __local_31 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_31 };
+            __local_40 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
         }) };
     };
     if __inline_String__get_byte_2: block -> u8 {
-        __local_32 = self.input;
-        __local_33 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_32.repr, __local_33);
+        __local_41 = self.input;
+        __local_42 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
     } != 34 {
         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde/DeserializeError" {
-            __local_34 = String { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_35 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_34), offset: __local_35 };
+            __local_43 = String { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: "core:serde/DeserializeError" { kind: 0, message: ref.as_non_null(__local_43), offset: __local_44 };
         }) };
     };
     self.pos = self.pos + 1;
-    result = String { repr: builtin::array_new<u8>(32), used: 0 };
-    _hfs_pos_63 = self.pos;
+    prefix_start = self.pos;
+    scan_pos = self.pos;
+    _licm_input_89 = self.input;
+    _licm_used_90 = _licm_input_89.used;
+    _licm_repr_91 = _licm_input_89.repr;
     b330: block {
         l331: loop {
-            if (_hfs_pos_63 < __inline_String__len_5: block -> i32 {
-                __local_37 = self.input;
-                break __inline_String__len_5: __local_37.used;
-            }) == 0 {
-                self.pos = _hfs_pos_63;
+            if (scan_pos < _licm_used_90) == 0 {
                 break b330;
             };
-            b = __inline_String__get_byte_6: block -> u8 {
-                __local_38 = self.input;
-                __local_39 = _hfs_pos_63;
-                break __inline_String__get_byte_6: builtin::array_get_u8(__local_38.repr, __local_39);
+            sb = __inline_String__get_byte_5: block -> u8 {
+                __local_47 = scan_pos;
+                break __inline_String__get_byte_5: builtin::array_get_u8(_licm_repr_91, __local_47);
+            };
+            if if sb == 34 -> i32 {
+                1;
+            } else {
+                sb == 92;
+            } {
+                break b330;
+            };
+            scan_pos = scan_pos + 1;
+            continue l331;
+        };
+    };
+    prefix_len = scan_pos - prefix_start;
+    if if scan_pos < __inline_String__len_6: block -> i32 {
+        __local_48 = self.input;
+        break __inline_String__len_6: __local_48.used;
+    } -> i32 {
+        __inline_String__get_byte_7: block -> u8 {
+            __local_49 = self.input;
+            __local_50 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+        } == 34;
+    } else {
+        0;
+    } {
+        result_5 = String { repr: builtin::array_new<u8>(prefix_len), used: 0 };
+        start_6 = String::internal_reserve_uninit(result_5, prefix_len);
+        __for_0: block {
+            i_7 = 0;
+            _licm_input_92 = self.input;
+            _licm_repr_93 = result_5.repr;
+            _licm_repr_94 = _licm_input_92.repr;
+            block {
+                l338: loop {
+                    if (i_7 < prefix_len) == 0 {
+                        break __for_0;
+                    };
+                    index_53 = start_6 + i_7;
+                    value_54 = __inline_String__get_byte_10: block -> u8 {
+                        __local_56 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    };
+                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    i_7 = i_7 + 1;
+                    continue l338;
+                };
+            };
+        };
+        self.pos = scan_pos + 1;
+        return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_5) };
+    };
+    result_8 = __inline_String__with_capacity_11: block -> ref String {
+        __local_57 = prefix_len + 32;
+        break __inline_String__with_capacity_11: String { repr: builtin::array_new<u8>(__local_57), used: 0 };
+    };
+    start_9 = String::internal_reserve_uninit(result_8, prefix_len);
+    __for_1: block {
+        i_10 = 0;
+        _licm_input_95 = self.input;
+        _licm_repr_96 = result_8.repr;
+        _licm_repr_97 = _licm_input_95.repr;
+        block {
+            l341: loop {
+                if (i_10 < prefix_len) == 0 {
+                    break __for_1;
+                };
+                index_59 = start_9 + i_10;
+                value_60 = __inline_String__get_byte_13: block -> u8 {
+                    __local_62 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                };
+                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                i_10 = i_10 + 1;
+                continue l341;
+            };
+        };
+    };
+    self.pos = scan_pos;
+    _hfs_pos_98 = self.pos;
+    b343: block {
+        l344: loop {
+            if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
+                __local_63 = self.input;
+                break __inline_String__len_14: __local_63.used;
+            }) == 0 {
+                self.pos = _hfs_pos_98;
+                break b343;
+            };
+            b = __inline_String__get_byte_15: block -> u8 {
+                __local_64 = self.input;
+                __local_65 = _hfs_pos_98;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
             };
             if b == 34 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                self.pos = _hfs_pos_63;
-                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result) };
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                self.pos = _hfs_pos_98;
+                return Result<String,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(result_8) };
             };
             if b == 92 {
-                _hfs_pos_63 = _hfs_pos_63 + 1;
-                if _hfs_pos_63 >= __inline_String__len_7: block -> i32 {
-                    __local_40 = self.input;
-                    break __inline_String__len_7: __local_40.used;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
+                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
+                    __local_66 = self.input;
+                    break __inline_String__len_16: __local_66.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_8: block -> ref "core:serde/DeserializeError" {
-                        __local_41 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_8: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_41 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde/DeserializeError" {
+                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_17: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
                     }) };
                 };
-                esc = __inline_String__get_byte_9: block -> u8 {
-                    __local_42 = self.input;
-                    __local_43 = _hfs_pos_63;
-                    break __inline_String__get_byte_9: builtin::array_get_u8(__local_42.repr, __local_43);
+                esc = __inline_String__get_byte_18: block -> u8 {
+                    __local_68 = self.input;
+                    __local_69 = _hfs_pos_98;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
                 };
                 if esc == 34 {
-                    String::append_char(result, 34);
+                    String::append_char(result_8, 34);
                 } else if esc == 92 {
-                    String::append_char(result, 92);
+                    String::append_char(result_8, 92);
                 } else if esc == 47 {
-                    String::append_char(result, 47);
+                    String::append_char(result_8, 47);
                 } else if esc == 110 {
-                    String::append_char(result, 10);
+                    String::append_char(result_8, 10);
                 } else if esc == 114 {
-                    String::append_char(result, 13);
+                    String::append_char(result_8, 13);
                 } else if esc == 116 {
-                    String::append_char(result, 9);
+                    String::append_char(result_8, 9);
                 } else if esc == 98 {
-                    String::append_char(result, 8);
+                    String::append_char(result_8, 8);
                 } else if esc == 102 {
-                    String::append_char(result, 12);
+                    String::append_char(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_63;
+                    self.pos = _hfs_pos_98;
                     r = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_63 = self.pos;
+                    _hfs_pos_98 = self.pos;
                     __pattern_temp_0 = r;
                     if ref.test Result<char,DeserializeError>::Ok(__pattern_temp_0) {
-                        c_5 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
-                        String::append_char(result, c_5);
+                        c_14 = ref.cast Result<char,DeserializeError>::Ok(__pattern_temp_0).payload_0;
+                        String::append_char(result_8, c_14);
                     };
                     __pattern_temp_1 = r;
                     if ref.test Result<char,DeserializeError>::Err(__pattern_temp_1) {
                         e = value_copy "core:serde/DeserializeError"(ref.cast Result<char,DeserializeError>::Err(__pattern_temp_1).payload_0);
-                        self.pos = _hfs_pos_63;
+                        self.pos = _hfs_pos_98;
                         return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e) };
                     };
                 } else {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_12: block -> ref "core:serde/DeserializeError" {
-                        __local_46 = __tmpl: block -> ref String {
-                            __local_23 = String { repr: builtin::array_new<u8>(34), used: 0 };
-                            String::append(__local_23, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_24 = __inline_Formatter__new_11: block -> ref Formatter {
-                                __local_45 = __local_23;
-                                break __inline_Formatter__new_11: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_45) };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde/DeserializeError" {
+                        __local_72 = __tmpl: block -> ref String {
+                            __local_32 = String { repr: builtin::array_new<u8>(34), used: 0 };
+                            String::append(__local_32, String { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_33 = __inline_Formatter__new_20: block -> ref Formatter {
+                                __local_71 = __local_32;
+                                break __inline_Formatter__new_20: Formatter { fill: 32, align: 2, sign_plus: 0, alternate: 0, zero_pad: 0, width: -1, precision: -1, buf: ref.as_non_null(__local_71) };
                             };
-                            char^Display::fmt(esc & 255, __local_24);
-                            String::append_char(__local_23, 39);
-                            break __tmpl: __local_23;
+                            char^Display::fmt(esc & 255, __local_33);
+                            String::append_char(__local_32, 39);
+                            break __tmpl: __local_32;
                         };
-                        __local_47 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__malformed_12: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_46), offset: __local_47 };
+                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__malformed_21: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_72), offset: __local_73 };
                     }) };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + 1;
+                _hfs_pos_98 = _hfs_pos_98 + 1;
             } else {
                 seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_63 + seq_len) > __inline_String__len_13: block -> i32 {
-                    __local_48 = self.input;
-                    break __inline_String__len_13: __local_48.used;
+                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
+                    __local_74 = self.input;
+                    break __inline_String__len_22: __local_74.used;
                 } {
-                    self.pos = _hfs_pos_63;
-                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_14: block -> ref "core:serde/DeserializeError" {
-                        __local_49 = builtin::i64_extend_i32_s(_hfs_pos_63);
-                        break __inline_DeserializeError__eof_14: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_49 };
+                    self.pos = _hfs_pos_98;
+                    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde/DeserializeError" {
+                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
+                        break __inline_DeserializeError__eof_23: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
                     }) };
                 };
                 if seq_len == 1 {
-                    String::append_char(result, b & 255);
+                    String::append_char(result_8, b & 255);
                 } else if seq_len == 2 {
-                    b0_8 = b;
-                    b1_9 = __inline_String__get_byte_15: block -> u8 {
-                        __local_50 = self.input;
-                        __local_51 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_15: builtin::array_get_u8(__local_50.repr, __local_51);
+                    b0_17 = b;
+                    b1_18 = __inline_String__get_byte_24: block -> u8 {
+                        __local_76 = self.input;
+                        __local_77 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
                     };
-                    code_10 = ((b0_8 & 31) << 6) | (b1_9 & 63);
+                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
                     let __sroa___pattern_temp_2_discriminant: i32;
                     let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_10);
+                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = char::from_u32(code_19);
                     if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_11 = __sroa___pattern_temp_2_payload_0;
-                        String::append_char(result, c_11);
+                        c_20 = __sroa___pattern_temp_2_payload_0;
+                        String::append_char(result_8, c_20);
                     };
                 } else if seq_len == 3 {
-                    b0_12 = b;
-                    b1_13 = __inline_String__get_byte_16: block -> u8 {
-                        __local_52 = self.input;
-                        __local_53 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_16: builtin::array_get_u8(__local_52.repr, __local_53);
+                    b0_21 = b;
+                    b1_22 = __inline_String__get_byte_25: block -> u8 {
+                        __local_78 = self.input;
+                        __local_79 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
                     };
-                    b2_14 = __inline_String__get_byte_17: block -> u8 {
-                        __local_54 = self.input;
-                        __local_55 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_17: builtin::array_get_u8(__local_54.repr, __local_55);
+                    b2_23 = __inline_String__get_byte_26: block -> u8 {
+                        __local_80 = self.input;
+                        __local_81 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
                     };
-                    code_15 = (((b0_12 & 15) << 12) | ((b1_13 & 63) << 6)) | (b2_14 & 63);
+                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
                     let __sroa___pattern_temp_3_discriminant: i32;
                     let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_15);
+                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = char::from_u32(code_24);
                     if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_16 = __sroa___pattern_temp_3_payload_0;
-                        String::append_char(result, c_16);
+                        c_25 = __sroa___pattern_temp_3_payload_0;
+                        String::append_char(result_8, c_25);
                     };
                 } else {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_18: block -> u8 {
-                        __local_56 = self.input;
-                        __local_57 = _hfs_pos_63 + 1;
-                        break __inline_String__get_byte_18: builtin::array_get_u8(__local_56.repr, __local_57);
+                    b0_26 = b;
+                    b1_27 = __inline_String__get_byte_27: block -> u8 {
+                        __local_82 = self.input;
+                        __local_83 = _hfs_pos_98 + 1;
+                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
                     };
-                    b2_19 = __inline_String__get_byte_19: block -> u8 {
-                        __local_58 = self.input;
-                        __local_59 = _hfs_pos_63 + 2;
-                        break __inline_String__get_byte_19: builtin::array_get_u8(__local_58.repr, __local_59);
+                    b2_28 = __inline_String__get_byte_28: block -> u8 {
+                        __local_84 = self.input;
+                        __local_85 = _hfs_pos_98 + 2;
+                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
                     };
-                    b3 = __inline_String__get_byte_20: block -> u8 {
-                        __local_60 = self.input;
-                        __local_61 = _hfs_pos_63 + 3;
-                        break __inline_String__get_byte_20: builtin::array_get_u8(__local_60.repr, __local_61);
+                    b3 = __inline_String__get_byte_29: block -> u8 {
+                        __local_86 = self.input;
+                        __local_87 = _hfs_pos_98 + 3;
+                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
                     };
-                    code_21 = ((((b0_17 & 7) << 18) | ((b1_18 & 63) << 12)) | ((b2_19 & 63) << 6)) | (b3 & 63);
+                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
                     let __sroa___pattern_temp_4_discriminant: i32;
                     let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_21);
+                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = char::from_u32(code_30);
                     if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_22 = __sroa___pattern_temp_4_payload_0;
-                        String::append_char(result, c_22);
+                        c_31 = __sroa___pattern_temp_4_payload_0;
+                        String::append_char(result_8, c_31);
                     };
                 };
-                _hfs_pos_63 = _hfs_pos_63 + seq_len;
+                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l331;
+            continue l344;
         };
     };
-    self.pos = _hfs_pos_63;
-    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_21: block -> ref "core:serde/DeserializeError" {
-        __local_62 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_21: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_62 };
+    self.pos = _hfs_pos_98;
+    return Result<String,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde/DeserializeError" {
+        __local_88 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_30: "core:serde/DeserializeError" { kind: 8, message: String { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
     }) };
 }
 
@@ -4218,15 +4337,15 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         }) };
     };
     code = 0;
-    __for_0: block {
+    __for_2: block {
         i = 0;
         _licm_input_15 = self.input;
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l356: loop {
+            l369: loop {
                 if (i < 4) == 0 {
-                    break __for_0;
+                    break __for_2;
                 };
                 b = __inline_String__get_byte_2: block -> u8 {
                     __local_10 = _licm_pos_16 + i;
@@ -4259,7 +4378,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l356;
+                continue l369;
             };
         };
     };
@@ -4329,11 +4448,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b367: block {
-        l368: loop {
+    b380: block {
+        l381: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b367;
+                break b380;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -4347,9 +4466,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b367;
+                break b380;
             };
-            continue l368;
+            continue l381;
         };
     };
     self.pos = _hfs_pos_36;
@@ -4370,11 +4489,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b374: block {
-            l375: loop {
+        b387: block {
+            l388: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b374;
+                    break b387;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -4388,9 +4507,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b374;
+                    break b387;
                 };
-                continue l375;
+                continue l388;
             };
         };
         self.pos = _hfs_pos_37;
@@ -4431,11 +4550,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b385: block {
-                l386: loop {
+            b398: block {
+                l399: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b385;
+                        break b398;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -4449,9 +4568,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b385;
+                        break b398;
                     };
-                    continue l386;
+                    continue l399;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -4545,11 +4664,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b395: block {
-        l396: loop {
+    b408: block {
+        l409: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b395;
+                break b408;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -4576,12 +4695,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b404: block {
-                        l405: loop {
+                    b417: block {
+                        l418: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b404;
+                                break b417;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -4598,9 +4717,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b404;
+                                break b417;
                             };
-                            continue l405;
+                            continue l418;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -4631,12 +4750,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b415: block {
-                            l416: loop {
+                        b428: block {
+                            l429: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b415;
+                                    break b428;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -4652,9 +4771,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b415;
+                                    break b428;
                                 };
-                                continue l416;
+                                continue l429;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -4691,9 +4810,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b395;
+                break b408;
             };
-            continue l396;
+            continue l409;
         };
     };
     self.pos = _hfs_pos_51;
@@ -4805,11 +4924,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b431: block {
-        l432: loop {
+    b444: block {
+        l445: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b431;
+                break b444;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -4827,9 +4946,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b431;
+                break b444;
             };
-            continue l432;
+            continue l445;
         };
     };
     self.pos = _hfs_pos_57;
@@ -4851,11 +4970,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b439: block {
-            l440: loop {
+        b452: block {
+            l453: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b439;
+                    break b452;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -4874,9 +4993,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b439;
+                    break b452;
                 };
-                continue l440;
+                continue l453;
             };
         };
         self.pos = _hfs_pos_58;
@@ -4918,11 +5037,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b451: block {
-                l452: loop {
+            b464: block {
+                l465: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b451;
+                        break b464;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -4937,9 +5056,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b451;
+                        break b464;
                     };
-                    continue l452;
+                    continue l465;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -4989,11 +5108,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b462: block {
-        l463: loop {
+    b475: block {
+        l476: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b462;
+                break b475;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -5022,7 +5141,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l463;
+            continue l476;
         };
     };
     self.pos = _hfs_pos_14;
@@ -5125,7 +5244,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l478: loop {
+            l491: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -5167,7 +5286,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l478;
+                continue l491;
             };
         };
         self.pos = _hfs_pos_49;
@@ -5192,7 +5311,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l487: loop {
+            l500: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -5272,7 +5391,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l487;
+                continue l500;
             };
         };
         self.pos = _hfs_pos_50;
@@ -5383,13 +5502,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b505: block {
-        l506: loop {
+    b518: block {
+        l519: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b505;
+                break b518;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -5397,14 +5516,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b505;
+                break b518;
             };
             if b == 92 {
                 has_escape = 1;
-                break b505;
+                break b518;
             };
             self.de.pos = self.de.pos + 1;
-            continue l506;
+            continue l519;
         };
     };
     if has_escape == 0 {
@@ -5524,13 +5643,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l526: loop {
+            l539: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l526;
+                continue l539;
             };
         };
     };
@@ -5619,10 +5738,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b536: block {
-            l537: loop {
+        b549: block {
+            l550: loop {
                 if (i_8 >= 0) == 0 {
-                    break b536;
+                    break b549;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -5631,7 +5750,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l537;
+                continue l550;
             };
         };
         __for_1: block {
@@ -5639,14 +5758,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l540: loop {
+                l553: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l540;
+                    continue l553;
                 };
             };
         };
@@ -5656,10 +5775,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b542: block {
-            l543: loop {
+        b555: block {
+            l556: loop {
                 if (i_10 >= 0) == 0 {
-                    break b542;
+                    break b555;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -5668,7 +5787,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l543;
+                continue l556;
             };
         };
         __for_2: block {
@@ -5676,14 +5795,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l546: loop {
+                l559: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l546;
+                    continue l559;
                 };
             };
         };
@@ -5785,8 +5904,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b565: block {
-        l566: loop {
+    b578: block {
+        l579: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -5811,9 +5930,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b565;
+                break b578;
             };
-            continue l566;
+            continue l579;
         };
     };
     String::append_char(f.buf, 34);


### PR DESCRIPTION
## Summary
Optimizes the JSON string deserialization path in the WADO compiler by implementing a two-phase parsing strategy that reduces memory allocations and improves performance for strings without escape sequences.

## Key Changes
- **Two-phase parsing approach**: 
  - Phase 1 scans ahead to identify the escape-free prefix and determine if the string contains any escape sequences
  - This allows precise pre-sizing of the string allocation, eliminating repeated `grow()` calls
  
- **Fast path for unescaped strings**: When a string contains no escape sequences, the code allocates exactly the required capacity and copies raw bytes directly, avoiding the overhead of escape processing

- **Improved slow path**: For strings with escape sequences, the escape-free prefix is pre-copied with a well-sized initial allocation (prefix length + 32 bytes), reducing the likelihood of reallocation during escape sequence processing

- **Added `profile.json` to `.gitignore`**: Excludes profiling output from version control

## Implementation Details
- Uses `internal_reserve_uninit()` and `set_byte()` for efficient low-level byte manipulation
- Maintains backward compatibility with existing deserialization behavior
- The optimization is transparent to callers and provides measurable performance improvements for typical JSON payloads

https://claude.ai/code/session_01HCgDwAD8amDPTLMp5iNa9z