### PR TITLE
Optimize array deserialization with lazy allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ wado-compiler/tests/fixtures/testdata/test_output.txt
 plan.md
 PLAN.md
 profile.json
+*.jitdump
+jit-*.dump

--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -593,6 +593,7 @@ pub struct Array<T> {
 
 impl Array {
     pub fn with_capacity(capacity: i32) -> Array<T>;
+    pub fn grow(&mut self);
     pub fn filled(n: i32, element: T) -> Array<T>;
     pub fn len(&self) -> i32;
     pub fn is_empty(&self) -> bool;

--- a/docs/stdlib-core.md
+++ b/docs/stdlib-core.md
@@ -1127,6 +1127,8 @@ _Fields are private._
 
 ##### `pub fn with_capacity(capacity: i32) -> Array<T>`
 
+##### `pub fn grow(&mut self)`
+
 ##### `pub fn filled(n: i32, element: T) -> Array<T>`
 
 ##### `pub fn len(&self) -> i32`

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -22,7 +22,7 @@ pub struct Array<T> {
 impl Array<T> {
     pub fn with_capacity(capacity: i32) -> Array<T> {
         return Array {
-            repr: builtin::array_new::<T>(i32_max(capacity, 2)),
+            repr: builtin::array_new::<T>(capacity),
             used: 0,
         };
     }

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -22,14 +22,14 @@ pub struct Array<T> {
 impl Array<T> {
     pub fn with_capacity(capacity: i32) -> Array<T> {
         return Array {
-            repr: builtin::array_new::<T>(i32_max(capacity, 8)),
+            repr: builtin::array_new::<T>(i32_max(capacity, 2)),
             used: 0,
         };
     }
 
     pub fn grow(&mut self) {
         let capacity = builtin::array_len(self.repr);
-        let new_capacity = i32_max(capacity * 2, 32);
+        let new_capacity = i32_max(capacity * 2, 4);
         let new_repr = builtin::array_new::<T>(new_capacity);
         let old_repr = self.repr;
         let used = self.used;

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -22,9 +22,21 @@ pub struct Array<T> {
 impl Array<T> {
     pub fn with_capacity(capacity: i32) -> Array<T> {
         return Array {
-            repr: builtin::array_new::<T>(capacity),
+            repr: builtin::array_new::<T>(i32_max(capacity, 8)),
             used: 0,
         };
+    }
+
+    pub fn grow(&mut self) {
+        let capacity = builtin::array_len(self.repr);
+        let new_capacity = i32_max(capacity * 2, 32);
+        let new_repr = builtin::array_new::<T>(new_capacity);
+        let old_repr = self.repr;
+        let used = self.used;
+        for let mut i = 0; i < used; i += 1 {
+            builtin::array_set::<T>(new_repr, i, builtin::array_get::<T>(old_repr, i));
+        }
+        self.repr = new_repr;
     }
 
     pub fn filled(n: i32, element: T) -> Array<T> {
@@ -52,17 +64,8 @@ impl Array<T> {
     #[comp_feature("array_append")]
     pub fn append(&mut self, value: T) {
         let used = self.used;
-        let capacity = builtin::array_len(self.repr);
-        if builtin::unlikely(used >= capacity) {
-            let new_capacity = i32_max(capacity * 2, 4);
-            let new_repr = builtin::array_new::<T>(new_capacity);
-            // Use element-by-element loop: Wasm array.copy is a libcall in wasmtime
-            // (~3μs/element), while a JIT-compiled loop runs at ~1ns/element.
-            let old_repr = self.repr;
-            for let mut i = 0; i < used; i += 1 {
-                builtin::array_set::<T>(new_repr, i, builtin::array_get::<T>(old_repr, i));
-            }
-            self.repr = new_repr;
+        if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+            self.grow();
         }
         builtin::array_set::<T>(self.repr, used, value);
         self.used = used + 1;

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -507,24 +507,43 @@ impl<T: Deserialize> Deserialize for Array<T> {
     fn deserialize<D: Deserializer>(d: &mut D) -> Result<Array<T>, DeserializeError> {
         let seq_result = d.begin_seq();
         if let Ok(mut seq) = seq_result {
-            let mut items: Array<T> = [];
-            loop {
-                let next = seq.next_element::<T>();
-                if let Ok(opt) = next {
-                    if let Some(item) = opt {
-                        items.append(item);
-                    } else {
-                        let end_result = seq.end();
-                        if let Err(e) = end_result {
+            // Peek at the first element before allocating backing storage.
+            // Empty arrays (very common in practice) avoid any capacity allocation.
+            // Non-empty arrays start at capacity 4, covering 1–4 elements without a grow.
+            let first = seq.next_element::<T>();
+            if let Ok(first_opt) = first {
+                if let Some(first_elem) = first_opt {
+                    let mut items = Array::<T>::with_capacity(2);
+                    items.append(first_elem);
+                    loop {
+                        let next = seq.next_element::<T>();
+                        if let Ok(next_opt) = next {
+                            if let Some(item) = next_opt {
+                                items.append(item);
+                            } else {
+                                let end_result = seq.end();
+                                if let Err(e) = end_result {
+                                    return Result::<Array<T>, DeserializeError>::Err(e);
+                                }
+                                return Result::<Array<T>, DeserializeError>::Ok(items);
+                            }
+                        }
+                        if let Err(e) = next {
                             return Result::<Array<T>, DeserializeError>::Err(e);
                         }
-                        return Result::<Array<T>, DeserializeError>::Ok(items);
                     }
-                }
-                if let Err(e) = next {
-                    return Result::<Array<T>, DeserializeError>::Err(e);
+                } else {
+                    let end_result = seq.end();
+                    if let Err(e) = end_result {
+                        return Result::<Array<T>, DeserializeError>::Err(e);
+                    }
+                    return Result::<Array<T>, DeserializeError>::Ok([] as Array<T>);
                 }
             }
+            if let Err(e) = first {
+                return Result::<Array<T>, DeserializeError>::Err(e);
+            }
+            unreachable();
         }
         if let Err(e) = seq_result {
             return Result::<Array<T>, DeserializeError>::Err(e);

--- a/wado-compiler/tests/fixtures.golden/array_append_collapse.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_append_collapse.wir.wado
@@ -113,9 +113,15 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<i64>::append" = fn(ref Array<i64>, i64);
+
+type "functype/Array<i64>::grow" = fn(ref Array<i64>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1585,110 +1591,128 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l68: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l68;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<i32>::append(self, value) {
-    let used: i32;
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l72: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l72;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l68: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l68;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<i32>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i32>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l72: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l72;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i64>::grow(self);
+    };
+    builtin::array_set<i64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i64>;
     let old_repr: ref array<i64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l76: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                    i = i + 1;
-                    continue l76;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l76: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
+                i = i + 1;
+                continue l76;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds.wir.wado
@@ -91,6 +91,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -615,38 +617,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l35: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l35;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l35: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l35;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_negative.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_negative.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/subtask-drop" = fn(i32);
@@ -216,38 +218,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_read.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_read.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/subtask-drop" = fn(i32);
@@ -216,38 +218,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_write.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_check_oob_write.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/subtask-drop" = fn(i32);
@@ -214,38 +216,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_const.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_const.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -982,38 +984,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l48: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l48;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l48: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l48;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_const_wir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_const_wir.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -486,38 +488,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -514,38 +516,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l30: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l30;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l30: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l30;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard_wir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_loop_guard_wir.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -466,38 +468,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_after_mutation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_after_mutation.wir.wado
@@ -79,6 +79,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -452,38 +454,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_complex.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/subtask-drop" = fn(i32);
@@ -219,38 +221,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_loop_dynamic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_loop_dynamic.wir.wado
@@ -79,6 +79,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -575,38 +577,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l35: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l35;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l35: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l35;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_preserved_wir.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_preserved_wir.wir.wado
@@ -62,6 +62,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -262,38 +264,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l10: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l10;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l10: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l10;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_simple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_bounds_elim_oob_simple.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/subtask-drop" = fn(i32);
@@ -216,38 +218,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_explicit_cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_explicit_cast.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -480,38 +482,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_f64.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_f64.wir.wado
@@ -102,6 +102,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -109,6 +111,8 @@ type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
 type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/Array<f64>::append" = fn(ref Array<f64>, f64);
+
+type "functype/Array<f64>::grow" = fn(ref Array<f64>);
 
 type "functype/Formatter::apply_padding" = fn(ref Formatter, i32);
 
@@ -1195,38 +1199,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l117: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l117;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l117: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l117;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {
@@ -1445,38 +1455,44 @@ fn String::append(self, other) {
 
 fn Array<f64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f64>::grow(self);
+    };
+    builtin::array_set<f64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<f64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<f64>;
     let old_repr: ref array<f64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l144: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                    i = i + 1;
-                    continue l144;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l144: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
+                i = i + 1;
+                continue l144;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<f64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::apply_padding(self, start_pos) {

--- a/wado-compiler/tests/fixtures.golden/array_index_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_1.wir.wado
@@ -127,6 +127,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Tree<String>::check" = fn(ref Tree<String>) -> i32;
 
 type "functype/Node<String>::find_index" = fn(ref Node<String>, ref String) -> i32;
@@ -137,7 +139,11 @@ type "functype/Node<String>::count_active" = fn(ref Node<String>) -> i32;
 
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
 
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -895,38 +901,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l55: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l55;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l55: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l55;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Tree<String>::check(self) {
@@ -1057,74 +1069,86 @@ fn Node<String>::count_active(self) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<bool>;
-    let old_repr: ref array<bool>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l75: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l75;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
     };
     builtin::array_set<bool>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<bool>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<bool>;
+    let old_repr: ref array<bool>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l75: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l75;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l79: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l79;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l79: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l79;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_index_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_2.wir.wado
@@ -110,11 +110,17 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Container<String>::count_flagged" = fn(ref Container<String>) -> i32;
 
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
+
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -692,74 +698,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l40;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l40;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l44: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l44;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l44: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l44;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Container<String>::count_flagged(self) {
@@ -800,38 +818,44 @@ fn Container<String>::count_flagged(self) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
+    };
+    builtin::array_set<bool>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<bool>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<bool>;
     let old_repr: ref array<bool>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l53: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l53;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l53: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l53;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<bool>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_method.wir.wado
@@ -111,13 +111,19 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Container<String,i32>::is_full" = fn(ref Container<String,i32>, i32) -> bool;
 
 type "functype/Container<String,i32>::find_key_index" = fn(ref Container<String,i32>, ref String) -> i32;
 
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
 
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -558,38 +564,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l34: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l34;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l34: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l34;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Container<String,i32>::is_full(self, max_keys) {
@@ -667,74 +679,86 @@ fn Container<String,i32>::find_key_index(self, key) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<bool>;
-    let old_repr: ref array<bool>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l48: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l48;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
     };
     builtin::array_set<bool>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<bool>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<bool>;
+    let old_repr: ref array<bool>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l48: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l48;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_inline_recursive.wir.wado
@@ -102,9 +102,13 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Node<String>::traverse" = fn(ref Node<String>, i32);
 
 type "functype/Array<Node<String>>::append" = fn(ref Array<Node<String>>, ref Node<String>);
+
+type "functype/Array<Node<String>>::grow" = fn(ref Array<Node<String>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -496,38 +500,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l26: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l26;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l26: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l26;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Node<String>::traverse(self, depth) with Stdout {
@@ -562,38 +572,44 @@ fn Node<String>::traverse(self, depth) with Stdout {
 
 fn Array<Node<String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Node<String>>::grow(self);
+    };
+    builtin::array_set<ref Node<String>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Node<String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Node<String>>;
     let old_repr: ref array<Node<String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Node<String>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l34: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Node<String>>(new_repr, i, builtin::array_get<ref Node<String>>(old_repr, i));
-                    i = i + 1;
-                    continue l34;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Node<String>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l34: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Node<String>>(new_repr, i, builtin::array_get<ref Node<String>>(old_repr, i));
+                i = i + 1;
+                continue l34;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Node<String>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_large_literal_dynamic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_large_literal_dynamic.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -1011,38 +1013,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l47: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l47;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l47: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l47;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_literal_coerce_u8.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_literal_coerce_u8.wir.wado
@@ -99,9 +99,15 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u16>::append" = fn(ref Array<u16>, u16);
 
+type "functype/Array<u16>::grow" = fn(ref Array<u16>);
+
 type "functype/Array<i64>::append" = fn(ref Array<i64>, i64);
 
+type "functype/Array<i64>::grow" = fn(ref Array<i64>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -711,110 +717,128 @@ fn String::append_char(self, c) {
 
 fn Array<u16>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<u16>;
-    let old_repr: ref array<u16>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u16>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u16>(new_repr, i, builtin::array_get<u16>(old_repr, i));
-                    i = i + 1;
-                    continue l40;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u16>::grow(self);
     };
     builtin::array_set<u16>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<i64>::append(self, value) {
-    let used: i32;
+fn Array<u16>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<i64>;
-    let old_repr: ref array<i64>;
+    let new_repr: ref array<u16>;
+    let old_repr: ref array<u16>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l44: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                    i = i + 1;
-                    continue l44;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u16>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u16>(new_repr, i, builtin::array_get<u16>(old_repr, i));
+                i = i + 1;
+                continue l40;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<i64>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i64>::grow(self);
     };
     builtin::array_set<i64>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i64>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i64>;
+    let old_repr: ref array<i64>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l44: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
+                i = i + 1;
+                continue l44;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l48: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l48;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l48: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l48;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_new.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_new.wir.wado
@@ -142,6 +142,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -154,9 +156,15 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<f64>::append" = fn(ref Array<f64>, f64);
+
+type "functype/Array<f64>::grow" = fn(ref Array<f64>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -2741,38 +2749,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l183: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l183;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l183: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l183;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -3131,38 +3145,44 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l225: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l225;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l225: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l225;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {
@@ -3177,38 +3197,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l230: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l230;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l230: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l230;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<f64>^Iterator::next(self) {
@@ -3223,38 +3249,44 @@ fn ArrayIter<f64>^Iterator::next(self) {
 
 fn Array<f64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f64>::grow(self);
+    };
+    builtin::array_set<f64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<f64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<f64>;
     let old_repr: ref array<f64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l235: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                    i = i + 1;
-                    continue l235;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l235: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
+                i = i + 1;
+                continue l235;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<f64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_of_generic_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_of_generic_struct.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Box<i32>>::append" = fn(ref Array<Box<i32>>, ref "core:internal/Box<i32>");
 
+type "functype/Array<Box<i32>>::grow" = fn(ref Array<Box<i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -596,38 +598,44 @@ fn String::append_char(self, c) {
 
 fn Array<Box<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Box<i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:internal/Box<i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Box<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Box<i32>>;
     let old_repr: ref array<Box<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:internal/Box<i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:internal/Box<i32>">(new_repr, i, builtin::array_get<ref "core:internal/Box<i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:internal/Box<i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:internal/Box<i32>">(new_repr, i, builtin::array_get<ref "core:internal/Box<i32>">(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:internal/Box<i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_param_coercion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_param_coercion.wir.wado
@@ -89,6 +89,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -466,38 +468,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_return.wir.wado
@@ -89,6 +89,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -486,38 +488,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_specialized.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_specialized.wir.wado
@@ -306,6 +306,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -318,31 +320,59 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
+
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
 
 type "functype/Array<u32>::append" = fn(ref Array<u32>, u32);
 
+type "functype/Array<u32>::grow" = fn(ref Array<u32>);
+
 type "functype/Array<u16>::append" = fn(ref Array<u16>, u16);
+
+type "functype/Array<u16>::grow" = fn(ref Array<u16>);
 
 type "functype/Array<Tuple<bool,i32,String>>::append" = fn(ref Array<Tuple<bool,i32,String>>, ref "tuple/[bool, i32, String]");
 
+type "functype/Array<Tuple<bool,i32,String>>::grow" = fn(ref Array<Tuple<bool,i32,String>>);
+
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
+
+type "functype/Array<String>::grow" = fn(ref Array<String>);
 
 type "functype/Array<i8>::append" = fn(ref Array<i8>, i8);
 
+type "functype/Array<i8>::grow" = fn(ref Array<i8>);
+
 type "functype/Array<i64>::append" = fn(ref Array<i64>, i64);
+
+type "functype/Array<i64>::grow" = fn(ref Array<i64>);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<i16>::append" = fn(ref Array<i16>, i16);
+
+type "functype/Array<i16>::grow" = fn(ref Array<i16>);
 
 type "functype/Array<f64>::append" = fn(ref Array<f64>, f64);
 
+type "functype/Array<f64>::grow" = fn(ref Array<f64>);
+
 type "functype/Array<f32>::append" = fn(ref Array<f32>, f32);
+
+type "functype/Array<f32>::grow" = fn(ref Array<f32>);
 
 type "functype/Array<char>::append" = fn(ref Array<char>, char);
 
+type "functype/Array<char>::grow" = fn(ref Array<char>);
+
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
+
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -2209,38 +2239,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l173: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l173;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l173: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l173;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -2758,38 +2794,44 @@ fn ArrayIter<u8>^Iterator::next(self) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l229: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l229;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l229: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l229;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<u64>^Iterator::next(self) {
@@ -2804,38 +2846,44 @@ fn ArrayIter<u64>^Iterator::next(self) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l234: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l234;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l234: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l234;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<u32>^Iterator::next(self) {
@@ -2850,38 +2898,44 @@ fn ArrayIter<u32>^Iterator::next(self) {
 
 fn Array<u32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u32>::grow(self);
+    };
+    builtin::array_set<u32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u32>;
     let old_repr: ref array<u32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l239: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u32>(new_repr, i, builtin::array_get<u32>(old_repr, i));
-                    i = i + 1;
-                    continue l239;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l239: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u32>(new_repr, i, builtin::array_get<u32>(old_repr, i));
+                i = i + 1;
+                continue l239;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<u16>^Iterator::next(self) {
@@ -2896,38 +2950,44 @@ fn ArrayIter<u16>^Iterator::next(self) {
 
 fn Array<u16>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u16>::grow(self);
+    };
+    builtin::array_set<u16>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u16>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u16>;
     let old_repr: ref array<u16>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u16>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l244: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u16>(new_repr, i, builtin::array_get<u16>(old_repr, i));
-                    i = i + 1;
-                    continue l244;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u16>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l244: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u16>(new_repr, i, builtin::array_get<u16>(old_repr, i));
+                i = i + 1;
+                continue l244;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u16>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<Tuple<bool,i32,String>>^Iterator::next(self) {
@@ -2942,38 +3002,44 @@ fn ArrayIter<Tuple<bool,i32,String>>^Iterator::next(self) {
 
 fn Array<Tuple<bool,i32,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<bool,i32,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[bool, i32, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<bool,i32,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<bool,i32,String>>;
     let old_repr: ref array<Tuple<bool,i32,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[bool, i32, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l249: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[bool, i32, String]">(new_repr, i, builtin::array_get<ref "tuple/[bool, i32, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l249;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[bool, i32, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l249: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[bool, i32, String]">(new_repr, i, builtin::array_get<ref "tuple/[bool, i32, String]">(old_repr, i));
+                i = i + 1;
+                continue l249;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[bool, i32, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<String>^Iterator::next(self) {
@@ -2988,38 +3054,44 @@ fn ArrayIter<String>^Iterator::next(self) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l254: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l254;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l254: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l254;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i8>^Iterator::next(self) {
@@ -3034,38 +3106,44 @@ fn ArrayIter<i8>^Iterator::next(self) {
 
 fn Array<i8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i8>::grow(self);
+    };
+    builtin::array_set<i8>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i8>;
     let old_repr: ref array<i8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l259: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i8>(new_repr, i, builtin::array_get<i8>(old_repr, i));
-                    i = i + 1;
-                    continue l259;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l259: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i8>(new_repr, i, builtin::array_get<i8>(old_repr, i));
+                i = i + 1;
+                continue l259;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i8>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i64>^Iterator::next(self) {
@@ -3080,38 +3158,44 @@ fn ArrayIter<i64>^Iterator::next(self) {
 
 fn Array<i64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i64>::grow(self);
+    };
+    builtin::array_set<i64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i64>;
     let old_repr: ref array<i64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l264: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                    i = i + 1;
-                    continue l264;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l264: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
+                i = i + 1;
+                continue l264;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {
@@ -3126,38 +3210,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l269: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l269;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l269: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l269;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i16>^Iterator::next(self) {
@@ -3172,38 +3262,44 @@ fn ArrayIter<i16>^Iterator::next(self) {
 
 fn Array<i16>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i16>::grow(self);
+    };
+    builtin::array_set<i16>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i16>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i16>;
     let old_repr: ref array<i16>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i16>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l274: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i16>(new_repr, i, builtin::array_get<i16>(old_repr, i));
-                    i = i + 1;
-                    continue l274;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i16>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l274: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i16>(new_repr, i, builtin::array_get<i16>(old_repr, i));
+                i = i + 1;
+                continue l274;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i16>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<f64>^Iterator::next(self) {
@@ -3218,38 +3314,44 @@ fn ArrayIter<f64>^Iterator::next(self) {
 
 fn Array<f64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f64>::grow(self);
+    };
+    builtin::array_set<f64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<f64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<f64>;
     let old_repr: ref array<f64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l279: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                    i = i + 1;
-                    continue l279;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l279: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
+                i = i + 1;
+                continue l279;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<f64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<f32>^Iterator::next(self) {
@@ -3264,38 +3366,44 @@ fn ArrayIter<f32>^Iterator::next(self) {
 
 fn Array<f32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f32>::grow(self);
+    };
+    builtin::array_set<f32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<f32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<f32>;
     let old_repr: ref array<f32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l284: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f32>(new_repr, i, builtin::array_get<f32>(old_repr, i));
-                    i = i + 1;
-                    continue l284;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l284: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f32>(new_repr, i, builtin::array_get<f32>(old_repr, i));
+                i = i + 1;
+                continue l284;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<f32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<char>^Iterator::next(self) {
@@ -3310,38 +3418,44 @@ fn ArrayIter<char>^Iterator::next(self) {
 
 fn Array<char>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<char>::grow(self);
+    };
+    builtin::array_set<char>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<char>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<char>;
     let old_repr: ref array<char>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<char>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l289: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<char>(new_repr, i, builtin::array_get<char>(old_repr, i));
-                    i = i + 1;
-                    continue l289;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<char>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l289: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<char>(new_repr, i, builtin::array_get<char>(old_repr, i));
+                i = i + 1;
+                continue l289;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<char>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<bool>^Iterator::next(self) {
@@ -3356,38 +3470,44 @@ fn ArrayIter<bool>^Iterator::next(self) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
+    };
+    builtin::array_set<bool>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<bool>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<bool>;
     let old_repr: ref array<bool>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l294: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l294;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l294: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l294;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<bool>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_string.wir.wado
@@ -74,6 +74,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -399,38 +401,44 @@ fn String::append(self, other) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l19: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l19;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l19: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l19;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/array_tuple_unit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_tuple_unit.wir.wado
@@ -89,6 +89,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<i32,unit>>::append" = fn(ref Array<Tuple<i32,unit>>, ref "tuple/[i32, unit]");
 
+type "functype/Array<Tuple<i32,unit>>::grow" = fn(ref Array<Tuple<i32,unit>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -436,38 +438,44 @@ fn ArrayIter<Tuple<i32,unit>>^Iterator::next(self) {
 
 fn Array<Tuple<i32,unit>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<i32,unit>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[i32, unit]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<i32,unit>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<i32,unit>>;
     let old_repr: ref array<Tuple<i32,unit>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[i32, unit]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[i32, unit]">(new_repr, i, builtin::array_get<ref "tuple/[i32, unit]">(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[i32, unit]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[i32, unit]">(new_repr, i, builtin::array_get<ref "tuple/[i32, unit]">(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[i32, unit]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/array_type_annotation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_type_annotation.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -480,38 +482,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_float.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_float.wir.wado
@@ -93,6 +93,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1274,38 +1276,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l127: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l127;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l127: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l127;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/auto_deref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref.wir.wado
@@ -103,6 +103,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -796,38 +798,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l43: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l43;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l43: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l43;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/base64_decode.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/base64_decode.wir.wado
@@ -101,6 +101,8 @@ type "functype/write_decimal_digits" = fn(ref array<u8>, i32, i64, i32);
 
 type "functype/core:base64/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/core:base64/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -113,7 +115,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Array<u8>^Eq::eq" = fn(ref Array<u8>, ref Array<u8>) -> bool;
 
@@ -1390,38 +1396,44 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn "core:base64/Array<u8>::append"(self, value) {  // from core:base64
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        "core:base64/Array<u8>::grow"(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn "core:base64/Array<u8>::grow"(self) {  // from core:base64
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l116: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l116;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l116: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l116;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1558,74 +1570,86 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<u8>;
-    let old_repr: ref array<u8>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l132: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l132;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
     };
     builtin::array_set_u8(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<u8>::append(self, value) {
-    let used: i32;
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l136: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l136;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l132: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l132;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<u8>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
     };
     builtin::array_set_u8(self.repr, used, value);
     self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<u8>;
+    let old_repr: ref array<u8>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l136: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l136;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<u8>^Eq::eq(self, other) {

--- a/wado-compiler/tests/fixtures.golden/base64_encode.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/base64_encode.wir.wado
@@ -95,6 +95,8 @@ type "functype/write_decimal_digits" = fn(ref array<u8>, i32, i64, i32);
 
 type "functype/core:base64/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/core:base64/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -108,6 +110,8 @@ type "functype/StrUtf8ByteIter^Iterator::collect" = fn(ref StrUtf8ByteIter) -> r
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1051,38 +1055,44 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn "core:base64/Array<u8>::append"(self, value) {  // from core:base64
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        "core:base64/Array<u8>::grow"(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn "core:base64/Array<u8>::grow"(self) {  // from core:base64
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1306,38 +1316,44 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l77: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l77;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l77: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l77;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/cli_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cli_args.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -468,38 +470,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/closure_capture.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_capture.wir.wado
@@ -113,6 +113,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/__Closure_5::__call" = fn(ref __Closure_5) -> ref String;
 
 type "functype/__Closure_10::__call" = fn(ref __Closure_10) -> ref String;
@@ -770,38 +772,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l34: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l34;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l34: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l34;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/closure_fn.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_fn.wir.wado
@@ -97,6 +97,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/__Closure_1::__call" = fn(ref __Closure_1, i32);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -554,38 +556,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/closure_iterator.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_iterator.wir.wado
@@ -166,6 +166,8 @@ type "functype/MapIter<i32,i32>^Iterator::collect" = fn(ref "core:allocator/MapI
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/FilterIter<i32>^Iterator::collect" = fn(ref "core:allocator/FilterIter<i32>") -> ref Array<i32>;
 
 type "functype/MapIter<i32,i32>::fold<i32>" = fn(ref "core:allocator/MapIter<i32,i32>", i32, ref struct) -> i32;
@@ -838,38 +840,44 @@ fn MapIter<i32,i32>^Iterator::collect(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l43: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l43;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l43: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l43;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn MapIter<i32,i32>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_c_style_for.wir.wado
@@ -98,6 +98,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Fn<1,i32>>::append" = fn(ref Array<Fn<1,i32>>, ref struct);
 
+type "functype/Array<Fn<1,i32>>::grow" = fn(ref Array<Fn<1,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -592,38 +594,44 @@ fn String::append_char(self, c) {
 
 fn Array<Fn<1,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Fn<1,i32>>::grow(self);
+    };
+    builtin::array_set<ref struct>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Fn<1,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Fn<1,i32>>;
     let old_repr: ref array<Fn<1,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref struct>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref struct>(new_repr, i, builtin::array_get<ref struct>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref struct>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref struct>(new_repr, i, builtin::array_get<ref struct>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref struct>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn __Closure_0::__call(self, _) {

--- a/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_loop_scope_for_of.wir.wado
@@ -111,7 +111,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Fn<1,i32>>::append" = fn(ref Array<Fn<1,i32>>, ref struct);
 
+type "functype/Array<Fn<1,i32>>::grow" = fn(ref Array<Fn<1,i32>>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -618,38 +622,44 @@ fn String::append_char(self, c) {
 
 fn Array<Fn<1,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Fn<1,i32>>::grow(self);
+    };
+    builtin::array_set<ref struct>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Fn<1,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Fn<1,i32>>;
     let old_repr: ref array<Fn<1,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref struct>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref struct>(new_repr, i, builtin::array_get<ref struct>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref struct>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref struct>(new_repr, i, builtin::array_get<ref struct>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref struct>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {
@@ -664,38 +674,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l44: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l44;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l44: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l44;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn __Closure_0::__call(self, _) {

--- a/wado-compiler/tests/fixtures.golden/closure_sort_by.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_sort_by.wir.wado
@@ -106,6 +106,8 @@ type "functype/Array<i32>::sort_by" = fn(ref Array<i32>, ref struct);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<i32>::sort_by$__Closure_0" = fn(ref Array<i32>, ref __Closure_0);
 
 type "functype/Array<i32>::sort_by$__Closure_1" = fn(ref Array<i32>, ref __Closure_1);
@@ -632,38 +634,44 @@ fn Array<i32>::sort_by(self, cmp) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l50: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l50;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l50: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l50;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn __Closure_0::__call(self, a, b) {

--- a/wado-compiler/tests/fixtures.golden/coerce_float.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1213,38 +1215,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l116: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l116;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l116: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l116;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_args.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_args.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1295,38 +1297,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l121: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l121;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l121: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l121;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_let.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1295,38 +1297,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l121: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l121;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l121: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l121;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/coerce_float_literal_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/coerce_float_literal_return.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1295,38 +1297,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l121: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l121;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l121: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l121;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/const_fold.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/const_fold.wir.wado
@@ -79,6 +79,8 @@ type "functype/write_decimal_digits" = fn(ref array<u8>, i32, i64, i32);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -527,38 +529,44 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l17: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l17;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l17: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l17;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/contextual_keyword.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/contextual_keyword.wir.wado
@@ -85,6 +85,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -463,38 +465,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/cross_destruct_patterns.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_destruct_patterns.wir.wado
@@ -114,6 +114,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tagged>::append" = fn(ref Array<Tagged>, ref Tagged);
 
+type "functype/Array<Tagged>::grow" = fn(ref Array<Tagged>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -608,38 +610,44 @@ fn ArrayIter<Tagged>^Iterator::next(self) {
 
 fn Array<Tagged>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tagged>::grow(self);
+    };
+    builtin::array_set<ref Tagged>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tagged>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tagged>;
     let old_repr: ref array<Tagged>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Tagged>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Tagged>(new_repr, i, builtin::array_get<ref Tagged>(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Tagged>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Tagged>(new_repr, i, builtin::array_get<ref Tagged>(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Tagged>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/cross_module_treemap_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_treemap_variant.wir.wado
@@ -130,6 +130,8 @@ type "functype/./sub/cross_module_treemap_variant_helper.wado/TreeMap<String,Val
 
 type "functype/./sub/cross_module_treemap_variant_helper.wado/Array<Tuple<String,Value>>::append" = fn(ref Array<Tuple<String,Value>>, ref "tuple/[String, Value]");
 
+type "functype/./sub/cross_module_treemap_variant_helper.wado/Array<Tuple<String,Value>>::grow" = fn(ref Array<Tuple<String,Value>>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append" = fn(ref String, ref String);
@@ -147,6 +149,8 @@ type "functype/TreeMap<String,Value>::split" = fn(ref "./sub/cross_module_treema
 type "functype/TreeMap<String,Value>::skew" = fn(ref "./sub/cross_module_treemap_variant_helper.wado/TreeMap<String,Value>", ref Option<TreeMapNode<String>>) -> ref Option<TreeMapNode<String>>;
 
 type "functype/Array<TreeMapEntry<String,Value>>::append" = fn(ref Array<TreeMapEntry<String,Value>>, ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>");
+
+type "functype/Array<TreeMapEntry<String,Value>>::grow" = fn(ref Array<TreeMapEntry<String,Value>>);
 
 type "functype/TreeMap<String,Value>::find_index" = fn(ref "./sub/cross_module_treemap_variant_helper.wado/TreeMap<String,Value>", ref String) -> i32;
 
@@ -466,38 +470,44 @@ fn "./sub/cross_module_treemap_variant_helper.wado/TreeMap<String,Value>::entrie
 
 fn "./sub/cross_module_treemap_variant_helper.wado/Array<Tuple<String,Value>>::append"(self, value) {  // from ./sub/cross_module_treemap_variant_helper.wado
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        "./sub/cross_module_treemap_variant_helper.wado/Array<Tuple<String,Value>>::grow"(self);
+    };
+    builtin::array_set<ref "tuple/[String, Value]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn "./sub/cross_module_treemap_variant_helper.wado/Array<Tuple<String,Value>>::grow"(self) {  // from ./sub/cross_module_treemap_variant_helper.wado
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,Value>>;
     let old_repr: ref array<Tuple<String,Value>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, Value]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l20: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, Value]">(new_repr, i, builtin::array_get<ref "tuple/[String, Value]">(old_repr, i));
-                    i = i + 1;
-                    continue l20;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, Value]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l20: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, Value]">(new_repr, i, builtin::array_get<ref "tuple/[String, Value]">(old_repr, i));
+                i = i + 1;
+                continue l20;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, Value]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn "./sub/cross_module_treemap_variant_helper.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(self) {  // from ./sub/cross_module_treemap_variant_helper.wado
@@ -720,38 +730,44 @@ fn TreeMap<String,Value>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,Value>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,Value>>::grow(self);
+    };
+    builtin::array_set<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,Value>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,Value>>;
     let old_repr: ref array<TreeMapEntry<String,Value>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "./sub/cross_module_treemap_variant_helper.wado/TreeMapEntry<String,Value>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,Value>::find_index(self, key) {

--- a/wado-compiler/tests/fixtures.golden/default_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/default_trait.wir.wado
@@ -86,6 +86,8 @@ type "functype/write_decimal_digits" = fn(ref array<u8>, i32, i64, i32);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -405,38 +407,44 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l19: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l19;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l19: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l19;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
@@ -116,6 +116,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
 
+type "functype/Array<Tuple<String,String>>::grow" = fn(ref Array<Tuple<String,String>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::pad" = fn(ref Formatter, ref String);
@@ -622,38 +624,44 @@ fn String::append_char(self, c) {
 
 fn Array<Tuple<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,String>>;
     let old_repr: ref array<Tuple<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l37: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l37;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l37: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
+                i = i + 1;
+                continue l37;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn MiniDict<String,String>::has(self, key) {

--- a/wado-compiler/tests/fixtures.golden/display_all_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_all_primitives.wir.wado
@@ -105,6 +105,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -2384,38 +2386,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l148: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l148;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l148: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l148;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/display_fts_precision.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_fts_precision.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -2231,38 +2233,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/display_template_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_1.wir.wado
@@ -125,6 +125,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/u128::fmt_base" = fn(ref u128, ref Formatter, i32, bool);
 
 type "functype/i128::fmt_base" = fn(ref i128, ref Formatter, i32, bool);
@@ -7142,38 +7144,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l309: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l309;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l309: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l309;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn u128::fmt_base(self, f, base, upper) {

--- a/wado-compiler/tests/fixtures.golden/display_template_specifiers_inspect.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_template_specifiers_inspect.wir.wado
@@ -188,6 +188,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/u128::div_rem" = fn(ref u128, ref u128) -> ref "tuple/[u128, u128]";
 
 type "functype/u128::get_bit" = fn(ref u128, i32) -> bool;
@@ -4051,38 +4053,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l195: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l195;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l195: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l195;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn u128::div_rem(self, divisor) {

--- a/wado-compiler/tests/fixtures.golden/float_to_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/float_to_string.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1175,38 +1177,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/for_let_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_let_basic.wir.wado
@@ -85,6 +85,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -473,38 +475,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/for_of_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_1.wir.wado
@@ -95,6 +95,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -609,38 +611,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l43: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l43;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l43: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l43;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/for_of_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/for_of_2.wir.wado
@@ -170,13 +170,23 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<Tuple<i32,i32>>::append" = fn(ref Array<Tuple<i32,i32>>, ref "tuple/[i32, i32]");
+
+type "functype/Array<Tuple<i32,i32>>::grow" = fn(ref Array<Tuple<i32,i32>>);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
 
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
+
 type "functype/Array<Tuple<String,i32>>::append" = fn(ref Array<Tuple<String,i32>>, ref "tuple/[String, i32]");
 
+type "functype/Array<Tuple<String,i32>>::grow" = fn(ref Array<Tuple<String,i32>>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -850,38 +860,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<Tuple<i32,i32>>^Iterator::next(self) {
@@ -896,38 +912,44 @@ fn ArrayIter<Tuple<i32,i32>>^Iterator::next(self) {
 
 fn Array<Tuple<i32,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<i32,i32>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[i32, i32]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<i32,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<i32,i32>>;
     let old_repr: ref array<Tuple<i32,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[i32, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l57: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[i32, i32]">(new_repr, i, builtin::array_get<ref "tuple/[i32, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l57;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[i32, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l57: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[i32, i32]">(new_repr, i, builtin::array_get<ref "tuple/[i32, i32]">(old_repr, i));
+                i = i + 1;
+                continue l57;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[i32, i32]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<Tuple<String,i32>>^Iterator::next(self) {
@@ -952,38 +974,44 @@ fn ArrayIter<Point>^Iterator::next(self) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l63: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l63;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l63: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l63;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<String>^Iterator::next(self) {
@@ -1008,74 +1036,86 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<Tuple<String,i32>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<String,i32>>;
-    let old_repr: ref array<Tuple<String,i32>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l69: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l69;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,i32>>::grow(self);
     };
     builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Tuple<String,i32>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Tuple<String,i32>>;
+    let old_repr: ref array<Tuple<String,i32>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l69: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
+                i = i + 1;
+                continue l69;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l73: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l73;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l73: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l73;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/forof-generic-array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/forof-generic-array.wir.wado
@@ -60,6 +60,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -243,38 +245,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l12: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l12;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l12: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l12;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/from-literal-cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-cast.wir.wado
@@ -100,6 +100,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -801,38 +803,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l44: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l44;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l44: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l44;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-custom.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-custom.wir.wado
@@ -107,7 +107,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -916,74 +920,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l48: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l48;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l48: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l48;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-enum-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-enum-concrete.wir.wado
@@ -99,7 +99,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -559,74 +563,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l29;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l33: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l33;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l33: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l33;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-flags-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-flags-concrete.wir.wado
@@ -99,7 +99,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -559,74 +563,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l29;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l33: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l33;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l33: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l33;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-fn-arg.wir.wado
@@ -107,7 +107,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -619,74 +623,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l31: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l31;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l31: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l31;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l35: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l35;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l35: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l35;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-nested-generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-nested-generic.wir.wado
@@ -99,7 +99,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -507,74 +511,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l27: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l27;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l27: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l27;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l31: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l31;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l31: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l31;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-newtype-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-newtype-concrete.wir.wado
@@ -99,7 +99,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -559,74 +563,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l29;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l33: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l33;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l33: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l33;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-return.wir.wado
@@ -139,6 +139,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/TreeMap<String,i32>::keys" = fn(ref "core:allocator/TreeMap<String,i32>") -> ref Array<String>;
 
 type "functype/TreeMap<String,i32>::insert" = fn(ref "core:allocator/TreeMap<String,i32>", ref String, i32);
@@ -150,6 +152,8 @@ type "functype/TreeMap<String,i32>::split" = fn(ref "core:allocator/TreeMap<Stri
 type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<String,i32>", ref Option<TreeMapNode<String>>) -> ref Option<TreeMapNode<String>>;
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
+
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
 
 type "functype/TreeMap<String,i32>::find_index" = fn(ref "core:allocator/TreeMap<String,i32>", ref String) -> i32;
 
@@ -635,38 +639,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::keys(self) {
@@ -811,38 +821,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l60: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l60;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l60: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l60;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::find_index(self, key) {

--- a/wado-compiler/tests/fixtures.golden/from-literal-variant-concrete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-variant-concrete.wir.wado
@@ -99,7 +99,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -559,74 +563,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l29;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l33: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l33;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l33: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l33;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/from_numeric_widening.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from_numeric_widening.wir.wado
@@ -101,6 +101,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1419,38 +1421,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l131: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l131;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l131: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l131;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/generic-array-direct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-array-direct.wir.wado
@@ -79,6 +79,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -407,38 +409,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l25: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l25;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l25: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l25;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-method-closure-param-quicksort.wir.wado
@@ -114,6 +114,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -655,38 +657,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l48: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l48;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l48: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l48;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn __Closure_0::__call(self, a, b) {

--- a/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-field-monomorphization.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -535,38 +537,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/generic-struct-import.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic-struct-import.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -816,38 +818,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l63: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l63;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l63: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l63;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_generic.wir.wado
@@ -92,6 +92,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Pair<i32,String>>::append" = fn(ref Array<Pair<i32,String>>, ref Pair<i32,String>);
 
+type "functype/Array<Pair<i32,String>>::grow" = fn(ref Array<Pair<i32,String>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -495,38 +497,44 @@ fn String::append_char(self, c) {
 
 fn Array<Pair<i32,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Pair<i32,String>>::grow(self);
+    };
+    builtin::array_set<ref Pair<i32,String>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Pair<i32,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Pair<i32,String>>;
     let old_repr: ref array<Pair<i32,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Pair<i32,String>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l30: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Pair<i32,String>>(new_repr, i, builtin::array_get<ref Pair<i32,String>>(old_repr, i));
-                    i = i + 1;
-                    continue l30;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Pair<i32,String>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l30: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Pair<i32,String>>(new_repr, i, builtin::array_get<ref Pair<i32,String>>(old_repr, i));
+                i = i + 1;
+                continue l30;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Pair<i32,String>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/generic_array_of_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_array_of_struct.wir.wado
@@ -92,6 +92,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
 
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -509,38 +511,44 @@ fn String::append_char(self, c) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l30: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l30;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l30: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l30;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/generic_function_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_1.wir.wado
@@ -103,6 +103,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1440,38 +1442,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l130: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l130;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l130: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l130;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/generic_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method.wir.wado
@@ -105,6 +105,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1312,38 +1314,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l122: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l122;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l122: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l122;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/generic_struct_explicit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_explicit.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1469,38 +1471,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l130: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l130;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l130: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l130;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/generic_struct_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_types.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1292,38 +1294,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l123: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l123;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l123: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l123;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/global_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_basic.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1258,38 +1260,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l123: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l123;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l123: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l123;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/global_expressions.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_expressions.wir.wado
@@ -105,6 +105,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1327,38 +1329,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l125: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l125;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l125: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l125;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/global_object.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/global_object.wir.wado
@@ -100,6 +100,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -597,38 +599,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l28: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l28;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l28: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l28;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-body-contains.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-body-contains.wir.wado
@@ -257,6 +257,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -860,38 +862,44 @@ fn "core:internal/cm_stream_write_u8"(handle, data) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l45: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l45;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l45: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l45;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/http-echo-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-echo-headers.wir.wado
@@ -306,7 +306,11 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<Array<u8>>::append" = fn(ref Array<Array<u8>>, ref Array<u8>);
 
+type "functype/Array<Array<u8>>::grow" = fn(ref Array<Array<u8>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/wasi/future-new" = fn() -> i64;
 
@@ -1085,74 +1089,86 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<Array<u8>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Array<u8>>;
-    let old_repr: ref array<Array<u8>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l61: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
-                    i = i + 1;
-                    continue l61;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<u8>>::grow(self);
     };
     builtin::array_set<ref Array<u8>>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Array<u8>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Array<u8>>;
+    let old_repr: ref array<Array<u8>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l61: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
+                i = i + 1;
+                continue l61;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l65: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l65;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l65: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l65;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/http-fields-copy-all.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-copy-all.wir.wado
@@ -330,7 +330,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<String,Array<u8>>>::append" = fn(ref Array<Tuple<String,Array<u8>>>, ref "tuple/[String, Array<u8>]");
 
+type "functype/Array<Tuple<String,Array<u8>>>::grow" = fn(ref Array<Tuple<String,Array<u8>>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1323,74 +1327,86 @@ fn String::append_char(self, c) {
 
 fn Array<Tuple<String,Array<u8>>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<String,Array<u8>>>;
-    let old_repr: ref array<Tuple<String,Array<u8>>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, Array<u8>]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l79: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Array<u8>]">(old_repr, i));
-                    i = i + 1;
-                    continue l79;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,Array<u8>>>::grow(self);
     };
     builtin::array_set<ref "tuple/[String, Array<u8>]">(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Tuple<String,Array<u8>>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Tuple<String,Array<u8>>>;
+    let old_repr: ref array<Tuple<String,Array<u8>>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, Array<u8>]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l79: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref "tuple/[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Array<u8>]">(old_repr, i));
+                i = i + 1;
+                continue l79;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l83: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l83;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l83: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l83;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-fields-from-list.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-from-list.wir.wado
@@ -333,7 +333,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<String,Array<u8>>>::append" = fn(ref Array<Tuple<String,Array<u8>>>, ref "tuple/[String, Array<u8>]");
 
+type "functype/Array<Tuple<String,Array<u8>>>::grow" = fn(ref Array<Tuple<String,Array<u8>>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1291,74 +1295,86 @@ fn String::append_char(self, c) {
 
 fn Array<Tuple<String,Array<u8>>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<String,Array<u8>>>;
-    let old_repr: ref array<Tuple<String,Array<u8>>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, Array<u8>]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l74: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Array<u8>]">(old_repr, i));
-                    i = i + 1;
-                    continue l74;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,Array<u8>>>::grow(self);
     };
     builtin::array_set<ref "tuple/[String, Array<u8>]">(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Tuple<String,Array<u8>>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Tuple<String,Array<u8>>>;
+    let old_repr: ref array<Tuple<String,Array<u8>>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, Array<u8>]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l74: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref "tuple/[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Array<u8>]">(old_repr, i));
+                i = i + 1;
+                continue l74;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l78: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l78;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l78: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l78;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-fields-get-and-delete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-get-and-delete.wir.wado
@@ -342,7 +342,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Array<u8>>::append" = fn(ref Array<Array<u8>>, ref Array<u8>);
 
+type "functype/Array<Array<u8>>::grow" = fn(ref Array<Array<u8>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1437,74 +1441,86 @@ fn String::append_char(self, c) {
 
 fn Array<Array<u8>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Array<u8>>;
-    let old_repr: ref array<Array<u8>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l84: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
-                    i = i + 1;
-                    continue l84;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<u8>>::grow(self);
     };
     builtin::array_set<ref Array<u8>>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Array<u8>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Array<u8>>;
+    let old_repr: ref array<Array<u8>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l84: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
+                i = i + 1;
+                continue l84;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l88: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l88;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l88: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l88;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-fields-set.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-set.wir.wado
@@ -331,7 +331,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Array<u8>>::append" = fn(ref Array<Array<u8>>, ref Array<u8>);
 
+type "functype/Array<Array<u8>>::grow" = fn(ref Array<Array<u8>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1434,74 +1438,86 @@ fn String::append_char(self, c) {
 
 fn Array<Array<u8>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Array<u8>>;
-    let old_repr: ref array<Array<u8>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l86: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
-                    i = i + 1;
-                    continue l86;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<u8>>::grow(self);
     };
     builtin::array_set<ref Array<u8>>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Array<u8>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Array<u8>>;
+    let old_repr: ref array<Array<u8>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l86: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
+                i = i + 1;
+                continue l86;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l90: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l90;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l90: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l90;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields.wir.wado
@@ -324,6 +324,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::pad" = fn(ref Formatter, ref String);
@@ -1484,38 +1486,44 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l82: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l82;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l82: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l82;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-request-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-request-headers.wir.wado
@@ -311,7 +311,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Array<u8>>::append" = fn(ref Array<Array<u8>>, ref Array<u8>);
 
+type "functype/Array<Array<u8>>::grow" = fn(ref Array<Array<u8>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1287,74 +1291,86 @@ fn String::append_char(self, c) {
 
 fn Array<Array<u8>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Array<u8>>;
-    let old_repr: ref array<Array<u8>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l75: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
-                    i = i + 1;
-                    continue l75;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<u8>>::grow(self);
     };
     builtin::array_set<ref Array<u8>>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Array<u8>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Array<u8>>;
+    let old_repr: ref array<Array<u8>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l75: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
+                i = i + 1;
+                continue l75;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l79: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l79;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l79: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l79;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-response-get-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-response-get-headers.wir.wado
@@ -320,6 +320,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::pad" = fn(ref Formatter, ref String);
@@ -1234,38 +1236,44 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l69: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l69;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l69: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l69;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/http-response-headers-multi.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-response-headers-multi.wir.wado
@@ -263,6 +263,8 @@ type "functype/core:internal/cm_lower_list_u8" = fn(ref array<u8>, i32) -> i64;
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/future-write" = fn(i32, i32) -> i32;
@@ -868,38 +870,44 @@ fn "core:internal/cm_lower_list_u8"(data, len) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l47: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l47;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l47: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l47;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/http-response-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-response-headers.wir.wado
@@ -263,6 +263,8 @@ type "functype/core:internal/cm_lower_list_u8" = fn(ref array<u8>, i32) -> i64;
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/future-write" = fn(i32, i32) -> i32;
@@ -861,38 +863,44 @@ fn "core:internal/cm_lower_list_u8"(data, len) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l47: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l47;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l47: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l47;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/index_assign.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign.wir.wado
@@ -145,6 +145,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -157,11 +159,19 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<f64>::append" = fn(ref Array<f64>, f64);
+
+type "functype/Array<f64>::grow" = fn(ref Array<f64>);
 
 type "functype/Array<i64>::append" = fn(ref Array<i64>, i64);
 
+type "functype/Array<i64>::grow" = fn(ref Array<i64>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -2508,38 +2518,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l225: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l225;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l225: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l225;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -2856,146 +2872,170 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l260: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l260;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<f64>::append(self, value) {
-    let used: i32;
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<f64>;
-    let old_repr: ref array<f64>;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l264: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                    i = i + 1;
-                    continue l264;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l260: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l260;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<f64>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f64>::grow(self);
     };
     builtin::array_set<f64>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<i64>::append(self, value) {
-    let used: i32;
+fn Array<f64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<i64>;
-    let old_repr: ref array<i64>;
+    let new_repr: ref array<f64>;
+    let old_repr: ref array<f64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l268: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                    i = i + 1;
-                    continue l268;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l264: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
+                i = i + 1;
+                continue l264;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<i64>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i64>::grow(self);
     };
     builtin::array_set<i64>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i64>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i64>;
+    let old_repr: ref array<i64>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l268: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
+                i = i + 1;
+                continue l268;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l272: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l272;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l272: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l272;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/index_assign_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/index_assign_types.wir.wado
@@ -134,6 +134,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -146,13 +148,23 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
 
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
+
 type "functype/Array<f64>::append" = fn(ref Array<f64>, f64);
+
+type "functype/Array<f64>::grow" = fn(ref Array<f64>);
 
 type "functype/Array<f32>::append" = fn(ref Array<f32>, f32);
 
+type "functype/Array<f32>::grow" = fn(ref Array<f32>);
+
 type "functype/Array<i64>::append" = fn(ref Array<i64>, i64);
 
+type "functype/Array<i64>::grow" = fn(ref Array<i64>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1566,38 +1578,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l140: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l140;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l140: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l140;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1983,182 +2001,212 @@ fn String::append_char(self, c) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<bool>;
-    let old_repr: ref array<bool>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l181: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l181;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
     };
     builtin::array_set<bool>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<f64>::append(self, value) {
-    let used: i32;
+fn Array<bool>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<f64>;
-    let old_repr: ref array<f64>;
+    let new_repr: ref array<bool>;
+    let old_repr: ref array<bool>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l185: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                    i = i + 1;
-                    continue l185;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l181: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l181;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<f64>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f64>::grow(self);
     };
     builtin::array_set<f64>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<f32>::append(self, value) {
-    let used: i32;
+fn Array<f64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<f32>;
-    let old_repr: ref array<f32>;
+    let new_repr: ref array<f64>;
+    let old_repr: ref array<f64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l189: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f32>(new_repr, i, builtin::array_get<f32>(old_repr, i));
-                    i = i + 1;
-                    continue l189;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l185: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
+                i = i + 1;
+                continue l185;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<f32>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f32>::grow(self);
     };
     builtin::array_set<f32>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<i64>::append(self, value) {
-    let used: i32;
+fn Array<f32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<i64>;
-    let old_repr: ref array<i64>;
+    let new_repr: ref array<f32>;
+    let old_repr: ref array<f32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l193: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                    i = i + 1;
-                    continue l193;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l189: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f32>(new_repr, i, builtin::array_get<f32>(old_repr, i));
+                i = i + 1;
+                continue l189;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<i64>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i64>::grow(self);
     };
     builtin::array_set<i64>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i64>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i64>;
+    let old_repr: ref array<i64>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l193: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
+                i = i + 1;
+                continue l193;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l197: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l197;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l197: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l197;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_minimal.wir.wado
@@ -79,6 +79,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -416,38 +418,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l28: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l28;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l28: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l28;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inline_array_append_nested.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_array_append_nested.wir.wado
@@ -95,6 +95,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -547,38 +549,44 @@ fn Container::process(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l36;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l36;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inline_cross_module_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_cross_module_method.wir.wado
@@ -79,6 +79,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -428,38 +430,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l26: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l26;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l26: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l26;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inline_generic_nested_ref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_generic_nested_ref.wir.wado
@@ -91,6 +91,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Item>::append" = fn(ref Array<Item>, ref Item);
 
+type "functype/Array<Item>::grow" = fn(ref Array<Item>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -471,38 +473,44 @@ fn String::append_char(self, c) {
 
 fn Array<Item>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Item>::grow(self);
+    };
+    builtin::array_set<ref Item>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Item>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Item>;
     let old_repr: ref array<Item>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Item>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Item>(new_repr, i, builtin::array_get<ref Item>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Item>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Item>(new_repr, i, builtin::array_get<ref Item>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Item>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inline_method_minimal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_method_minimal.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -485,38 +487,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l28: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l28;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l28: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l28;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inline_primitive_method.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inline_primitive_method.wir.wado
@@ -101,6 +101,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1239,38 +1241,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l122: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l122;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l122: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l122;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i64::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/inspect_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_array.wir.wado
@@ -124,13 +124,19 @@ type "functype/Array<Option<i32>>^Inspect::inspect" = fn(ref Array<Option<i32>>,
 
 type "functype/Array<Option<i32>>::append" = fn(ref Array<Option<i32>>, ref Option<i32>);
 
+type "functype/Array<Option<i32>>::grow" = fn(ref Array<Option<i32>>);
+
 type "functype/Array<Point>^Inspect::inspect" = fn(ref Array<Point>, ref Formatter);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
 
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
+
 type "functype/Array<i32>^Inspect::inspect" = fn(ref Array<i32>, ref Formatter);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -671,38 +677,44 @@ fn Option<i32>^Inspect::inspect(self, f) {
 
 fn Array<Option<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Option<i32>>::grow(self);
+    };
+    builtin::array_set<ref Option<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Option<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Option<i32>>;
     let old_repr: ref array<Option<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Option<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<Point>^Inspect::inspect(self, f) {
@@ -739,38 +751,44 @@ fn Array<Point>^Inspect::inspect(self, f) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l40;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l40;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<i32>^Inspect::inspect(self, f) {
@@ -807,38 +825,44 @@ fn Array<i32>^Inspect::inspect(self, f) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l48: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l48;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l48: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l48;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inspect_float_special.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_float_special.wir.wado
@@ -97,6 +97,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1426,38 +1428,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l127: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l127;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l127: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l127;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::inspect_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_1.wir.wado
@@ -186,6 +186,8 @@ type "functype/Matrix^Inspect::inspect" = fn(ref Matrix, ref Formatter);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<Array<i32>>^Inspect::inspect" = fn(ref Array<Array<i32>>, ref Formatter);
 
 type "functype/Array<i32>^Inspect::inspect" = fn(ref Array<i32>, ref Formatter);
@@ -196,21 +198,33 @@ type "functype/Array<String>^Inspect::inspect" = fn(ref Array<String>, ref Forma
 
 type "functype/Array<Array<String>>::append" = fn(ref Array<Array<String>>, ref Array<String>);
 
+type "functype/Array<Array<String>>::grow" = fn(ref Array<Array<String>>);
+
 type "functype/Array<Option<i32>>^Inspect::inspect" = fn(ref Array<Option<i32>>, ref Formatter);
 
 type "functype/Array<Option<i32>>::append" = fn(ref Array<Option<i32>>, ref Option<i32>);
+
+type "functype/Array<Option<i32>>::grow" = fn(ref Array<Option<i32>>);
 
 type "functype/Array<Array<Array<i32>>>^Inspect::inspect" = fn(ref Array<Array<Array<i32>>>, ref Formatter);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<Array<i32>>::append" = fn(ref Array<Array<i32>>, ref Array<i32>);
 
+type "functype/Array<Array<i32>>::grow" = fn(ref Array<Array<i32>>);
+
 type "functype/Array<Array<Array<i32>>>::append" = fn(ref Array<Array<Array<i32>>>, ref Array<Array<i32>>);
+
+type "functype/Array<Array<Array<i32>>>::grow" = fn(ref Array<Array<Array<i32>>>);
 
 type "functype/Array<Point>^Inspect::inspect" = fn(ref Array<Point>, ref Formatter);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
+
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -872,38 +886,44 @@ fn Matrix^Inspect::inspect(self, f) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l30: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l30;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l30: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l30;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<Array<i32>>^Inspect::inspect(self, f) {
@@ -1036,38 +1056,44 @@ fn Array<String>^Inspect::inspect(self, f) {
 
 fn Array<Array<String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<String>>::grow(self);
+    };
+    builtin::array_set<ref Array<String>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<String>>;
     let old_repr: ref array<Array<String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<String>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l50: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<String>>(new_repr, i, builtin::array_get<ref Array<String>>(old_repr, i));
-                    i = i + 1;
-                    continue l50;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<String>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l50: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<String>>(new_repr, i, builtin::array_get<ref Array<String>>(old_repr, i));
+                i = i + 1;
+                continue l50;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<String>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<Option<i32>>^Inspect::inspect(self, f) {
@@ -1120,38 +1146,44 @@ fn Option<i32>^Inspect::inspect(self, f) {
 
 fn Array<Option<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Option<i32>>::grow(self);
+    };
+    builtin::array_set<ref Option<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Option<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Option<i32>>;
     let old_repr: ref array<Option<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l60: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l60;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l60: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
+                i = i + 1;
+                continue l60;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Option<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<Array<Array<i32>>>^Inspect::inspect(self, f) {
@@ -1188,110 +1220,128 @@ fn Array<Array<Array<i32>>>^Inspect::inspect(self, f) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l68: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l68;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<Array<i32>>::append(self, value) {
-    let used: i32;
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<Array<i32>>;
-    let old_repr: ref array<Array<i32>>;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l72: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l72;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l68: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l68;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<Array<i32>>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<i32>>::grow(self);
     };
     builtin::array_set<ref Array<i32>>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Array<i32>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Array<i32>>;
+    let old_repr: ref array<Array<i32>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l72: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
+                i = i + 1;
+                continue l72;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<Array<Array<i32>>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<Array<i32>>>::grow(self);
+    };
+    builtin::array_set<ref Array<Array<i32>>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<Array<i32>>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<Array<i32>>>;
     let old_repr: ref array<Array<Array<i32>>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<Array<i32>>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l76: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<Array<i32>>>(new_repr, i, builtin::array_get<ref Array<Array<i32>>>(old_repr, i));
-                    i = i + 1;
-                    continue l76;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<Array<i32>>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l76: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<Array<i32>>>(new_repr, i, builtin::array_get<ref Array<Array<i32>>>(old_repr, i));
+                i = i + 1;
+                continue l76;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<Array<i32>>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Option<Point>^Inspect::inspect(self, f) {
@@ -1344,38 +1394,44 @@ fn Array<Point>^Inspect::inspect(self, f) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l86: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l86;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l86: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l86;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_2.wir.wado
@@ -133,9 +133,15 @@ type "functype/Array<Tuple<i32,String>>^Inspect::inspect" = fn(ref Array<Tuple<i
 
 type "functype/Array<Tuple<i32,String>>::append" = fn(ref Array<Tuple<i32,String>>, ref "tuple/[i32, String]");
 
+type "functype/Array<Tuple<i32,String>>::grow" = fn(ref Array<Tuple<i32,String>>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<Array<i32>>::append" = fn(ref Array<Array<i32>>, ref Array<i32>);
+
+type "functype/Array<Array<i32>>::grow" = fn(ref Array<Array<i32>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -745,110 +751,128 @@ fn Array<Tuple<i32,String>>^Inspect::inspect(self, f) {
 
 fn Array<Tuple<i32,String>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<i32,String>>;
-    let old_repr: ref array<Tuple<i32,String>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[i32, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l42: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[i32, String]">(new_repr, i, builtin::array_get<ref "tuple/[i32, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l42;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<i32,String>>::grow(self);
     };
     builtin::array_set<ref "tuple/[i32, String]">(self.repr, used, value);
     self.used = used + 1;
 }
 
-fn Array<i32>::append(self, value) {
-    let used: i32;
+fn Array<Tuple<i32,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
+    let new_repr: ref array<Tuple<i32,String>>;
+    let old_repr: ref array<Tuple<i32,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l46: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l46;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[i32, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l42: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[i32, String]">(new_repr, i, builtin::array_get<ref "tuple/[i32, String]">(old_repr, i));
+                i = i + 1;
+                continue l42;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
+fn Array<i32>::append(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i32>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l46: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l46;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<Array<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<i32>>::grow(self);
+    };
+    builtin::array_set<ref Array<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<i32>>;
     let old_repr: ref array<Array<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l50: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l50;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l50: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
+                i = i + 1;
+                continue l50;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct3_test.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_nested_array_struct3_test.wir.wado
@@ -105,7 +105,11 @@ type "functype/Array<i32>^Inspect::inspect" = fn(ref Array<i32>, ref Formatter);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<Array<i32>>::append" = fn(ref Array<Array<i32>>, ref Array<i32>);
+
+type "functype/Array<Array<i32>>::grow" = fn(ref Array<Array<i32>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -554,74 +558,86 @@ fn Array<i32>^Inspect::inspect(self, f) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l34: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l34;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i32>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l34: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l34;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<Array<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<i32>>::grow(self);
+    };
+    builtin::array_set<ref Array<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<i32>>;
     let old_repr: ref array<Array<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l38: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l38;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l38: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
+                i = i + 1;
+                continue l38;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/inspect_newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_newtype.wir.wado
@@ -101,6 +101,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1313,38 +1315,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l128: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l128;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l128: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l128;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/inspect_no_display.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_no_display.wir.wado
@@ -145,6 +145,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -162,6 +164,8 @@ type "functype/Point^Inspect::inspect" = fn(ref Point, ref Formatter);
 type "functype/Array<Point>^Inspect::inspect" = fn(ref Array<Point>, ref Formatter);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
+
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1470,38 +1474,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l128: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l128;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l128: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l128;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1900,38 +1910,44 @@ fn Array<Point>^Inspect::inspect(self, f) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l177: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l177;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l177: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l177;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Option<Point>^Inspect::inspect(self, f) {

--- a/wado-compiler/tests/fixtures.golden/inspect_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_primitives.wir.wado
@@ -101,6 +101,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1374,38 +1376,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l130: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l130;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l130: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l130;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/inspect_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_variant.wir.wado
@@ -118,6 +118,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1287,38 +1289,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l120: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l120;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l120: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l120;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::inspect_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/internal_f64_to_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/internal_f64_to_string.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1144,38 +1146,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/into_iterator_item_bound.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/into_iterator_item_bound.wir.wado
@@ -85,6 +85,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -441,38 +443,44 @@ fn ArrayIter<u8>^Iterator::next(self) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/iterator_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_basic.wir.wado
@@ -85,6 +85,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -513,38 +515,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l30: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l30;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l30: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l30;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/iterator_into_iter.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_into_iter.wir.wado
@@ -85,6 +85,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -440,38 +442,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/iterator_strings.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_strings.wir.wado
@@ -60,6 +60,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -235,38 +237,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l11: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l11;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l11: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l11;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<String>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-blanket-impl.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-blanket-impl.wir.wado
@@ -99,7 +99,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -561,74 +565,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l29;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l33: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l33;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l33: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l33;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.wir.wado
@@ -101,7 +101,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -811,74 +815,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l41: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l41;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l41: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l41;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l45: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l45;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l45: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l45;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Bag<i32>::get_by_key(self, key) {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -910,38 +912,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l65: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l65;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l65: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l65;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.wir.wado
@@ -106,7 +106,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -784,38 +788,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn FrozenMap<i32>::get(self, key) {
@@ -866,38 +876,44 @@ fn FrozenMap<i32>::get(self, key) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l49: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l49;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l49: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l49;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/labeled_block.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/labeled_block.wir.wado
@@ -119,6 +119,8 @@ type "functype/ArrayIter<i32>^Iterator::next" = fn(ref "core:allocator/ArrayIter
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -847,38 +849,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/match_comprehensive.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_comprehensive.wir.wado
@@ -150,7 +150,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Option<i32>>::append" = fn(ref Array<Option<i32>>, ref Option<i32>);
 
+type "functype/Array<Option<i32>>::grow" = fn(ref Array<Option<i32>>);
+
 type "functype/Array<Tree>::append" = fn(ref Array<Tree>, ref Tree);
+
+type "functype/Array<Tree>::grow" = fn(ref Array<Tree>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1072,38 +1076,44 @@ fn ArrayIter<Option<i32>>^Iterator::next(self) {
 
 fn Array<Option<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Option<i32>>::grow(self);
+    };
+    builtin::array_set<ref Option<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Option<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Option<i32>>;
     let old_repr: ref array<Option<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l66: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l66;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l66: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
+                i = i + 1;
+                continue l66;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Option<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<Tree>^Iterator::next(self) {
@@ -1118,38 +1128,44 @@ fn ArrayIter<Tree>^Iterator::next(self) {
 
 fn Array<Tree>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tree>::grow(self);
+    };
+    builtin::array_set<ref Tree>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tree>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tree>;
     let old_repr: ref array<Tree>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Tree>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l71: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Tree>(new_repr, i, builtin::array_get<ref Tree>(old_repr, i));
-                    i = i + 1;
-                    continue l71;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Tree>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l71: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Tree>(new_repr, i, builtin::array_get<ref Tree>(old_repr, i));
+                i = i + 1;
+                continue l71;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Tree>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/match_variant_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_1.wir.wado
@@ -117,6 +117,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1242,38 +1244,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l121: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l121;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l121: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l121;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/match_variant_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_2.wir.wado
@@ -131,6 +131,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1359,38 +1361,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l138: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l138;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l138: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l138;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/match_variant_import.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_import.wir.wado
@@ -111,6 +111,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1266,38 +1268,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l131: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l131;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l131: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l131;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/match_variant_import_module.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_import_module.wir.wado
@@ -111,6 +111,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1264,38 +1266,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l131: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l131;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l131: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l131;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/match_variant_tuple_payload.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_variant_tuple_payload.wir.wado
@@ -116,6 +116,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1192,38 +1194,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l117: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l117;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l117: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l117;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/mixed_int_float_arithmetic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mixed_int_float_arithmetic.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1147,38 +1149,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/mut_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param.wir.wado
@@ -108,6 +108,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/__Closure_1::__call" = fn(ref __Closure_1, i32) -> i32;
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1510,38 +1512,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l62: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l62;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l62: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l62;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn __Closure_1::__call(self, n) {

--- a/wado-compiler/tests/fixtures.golden/mut_param_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param_merged.wir.wado
@@ -110,6 +110,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -1582,38 +1584,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l61: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l61;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l61: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l61;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/nested_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array.wir.wado
@@ -154,15 +154,23 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Option<i32>>::append" = fn(ref Array<Option<i32>>, ref Option<i32>);
 
+type "functype/Array<Option<i32>>::grow" = fn(ref Array<Option<i32>>);
+
 type "functype/Array<Array<i32>>^Inspect::inspect" = fn(ref Array<Array<i32>>, ref Formatter);
 
 type "functype/Array<i32>^Inspect::inspect" = fn(ref Array<i32>, ref Formatter);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<Array<i32>>::append" = fn(ref Array<Array<i32>>, ref Array<i32>);
 
+type "functype/Array<Array<i32>>::grow" = fn(ref Array<Array<i32>>);
+
 type "functype/Array<Array<Array<i32>>>::append" = fn(ref Array<Array<Array<i32>>>, ref Array<Array<i32>>);
+
+type "functype/Array<Array<Array<i32>>>::grow" = fn(ref Array<Array<Array<i32>>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1035,38 +1043,44 @@ fn ArrayIter<Option<i32>>^Iterator::next(self) {
 
 fn Array<Option<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Option<i32>>::grow(self);
+    };
+    builtin::array_set<ref Option<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Option<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Option<i32>>;
     let old_repr: ref array<Option<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l63: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l63;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l63: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
+                i = i + 1;
+                continue l63;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Option<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<Array<i32>>^Inspect::inspect(self, f) {
@@ -1135,38 +1149,44 @@ fn Array<i32>^Inspect::inspect(self, f) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l75: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l75;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l75: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l75;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {
@@ -1201,74 +1221,86 @@ fn ArrayIter<Array<Array<i32>>>^Iterator::next(self) {
 
 fn Array<Array<i32>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Array<i32>>;
-    let old_repr: ref array<Array<i32>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l82: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l82;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<i32>>::grow(self);
     };
     builtin::array_set<ref Array<i32>>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Array<i32>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Array<i32>>;
+    let old_repr: ref array<Array<i32>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l82: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
+                i = i + 1;
+                continue l82;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<Array<Array<i32>>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<Array<i32>>>::grow(self);
+    };
+    builtin::array_set<ref Array<Array<i32>>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<Array<i32>>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<Array<i32>>>;
     let old_repr: ref array<Array<Array<i32>>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<Array<i32>>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l86: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<Array<i32>>>(new_repr, i, builtin::array_get<ref Array<Array<i32>>>(old_repr, i));
-                    i = i + 1;
-                    continue l86;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<Array<i32>>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l86: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<Array<i32>>>(new_repr, i, builtin::array_get<ref Array<Array<i32>>>(old_repr, i));
+                i = i + 1;
+                continue l86;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<Array<i32>>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/never_as_bottom_type.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/never_as_bottom_type.wir.wado
@@ -97,6 +97,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -690,38 +692,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/newtype_array_sort.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_array_sort.wir.wado
@@ -97,6 +97,8 @@ type "functype/Array<i32>::sorted" = fn(ref Array<i32>) -> ref Array<i32>;
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<i32>::sort_by$__Closure_0" = fn(ref Array<i32>, ref __Closure_0);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -607,38 +609,44 @@ fn Array<i32>::sorted(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l35: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l35;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l35: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l35;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<i32>::sort_by$__Closure_0(self, cmp) {

--- a/wado-compiler/tests/fixtures.golden/newtype_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_basic.wir.wado
@@ -97,6 +97,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1301,38 +1303,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l120: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l120;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l120: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l120;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/newtype_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_generic.wir.wado
@@ -94,7 +94,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -531,74 +535,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l27: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l27;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l27: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l27;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l31: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l31;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l31: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l31;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/newtype_generic_container_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_generic_container_return.wir.wado
@@ -102,6 +102,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
 
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -531,38 +533,44 @@ fn String::append_char(self, c) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l28: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l28;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l28: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l28;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/newtype_impl.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_impl.wir.wado
@@ -97,6 +97,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1260,38 +1262,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l120: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l120;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l120: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l120;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::inspect_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/newtype_operator_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_operator_trait.wir.wado
@@ -106,6 +106,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1903,38 +1905,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l140: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l140;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l140: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l140;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/newtype_option_pattern.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_option_pattern.wir.wado
@@ -107,6 +107,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1322,38 +1324,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l124: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l124;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l124: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l124;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::inspect_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/number_literal.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/number_literal.wir.wado
@@ -108,6 +108,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1582,38 +1584,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l131: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l131;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l131: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l131;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/opt_const.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_const.wir.wado
@@ -103,6 +103,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1586,38 +1588,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l134: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l134;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l134: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l134;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/opt_crossmod_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_crossmod_array.wir.wado
@@ -110,7 +110,11 @@ type "functype/write_decimal_digits" = fn(ref array<u8>, i32, i64, i32);
 
 type "functype/./sub/opt_crossmod_level2.wado/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/./sub/opt_crossmod_level2.wado/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/./sub/opt_crossmod_level2.wado/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/./sub/opt_crossmod_level2.wado/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/String::grow" = fn(ref String, i32);
 
@@ -123,6 +127,8 @@ type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1142,74 +1148,86 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn "./sub/opt_crossmod_level2.wado/Array<String>::append"(self, value) {  // from ./sub/opt_crossmod_level2.wado
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l41: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l41;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        "./sub/opt_crossmod_level2.wado/Array<String>::grow"(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn "./sub/opt_crossmod_level2.wado/Array<String>::grow"(self) {  // from ./sub/opt_crossmod_level2.wado
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l41: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l41;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn "./sub/opt_crossmod_level2.wado/Array<i32>::append"(self, value) {  // from ./sub/opt_crossmod_level2.wado
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        "./sub/opt_crossmod_level2.wado/Array<i32>::grow"(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn "./sub/opt_crossmod_level2.wado/Array<i32>::grow"(self) {  // from ./sub/opt_crossmod_level2.wado
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l45: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l45;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l45: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l45;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1397,38 +1415,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l67: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l67;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l67: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l67;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/opt_labeled_block_fusion.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_labeled_block_fusion.wir.wado
@@ -105,6 +105,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -612,38 +614,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l36;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l36;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<i32>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/opt_sroa.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa.wir.wado
@@ -149,6 +149,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1895,38 +1897,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l152: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l152;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l152: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l152;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_box_parameter.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_box_parameter.wir.wado
@@ -172,6 +172,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -3671,38 +3673,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l198: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l198;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l198: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l198;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_edge_cases.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_edge_cases.wir.wado
@@ -147,6 +147,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -2422,38 +2424,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l159: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l159;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l159: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l159;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_newtype_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_newtype_param.wir.wado
@@ -103,6 +103,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1751,38 +1753,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l141: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l141;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l141: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l141;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_single_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_single_field.wir.wado
@@ -111,6 +111,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -2096,38 +2098,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l151: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l151;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l151: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l151;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/ordering-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ordering-basic.wir.wado
@@ -64,6 +64,8 @@ type "functype/Array<i32>^Ord::cmp" = fn(ref Array<i32>, ref Array<i32>) -> enum
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -428,38 +430,44 @@ fn Array<i32>^Ord::cmp(self, other) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l44: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l44;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l44: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l44;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
@@ -135,6 +135,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -1115,38 +1117,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/precedence_arithmetic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/precedence_arithmetic.wir.wado
@@ -21,6 +21,8 @@ type "functype/__initialize_module" = fn();
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 import fn realloc from "mem/realloc";
 import fn task-return from "wasi/task-return";
 import memory (1) from "mem/memory";
@@ -53,38 +55,44 @@ fn __initialize_module() {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l4: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l4;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l4: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l4;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/primitive_arithmetic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/primitive_arithmetic.wir.wado
@@ -115,6 +115,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1843,38 +1845,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l128: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l128;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l128: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l128;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/ref_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_array.wir.wado
@@ -91,6 +91,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -581,38 +583,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/ref_mut.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_mut.wir.wado
@@ -93,6 +93,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -571,38 +573,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/ref_mut_array_append_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_mut_array_append_complex.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -541,38 +543,44 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l36;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l36;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/ref_primitive.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_primitive.wir.wado
@@ -109,6 +109,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1396,38 +1398,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l123: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l123;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l123: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l123;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/ref_return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_return.wir.wado
@@ -95,6 +95,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -486,38 +488,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l27: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l27;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l27: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l27;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/result_unwrap_fresh_elision.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/result_unwrap_fresh_elision.wir.wado
@@ -102,6 +102,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -507,38 +509,44 @@ fn String::append_char(self, c) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l28: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l28;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l28: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l28;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/return_array_var.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/return_array_var.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -440,38 +442,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-custom.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-custom.wir.wado
@@ -91,6 +91,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -705,38 +707,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l34: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l34;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l34: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l34;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-fn-arg.wir.wado
@@ -91,6 +91,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -558,38 +560,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l28: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l28;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l28: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l28;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-immutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-immutable.wir.wado
@@ -91,6 +91,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -743,38 +745,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l36;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l36;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/sequence-literal-newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/sequence-literal-newtype.wir.wado
@@ -112,6 +112,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -123,6 +125,8 @@ type "functype/String::append" = fn(ref String, ref String);
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<f64>::append" = fn(ref Array<f64>, f64);
+
+type "functype/Array<f64>::grow" = fn(ref Array<f64>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -1499,38 +1503,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l132: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l132;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l132: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l132;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1850,38 +1860,44 @@ fn Vec3Builder^SequenceLiteralBuilder::build(self) {
 
 fn Array<f64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<f64>::grow(self);
+    };
+    builtin::array_set<f64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<f64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<f64>;
     let old_repr: ref array<f64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<f64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l171: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                    i = i + 1;
-                    continue l171;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<f64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l171: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
+                i = i + 1;
+                continue l171;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<f64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/serde_full_json_serialize.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_full_json_serialize.wir.wado
@@ -167,6 +167,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -178,6 +180,8 @@ type "functype/String::append" = fn(ref String, ref String);
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
+
+type "functype/Array<String>::grow" = fn(ref Array<String>);
 
 type "functype/JsonStructSerializer^SerializeStruct::field<Array<String>>" = fn(ref JsonStructSerializer, ref String, ref Array<String>) -> ref Result<unit,SerializeError>;
 
@@ -1357,38 +1361,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l122: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l122;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l122: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l122;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -1743,38 +1753,44 @@ fn JsonSerializer^Serializer::serialize_string(self, v) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l156: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l156;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l156: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l156;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn User^Serialize::serialize<JsonSerializer>(self, s) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_array_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_array_string.wir.wado
@@ -214,9 +214,13 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json/JsonSeqSerializer", ref String) -> ref Result<unit,SerializeError>;
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
+
+type "functype/Array<String>::grow" = fn(ref Array<String>);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
 
@@ -1386,38 +1390,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l129: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l129;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l129: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l129;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<String>^Serialize::serialize<JsonSerializer>(self, s) {
@@ -1503,38 +1513,44 @@ fn ArrayIter<String>^Iterator::next(self) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l141: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l141;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l141: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l141;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn "core:json/JsonSerializer^Serializer::serialize_i32"(self, v) {  // from core:json

--- a/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
@@ -338,6 +338,8 @@ type "functype/Array<String>^Deserialize::deserialize<JsonDeserializer>" = fn(re
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<String>,DeserializeError>;
 
 type "functype/__Closure_0::__call" = fn(ref __Closure_0, ref String, i32, i32) -> ref Option<i32>;
@@ -1989,58 +1991,89 @@ fn Option<String>^Deserialize::deserialize<JsonDeserializer>(d) {
 fn Array<String>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<String>;
+    let first: ref Result<Option<String>,DeserializeError>;
+    let first_opt: ref Option<String>;
+    let first_elem: ref String;
     let items: ref Array<String>;
     let next: ref Result<Option<String>,DeserializeError>;
-    let opt: ref Option<String>;
+    let next_opt: ref Option<String>;
     let item: ref String;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<String>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<String>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<String>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<String>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<String>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<String>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<String> {
-            __local_3 = Array<String> { repr: builtin::array_new<ref String>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l181: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<String>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<String>(ref.cast Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<String>::Some(opt) {
-                        item = value_copy String(ref.cast Option<String>::Some(opt).payload_0);
-                        Array<String>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<String>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<String>(ref.cast Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<String>::Some(first_opt) {
+                first_elem = value_copy String(ref.cast Option<String>::Some(first_opt).payload_0);
+                items = Array<String> { repr: builtin::array_new<ref String>(2), used: 0 };
+                Array<String>::append(items, first_elem);
+                block {
+                    l183: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<String>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<String>(ref.cast Result<Option<String>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<String>::Some(next_opt) {
+                                item = value_copy String(ref.cast Option<String>::Some(next_opt).payload_0);
+                                Array<String>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<String>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<String>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<String>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l183;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<String>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l181;
+                return Result<Array<String>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<String> {
+                    __local_15 = Array<String> { repr: builtin::array_new<ref String>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<String>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -2048,38 +2081,44 @@ fn Array<String>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l189: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l189;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l193: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l193;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<String>(self) {
@@ -2153,11 +2192,11 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b197: block {
-        l198: loop {
+    b201: block {
+        l202: loop {
             if (_hfs_pos_8 < _licm_used_6) == 0 {
                 self.pos = _hfs_pos_8;
-                break b197;
+                break b201;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2181,7 +2220,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
                 self.pos = _hfs_pos_8;
                 return;
             };
-            continue l198;
+            continue l202;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2264,12 +2303,12 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b206: block {
-        l207: loop {
+    b210: block {
+        l211: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= __sroa___iter_3_used {
                     self.pos = _hfs_pos_27;
-                    break b206;
+                    break b210;
                     self.pos = _hfs_pos_27;
                     break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
                 };
@@ -2303,7 +2342,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
                 self.pos = _hfs_pos_27;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l207;
+            continue l211;
         };
     };
     self.pos = _hfs_pos_27;
@@ -2425,10 +2464,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
     _licm_input_89 = self.input;
     _licm_used_90 = _licm_input_89.used;
     _licm_repr_91 = _licm_input_89.repr;
-    b213: block {
-        l214: loop {
+    b217: block {
+        l218: loop {
             if (scan_pos < _licm_used_90) == 0 {
-                break b213;
+                break b217;
             };
             sb = __inline_String__get_byte_5: block -> u8 {
                 __local_47 = scan_pos;
@@ -2439,10 +2478,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             } else {
                 sb == 92;
             } {
-                break b213;
+                break b217;
             };
             scan_pos = scan_pos + 1;
-            continue l214;
+            continue l218;
         };
     };
     prefix_len = scan_pos - prefix_start;
@@ -2466,7 +2505,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             _licm_repr_93 = result_5.repr;
             _licm_repr_94 = _licm_input_92.repr;
             block {
-                l221: loop {
+                l225: loop {
                     if (i_7 < prefix_len) == 0 {
                         break __for_0;
                     };
@@ -2477,7 +2516,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                     };
                     builtin::array_set_u8(_licm_repr_93, index_53, value_54);
                     i_7 = i_7 + 1;
-                    continue l221;
+                    continue l225;
                 };
             };
         };
@@ -2495,7 +2534,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
         _licm_repr_96 = result_8.repr;
         _licm_repr_97 = _licm_input_95.repr;
         block {
-            l224: loop {
+            l228: loop {
                 if (i_10 < prefix_len) == 0 {
                     break __for_1;
                 };
@@ -2506,20 +2545,20 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 builtin::array_set_u8(_licm_repr_96, index_59, value_60);
                 i_10 = i_10 + 1;
-                continue l224;
+                continue l228;
             };
         };
     };
     self.pos = scan_pos;
     _hfs_pos_98 = self.pos;
-    b226: block {
-        l227: loop {
+    b230: block {
+        l231: loop {
             if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
                 __local_63 = self.input;
                 break __inline_String__len_14: __local_63.used;
             }) == 0 {
                 self.pos = _hfs_pos_98;
-                break b226;
+                break b230;
             };
             b = __inline_String__get_byte_15: block -> u8 {
                 __local_64 = self.input;
@@ -2675,7 +2714,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l227;
+            continue l231;
         };
     };
     self.pos = _hfs_pos_98;
@@ -2719,7 +2758,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l252: loop {
+            l256: loop {
                 if (i < 4) == 0 {
                     break __for_2;
                 };
@@ -2754,7 +2793,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l252;
+                continue l256;
             };
         };
     };
@@ -2824,11 +2863,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b263: block {
-        l264: loop {
+    b267: block {
+        l268: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b263;
+                break b267;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -2842,9 +2881,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b263;
+                break b267;
             };
-            continue l264;
+            continue l268;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2865,11 +2904,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b270: block {
-            l271: loop {
+        b274: block {
+            l275: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b270;
+                    break b274;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -2883,9 +2922,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b270;
+                    break b274;
                 };
-                continue l271;
+                continue l275;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2926,11 +2965,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b281: block {
-                l282: loop {
+            b285: block {
+                l286: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b281;
+                        break b285;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -2944,9 +2983,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b281;
+                        break b285;
                     };
-                    continue l282;
+                    continue l286;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3040,11 +3079,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b291: block {
-        l292: loop {
+    b295: block {
+        l296: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b291;
+                break b295;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -3071,12 +3110,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b300: block {
-                        l301: loop {
+                    b304: block {
+                        l305: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b300;
+                                break b304;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -3093,9 +3132,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b300;
+                                break b304;
                             };
-                            continue l301;
+                            continue l305;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3126,12 +3165,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b311: block {
-                            l312: loop {
+                        b315: block {
+                            l316: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b311;
+                                    break b315;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -3147,9 +3186,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b311;
+                                    break b315;
                                 };
-                                continue l312;
+                                continue l316;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3186,9 +3225,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b291;
+                break b295;
             };
-            continue l292;
+            continue l296;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3214,11 +3253,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b322: block {
-        l323: loop {
+    b326: block {
+        l327: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b322;
+                break b326;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3247,7 +3286,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l323;
+            continue l327;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3350,7 +3389,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l338: loop {
+            l342: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3392,7 +3431,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l338;
+                continue l342;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3417,7 +3456,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l347: loop {
+            l351: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3497,7 +3536,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l347;
+                continue l351;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3608,13 +3647,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b365: block {
-        l366: loop {
+    b369: block {
+        l370: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b365;
+                break b369;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3622,14 +3661,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b365;
+                break b369;
             };
             if b == 92 {
                 has_escape = 1;
-                break b365;
+                break b369;
             };
             self.de.pos = self.de.pos + 1;
-            continue l366;
+            continue l370;
         };
     };
     if has_escape == 0 {
@@ -3811,13 +3850,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l392: loop {
+            l396: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l392;
+                continue l396;
             };
         };
     };
@@ -3950,8 +3989,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b415: block {
-        l416: loop {
+    b419: block {
+        l420: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -3976,9 +4015,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b415;
+                break b419;
             };
-            continue l416;
+            continue l420;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
@@ -531,6 +531,8 @@ type "functype/core:json/utf8_sequence_length" = fn(i32) -> i32;
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::get_byte" = fn(ref String, i32) -> u8;
 
 type "functype/String::grow" = fn(ref String, i32);
@@ -552,6 +554,8 @@ type "functype/Option<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref 
 type "functype/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Array<i32>,DeserializeError>;
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<i32>,DeserializeError>;
 
@@ -3508,38 +3512,44 @@ fn "core:json/utf8_sequence_length"(leading_byte) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l256: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l256;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l256: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l256;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {
@@ -4061,58 +4071,89 @@ fn Option<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
 fn Array<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<i32>;
+    let first: ref Result<Option<i32>,DeserializeError>;
+    let first_opt: ref Option<i32>;
+    let first_elem: i32;
     let items: ref Array<i32>;
     let next: ref Result<Option<i32>,DeserializeError>;
-    let opt: ref Option<i32>;
+    let next_opt: ref Option<i32>;
     let item: i32;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<i32>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<i32>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<i32>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<i32> {
-            __local_3 = Array<i32> { repr: builtin::array_new<i32>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l322: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<i32>::Some(opt) {
-                        item = ref.cast Option<i32>::Some(opt).payload_0;
-                        Array<i32>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<i32>::Some(first_opt) {
+                first_elem = ref.cast Option<i32>::Some(first_opt).payload_0;
+                items = Array<i32> { repr: builtin::array_new<i32>(2), used: 0 };
+                Array<i32>::append(items, first_elem);
+                block {
+                    l324: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<i32>::Some(next_opt) {
+                                item = ref.cast Option<i32>::Some(next_opt).payload_0;
+                                Array<i32>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l324;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l322;
+                return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<i32> {
+                    __local_15 = Array<i32> { repr: builtin::array_new<i32>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -4120,38 +4161,44 @@ fn Array<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l330: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l330;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l334: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l334;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<i32>(self) {
@@ -4234,8 +4281,8 @@ fn Point^Deserialize::deserialize<JsonDeserializer>(d) {
         seen = 0;
         x = 0;
         y = 0;
-        b339: block {
-            l340: loop {
+        b343: block {
+            l344: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = value_copy Result<Option<i32>,DeserializeError>(__next);
                 if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -4274,12 +4321,12 @@ fn Point^Deserialize::deserialize<JsonDeserializer>(d) {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         };
                     } else {
-                        break b339;
+                        break b343;
                     };
                 } else {
                     return Result<Point,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(ref.cast Result<Option<i32>,DeserializeError>::Err(__next).payload_0) };
                 };
-                continue l340;
+                continue l344;
             };
         };
         if (seen & 3) != 3 {
@@ -4363,11 +4410,11 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b352: block {
-        l353: loop {
+    b356: block {
+        l357: loop {
             if (_hfs_pos_8 < _licm_used_6) == 0 {
                 self.pos = _hfs_pos_8;
-                break b352;
+                break b356;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -4391,7 +4438,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
                 self.pos = _hfs_pos_8;
                 return;
             };
-            continue l353;
+            continue l357;
         };
     };
     self.pos = _hfs_pos_8;
@@ -4474,12 +4521,12 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b361: block {
-        l362: loop {
+    b365: block {
+        l366: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= __sroa___iter_3_used {
                     self.pos = _hfs_pos_27;
-                    break b361;
+                    break b365;
                     self.pos = _hfs_pos_27;
                     break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
                 };
@@ -4513,7 +4560,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
                 self.pos = _hfs_pos_27;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l362;
+            continue l366;
         };
     };
     self.pos = _hfs_pos_27;
@@ -4635,10 +4682,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
     _licm_input_89 = self.input;
     _licm_used_90 = _licm_input_89.used;
     _licm_repr_91 = _licm_input_89.repr;
-    b368: block {
-        l369: loop {
+    b372: block {
+        l373: loop {
             if (scan_pos < _licm_used_90) == 0 {
-                break b368;
+                break b372;
             };
             sb = __inline_String__get_byte_5: block -> u8 {
                 __local_47 = scan_pos;
@@ -4649,10 +4696,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             } else {
                 sb == 92;
             } {
-                break b368;
+                break b372;
             };
             scan_pos = scan_pos + 1;
-            continue l369;
+            continue l373;
         };
     };
     prefix_len = scan_pos - prefix_start;
@@ -4676,7 +4723,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             _licm_repr_93 = result_5.repr;
             _licm_repr_94 = _licm_input_92.repr;
             block {
-                l376: loop {
+                l380: loop {
                     if (i_7 < prefix_len) == 0 {
                         break __for_0;
                     };
@@ -4687,7 +4734,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                     };
                     builtin::array_set_u8(_licm_repr_93, index_53, value_54);
                     i_7 = i_7 + 1;
-                    continue l376;
+                    continue l380;
                 };
             };
         };
@@ -4705,7 +4752,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
         _licm_repr_96 = result_8.repr;
         _licm_repr_97 = _licm_input_95.repr;
         block {
-            l379: loop {
+            l383: loop {
                 if (i_10 < prefix_len) == 0 {
                     break __for_1;
                 };
@@ -4716,20 +4763,20 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 builtin::array_set_u8(_licm_repr_96, index_59, value_60);
                 i_10 = i_10 + 1;
-                continue l379;
+                continue l383;
             };
         };
     };
     self.pos = scan_pos;
     _hfs_pos_98 = self.pos;
-    b381: block {
-        l382: loop {
+    b385: block {
+        l386: loop {
             if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
                 __local_63 = self.input;
                 break __inline_String__len_14: __local_63.used;
             }) == 0 {
                 self.pos = _hfs_pos_98;
-                break b381;
+                break b385;
             };
             b = __inline_String__get_byte_15: block -> u8 {
                 __local_64 = self.input;
@@ -4885,7 +4932,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l382;
+            continue l386;
         };
     };
     self.pos = _hfs_pos_98;
@@ -4929,7 +4976,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l407: loop {
+            l411: loop {
                 if (i < 4) == 0 {
                     break __for_2;
                 };
@@ -4964,7 +5011,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l407;
+                continue l411;
             };
         };
     };
@@ -5034,11 +5081,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b418: block {
-        l419: loop {
+    b422: block {
+        l423: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b418;
+                break b422;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -5052,9 +5099,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b418;
+                break b422;
             };
-            continue l419;
+            continue l423;
         };
     };
     self.pos = _hfs_pos_36;
@@ -5075,11 +5122,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b425: block {
-            l426: loop {
+        b429: block {
+            l430: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b425;
+                    break b429;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -5093,9 +5140,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b425;
+                    break b429;
                 };
-                continue l426;
+                continue l430;
             };
         };
         self.pos = _hfs_pos_37;
@@ -5136,11 +5183,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b436: block {
-                l437: loop {
+            b440: block {
+                l441: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b436;
+                        break b440;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -5154,9 +5201,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b436;
+                        break b440;
                     };
-                    continue l437;
+                    continue l441;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -5250,11 +5297,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b446: block {
-        l447: loop {
+    b450: block {
+        l451: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b446;
+                break b450;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -5281,12 +5328,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b455: block {
-                        l456: loop {
+                    b459: block {
+                        l460: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b455;
+                                break b459;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -5303,9 +5350,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b455;
+                                break b459;
                             };
-                            continue l456;
+                            continue l460;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -5336,12 +5383,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b466: block {
-                            l467: loop {
+                        b470: block {
+                            l471: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b466;
+                                    break b470;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -5357,9 +5404,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b466;
+                                    break b470;
                                 };
-                                continue l467;
+                                continue l471;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -5396,9 +5443,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b446;
+                break b450;
             };
-            continue l447;
+            continue l451;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5493,11 +5540,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b482: block {
-        l483: loop {
+    b486: block {
+        l487: loop {
             if (_hfs_pos_49 < _licm_used_45) == 0 {
                 self.pos = _hfs_pos_49;
-                break b482;
+                break b486;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
@@ -5524,12 +5571,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b491: block {
-                        l492: loop {
+                    b495: block {
+                        l496: loop {
                             if (_hfs_pos_47 < _licm_used_45) == 0 {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b491;
+                                break b495;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
@@ -5546,9 +5593,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_49 = _hfs_pos_47;
                                 self.pos = _hfs_pos_49;
-                                break b491;
+                                break b495;
                             };
-                            continue l492;
+                            continue l496;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -5579,12 +5626,12 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_48 = _hfs_pos_49;
-                        b502: block {
-                            l503: loop {
+                        b506: block {
+                            l507: loop {
                                 if (_hfs_pos_48 < _licm_used_45) == 0 {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b502;
+                                    break b506;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
@@ -5600,9 +5647,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_49 = _hfs_pos_48;
                                     self.pos = _hfs_pos_49;
-                                    break b502;
+                                    break b506;
                                 };
-                                continue l503;
+                                continue l507;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -5628,9 +5675,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {  // from core:json
                 return Result<i64,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_49;
-                break b482;
+                break b486;
             };
-            continue l483;
+            continue l487;
         };
     };
     self.pos = _hfs_pos_49;
@@ -5656,11 +5703,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b511: block {
-        l512: loop {
+    b515: block {
+        l516: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b511;
+                break b515;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -5689,7 +5736,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l512;
+            continue l516;
         };
     };
     self.pos = _hfs_pos_14;
@@ -5792,7 +5839,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l527: loop {
+            l531: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -5834,7 +5881,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l527;
+                continue l531;
             };
         };
         self.pos = _hfs_pos_49;
@@ -5859,7 +5906,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l536: loop {
+            l540: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -5939,7 +5986,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l536;
+                continue l540;
             };
         };
         self.pos = _hfs_pos_50;
@@ -6050,13 +6097,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b554: block {
-        l555: loop {
+    b558: block {
+        l559: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b554;
+                break b558;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -6064,14 +6111,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b554;
+                break b558;
             };
             if b == 92 {
                 has_escape = 1;
-                break b554;
+                break b558;
             };
             self.de.pos = self.de.pos + 1;
-            continue l555;
+            continue l559;
         };
     };
     if has_escape == 0 {
@@ -6361,13 +6408,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l593: loop {
+            l597: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l593;
+                continue l597;
             };
         };
     };
@@ -6456,10 +6503,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b603: block {
-            l604: loop {
+        b607: block {
+            l608: loop {
                 if (i_8 >= 0) == 0 {
-                    break b603;
+                    break b607;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -6468,7 +6515,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l604;
+                continue l608;
             };
         };
         __for_1: block {
@@ -6476,14 +6523,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l607: loop {
+                l611: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l607;
+                    continue l611;
                 };
             };
         };
@@ -6493,10 +6540,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b609: block {
-            l610: loop {
+        b613: block {
+            l614: loop {
                 if (i_10 >= 0) == 0 {
-                    break b609;
+                    break b613;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -6505,7 +6552,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l610;
+                continue l614;
             };
         };
         __for_2: block {
@@ -6513,14 +6560,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l613: loop {
+                l617: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l613;
+                    continue l617;
                 };
             };
         };
@@ -6622,8 +6669,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b632: block {
-        l633: loop {
+    b636: block {
+        l637: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -6648,9 +6695,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b632;
+                break b636;
             };
-            continue l633;
+            continue l637;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_duplicate_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_duplicate_fields.wir.wado
@@ -244,6 +244,8 @@ type "functype/core:json/utf8_sequence_length" = fn(i32) -> i32;
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::get_byte" = fn(ref String, i32) -> u8;
 
 type "functype/String::grow" = fn(ref String, i32);
@@ -1638,38 +1640,44 @@ fn "core:json/utf8_sequence_length"(leading_byte) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l141: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l141;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l141: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l141;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
@@ -327,6 +327,8 @@ type "functype/core:json/write_escaped_string" = fn(ref String, ref String);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::get_byte" = fn(ref String, i32) -> u8;
 
 type "functype/String::grow" = fn(ref String, i32);
@@ -2055,38 +2057,44 @@ fn "core:json/write_escaped_string"(buf, s) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l178: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l178;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l178: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l178;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
@@ -409,6 +409,8 @@ type "functype/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<i32>,DeserializeError>;
 
 type "functype/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Option<String>,DeserializeError>;
@@ -1991,58 +1993,89 @@ fn User^Deserialize::deserialize<JsonDeserializer>(d) {
 fn Array<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<i32>;
+    let first: ref Result<Option<i32>,DeserializeError>;
+    let first_opt: ref Option<i32>;
+    let first_elem: i32;
     let items: ref Array<i32>;
     let next: ref Result<Option<i32>,DeserializeError>;
-    let opt: ref Option<i32>;
+    let next_opt: ref Option<i32>;
     let item: i32;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<i32>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<i32>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<i32>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<i32> {
-            __local_3 = Array<i32> { repr: builtin::array_new<i32>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l166: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<i32>::Some(opt) {
-                        item = ref.cast Option<i32>::Some(opt).payload_0;
-                        Array<i32>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<i32>::Some(first_opt) {
+                first_elem = ref.cast Option<i32>::Some(first_opt).payload_0;
+                items = Array<i32> { repr: builtin::array_new<i32>(2), used: 0 };
+                Array<i32>::append(items, first_elem);
+                block {
+                    l168: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<i32>::Some(next_opt) {
+                                item = ref.cast Option<i32>::Some(next_opt).payload_0;
+                                Array<i32>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l168;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l166;
+                return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<i32> {
+                    __local_15 = Array<i32> { repr: builtin::array_new<i32>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -2050,38 +2083,44 @@ fn Array<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l174: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l174;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l178: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l178;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<i32>(self) {
@@ -2233,8 +2272,8 @@ fn Array<i32>^Serialize::serialize<JsonSerializer>(self, s) {
             __local_16 = self;
             break __inline_Array_i32__IntoIterator__into_iter_2: "core:serde/ArrayIter<i32>" { repr: ref.as_non_null(__local_16.repr), used: __local_16.used, index: 0 };
         };
-        b189: block {
-            l190: loop {
+        b193: block {
+            l194: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: i32;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<i32>^Iterator::next(__iter_4);
@@ -2245,9 +2284,9 @@ fn Array<i32>^Serialize::serialize<JsonSerializer>(self, s) {
                         return Result<unit,SerializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_7) };
                     };
                 } else {
-                    break b189;
+                    break b193;
                 };
-                continue l190;
+                continue l194;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref Result<unit,SerializeError> {
@@ -2376,11 +2415,11 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b199: block {
-        l200: loop {
+    b203: block {
+        l204: loop {
             if (_hfs_pos_8 < _licm_used_6) == 0 {
                 self.pos = _hfs_pos_8;
-                break b199;
+                break b203;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2404,7 +2443,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
                 self.pos = _hfs_pos_8;
                 return;
             };
-            continue l200;
+            continue l204;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2487,12 +2526,12 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b208: block {
-        l209: loop {
+    b212: block {
+        l213: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= __sroa___iter_3_used {
                     self.pos = _hfs_pos_27;
-                    break b208;
+                    break b212;
                     self.pos = _hfs_pos_27;
                     break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
                 };
@@ -2526,7 +2565,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
                 self.pos = _hfs_pos_27;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l209;
+            continue l213;
         };
     };
     self.pos = _hfs_pos_27;
@@ -2648,10 +2687,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
     _licm_input_89 = self.input;
     _licm_used_90 = _licm_input_89.used;
     _licm_repr_91 = _licm_input_89.repr;
-    b215: block {
-        l216: loop {
+    b219: block {
+        l220: loop {
             if (scan_pos < _licm_used_90) == 0 {
-                break b215;
+                break b219;
             };
             sb = __inline_String__get_byte_5: block -> u8 {
                 __local_47 = scan_pos;
@@ -2662,10 +2701,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             } else {
                 sb == 92;
             } {
-                break b215;
+                break b219;
             };
             scan_pos = scan_pos + 1;
-            continue l216;
+            continue l220;
         };
     };
     prefix_len = scan_pos - prefix_start;
@@ -2689,7 +2728,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             _licm_repr_93 = result_5.repr;
             _licm_repr_94 = _licm_input_92.repr;
             block {
-                l223: loop {
+                l227: loop {
                     if (i_7 < prefix_len) == 0 {
                         break __for_0;
                     };
@@ -2700,7 +2739,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                     };
                     builtin::array_set_u8(_licm_repr_93, index_53, value_54);
                     i_7 = i_7 + 1;
-                    continue l223;
+                    continue l227;
                 };
             };
         };
@@ -2718,7 +2757,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
         _licm_repr_96 = result_8.repr;
         _licm_repr_97 = _licm_input_95.repr;
         block {
-            l226: loop {
+            l230: loop {
                 if (i_10 < prefix_len) == 0 {
                     break __for_1;
                 };
@@ -2729,20 +2768,20 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 builtin::array_set_u8(_licm_repr_96, index_59, value_60);
                 i_10 = i_10 + 1;
-                continue l226;
+                continue l230;
             };
         };
     };
     self.pos = scan_pos;
     _hfs_pos_98 = self.pos;
-    b228: block {
-        l229: loop {
+    b232: block {
+        l233: loop {
             if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
                 __local_63 = self.input;
                 break __inline_String__len_14: __local_63.used;
             }) == 0 {
                 self.pos = _hfs_pos_98;
-                break b228;
+                break b232;
             };
             b = __inline_String__get_byte_15: block -> u8 {
                 __local_64 = self.input;
@@ -2898,7 +2937,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l229;
+            continue l233;
         };
     };
     self.pos = _hfs_pos_98;
@@ -2942,7 +2981,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l254: loop {
+            l258: loop {
                 if (i < 4) == 0 {
                     break __for_2;
                 };
@@ -2977,7 +3016,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l254;
+                continue l258;
             };
         };
     };
@@ -3047,11 +3086,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b265: block {
-        l266: loop {
+    b269: block {
+        l270: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b265;
+                break b269;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -3065,9 +3104,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b265;
+                break b269;
             };
-            continue l266;
+            continue l270;
         };
     };
     self.pos = _hfs_pos_36;
@@ -3088,11 +3127,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b272: block {
-            l273: loop {
+        b276: block {
+            l277: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b272;
+                    break b276;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -3106,9 +3145,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b272;
+                    break b276;
                 };
-                continue l273;
+                continue l277;
             };
         };
         self.pos = _hfs_pos_37;
@@ -3149,11 +3188,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b283: block {
-                l284: loop {
+            b287: block {
+                l288: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b283;
+                        break b287;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -3167,9 +3206,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b283;
+                        break b287;
                     };
-                    continue l284;
+                    continue l288;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3263,11 +3302,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b293: block {
-        l294: loop {
+    b297: block {
+        l298: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b293;
+                break b297;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -3294,12 +3333,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b302: block {
-                        l303: loop {
+                    b306: block {
+                        l307: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b302;
+                                break b306;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -3316,9 +3355,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b302;
+                                break b306;
                             };
-                            continue l303;
+                            continue l307;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3349,12 +3388,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b313: block {
-                            l314: loop {
+                        b317: block {
+                            l318: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b313;
+                                    break b317;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -3370,9 +3409,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b313;
+                                    break b317;
                                 };
-                                continue l314;
+                                continue l318;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3409,9 +3448,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b293;
+                break b297;
             };
-            continue l294;
+            continue l298;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3437,11 +3476,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b324: block {
-        l325: loop {
+    b328: block {
+        l329: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b324;
+                break b328;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3470,7 +3509,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l325;
+            continue l329;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3573,7 +3612,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l340: loop {
+            l344: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -3615,7 +3654,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l340;
+                continue l344;
             };
         };
         self.pos = _hfs_pos_49;
@@ -3640,7 +3679,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l349: loop {
+            l353: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -3720,7 +3759,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l349;
+                continue l353;
             };
         };
         self.pos = _hfs_pos_50;
@@ -3831,13 +3870,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b367: block {
-        l368: loop {
+    b371: block {
+        l372: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b367;
+                break b371;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -3845,14 +3884,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b367;
+                break b371;
             };
             if b == 92 {
                 has_escape = 1;
-                break b367;
+                break b371;
             };
             self.de.pos = self.de.pos + 1;
-            continue l368;
+            continue l372;
         };
     };
     if has_escape == 0 {
@@ -3984,13 +4023,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l389: loop {
+            l393: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l389;
+                continue l393;
             };
         };
     };
@@ -4123,8 +4162,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b412: block {
-        l413: loop {
+    b416: block {
+        l417: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -4149,9 +4188,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b412;
+                break b416;
             };
-            continue l413;
+            continue l417;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
@@ -340,6 +340,8 @@ type "functype/core:json/write_escaped_string" = fn(ref String, ref String);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -3908,38 +3910,44 @@ fn "core:json/write_escaped_string"(buf, s) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l249: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l249;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l249: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l249;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
@@ -1081,6 +1081,8 @@ type "functype/core:json/write_escaped_string" = fn(ref String, ref String);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::get_byte" = fn(ref String, i32) -> u8;
 
 type "functype/String::grow" = fn(ref String, i32);
@@ -1101,6 +1103,8 @@ type "functype/Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>" = 
 
 type "functype/Array<Option<i32>>::append" = fn(ref Array<Option<i32>>, ref Option<i32>);
 
+type "functype/Array<Option<i32>>::grow" = fn(ref Array<Option<i32>>);
+
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<Option<i32>>,DeserializeError>;
 
 type "functype/Option<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Option<i32>,DeserializeError>;
@@ -1110,6 +1114,8 @@ type "functype/Option<Array<i32>>^Deserialize::deserialize<JsonDeserializer>" = 
 type "functype/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Array<i32>,DeserializeError>;
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<i32>,DeserializeError>;
 
@@ -1127,6 +1133,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/TreeMap<String,i32>::find_index" = fn(ref "core:allocator/TreeMap<String,i32>", ref String) -> i32;
 
 type "functype/JsonStructSerializer^SerializeStruct::field<TreeMap<String,i32>>" = fn(ref "core:json/JsonStructSerializer", ref String, ref "core:allocator/TreeMap<String,i32>") -> ref Result<unit,SerializeError>;
@@ -1137,6 +1145,8 @@ type "functype/TreeMap<String,i32>::entries" = fn(ref "core:allocator/TreeMap<St
 
 type "functype/Array<Tuple<String,i32>>::append" = fn(ref Array<Tuple<String,i32>>, ref "tuple/[String, i32]");
 
+type "functype/Array<Tuple<String,i32>>::grow" = fn(ref Array<Tuple<String,i32>>);
+
 type "functype/Shape^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Shape,DeserializeError>;
 
 type "functype/Inner^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Inner,DeserializeError>;
@@ -1146,6 +1156,8 @@ type "functype/JsonVariantSerializer^SerializeVariant::payload<Inner>" = fn(ref 
 type "functype/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json/JsonStructSerializer", ref String, ref String) -> ref Result<unit,SerializeError>;
 
 type "functype/Array<Direction>::append" = fn(ref Array<Direction>, enum:Direction);
+
+type "functype/Array<Direction>::grow" = fn(ref Array<Direction>);
 
 type "functype/Direction^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Direction,DeserializeError>;
 
@@ -1167,17 +1179,23 @@ type "functype/TreeMap<String,String>::skew" = fn(ref "core:allocator/TreeMap<St
 
 type "functype/Array<TreeMapEntry<String,String>>::append" = fn(ref Array<TreeMapEntry<String,String>>, ref "core:allocator/TreeMapEntry<String,String>");
 
+type "functype/Array<TreeMapEntry<String,String>>::grow" = fn(ref Array<TreeMapEntry<String,String>>);
+
 type "functype/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:json/JsonMapSerializer", ref String) -> ref Result<unit,SerializeError>;
 
 type "functype/TreeMap<String,String>::entries" = fn(ref "core:allocator/TreeMap<String,String>") -> ref Array<Tuple<String,String>>;
 
 type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
 
+type "functype/Array<Tuple<String,String>>::grow" = fn(ref Array<Tuple<String,String>>);
+
 type "functype/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Result<i32,String>,DeserializeError>;
 
 type "functype/Array<Inner>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Array<Inner>,DeserializeError>;
 
 type "functype/Array<Inner>::append" = fn(ref Array<Inner>, ref Inner);
+
+type "functype/Array<Inner>::grow" = fn(ref Array<Inner>);
 
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<Inner>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<Inner>,DeserializeError>;
 
@@ -1194,6 +1212,8 @@ type "functype/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(r
 type "functype/Array<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Array<String>,DeserializeError>;
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
+
+type "functype/Array<String>::grow" = fn(ref Array<String>);
 
 type "functype/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<Option<String>,DeserializeError>;
 
@@ -6924,38 +6944,44 @@ fn "core:json/write_escaped_string"(buf, s) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l415: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l415;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l415: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l415;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {
@@ -7476,58 +7502,89 @@ fn String::append_char(self, c) {
 fn Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<Option<i32>>;
+    let first: ref Result<Option<Option<i32>>,DeserializeError>;
+    let first_opt: ref Option<Option<i32>>;
+    let first_elem: ref Option<i32>;
     let items: ref Array<Option<i32>>;
     let next: ref Result<Option<Option<i32>>,DeserializeError>;
-    let opt: ref Option<Option<i32>>;
+    let next_opt: ref Option<Option<i32>>;
     let item: ref Option<i32>;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<Option<i32>>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<Option<i32>>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<Option<i32>>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<Option<i32>>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<Option<i32>>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<Option<i32>>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<Option<i32>> {
-            __local_3 = Array<Option<i32>> { repr: builtin::array_new<ref Option<i32>>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l477: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<Option<i32>>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<Option<i32>>(ref.cast Result<Option<Option<i32>>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<Option<i32>>::Some(opt) {
-                        item = value_copy Option<i32>(ref.cast Option<Option<i32>>::Some(opt).payload_0);
-                        Array<Option<i32>>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<Option<i32>>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<Option<i32>>(ref.cast Result<Option<Option<i32>>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<Option<i32>>::Some(first_opt) {
+                first_elem = value_copy Option<i32>(ref.cast Option<Option<i32>>::Some(first_opt).payload_0);
+                items = Array<Option<i32>> { repr: builtin::array_new<ref Option<i32>>(2), used: 0 };
+                Array<Option<i32>>::append(items, first_elem);
+                block {
+                    l479: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<Option<i32>>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<Option<i32>>(ref.cast Result<Option<Option<i32>>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<Option<i32>>::Some(next_opt) {
+                                item = value_copy Option<i32>(ref.cast Option<Option<i32>>::Some(next_opt).payload_0);
+                                Array<Option<i32>>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<Option<i32>>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<Option<i32>>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<Option<i32>>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<Option<i32>>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l479;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<Option<i32>>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<Option<i32>>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l477;
+                return Result<Array<Option<i32>>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<Option<i32>> {
+                    __local_15 = Array<Option<i32>> { repr: builtin::array_new<ref Option<i32>>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<Option<i32>>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<Option<i32>>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<Option<i32>>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -7535,38 +7592,44 @@ fn Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<Option<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Option<i32>>::grow(self);
+    };
+    builtin::array_set<ref Option<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Option<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Option<i32>>;
     let old_repr: ref array<Option<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l485: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l485;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Option<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l489: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Option<i32>>(new_repr, i, builtin::array_get<ref Option<i32>>(old_repr, i));
+                i = i + 1;
+                continue l489;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Option<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>(self) {
@@ -7683,8 +7746,8 @@ fn Array<Option<i32>>^Serialize::serialize<JsonSerializer>(self, s) {
             __local_16 = self;
             break __inline_Array_Option_i32___IntoIterator__into_iter_2: "core:serde/ArrayIter<Option<i32>>" { repr: ref.as_non_null(__local_16.repr), used: __local_16.used, index: 0 };
         };
-        b499: block {
-            l500: loop {
+        b503: block {
+            l504: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: ref null Option<i32>;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<Option<i32>>^Iterator::next(__iter_4);
@@ -7695,9 +7758,9 @@ fn Array<Option<i32>>^Serialize::serialize<JsonSerializer>(self, s) {
                         return 1; ref.as_non_null(e_7);
                     };
                 } else {
-                    break b499;
+                    break b503;
                 };
-                continue l500;
+                continue l504;
             };
         };
         block {
@@ -7796,58 +7859,89 @@ fn Option<Array<i32>>^Deserialize::deserialize<JsonDeserializer>(d) {
 fn Array<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<i32>;
+    let first: ref Result<Option<i32>,DeserializeError>;
+    let first_opt: ref Option<i32>;
+    let first_elem: i32;
     let items: ref Array<i32>;
     let next: ref Result<Option<i32>,DeserializeError>;
-    let opt: ref Option<i32>;
+    let next_opt: ref Option<i32>;
     let item: i32;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<i32>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<i32>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<i32>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<i32>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<i32> {
-            __local_3 = Array<i32> { repr: builtin::array_new<i32>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l514: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<i32>::Some(opt) {
-                        item = ref.cast Option<i32>::Some(opt).payload_0;
-                        Array<i32>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<i32>::Some(first_opt) {
+                first_elem = ref.cast Option<i32>::Some(first_opt).payload_0;
+                items = Array<i32> { repr: builtin::array_new<i32>(2), used: 0 };
+                Array<i32>::append(items, first_elem);
+                block {
+                    l520: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<i32>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<i32>(ref.cast Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<i32>::Some(next_opt) {
+                                item = ref.cast Option<i32>::Some(next_opt).payload_0;
+                                Array<i32>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l520;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l514;
+                return Result<Array<i32>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<i32> {
+                    __local_15 = Array<i32> { repr: builtin::array_new<i32>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<i32>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<i32>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -7855,38 +7949,44 @@ fn Array<i32>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l522: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l522;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l530: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l530;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<i32>(self) {
@@ -7968,8 +8068,8 @@ fn Array<i32>^Serialize::serialize<JsonSerializer>(self, s) {
             __local_16 = self;
             break __inline_Array_i32__IntoIterator__into_iter_2: "core:serde/ArrayIter<i32>" { repr: ref.as_non_null(__local_16.repr), used: __local_16.used, index: 0 };
         };
-        b531: block {
-            l532: loop {
+        b539: block {
+            l540: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: i32;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<i32>^Iterator::next(__iter_4);
@@ -7980,9 +8080,9 @@ fn Array<i32>^Serialize::serialize<JsonSerializer>(self, s) {
                         return Result<unit,SerializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_7) };
                     };
                 } else {
-                    break b531;
+                    break b539;
                 };
-                continue l532;
+                continue l540;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref Result<unit,SerializeError> {
@@ -8046,8 +8146,8 @@ fn Config^Deserialize::deserialize<JsonDeserializer>(d) {
             __local_14 = Array<TreeMapEntry<String,i32>> { repr: builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(0), used: 0 };
             break __seq_lit: __local_14;
         }), size: 0, deleted_count: 0 };
-        b539: block {
-            l540: loop {
+        b547: block {
+            l548: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = value_copy Result<Option<i32>,DeserializeError>(__next);
                 if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -8070,12 +8170,12 @@ fn Config^Deserialize::deserialize<JsonDeserializer>(d) {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         };
                     } else {
-                        break b539;
+                        break b547;
                     };
                 } else {
                     return Result<Config,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(ref.cast Result<Option<i32>,DeserializeError>::Err(__next).payload_0) };
                 };
-                continue l540;
+                continue l548;
             };
         };
         if (seen & 1) != 1 {
@@ -8119,7 +8219,7 @@ fn TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>(d) {
             break __seq_lit: __local_22;
         }), size: 0, deleted_count: 0 };
         block {
-            l548: loop {
+            l556: loop {
                 key_r = "core:json/JsonMapAccess^DeserializeMap::next_key_string"(ma);
                 __pattern_temp_1 = key_r;
                 if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -8154,7 +8254,7 @@ fn TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>(d) {
                     e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_6).payload_0);
                     return Result<TreeMap<String,i32>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
                 };
-                continue l548;
+                continue l556;
             };
         };
     };
@@ -8266,38 +8366,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l570: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l570;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l578: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l578;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::find_index(self, key) {
@@ -8313,8 +8419,8 @@ fn TreeMap<String,i32>::find_index(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b572: block {
-        l573: loop {
+    b580: block {
+        l581: loop {
             __pattern_temp_0 = value_copy Option<TreeMapNode<String>>(current);
             if ref.test Option<TreeMapNode<String>>::Some(__pattern_temp_0) {
                 n = ref.cast Option<TreeMapNode<String>>::Some(__pattern_temp_0).payload_0;
@@ -8338,9 +8444,9 @@ fn TreeMap<String,i32>::find_index(self, key) {
                     current = value_copy Option<TreeMapNode<String>>(n.right);
                 };
             } else {
-                break b572;
+                break b580;
             };
-            continue l573;
+            continue l581;
         };
     };
     return -1;
@@ -8400,8 +8506,8 @@ fn TreeMap<String,i32>^Serialize::serialize<JsonSerializer>(self, s) {
     if ref.test Result<JsonMapSerializer,SerializeError>::Ok(__pattern_temp_0) {
         m = value_copy "core:json/JsonMapSerializer"(ref.cast Result<JsonMapSerializer,SerializeError>::Ok(__pattern_temp_0).payload_0);
         __iter_5 = "core:serde/ArrayIter<Tuple<String,i32>>" { repr: ref.as_non_null(entries.repr), used: entries.used, index: 0 };
-        b581: block {
-            l582: loop {
+        b589: block {
+            l590: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: ref null "tuple/[String, i32]";
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<Tuple<String,i32>>^Iterator::next(__iter_5);
@@ -8419,9 +8525,9 @@ fn TreeMap<String,i32>^Serialize::serialize<JsonSerializer>(self, s) {
                         return Result<unit,SerializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
                     };
                 } else {
-                    break b581;
+                    break b589;
                 };
-                continue l582;
+                continue l590;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref Result<unit,SerializeError> {
@@ -8494,8 +8600,8 @@ fn TreeMap<String,i32>::entries(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_i32___IntoIterator__into_iter_3: "core:serde/ArrayIter<TreeMapEntry<String,i32>>" { repr: ref.as_non_null(__local_9.repr), used: __local_9.used, index: 0 };
     };
-    b589: block {
-        l590: loop {
+    b597: block {
+        l598: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: ref null "core:allocator/TreeMapEntry<String,i32>";
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = ArrayIter<TreeMapEntry<String,i32>>^Iterator::next(__iter_3);
@@ -8505,9 +8611,9 @@ fn TreeMap<String,i32>::entries(self) {
                     Array<Tuple<String,i32>>::append(result, "tuple/[String, i32]" { 0: ref.as_non_null(entry.key), 1: entry.value });
                 };
             } else {
-                break b589;
+                break b597;
             };
-            continue l590;
+            continue l598;
         };
     };
     return result;
@@ -8515,38 +8621,44 @@ fn TreeMap<String,i32>::entries(self) {
 
 fn Array<Tuple<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,i32>>;
     let old_repr: ref array<Tuple<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l595: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l595;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l603: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
+                i = i + 1;
+                continue l603;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,i32>>^Iterator::next(self) {
@@ -8717,8 +8829,8 @@ fn Inner^Deserialize::deserialize<JsonDeserializer>(d) {
         seen = 0;
         value = 0;
         label = String { repr: builtin::array_new<u8>(0), used: 0 };
-        b618: block {
-            l619: loop {
+        b626: block {
+            l627: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = value_copy Result<Option<i32>,DeserializeError>(__next);
                 if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -8757,12 +8869,12 @@ fn Inner^Deserialize::deserialize<JsonDeserializer>(d) {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         };
                     } else {
-                        break b618;
+                        break b626;
                     };
                 } else {
                     return Result<Inner,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(ref.cast Result<Option<i32>,DeserializeError>::Err(__next).payload_0) };
                 };
-                continue l619;
+                continue l627;
             };
         };
         if (seen & 3) != 3 {
@@ -8900,38 +9012,44 @@ fn JsonStructSerializer^SerializeStruct::field<i32>(self, name, value) {
 
 fn Array<Direction>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Direction>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Direction>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Direction>;
     let old_repr: ref array<Direction>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l636: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l636;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l644: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l644;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Direction^Deserialize::deserialize<JsonDeserializer>(d) {
@@ -9153,8 +9271,8 @@ fn TreeMap<String,String>::find_index(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b665: block {
-        l666: loop {
+    b673: block {
+        l674: loop {
             __pattern_temp_0 = value_copy Option<TreeMapNode<String>>(current);
             if ref.test Option<TreeMapNode<String>>::Some(__pattern_temp_0) {
                 n = ref.cast Option<TreeMapNode<String>>::Some(__pattern_temp_0).payload_0;
@@ -9178,9 +9296,9 @@ fn TreeMap<String,String>::find_index(self, key) {
                     current = value_copy Option<TreeMapNode<String>>(n.right);
                 };
             } else {
-                break b665;
+                break b673;
             };
-            continue l666;
+            continue l674;
         };
     };
     return -1;
@@ -9217,7 +9335,7 @@ fn TreeMap<String,String>^Deserialize::deserialize<JsonDeserializer>(d) {
             break __seq_lit: __local_22;
         }), size: 0, deleted_count: 0 };
         block {
-            l674: loop {
+            l682: loop {
                 key_r = "core:json/JsonMapAccess^DeserializeMap::next_key_string"(ma);
                 __pattern_temp_1 = key_r;
                 if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -9252,7 +9370,7 @@ fn TreeMap<String,String>^Deserialize::deserialize<JsonDeserializer>(d) {
                     e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_6).payload_0);
                     return Result<TreeMap<String,String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
                 };
-                continue l674;
+                continue l682;
             };
         };
     };
@@ -9364,38 +9482,44 @@ fn TreeMap<String,String>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,String>>;
     let old_repr: ref array<TreeMapEntry<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,String>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l696: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,String>">(old_repr, i));
-                    i = i + 1;
-                    continue l696;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,String>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l704: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,String>">(old_repr, i));
+                i = i + 1;
+                continue l704;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,String>^Serialize::serialize<JsonSerializer>(self, s) {
@@ -9424,8 +9548,8 @@ fn TreeMap<String,String>^Serialize::serialize<JsonSerializer>(self, s) {
     if ref.test Result<JsonMapSerializer,SerializeError>::Ok(__pattern_temp_0) {
         m = value_copy "core:json/JsonMapSerializer"(ref.cast Result<JsonMapSerializer,SerializeError>::Ok(__pattern_temp_0).payload_0);
         __iter_5 = "core:serde/ArrayIter<Tuple<String,String>>" { repr: ref.as_non_null(entries.repr), used: entries.used, index: 0 };
-        b699: block {
-            l700: loop {
+        b707: block {
+            l708: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: ref null "tuple/[String, String]";
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<Tuple<String,String>>^Iterator::next(__iter_5);
@@ -9444,9 +9568,9 @@ fn TreeMap<String,String>^Serialize::serialize<JsonSerializer>(self, s) {
                         return 1; ref.as_non_null(e_12);
                     };
                 } else {
-                    break b699;
+                    break b707;
                 };
-                continue l700;
+                continue l708;
             };
         };
         block {
@@ -9501,8 +9625,8 @@ fn TreeMap<String,String>::entries(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_String___IntoIterator__into_iter_3: "core:serde/ArrayIter<TreeMapEntry<String,String>>" { repr: ref.as_non_null(__local_9.repr), used: __local_9.used, index: 0 };
     };
-    b706: block {
-        l707: loop {
+    b714: block {
+        l715: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: ref null "core:allocator/TreeMapEntry<String,String>";
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = ArrayIter<TreeMapEntry<String,String>>^Iterator::next(__iter_3);
@@ -9512,9 +9636,9 @@ fn TreeMap<String,String>::entries(self) {
                     Array<Tuple<String,String>>::append(result, "tuple/[String, String]" { 0: ref.as_non_null(entry.key), 1: ref.as_non_null(entry.value) });
                 };
             } else {
-                break b706;
+                break b714;
             };
-            continue l707;
+            continue l715;
         };
     };
     return result;
@@ -9522,38 +9646,44 @@ fn TreeMap<String,String>::entries(self) {
 
 fn Array<Tuple<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,String>>;
     let old_repr: ref array<Tuple<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l712: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l712;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l720: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
+                i = i + 1;
+                continue l720;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,String>>^Iterator::next(self) {
@@ -9769,58 +9899,89 @@ fn Result<i32,String>^Serialize::serialize<JsonSerializer>(self, s) {
 fn Array<Inner>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<Inner>;
+    let first: ref Result<Option<Inner>,DeserializeError>;
+    let first_opt: ref Option<Inner>;
+    let first_elem: ref Inner;
     let items: ref Array<Inner>;
     let next: ref Result<Option<Inner>,DeserializeError>;
-    let opt: ref Option<Inner>;
+    let next_opt: ref Option<Inner>;
     let item: ref Inner;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<Inner>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<Inner>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<Inner>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<Inner>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<Inner>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<Inner>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<Inner> {
-            __local_3 = Array<Inner> { repr: builtin::array_new<ref Inner>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l739: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<Inner>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<Inner>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<Inner>(ref.cast Result<Option<Inner>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<Inner>::Some(opt) {
-                        item = value_copy Inner(ref.cast Option<Inner>::Some(opt).payload_0);
-                        Array<Inner>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<Inner>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<Inner>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<Inner>(ref.cast Result<Option<Inner>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<Inner>::Some(first_opt) {
+                first_elem = value_copy Inner(ref.cast Option<Inner>::Some(first_opt).payload_0);
+                items = Array<Inner> { repr: builtin::array_new<ref Inner>(2), used: 0 };
+                Array<Inner>::append(items, first_elem);
+                block {
+                    l749: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<Inner>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<Inner>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<Inner>(ref.cast Result<Option<Inner>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<Inner>::Some(next_opt) {
+                                item = value_copy Inner(ref.cast Option<Inner>::Some(next_opt).payload_0);
+                                Array<Inner>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<Inner>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<Inner>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<Inner>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<Inner>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l749;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<Inner>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<Inner>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l739;
+                return Result<Array<Inner>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<Inner> {
+                    __local_15 = Array<Inner> { repr: builtin::array_new<ref Inner>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<Inner>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<Inner>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<Inner>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -9828,38 +9989,44 @@ fn Array<Inner>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<Inner>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Inner>::grow(self);
+    };
+    builtin::array_set<ref Inner>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Inner>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Inner>;
     let old_repr: ref array<Inner>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Inner>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l747: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Inner>(new_repr, i, builtin::array_get<ref Inner>(old_repr, i));
-                    i = i + 1;
-                    continue l747;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Inner>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l759: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Inner>(new_repr, i, builtin::array_get<ref Inner>(old_repr, i));
+                i = i + 1;
+                continue l759;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Inner>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<Inner>(self) {
@@ -9938,8 +10105,8 @@ fn Array<Inner>^Serialize::serialize<JsonSerializer>(self, s) {
             __local_16 = self;
             break __inline_Array_Inner__IntoIterator__into_iter_2: "core:serde/ArrayIter<Inner>" { repr: ref.as_non_null(__local_16.repr), used: __local_16.used, index: 0 };
         };
-        b756: block {
-            l757: loop {
+        b768: block {
+            l769: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: ref null Inner;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<Inner>^Iterator::next(__iter_4);
@@ -9951,9 +10118,9 @@ fn Array<Inner>^Serialize::serialize<JsonSerializer>(self, s) {
                         return 1; ref.as_non_null(e_7);
                     };
                 } else {
-                    break b756;
+                    break b768;
                 };
-                continue l757;
+                continue l769;
             };
         };
         block {
@@ -10015,8 +10182,8 @@ fn Outer^Deserialize::deserialize<JsonDeserializer>(d) {
         seen = 0;
         inner = ref.null none;
         count = 0;
-        b764: block {
-            l765: loop {
+        b776: block {
+            l777: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = value_copy Result<Option<i32>,DeserializeError>(__next);
                 if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -10052,12 +10219,12 @@ fn Outer^Deserialize::deserialize<JsonDeserializer>(d) {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         };
                     } else {
-                        break b764;
+                        break b776;
                     };
                 } else {
                     return Result<Outer,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(ref.cast Result<Option<i32>,DeserializeError>::Err(__next).payload_0) };
                 };
-                continue l765;
+                continue l777;
             };
         };
         if (seen & 3) != 3 {
@@ -10155,8 +10322,8 @@ fn FullStruct^Deserialize::deserialize<JsonDeserializer>(d) {
         };
         address = Option<String> { 1 };
         rating = Option<i32> { 1 };
-        b775: block {
-            l776: loop {
+        b787: block {
+            l788: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = value_copy Result<Option<i32>,DeserializeError>(__next);
                 if ref.test Result<Option<i32>,DeserializeError>::Ok(__pattern_temp_1) {
@@ -10251,12 +10418,12 @@ fn FullStruct^Deserialize::deserialize<JsonDeserializer>(d) {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         };
                     } else {
-                        break b775;
+                        break b787;
                     };
                 } else {
                     return Result<FullStruct,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(ref.cast Result<Option<i32>,DeserializeError>::Err(__next).payload_0) };
                 };
-                continue l776;
+                continue l788;
             };
         };
         if (seen & 127) != 127 {
@@ -10311,58 +10478,89 @@ fn Option<String>^Deserialize::deserialize<JsonDeserializer>(d) {
 fn Array<String>^Deserialize::deserialize<JsonDeserializer>(d) {
     let seq_result: ref Result<JsonSeqAccess,DeserializeError>;
     let seq: ref "core:json/JsonSeqAccess";
-    let __local_3: ref Array<String>;
+    let first: ref Result<Option<String>,DeserializeError>;
+    let first_opt: ref Option<String>;
+    let first_elem: ref String;
     let items: ref Array<String>;
     let next: ref Result<Option<String>,DeserializeError>;
-    let opt: ref Option<String>;
+    let next_opt: ref Option<String>;
     let item: ref String;
-    let end_result: ref Result<unit,DeserializeError>;
-    let e_9: ref "core:serde/DeserializeError";
-    let e_10: ref "core:serde/DeserializeError";
+    let end_result_10: ref Result<unit,DeserializeError>;
     let e_11: ref "core:serde/DeserializeError";
+    let e_12: ref "core:serde/DeserializeError";
+    let end_result_13: ref Result<unit,DeserializeError>;
+    let e_14: ref "core:serde/DeserializeError";
+    let __local_15: ref Array<String>;
+    let e_16: ref "core:serde/DeserializeError";
+    let e_17: ref "core:serde/DeserializeError";
     let __pattern_temp_0: ref Result<JsonSeqAccess,DeserializeError>;
     let __pattern_temp_1: ref Result<Option<String>,DeserializeError>;
-    let __pattern_temp_4: ref Result<Option<String>,DeserializeError>;
-    let __pattern_temp_5: ref Result<JsonSeqAccess,DeserializeError>;
+    let __pattern_temp_3: ref Result<Option<String>,DeserializeError>;
+    let __pattern_temp_6: ref Result<Option<String>,DeserializeError>;
+    let __pattern_temp_8: ref Result<Option<String>,DeserializeError>;
+    let __pattern_temp_9: ref Result<JsonSeqAccess,DeserializeError>;
     seq_result = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     __pattern_temp_0 = seq_result;
     if ref.test Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0) {
         seq = value_copy "core:json/JsonSeqAccess"(ref.cast Result<JsonSeqAccess,DeserializeError>::Ok(__pattern_temp_0).payload_0);
-        items = __seq_lit: block -> ref Array<String> {
-            __local_3 = Array<String> { repr: builtin::array_new<ref String>(0), used: 0 };
-            break __seq_lit: __local_3;
-        };
-        block {
-            l801: loop {
-                next = JsonSeqAccess^DeserializeSeq::next_element<String>(seq);
-                __pattern_temp_1 = next;
-                if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1) {
-                    opt = value_copy Option<String>(ref.cast Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
-                    if ref.test Option<String>::Some(opt) {
-                        item = value_copy String(ref.cast Option<String>::Some(opt).payload_0);
-                        Array<String>::append(items, item);
-                    } else {
-                        end_result = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
-                        if ref.test Result<unit,DeserializeError>::Err(end_result) {
-                            e_9 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result).payload_0);
-                            return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_9) };
+        first = JsonSeqAccess^DeserializeSeq::next_element<String>(seq);
+        __pattern_temp_1 = first;
+        if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1) {
+            first_opt = value_copy Option<String>(ref.cast Result<Option<String>,DeserializeError>::Ok(__pattern_temp_1).payload_0);
+            if ref.test Option<String>::Some(first_opt) {
+                first_elem = value_copy String(ref.cast Option<String>::Some(first_opt).payload_0);
+                items = Array<String> { repr: builtin::array_new<ref String>(2), used: 0 };
+                Array<String>::append(items, first_elem);
+                block {
+                    l815: loop {
+                        next = JsonSeqAccess^DeserializeSeq::next_element<String>(seq);
+                        __pattern_temp_3 = next;
+                        if ref.test Result<Option<String>,DeserializeError>::Ok(__pattern_temp_3) {
+                            next_opt = value_copy Option<String>(ref.cast Result<Option<String>,DeserializeError>::Ok(__pattern_temp_3).payload_0);
+                            if ref.test Option<String>::Some(next_opt) {
+                                item = value_copy String(ref.cast Option<String>::Some(next_opt).payload_0);
+                                Array<String>::append(items, item);
+                            } else {
+                                end_result_10 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                                if ref.test Result<unit,DeserializeError>::Err(end_result_10) {
+                                    e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_10).payload_0);
+                                    return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+                                };
+                                return Result<Array<String>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                            };
                         };
-                        return Result<Array<String>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(items) };
+                        __pattern_temp_6 = next;
+                        if ref.test Result<Option<String>,DeserializeError>::Err(__pattern_temp_6) {
+                            e_12 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_6).payload_0);
+                            return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_12) };
+                        };
+                        continue l815;
                     };
                 };
-                __pattern_temp_4 = next;
-                if ref.test Result<Option<String>,DeserializeError>::Err(__pattern_temp_4) {
-                    e_10 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_4).payload_0);
-                    return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_10) };
+            } else {
+                end_result_13 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
+                if ref.test Result<unit,DeserializeError>::Err(end_result_13) {
+                    e_14 = value_copy "core:serde/DeserializeError"(ref.cast Result<unit,DeserializeError>::Err(end_result_13).payload_0);
+                    return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_14) };
                 };
-                continue l801;
+                return Result<Array<String>,DeserializeError>::Ok { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref Array<String> {
+                    __local_15 = Array<String> { repr: builtin::array_new<ref String>(0), used: 0 };
+                    break __seq_lit: __local_15;
+                }) };
             };
         };
+        __pattern_temp_8 = first;
+        if ref.test Result<Option<String>,DeserializeError>::Err(__pattern_temp_8) {
+            e_16 = value_copy "core:serde/DeserializeError"(ref.cast Result<Option<String>,DeserializeError>::Err(__pattern_temp_8).payload_0);
+            return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_16) };
+        };
+        "core:internal/unreachable"();
+        unreachable;
     };
-    __pattern_temp_5 = seq_result;
-    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5) {
-        e_11 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_5).payload_0);
-        return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_11) };
+    __pattern_temp_9 = seq_result;
+    if ref.test Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9) {
+        e_17 = value_copy "core:serde/DeserializeError"(ref.cast Result<JsonSeqAccess,DeserializeError>::Err(__pattern_temp_9).payload_0);
+        return Result<Array<String>,DeserializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_17) };
     };
     "core:internal/unreachable"();
     unreachable;
@@ -10370,38 +10568,44 @@ fn Array<String>^Deserialize::deserialize<JsonDeserializer>(d) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l809: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l809;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l825: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l825;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn JsonSeqAccess^DeserializeSeq::next_element<String>(self) {
@@ -10587,8 +10791,8 @@ fn Array<String>^Serialize::serialize<JsonSerializer>(self, s) {
             __local_16 = self;
             break __inline_Array_String__IntoIterator__into_iter_2: "core:serde/ArrayIter<String>" { repr: ref.as_non_null(__local_16.repr), used: __local_16.used, index: 0 };
         };
-        b823: block {
-            l824: loop {
+        b839: block {
+            l840: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: ref null String;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<String>^Iterator::next(__iter_4);
@@ -10600,9 +10804,9 @@ fn Array<String>^Serialize::serialize<JsonSerializer>(self, s) {
                         return Result<unit,SerializeError>::Err { discriminant: 1, payload_0: ref.as_non_null(e_7) };
                     };
                 } else {
-                    break b823;
+                    break b839;
                 };
-                continue l824;
+                continue l840;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref Result<unit,SerializeError> {
@@ -10778,11 +10982,11 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b835: block {
-        l836: loop {
+    b851: block {
+        l852: loop {
             if (_hfs_pos_8 < _licm_used_6) == 0 {
                 self.pos = _hfs_pos_8;
-                break b835;
+                break b851;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -10806,7 +11010,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {  // from core:json
                 self.pos = _hfs_pos_8;
                 return;
             };
-            continue l836;
+            continue l852;
         };
     };
     self.pos = _hfs_pos_8;
@@ -10889,12 +11093,12 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b844: block {
-        l845: loop {
+    b860: block {
+        l861: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= __sroa___iter_3_used {
                     self.pos = _hfs_pos_27;
-                    break b844;
+                    break b860;
                     self.pos = _hfs_pos_27;
                     break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
                 };
@@ -10928,7 +11132,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {  // from core:json
                 self.pos = _hfs_pos_27;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l845;
+            continue l861;
         };
     };
     self.pos = _hfs_pos_27;
@@ -11050,10 +11254,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
     _licm_input_89 = self.input;
     _licm_used_90 = _licm_input_89.used;
     _licm_repr_91 = _licm_input_89.repr;
-    b851: block {
-        l852: loop {
+    b867: block {
+        l868: loop {
             if (scan_pos < _licm_used_90) == 0 {
-                break b851;
+                break b867;
             };
             sb = __inline_String__get_byte_5: block -> u8 {
                 __local_47 = scan_pos;
@@ -11064,10 +11268,10 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             } else {
                 sb == 92;
             } {
-                break b851;
+                break b867;
             };
             scan_pos = scan_pos + 1;
-            continue l852;
+            continue l868;
         };
     };
     prefix_len = scan_pos - prefix_start;
@@ -11091,7 +11295,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
             _licm_repr_93 = result_5.repr;
             _licm_repr_94 = _licm_input_92.repr;
             block {
-                l859: loop {
+                l875: loop {
                     if (i_7 < prefix_len) == 0 {
                         break __for_0;
                     };
@@ -11102,7 +11306,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                     };
                     builtin::array_set_u8(_licm_repr_93, index_53, value_54);
                     i_7 = i_7 + 1;
-                    continue l859;
+                    continue l875;
                 };
             };
         };
@@ -11120,7 +11324,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
         _licm_repr_96 = result_8.repr;
         _licm_repr_97 = _licm_input_95.repr;
         block {
-            l862: loop {
+            l878: loop {
                 if (i_10 < prefix_len) == 0 {
                     break __for_1;
                 };
@@ -11131,20 +11335,20 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 builtin::array_set_u8(_licm_repr_96, index_59, value_60);
                 i_10 = i_10 + 1;
-                continue l862;
+                continue l878;
             };
         };
     };
     self.pos = scan_pos;
     _hfs_pos_98 = self.pos;
-    b864: block {
-        l865: loop {
+    b880: block {
+        l881: loop {
             if (_hfs_pos_98 < __inline_String__len_14: block -> i32 {
                 __local_63 = self.input;
                 break __inline_String__len_14: __local_63.used;
             }) == 0 {
                 self.pos = _hfs_pos_98;
-                break b864;
+                break b880;
             };
             b = __inline_String__get_byte_15: block -> u8 {
                 __local_64 = self.input;
@@ -11300,7 +11504,7 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {  // from core:json
                 };
                 _hfs_pos_98 = _hfs_pos_98 + seq_len;
             };
-            continue l865;
+            continue l881;
         };
     };
     self.pos = _hfs_pos_98;
@@ -11344,7 +11548,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
         _licm_pos_16 = self.pos;
         _licm_repr_17 = _licm_input_15.repr;
         block {
-            l890: loop {
+            l906: loop {
                 if (i < 4) == 0 {
                     break __for_2;
                 };
@@ -11379,7 +11583,7 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {  // from core:json
                     }) };
                 };
                 i = i + 1;
-                continue l890;
+                continue l906;
             };
         };
     };
@@ -11449,11 +11653,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b901: block {
-        l902: loop {
+    b917: block {
+        l918: loop {
             if (_hfs_pos_36 < _licm_used_28) == 0 {
                 self.pos = _hfs_pos_36;
-                break b901;
+                break b917;
             };
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
@@ -11467,9 +11671,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
                 self.pos = _hfs_pos_36;
-                break b901;
+                break b917;
             };
-            continue l902;
+            continue l918;
         };
     };
     self.pos = _hfs_pos_36;
@@ -11490,11 +11694,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b908: block {
-            l909: loop {
+        b924: block {
+            l925: loop {
                 if (_hfs_pos_37 < _licm_used_31) == 0 {
                     self.pos = _hfs_pos_37;
-                    break b908;
+                    break b924;
                 };
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
@@ -11508,9 +11712,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
                     self.pos = _hfs_pos_37;
-                    break b908;
+                    break b924;
                 };
-                continue l909;
+                continue l925;
             };
         };
         self.pos = _hfs_pos_37;
@@ -11551,11 +11755,11 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b919: block {
-                l920: loop {
+            b935: block {
+                l936: loop {
                     if (_hfs_pos_38 < _licm_used_34) == 0 {
                         self.pos = _hfs_pos_38;
-                        break b919;
+                        break b935;
                     };
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
@@ -11569,9 +11773,9 @@ fn "core:json/JsonDeserializer::skip_number"(self) {  // from core:json
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
                         self.pos = _hfs_pos_38;
-                        break b919;
+                        break b935;
                     };
-                    continue l920;
+                    continue l936;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -11665,11 +11869,11 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b929: block {
-        l930: loop {
+    b945: block {
+        l946: loop {
             if (_hfs_pos_51 < _licm_used_47) == 0 {
                 self.pos = _hfs_pos_51;
-                break b929;
+                break b945;
             };
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
@@ -11696,12 +11900,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b938: block {
-                        l939: loop {
+                    b954: block {
+                        l955: loop {
                             if (_hfs_pos_49 < _licm_used_47) == 0 {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b938;
+                                break b954;
                             };
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
@@ -11718,9 +11922,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             } else {
                                 _hfs_pos_51 = _hfs_pos_49;
                                 self.pos = _hfs_pos_51;
-                                break b938;
+                                break b954;
                             };
-                            continue l939;
+                            continue l955;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -11751,12 +11955,12 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                             };
                         };
                         _hfs_pos_50 = _hfs_pos_51;
-                        b949: block {
-                            l950: loop {
+                        b965: block {
+                            l966: loop {
                                 if (_hfs_pos_50 < _licm_used_47) == 0 {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b949;
+                                    break b965;
                                 };
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
@@ -11772,9 +11976,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                                 } else {
                                     _hfs_pos_51 = _hfs_pos_50;
                                     self.pos = _hfs_pos_51;
-                                    break b949;
+                                    break b965;
                                 };
-                                continue l950;
+                                continue l966;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -11811,9 +12015,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {  // from core:json
                 return Result<i32,DeserializeError>::Ok { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
                 self.pos = _hfs_pos_51;
-                break b929;
+                break b945;
             };
-            continue l930;
+            continue l946;
         };
     };
     self.pos = _hfs_pos_51;
@@ -11925,11 +12129,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b965: block {
-        l966: loop {
+    b981: block {
+        l982: loop {
             if (_hfs_pos_57 < _licm_used_49) == 0 {
                 self.pos = _hfs_pos_57;
-                break b965;
+                break b981;
             };
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
@@ -11947,9 +12151,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
                 self.pos = _hfs_pos_57;
-                break b965;
+                break b981;
             };
-            continue l966;
+            continue l982;
         };
     };
     self.pos = _hfs_pos_57;
@@ -11971,11 +12175,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b973: block {
-            l974: loop {
+        b989: block {
+            l990: loop {
                 if (_hfs_pos_58 < _licm_used_52) == 0 {
                     self.pos = _hfs_pos_58;
-                    break b973;
+                    break b989;
                 };
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
@@ -11994,9 +12198,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
                     self.pos = _hfs_pos_58;
-                    break b973;
+                    break b989;
                 };
-                continue l974;
+                continue l990;
             };
         };
         self.pos = _hfs_pos_58;
@@ -12038,11 +12242,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b985: block {
-                l986: loop {
+            b1001: block {
+                l1002: loop {
                     if (_hfs_pos_59 < _licm_used_55) == 0 {
                         self.pos = _hfs_pos_59;
-                        break b985;
+                        break b1001;
                     };
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
@@ -12057,9 +12261,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {  // from core:json
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
                         self.pos = _hfs_pos_59;
-                        break b985;
+                        break b1001;
                     };
-                    continue l986;
+                    continue l1002;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -12109,11 +12313,11 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b996: block {
-        l997: loop {
+    b1012: block {
+        l1013: loop {
             if (_hfs_pos_14 < _licm_used_12) == 0 {
                 self.pos = _hfs_pos_14;
-                break b996;
+                break b1012;
             };
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -12142,7 +12346,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {  // from core:json
                 };
             };
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l997;
+            continue l1013;
         };
     };
     self.pos = _hfs_pos_14;
@@ -12245,7 +12449,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_49 = self.pos;
         block {
-            l1012: loop {
+            l1028: loop {
                 self.pos = _hfs_pos_49;
                 r = "core:json/JsonDeserializer::skip_value"(self);
                 _hfs_pos_49 = self.pos;
@@ -12287,7 +12491,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_8: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_29), offset: __local_30 };
                     }) };
                 };
-                continue l1012;
+                continue l1028;
             };
         };
         self.pos = _hfs_pos_49;
@@ -12312,7 +12516,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
         };
         _hfs_pos_50 = self.pos;
         block {
-            l1021: loop {
+            l1037: loop {
                 self.pos = _hfs_pos_50;
                 "core:json/JsonDeserializer::skip_whitespace"(self);
                 _hfs_pos_50 = self.pos;
@@ -12392,7 +12596,7 @@ fn "core:json/JsonDeserializer::skip_value"(self) {  // from core:json
                         break __inline_DeserializeError__malformed_17: "core:serde/DeserializeError" { kind: 6, message: ref.as_non_null(__local_43), offset: __local_44 };
                     }) };
                 };
-                continue l1021;
+                continue l1037;
             };
         };
         self.pos = _hfs_pos_50;
@@ -12562,13 +12766,13 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b1046: block {
-        l1047: loop {
+    b1062: block {
+        l1063: loop {
             if (self.de.pos < __inline_String__len_6: block -> i32 {
                 __local_34 = self.de.input;
                 break __inline_String__len_6: __local_34.used;
             }) == 0 {
-                break b1046;
+                break b1062;
             };
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_35 = self.de.input;
@@ -12576,14 +12780,14 @@ fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {  // from c
                 break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
             };
             if b == 34 {
-                break b1046;
+                break b1062;
             };
             if b == 92 {
                 has_escape = 1;
-                break b1046;
+                break b1062;
             };
             self.de.pos = self.de.pos + 1;
-            continue l1047;
+            continue l1063;
         };
     };
     if has_escape == 0 {
@@ -12850,13 +13054,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l1082: loop {
+            l1098: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l1082;
+                continue l1098;
             };
         };
     };
@@ -12945,10 +13149,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b1092: block {
-            l1093: loop {
+        b1108: block {
+            l1109: loop {
                 if (i_8 >= 0) == 0 {
-                    break b1092;
+                    break b1108;
                 };
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -12957,7 +13161,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l1093;
+                continue l1109;
             };
         };
         __for_1: block {
@@ -12965,14 +13169,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l1096: loop {
+                l1112: loop {
                     if (j_9 < left_pad) == 0 {
                         break __for_1;
                     };
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l1096;
+                    continue l1112;
                 };
             };
         };
@@ -12982,10 +13186,10 @@ fn Formatter::apply_padding(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b1098: block {
-            l1099: loop {
+        b1114: block {
+            l1115: loop {
                 if (i_10 >= 0) == 0 {
-                    break b1098;
+                    break b1114;
                 };
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -12994,7 +13198,7 @@ fn Formatter::apply_padding(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l1099;
+                continue l1115;
             };
         };
         __for_2: block {
@@ -13002,14 +13206,14 @@ fn Formatter::apply_padding(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l1102: loop {
+                l1118: loop {
                     if (j_11 < padding) == 0 {
                         break __for_2;
                     };
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l1102;
+                    continue l1118;
                 };
             };
         };
@@ -13111,8 +13315,8 @@ fn String^Inspect::inspect(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b1121: block {
-        l1122: loop {
+    b1137: block {
+        l1138: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = StrCharIter^Iterator::next(__iter_2);
@@ -13137,9 +13341,9 @@ fn String^Inspect::inspect(self, f) {
                     String::append_char(_licm_buf_33, c);
                 };
             } else {
-                break b1121;
+                break b1137;
             };
-            continue l1122;
+            continue l1138;
         };
     };
     String::append_char(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_scientific_notation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_scientific_notation.wir.wado
@@ -334,6 +334,8 @@ type "functype/core:json/utf8_sequence_length" = fn(i32) -> i32;
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -3819,38 +3821,44 @@ fn "core:json/utf8_sequence_length"(leading_byte) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l294: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l294;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l294: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l294;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_ser_error.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_ser_error.wir.wado
@@ -159,6 +159,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1857,38 +1859,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l158: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l158;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l158: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l158;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
@@ -307,6 +307,8 @@ type "functype/core:json/write_escaped_string" = fn(ref String, ref String);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1898,38 +1900,44 @@ fn "core:json/write_escaped_string"(buf, s) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l159: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l159;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l159: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l159;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
@@ -616,6 +616,8 @@ type "functype/TreeMap<String,Option<i32>>::entries" = fn(ref "core:allocator/Tr
 
 type "functype/Array<Tuple<String,Option<i32>>>::append" = fn(ref Array<Tuple<String,Option<i32>>>, ref "tuple/[String, Option<i32>]");
 
+type "functype/Array<Tuple<String,Option<i32>>>::grow" = fn(ref Array<Tuple<String,Option<i32>>>);
+
 type "functype/TreeMap<String,Option<i32>>::insert" = fn(ref "core:allocator/TreeMap<String,Option<i32>>", ref String, ref Option<i32>);
 
 type "functype/TreeMap<String,Option<i32>>::insert_node" = fn(ref "core:allocator/TreeMap<String,Option<i32>>", ref Option<TreeMapNode<String>>, ref String, i32) -> ref Option<TreeMapNode<String>>;
@@ -626,6 +628,8 @@ type "functype/TreeMap<String,Option<i32>>::skew" = fn(ref "core:allocator/TreeM
 
 type "functype/Array<TreeMapEntry<String,Option<i32>>>::append" = fn(ref Array<TreeMapEntry<String,Option<i32>>>, ref "core:allocator/TreeMapEntry<String,Option<i32>>");
 
+type "functype/Array<TreeMapEntry<String,Option<i32>>>::grow" = fn(ref Array<TreeMapEntry<String,Option<i32>>>);
+
 type "functype/TreeMap<String,Option<i32>>::find_index" = fn(ref "core:allocator/TreeMap<String,Option<i32>>", ref String) -> i32;
 
 type "functype/JsonMapSerializer^SerializeMap::value<Array<i32>>" = fn(ref "core:json/JsonMapSerializer", ref Array<i32>) -> ref Result<unit,SerializeError>;
@@ -634,7 +638,11 @@ type "functype/TreeMap<String,Array<i32>>::entries" = fn(ref "core:allocator/Tre
 
 type "functype/Array<Tuple<String,Array<i32>>>::append" = fn(ref Array<Tuple<String,Array<i32>>>, ref "tuple/[String, Array<i32>]");
 
+type "functype/Array<Tuple<String,Array<i32>>>::grow" = fn(ref Array<Tuple<String,Array<i32>>>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/TreeMap<String,Array<i32>>::insert" = fn(ref "core:allocator/TreeMap<String,Array<i32>>", ref String, ref Array<i32>);
 
@@ -646,11 +654,15 @@ type "functype/TreeMap<String,Array<i32>>::skew" = fn(ref "core:allocator/TreeMa
 
 type "functype/Array<TreeMapEntry<String,Array<i32>>>::append" = fn(ref Array<TreeMapEntry<String,Array<i32>>>, ref "core:allocator/TreeMapEntry<String,Array<i32>>");
 
+type "functype/Array<TreeMapEntry<String,Array<i32>>>::grow" = fn(ref Array<TreeMapEntry<String,Array<i32>>>);
+
 type "functype/TreeMap<String,Array<i32>>::find_index" = fn(ref "core:allocator/TreeMap<String,Array<i32>>", ref String) -> i32;
 
 type "functype/TreeMap<String,bool>::entries" = fn(ref "core:allocator/TreeMap<String,bool>") -> ref Array<Tuple<String,bool>>;
 
 type "functype/Array<Tuple<String,bool>>::append" = fn(ref Array<Tuple<String,bool>>, ref "tuple/[String, bool]");
+
+type "functype/Array<Tuple<String,bool>>::grow" = fn(ref Array<Tuple<String,bool>>);
 
 type "functype/TreeMap<String,bool>::insert" = fn(ref "core:allocator/TreeMap<String,bool>", ref String, bool);
 
@@ -662,6 +674,8 @@ type "functype/TreeMap<String,bool>::skew" = fn(ref "core:allocator/TreeMap<Stri
 
 type "functype/Array<TreeMapEntry<String,bool>>::append" = fn(ref Array<TreeMapEntry<String,bool>>, ref "core:allocator/TreeMapEntry<String,bool>");
 
+type "functype/Array<TreeMapEntry<String,bool>>::grow" = fn(ref Array<TreeMapEntry<String,bool>>);
+
 type "functype/TreeMap<String,bool>::find_index" = fn(ref "core:allocator/TreeMap<String,bool>", ref String) -> i32;
 
 type "functype/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:json/JsonMapSerializer", ref String) -> ref Result<unit,SerializeError>;
@@ -669,6 +683,8 @@ type "functype/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:jso
 type "functype/TreeMap<String,String>::entries" = fn(ref "core:allocator/TreeMap<String,String>") -> ref Array<Tuple<String,String>>;
 
 type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
+
+type "functype/Array<Tuple<String,String>>::grow" = fn(ref Array<Tuple<String,String>>);
 
 type "functype/TreeMap<String,String>::insert" = fn(ref "core:allocator/TreeMap<String,String>", ref String, ref String);
 
@@ -679,6 +695,8 @@ type "functype/TreeMap<String,String>::split" = fn(ref "core:allocator/TreeMap<S
 type "functype/TreeMap<String,String>::skew" = fn(ref "core:allocator/TreeMap<String,String>", ref Option<TreeMapNode<String>>) -> ref Option<TreeMapNode<String>>;
 
 type "functype/Array<TreeMapEntry<String,String>>::append" = fn(ref Array<TreeMapEntry<String,String>>, ref "core:allocator/TreeMapEntry<String,String>");
+
+type "functype/Array<TreeMapEntry<String,String>>::grow" = fn(ref Array<TreeMapEntry<String,String>>);
 
 type "functype/TreeMap<String,String>::find_index" = fn(ref "core:allocator/TreeMap<String,String>", ref String) -> i32;
 
@@ -698,9 +716,13 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/TreeMap<String,i32>::entries" = fn(ref "core:allocator/TreeMap<String,i32>") -> ref Array<Tuple<String,i32>>;
 
 type "functype/Array<Tuple<String,i32>>::append" = fn(ref Array<Tuple<String,i32>>, ref "tuple/[String, i32]");
+
+type "functype/Array<Tuple<String,i32>>::grow" = fn(ref Array<Tuple<String,i32>>);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
 
@@ -3256,38 +3278,44 @@ fn TreeMap<String,Option<i32>>::entries(self) {
 
 fn Array<Tuple<String,Option<i32>>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,Option<i32>>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, Option<i32>]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,Option<i32>>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,Option<i32>>>;
     let old_repr: ref array<Tuple<String,Option<i32>>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, Option<i32>]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l185: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, Option<i32>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Option<i32>]">(old_repr, i));
-                    i = i + 1;
-                    continue l185;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, Option<i32>]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l185: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, Option<i32>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Option<i32>]">(old_repr, i));
+                i = i + 1;
+                continue l185;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, Option<i32>]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,Option<i32>>>^Iterator::next(self) {
@@ -3399,38 +3427,44 @@ fn TreeMap<String,Option<i32>>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,Option<i32>>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,Option<i32>>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,Option<i32>>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,Option<i32>>>;
     let old_repr: ref array<TreeMapEntry<String,Option<i32>>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l202: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(old_repr, i));
-                    i = i + 1;
-                    continue l202;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l202: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(old_repr, i));
+                i = i + 1;
+                continue l202;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,Option<i32>>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,Option<i32>>::find_index(self, key) {
@@ -3680,38 +3714,44 @@ fn TreeMap<String,Array<i32>>::entries(self) {
 
 fn Array<Tuple<String,Array<i32>>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,Array<i32>>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, Array<i32>]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,Array<i32>>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,Array<i32>>>;
     let old_repr: ref array<Tuple<String,Array<i32>>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, Array<i32>]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l233: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, Array<i32>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Array<i32>]">(old_repr, i));
-                    i = i + 1;
-                    continue l233;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, Array<i32>]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l233: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, Array<i32>]">(new_repr, i, builtin::array_get<ref "tuple/[String, Array<i32>]">(old_repr, i));
+                i = i + 1;
+                continue l233;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, Array<i32>]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,Array<i32>>>^Iterator::next(self) {
@@ -3726,38 +3766,44 @@ fn ArrayIter<TreeMapEntry<String,Array<i32>>>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l238: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l238;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l238: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l238;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,Array<i32>>::insert(self, key, value) {
@@ -3859,38 +3905,44 @@ fn TreeMap<String,Array<i32>>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,Array<i32>>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,Array<i32>>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,Array<i32>>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,Array<i32>>>;
     let old_repr: ref array<TreeMapEntry<String,Array<i32>>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l254: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(old_repr, i));
-                    i = i + 1;
-                    continue l254;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l254: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(old_repr, i));
+                i = i + 1;
+                continue l254;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,Array<i32>>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,Array<i32>>::find_index(self, key) {
@@ -4062,38 +4114,44 @@ fn TreeMap<String,bool>::entries(self) {
 
 fn Array<Tuple<String,bool>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,bool>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, bool]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,bool>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,bool>>;
     let old_repr: ref array<Tuple<String,bool>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, bool]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l277: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, bool]">(new_repr, i, builtin::array_get<ref "tuple/[String, bool]">(old_repr, i));
-                    i = i + 1;
-                    continue l277;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, bool]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l277: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, bool]">(new_repr, i, builtin::array_get<ref "tuple/[String, bool]">(old_repr, i));
+                i = i + 1;
+                continue l277;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, bool]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,bool>>^Iterator::next(self) {
@@ -4205,38 +4263,44 @@ fn TreeMap<String,bool>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,bool>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,bool>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,bool>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,bool>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,bool>>;
     let old_repr: ref array<TreeMapEntry<String,bool>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,bool>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l294: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,bool>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,bool>">(old_repr, i));
-                    i = i + 1;
-                    continue l294;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,bool>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l294: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,bool>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,bool>">(old_repr, i));
+                i = i + 1;
+                continue l294;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,bool>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,bool>::find_index(self, key) {
@@ -4409,38 +4473,44 @@ fn TreeMap<String,String>::entries(self) {
 
 fn Array<Tuple<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,String>>;
     let old_repr: ref array<Tuple<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l317: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l317;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l317: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
+                i = i + 1;
+                continue l317;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,String>>^Iterator::next(self) {
@@ -4552,38 +4622,44 @@ fn TreeMap<String,String>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,String>>;
     let old_repr: ref array<TreeMapEntry<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,String>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l334: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,String>">(old_repr, i));
-                    i = i + 1;
-                    continue l334;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,String>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l334: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,String>">(old_repr, i));
+                i = i + 1;
+                continue l334;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,String>::find_index(self, key) {
@@ -4887,38 +4963,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l376: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l376;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l376: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l376;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>^Serialize::serialize<JsonSerializer>(self, s) {
@@ -5044,38 +5126,44 @@ fn TreeMap<String,i32>::entries(self) {
 
 fn Array<Tuple<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,i32>>;
     let old_repr: ref array<Tuple<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l392: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l392;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l392: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
+                i = i + 1;
+                continue l392;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,i32>>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
@@ -333,6 +333,8 @@ type "functype/core:json/write_escaped_string" = fn(ref String, ref String);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1879,38 +1881,44 @@ fn "core:json/write_escaped_string"(buf, s) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l151: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l151;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l151: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l151;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_unknown_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_unknown_fields.wir.wado
@@ -252,6 +252,8 @@ type "functype/core:json/utf8_sequence_length" = fn(i32) -> i32;
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::get_byte" = fn(ref String, i32) -> u8;
 
 type "functype/String::grow" = fn(ref String, i32);
@@ -1878,38 +1880,44 @@ fn "core:json/utf8_sequence_length"(leading_byte) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l149: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l149;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l149: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l149;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/serde_serialize_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_serialize_array.wir.wado
@@ -121,6 +121,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<String>^Serialize::serialize<JsonSerializer>" = fn(ref Array<String>, ref JsonSerializer) -> ref Result<unit,SerializeError>;
 
 type "functype/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref JsonSeqSerializer, ref String) -> ref Result<unit,SerializeError>;
@@ -128,6 +130,8 @@ type "functype/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref JsonSeq
 type "functype/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref Array<i32>, ref JsonSerializer) -> ref Result<unit,SerializeError>;
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -520,38 +524,44 @@ fn JsonSerializer^Serializer::serialize_string(self, v) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l25: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l25;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l25: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l25;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Array<String>^Serialize::serialize<JsonSerializer>(self, s) {
@@ -674,38 +684,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/serde_serialize_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_serialize_variant.wir.wado
@@ -142,6 +142,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1198,38 +1200,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
@@ -407,6 +407,8 @@ type "functype/core:json/write_escaped_string" = fn(ref String, ref String);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::get_byte" = fn(ref String, i32) -> u8;
 
 type "functype/String::grow" = fn(ref String, i32);
@@ -2780,38 +2782,44 @@ fn "core:json/write_escaped_string"(buf, s) {  // from core:json
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l220: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l220;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l220: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l220;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn char::from_u32(value) {

--- a/wado-compiler/tests/fixtures.golden/short_circuit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/short_circuit.wir.wado
@@ -89,6 +89,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -578,38 +580,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l45: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l45;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l45: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l45;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/simd_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/simd_basic.wir.wado
@@ -101,6 +101,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -2114,38 +2116,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l152: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l152;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l152: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l152;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/static_method_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_1.wir.wado
@@ -102,6 +102,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -687,38 +689,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/static_method_nested_generics.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_nested_generics.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -479,38 +481,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l27: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l27;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l27: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l27;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/stream-cm-stderr-write.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-cm-stderr-write.wir.wado
@@ -43,6 +43,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/stream-new" = fn() -> i64;
 
 type "functype/wasi/stream-drop-writable" = fn(i32);
@@ -186,38 +188,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l7: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l7;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l7: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l7;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/stream-http-echo.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-http-echo.wir.wado
@@ -278,6 +278,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<Array<u8>>::append" = fn(ref Array<Array<u8>>, ref Array<u8>);
 
+type "functype/Array<Array<u8>>::grow" = fn(ref Array<Array<u8>>);
+
 type "functype/wasi/future-new:transmission" = fn() -> i64;
 
 type "functype/wasi/stream-drop-readable" = fn(i32);
@@ -988,38 +990,44 @@ fn ArrayIter<Array<u8>>^Iterator::next(self) {
 
 fn Array<Array<u8>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<u8>>::grow(self);
+    };
+    builtin::array_set<ref Array<u8>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<u8>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<u8>>;
     let old_repr: ref array<Array<u8>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l56: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
-                    i = i + 1;
-                    continue l56;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<u8>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l56: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<u8>>(new_repr, i, builtin::array_get<ref Array<u8>>(old_repr, i));
+                i = i + 1;
+                continue l56;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<u8>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/stream-http-read-request-body.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-http-read-request-body.wir.wado
@@ -263,6 +263,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new:transmission" = fn() -> i64;
 
 type "functype/wasi/stream-drop-readable" = fn(i32);
@@ -952,38 +954,44 @@ fn "core:internal/cm_stream_write_u8"(handle, data) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/stream-http-response-body-multi.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-http-response-body-multi.wir.wado
@@ -257,6 +257,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -867,38 +869,44 @@ fn "core:internal/cm_stream_write_u8"(handle, data) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l45: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l45;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l45: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l45;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/stream-http-response-body-string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-http-response-body-string.wir.wado
@@ -265,6 +265,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -949,38 +951,44 @@ fn StrCharIter^Iterator::next(self) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l52: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l52;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l52: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l52;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/stream-http-response-body.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-http-response-body.wir.wado
@@ -257,6 +257,8 @@ type "functype/core:internal/cm_stream_write_u8" = fn(i32, ref Array<u8>);
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -860,38 +862,44 @@ fn "core:internal/cm_stream_write_u8"(handle, data) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l45: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l45;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l45: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l45;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__handle as "handle"

--- a/wado-compiler/tests/fixtures.golden/stream-write-hello.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-write-hello.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/stream-new" = fn() -> i64;
 
 type "functype/wasi/stream-drop-readable" = fn(i32);
@@ -244,38 +246,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/stream-write-multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/stream-write-multiple.wir.wado
@@ -54,6 +54,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/wasi/stream-new" = fn() -> i64;
 
 type "functype/wasi/stream-drop-readable" = fn(i32);
@@ -244,38 +246,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l9: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l9;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l9: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l9;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/string_from_utf8_lossy_newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_from_utf8_lossy_newtype.wir.wado
@@ -105,6 +105,8 @@ type "functype/ArrayIter<u8>^Iterator::next" = fn(ref "core:allocator/ArrayIter<
 
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
 
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -739,38 +741,44 @@ fn ArrayIter<u8>^Iterator::next(self) {
 
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l72: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l72;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l72: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l72;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/struct_destruct_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_destruct_for_of.wir.wado
@@ -90,6 +90,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Point>::append" = fn(ref Array<Point>, ref Point);
 
+type "functype/Array<Point>::grow" = fn(ref Array<Point>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -475,38 +477,44 @@ fn ArrayIter<Point>^Iterator::next(self) {
 
 fn Array<Point>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Point>::grow(self);
+    };
+    builtin::array_set<ref Point>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Point>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Point>;
     let old_repr: ref array<Point>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Point>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l32: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
-                    i = i + 1;
-                    continue l32;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Point>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l32: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Point>(new_repr, i, builtin::array_get<ref Point>(old_repr, i));
+                i = i + 1;
+                continue l32;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Point>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/struct_impl.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_impl.wir.wado
@@ -105,6 +105,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1370,38 +1372,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l122: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l122;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l122: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l122;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/template_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string.wir.wado
@@ -121,6 +121,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1634,38 +1636,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l124: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l124;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l124: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l124;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_unsafe.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_unsafe.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -1017,38 +1019,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l75: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l75;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l75: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l75;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/trait_bound_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_1.wir.wado
@@ -106,6 +106,8 @@ type "functype/Pair<i32>^Ord::cmp" = fn(ref Pair<i32>, ref Pair<i32>) -> enum:Or
 
 type "functype/Array<i32>::append" = fn(ref Array<Box<i32>>, ref "core:internal/Box<i32>");
 
+type "functype/Array<i32>::grow" = fn(ref Array<Box<i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -541,38 +543,44 @@ fn Pair<i32>^Ord::cmp(self, other) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<ref "core:internal/Box<i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Box<i32>>;
     let old_repr: ref array<Box<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:internal/Box<i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l34: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:internal/Box<i32>">(new_repr, i, builtin::array_get<ref "core:internal/Box<i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l34;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:internal/Box<i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l34: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:internal/Box<i32>">(new_repr, i, builtin::array_get<ref "core:internal/Box<i32>">(old_repr, i));
+                i = i + 1;
+                continue l34;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:internal/Box<i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/trait_bound_4.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_4.wir.wado
@@ -107,7 +107,11 @@ type "functype/Array<i32>^Eq::eq" = fn(ref Array<i32>, ref Array<i32>) -> bool;
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<Array<i32>>::append" = fn(ref Array<Array<i32>>, ref Array<i32>);
+
+type "functype/Array<Array<i32>>::grow" = fn(ref Array<Array<i32>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -599,74 +603,86 @@ fn Array<i32>^Eq::eq(self, other) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l36;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i32>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l36;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<Array<i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Array<i32>>::grow(self);
+    };
+    builtin::array_set<ref Array<i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Array<i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Array<i32>>;
     let old_repr: ref array<Array<i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l40;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref Array<i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref Array<i32>>(new_repr, i, builtin::array_get<ref Array<i32>>(old_repr, i));
+                i = i + 1;
+                continue l40;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref Array<i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/trait_bound_7.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_7.wir.wado
@@ -110,6 +110,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -589,38 +591,44 @@ fn Holder<i32>::min(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l40;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l40;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Result<i32,String>^Eq::eq(self, other) {

--- a/wado-compiler/tests/fixtures.golden/trait_default.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default.wir.wado
@@ -118,6 +118,8 @@ type "functype/ArrayIter<i32>^Iterator::next" = fn(ref "core:allocator/ArrayIter
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -609,38 +611,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/trait_multiple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_multiple.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1191,38 +1193,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-basic.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::pad" = fn(ref Formatter, ref String);
@@ -1043,38 +1045,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l70: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l70;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l70: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l70;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-cast.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -956,38 +958,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l66: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l66;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l66: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l66;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.wir.wado
@@ -158,11 +158,15 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/TreeMap<String,i32>::find_index" = fn(ref "core:allocator/TreeMap<String,i32>", ref String) -> i32;
 
 type "functype/TreeMap<String,i32>::entries" = fn(ref "core:allocator/TreeMap<String,i32>") -> ref Array<Tuple<String,i32>>;
 
 type "functype/Array<Tuple<String,i32>>::append" = fn(ref Array<Tuple<String,i32>>, ref "tuple/[String, i32]");
+
+type "functype/Array<Tuple<String,i32>>::grow" = fn(ref Array<Tuple<String,i32>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -775,38 +779,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l54: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l54;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l54: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l54;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::find_index(self, key) {
@@ -900,38 +910,44 @@ fn TreeMap<String,i32>::entries(self) {
 
 fn Array<Tuple<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,i32>>;
     let old_repr: ref array<Tuple<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l70: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l70;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l70: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
+                i = i + 1;
+                continue l70;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn ArrayIter<TreeMapEntry<String,i32>>^Iterator::next(self) {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,i32>::skew" = fn(ref "core:allocator/TreeMap<Strin
 
 type "functype/Array<TreeMapEntry<String,i32>>::append" = fn(ref Array<TreeMapEntry<String,i32>>, ref "core:allocator/TreeMapEntry<String,i32>");
 
+type "functype/Array<TreeMapEntry<String,i32>>::grow" = fn(ref Array<TreeMapEntry<String,i32>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -954,38 +956,44 @@ fn TreeMap<String,i32>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,i32>>;
     let old_repr: ref array<TreeMapEntry<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l66: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
-                    i = i + 1;
-                    continue l66;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,i32>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l66: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,i32>">(old_repr, i));
+                i = i + 1;
+                continue l66;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,i32>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.wir.wado
@@ -142,6 +142,8 @@ type "functype/TreeMap<String,String>::skew" = fn(ref "core:allocator/TreeMap<St
 
 type "functype/Array<TreeMapEntry<String,String>>::append" = fn(ref Array<TreeMapEntry<String,String>>, ref "core:allocator/TreeMapEntry<String,String>");
 
+type "functype/Array<TreeMapEntry<String,String>>::grow" = fn(ref Array<TreeMapEntry<String,String>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -986,38 +988,44 @@ fn TreeMap<String,String>::skew(self, node) {
 
 fn Array<TreeMapEntry<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<TreeMapEntry<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<TreeMapEntry<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<TreeMapEntry<String,String>>;
     let old_repr: ref array<TreeMapEntry<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,String>">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l67: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,String>">(old_repr, i));
-                    i = i + 1;
-                    continue l67;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "core:allocator/TreeMapEntry<String,String>">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l67: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:allocator/TreeMapEntry<String,String>">(old_repr, i));
+                i = i + 1;
+                continue l67;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "core:allocator/TreeMapEntry<String,String>">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/treemap_btree.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree.wir.wado
@@ -167,11 +167,17 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/BTreeNode<String,i32>::compact" = fn(ref BTreeNode<String,i32>);
 
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
 
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/TreeMap<String,i32>::needs_compaction" = fn(ref TreeMap<String,i32>) -> bool;
 
@@ -180,6 +186,8 @@ type "functype/TreeMap<String,i32>::iter" = fn(ref TreeMap<String,i32>) -> ref A
 type "functype/TreeMap<String,i32>::collect_entries" = fn(ref TreeMap<String,i32>, ref BTreeNode<String,i32>, ref Array<Tuple<String,i32>>);
 
 type "functype/Array<Tuple<String,i32>>::append" = fn(ref Array<Tuple<String,i32>>, ref "tuple/[String, i32]");
+
+type "functype/Array<Tuple<String,i32>>::grow" = fn(ref Array<Tuple<String,i32>>);
 
 type "functype/TreeMap<String,i32>::delete_in_node" = fn(ref TreeMap<String,i32>, ref BTreeNode<String,i32>, ref String) -> bool;
 
@@ -194,6 +202,8 @@ type "functype/TreeMap<String,i32>::sort_node_entries" = fn(ref TreeMap<String,i
 type "functype/TreeMap<String,i32>::split_child" = fn(ref TreeMap<String,i32>, ref BTreeNode<String,i32>, i32);
 
 type "functype/Array<BTreeNode<String,i32>>::append" = fn(ref Array<BTreeNode<String,i32>>, ref BTreeNode<String,i32>);
+
+type "functype/Array<BTreeNode<String,i32>>::grow" = fn(ref Array<BTreeNode<String,i32>>);
 
 type "functype/BTreeNode<String,i32>::new_internal" = fn() -> ref BTreeNode<String,i32>;
 
@@ -935,38 +945,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l55: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l55;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l55: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l55;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn BTreeNode<String,i32>::compact(self) {
@@ -1077,74 +1093,86 @@ fn BTreeNode<String,i32>::compact(self) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<bool>;
-    let old_repr: ref array<bool>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l69: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l69;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
     };
     builtin::array_set<bool>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<bool>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<bool>;
+    let old_repr: ref array<bool>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l69: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l69;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l73: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l73;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l73: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l73;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::needs_compaction(self) {
@@ -1283,38 +1311,44 @@ fn TreeMap<String,i32>::collect_entries(self, node, result) {
 
 fn Array<Tuple<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,i32>>;
     let old_repr: ref array<Tuple<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l92: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l92;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l92: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
+                i = i + 1;
+                continue l92;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::delete_in_node(self, node, key) {
@@ -1995,38 +2029,44 @@ fn TreeMap<String,i32>::split_child(self, parent, child_index) {
 
 fn Array<BTreeNode<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<BTreeNode<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref BTreeNode<String,i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<BTreeNode<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<BTreeNode<String,i32>>;
     let old_repr: ref array<BTreeNode<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref BTreeNode<String,i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l182: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref BTreeNode<String,i32>>(new_repr, i, builtin::array_get<ref BTreeNode<String,i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l182;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref BTreeNode<String,i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l182: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref BTreeNode<String,i32>>(new_repr, i, builtin::array_get<ref BTreeNode<String,i32>>(old_repr, i));
+                i = i + 1;
+                continue l182;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref BTreeNode<String,i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn BTreeNode<String,i32>::new_internal() {

--- a/wado-compiler/tests/fixtures.golden/treemap_btree2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree2.wir.wado
@@ -177,11 +177,17 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/BTreeNode<String,i32>::compact" = fn(ref BTreeNode<String,i32>);
 
 type "functype/Array<bool>::append" = fn(ref Array<bool>, bool);
 
+type "functype/Array<bool>::grow" = fn(ref Array<bool>);
+
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
+
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
 
 type "functype/TreeMap<String,i32>::needs_compaction" = fn(ref TreeMap<String,i32>) -> bool;
 
@@ -190,6 +196,8 @@ type "functype/TreeMap<String,i32>::iter" = fn(ref TreeMap<String,i32>) -> ref A
 type "functype/TreeMap<String,i32>::collect_entries" = fn(ref TreeMap<String,i32>, ref BTreeNode<String,i32>, ref Array<Tuple<String,i32>>);
 
 type "functype/Array<Tuple<String,i32>>::append" = fn(ref Array<Tuple<String,i32>>, ref "tuple/[String, i32]");
+
+type "functype/Array<Tuple<String,i32>>::grow" = fn(ref Array<Tuple<String,i32>>);
 
 type "functype/TreeMap<String,i32>::delete_in_node" = fn(ref TreeMap<String,i32>, ref BTreeNode<String,i32>, ref String) -> bool;
 
@@ -206,6 +214,8 @@ type "functype/TreeMap<String,i32>::sort_node_entries" = fn(ref TreeMap<String,i
 type "functype/TreeMap<String,i32>::split_child" = fn(ref TreeMap<String,i32>, ref BTreeNode<String,i32>, i32);
 
 type "functype/Array<BTreeNode<String,i32>>::append" = fn(ref Array<BTreeNode<String,i32>>, ref BTreeNode<String,i32>);
+
+type "functype/Array<BTreeNode<String,i32>>::grow" = fn(ref Array<BTreeNode<String,i32>>);
 
 type "functype/BTreeNode<String,i32>::new_internal" = fn() -> ref BTreeNode<String,i32>;
 
@@ -956,38 +966,44 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l51: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l51;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l51: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l51;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn BTreeNode<String,i32>::compact(self) {
@@ -1098,74 +1114,86 @@ fn BTreeNode<String,i32>::compact(self) {
 
 fn Array<bool>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<bool>;
-    let old_repr: ref array<bool>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<bool>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l65: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                    i = i + 1;
-                    continue l65;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<bool>::grow(self);
     };
     builtin::array_set<bool>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<bool>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<bool>;
+    let old_repr: ref array<bool>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<bool>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l65: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
+                i = i + 1;
+                continue l65;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l69: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l69;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l69: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l69;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::needs_compaction(self) {
@@ -1304,38 +1332,44 @@ fn TreeMap<String,i32>::collect_entries(self, node, result) {
 
 fn Array<Tuple<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,i32>>;
     let old_repr: ref array<Tuple<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l88: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
-                    i = i + 1;
-                    continue l88;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, i32]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l88: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, i32]">(new_repr, i, builtin::array_get<ref "tuple/[String, i32]">(old_repr, i));
+                i = i + 1;
+                continue l88;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, i32]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn TreeMap<String,i32>::delete_in_node(self, node, key) {
@@ -2051,38 +2085,44 @@ fn TreeMap<String,i32>::split_child(self, parent, child_index) {
 
 fn Array<BTreeNode<String,i32>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<BTreeNode<String,i32>>::grow(self);
+    };
+    builtin::array_set<ref BTreeNode<String,i32>>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<BTreeNode<String,i32>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<BTreeNode<String,i32>>;
     let old_repr: ref array<BTreeNode<String,i32>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref BTreeNode<String,i32>>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l180: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref BTreeNode<String,i32>>(new_repr, i, builtin::array_get<ref BTreeNode<String,i32>>(old_repr, i));
-                    i = i + 1;
-                    continue l180;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref BTreeNode<String,i32>>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l180: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref BTreeNode<String,i32>>(new_repr, i, builtin::array_get<ref BTreeNode<String,i32>>(old_repr, i));
+                i = i + 1;
+                continue l180;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref BTreeNode<String,i32>>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn BTreeNode<String,i32>::new_internal() {

--- a/wado-compiler/tests/fixtures.golden/try_op_option_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/try_op_option_basic.wir.wado
@@ -99,6 +99,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -595,38 +597,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l39: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l39;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l39: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l39;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/tuple_destruct_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_destruct_1.wir.wado
@@ -111,6 +111,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<i32,String>>::append" = fn(ref Array<Tuple<i32,String>>, ref "tuple/[i32, String]");
 
+type "functype/Array<Tuple<i32,String>>::grow" = fn(ref Array<Tuple<i32,String>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -611,38 +613,44 @@ fn ArrayIter<Tuple<i32,String>>^Iterator::next(self) {
 
 fn Array<Tuple<i32,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<i32,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[i32, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<i32,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<i32,String>>;
     let old_repr: ref array<Tuple<i32,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[i32, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l35: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[i32, String]">(new_repr, i, builtin::array_get<ref "tuple/[i32, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l35;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[i32, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l35: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[i32, String]">(new_repr, i, builtin::array_get<ref "tuple/[i32, String]">(old_repr, i));
+                i = i + 1;
+                continue l35;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[i32, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/tuple_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_for_of.wir.wado
@@ -147,6 +147,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -165,7 +167,11 @@ type "functype/String^Describe::describe" = fn(ref String) -> ref String;
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
+
+type "functype/Array<String>::grow" = fn(ref Array<String>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -2682,38 +2688,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l182: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l182;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l182: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l182;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {
@@ -3128,74 +3140,86 @@ fn String^Describe::describe(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l224: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l224;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i32>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l224: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l224;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<String>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
+    };
+    builtin::array_set<ref String>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<String>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<String>;
     let old_repr: ref array<String>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l228: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l228;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l228: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l228;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref String>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/type_cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/type_cast.wir.wado
@@ -155,6 +155,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -3098,38 +3100,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l186: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l186;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l186: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l186;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/u64_arithmetic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/u64_arithmetic.wir.wado
@@ -87,6 +87,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -735,38 +737,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l40;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l40;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/unary_neg_float.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/unary_neg_float.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1175,38 +1177,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/user_func.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/user_func.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1313,38 +1315,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l121: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l121;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l121: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l121;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/value_semantics.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/value_semantics.wir.wado
@@ -105,6 +105,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -619,38 +621,44 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/var_uninit_valid.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/var_uninit_valid.wir.wado
@@ -119,6 +119,8 @@ type "functype/write_decimal_digits" = fn(ref array<u8>, i32, i64, i32);
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -714,38 +716,44 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l41: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l41;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l41: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l41;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/variant_construct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_construct.wir.wado
@@ -133,7 +133,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -909,74 +913,86 @@ fn String::append_char(self, c) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<i32>;
-    let old_repr: ref array<i32>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l42: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l42;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
     };
     builtin::array_set<i32>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<i32>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<i32>;
+    let old_repr: ref array<i32>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l42: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l42;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l46: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l46;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l46: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l46;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/variant_if_let_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_if_let_basic.wir.wado
@@ -105,6 +105,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1191,38 +1193,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l117: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l117;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l117: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l117;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/variant_value_semantics.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_value_semantics.wir.wado
@@ -105,6 +105,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1188,38 +1190,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l118: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l118;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l118: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l118;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/wasi_cli.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_cli.wir.wado
@@ -107,7 +107,11 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
 
+type "functype/Array<String>::grow" = fn(ref Array<String>);
+
 type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
+
+type "functype/Array<Tuple<String,String>>::grow" = fn(ref Array<Tuple<String,String>>);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
@@ -580,74 +584,86 @@ fn String::append_char(self, c) {
 
 fn Array<String>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<String>;
-    let old_repr: ref array<String>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref String>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
-                    i = i + 1;
-                    continue l36;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<String>::grow(self);
     };
     builtin::array_set<ref String>(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<String>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<String>;
+    let old_repr: ref array<String>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref String>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref String>(new_repr, i, builtin::array_get<ref String>(old_repr, i));
+                i = i + 1;
+                continue l36;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<Tuple<String,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<String,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<String,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<String,String>>;
     let old_repr: ref array<Tuple<String,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l40: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l40;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[String, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l40: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[String, String]">(new_repr, i, builtin::array_get<ref "tuple/[String, String]">(old_repr, i));
+                i = i + 1;
+                continue l40;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[String, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem.wir.wado
@@ -98,6 +98,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<Descriptor,String>>::append" = fn(ref Array<Tuple<Descriptor,String>>, ref "tuple/[Descriptor, String]");
 
+type "functype/Array<Tuple<Descriptor,String>>::grow" = fn(ref Array<Tuple<Descriptor,String>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -537,38 +539,44 @@ fn String::append_char(self, c) {
 
 fn Array<Tuple<Descriptor,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<Descriptor,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<Descriptor,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<Descriptor,String>>;
     let old_repr: ref array<Tuple<Descriptor,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l36: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l36;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l36: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
+                i = i + 1;
+                continue l36;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem_open_at.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem_open_at.wir.wado
@@ -102,6 +102,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/Array<Tuple<Descriptor,String>>::append" = fn(ref Array<Tuple<Descriptor,String>>, ref "tuple/[Descriptor, String]");
 
+type "functype/Array<Tuple<Descriptor,String>>::grow" = fn(ref Array<Tuple<Descriptor,String>>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -496,38 +498,44 @@ fn String::append(self, other) {
 
 fn Array<Tuple<Descriptor,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<Descriptor,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<Descriptor,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<Descriptor,String>>;
     let old_repr: ref array<Tuple<Descriptor,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l25: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l25;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l25: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
+                i = i + 1;
+                continue l25;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem_read_stream.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem_read_stream.wir.wado
@@ -98,6 +98,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<Tuple<Descriptor,String>>::append" = fn(ref Array<Tuple<Descriptor,String>>, ref "tuple/[Descriptor, String]");
 
+type "functype/Array<Tuple<Descriptor,String>>::grow" = fn(ref Array<Tuple<Descriptor,String>>);
+
 type "functype/wasi/stream-drop-writable" = fn(i32);
 
 type "functype/wasi/stream-new" = fn() -> i64;
@@ -441,38 +443,44 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<Tuple<Descriptor,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<Descriptor,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<Descriptor,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<Descriptor,String>>;
     let old_repr: ref array<Tuple<Descriptor,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l20: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l20;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l20: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
+                i = i + 1;
+                continue l20;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem_read_transform_stream.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem_read_transform_stream.wir.wado
@@ -105,7 +105,11 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<Tuple<Descriptor,String>>::append" = fn(ref Array<Tuple<Descriptor,String>>, ref "tuple/[Descriptor, String]");
 
+type "functype/Array<Tuple<Descriptor,String>>::grow" = fn(ref Array<Tuple<Descriptor,String>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/wasi/stream-new" = fn() -> i64;
 
@@ -513,74 +517,86 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<Tuple<Descriptor,String>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<Descriptor,String>>;
-    let old_repr: ref array<Tuple<Descriptor,String>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l29;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<Descriptor,String>>::grow(self);
     };
     builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Tuple<Descriptor,String>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Tuple<Descriptor,String>>;
+    let old_repr: ref array<Tuple<Descriptor,String>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
+                i = i + 1;
+                continue l29;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l33: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l33;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l33: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l33;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem_stat.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem_stat.wir.wado
@@ -168,6 +168,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<Descriptor,String>>::append" = fn(ref Array<Tuple<Descriptor,String>>, ref "tuple/[Descriptor, String]");
 
+type "functype/Array<Tuple<Descriptor,String>>::grow" = fn(ref Array<Tuple<Descriptor,String>>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -897,38 +899,44 @@ fn String::append_char(self, c) {
 
 fn Array<Tuple<Descriptor,String>>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<Descriptor,String>>::grow(self);
+    };
+    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<Tuple<Descriptor,String>>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<Tuple<Descriptor,String>>;
     let old_repr: ref array<Tuple<Descriptor,String>>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l67: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l67;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l67: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
+                i = i + 1;
+                continue l67;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem_write_stream.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem_write_stream.wir.wado
@@ -103,7 +103,11 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/Array<Tuple<Descriptor,String>>::append" = fn(ref Array<Tuple<Descriptor,String>>, ref "tuple/[Descriptor, String]");
 
+type "functype/Array<Tuple<Descriptor,String>>::grow" = fn(ref Array<Tuple<Descriptor,String>>);
+
 type "functype/Array<u8>::append" = fn(ref Array<u8>, u8);
+
+type "functype/Array<u8>::grow" = fn(ref Array<u8>);
 
 type "functype/wasi/stream-new" = fn() -> i64;
 
@@ -454,74 +458,86 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn Array<Tuple<Descriptor,String>>::append(self, value) {
     let used: i32;
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref array<Tuple<Descriptor,String>>;
-    let old_repr: ref array<Tuple<Descriptor,String>>;
-    let i: i32;
-    let __local_8: i32;
     used = self.used;
-    capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l20: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
-                    i = i + 1;
-                    continue l20;
-                };
-            };
-        };
-        self.repr = ref.as_non_null(new_repr);
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<Tuple<Descriptor,String>>::grow(self);
     };
     builtin::array_set<ref "tuple/[Descriptor, String]">(self.repr, used, value);
     self.used = used + 1;
 }
 
+fn Array<Tuple<Descriptor,String>>::grow(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref array<Tuple<Descriptor,String>>;
+    let old_repr: ref array<Tuple<Descriptor,String>>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "tuple/[Descriptor, String]">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l20: loop {
+                if (i < used) == 0 {
+                    break __for_0;
+                };
+                builtin::array_set<ref "tuple/[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple/[Descriptor, String]">(old_repr, i));
+                i = i + 1;
+                continue l20;
+            };
+        };
+    };
+    self.repr = ref.as_non_null(new_repr);
+}
+
 fn Array<u8>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u8>::grow(self);
+    };
+    builtin::array_set_u8(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u8>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u8>;
     let old_repr: ref array<u8>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u8>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l24: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                    i = i + 1;
-                    continue l24;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u8>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l24: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
+                i = i + 1;
+                continue l24;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set_u8(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 export fn __cm_export__run as "run"

--- a/wado-compiler/tests/fixtures.golden/wasm_instructions_float_math.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_instructions_float_math.wir.wado
@@ -95,6 +95,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1767,38 +1769,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l123: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l123;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l123: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l123;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f32::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_newtype.wir.wado
@@ -99,6 +99,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::internal_reserve_uninit" = fn(ref String, i32) -> i32;
@@ -1233,38 +1235,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l122: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l122;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l122: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l122;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn i32::fmt_decimal(self, f) {

--- a/wado-compiler/tests/fixtures.golden/wasm_name_conflict_pub_use_alias.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasm_name_conflict_pub_use_alias.wir.wado
@@ -100,6 +100,8 @@ type "functype/fmt_float_special" = fn(ref Formatter, bool, enum:SpecialKind, re
 
 type "functype/Array<u64>::append" = fn(ref Array<u64>, u64);
 
+type "functype/Array<u64>::grow" = fn(ref Array<u64>);
+
 type "functype/String::grow" = fn(ref String, i32);
 
 type "functype/String::append_byte_filled" = fn(ref String, u8, i32);
@@ -1157,38 +1159,44 @@ fn fmt_float_special(f, is_neg, kind, zero_repr) {
 
 fn Array<u64>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<u64>::grow(self);
+    };
+    builtin::array_set<u64>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<u64>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<u64>;
     let old_repr: ref array<u64>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<u64>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l114: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                    i = i + 1;
-                    continue l114;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<u64>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l114: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
+                i = i + 1;
+                continue l114;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<u64>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn f64::fmt_into(self, f) {

--- a/wado-compiler/tests/fixtures.golden/while_let_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/while_let_basic.wir.wado
@@ -85,6 +85,8 @@ type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
 
+type "functype/Array<i32>::grow" = fn(ref Array<i32>);
+
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
 
 type "functype/Formatter::prepare_int_write" = fn(ref Formatter, bool, ref String, i32) -> i32;
@@ -433,38 +435,44 @@ fn ArrayIter<i32>^Iterator::next(self) {
 
 fn Array<i32>::append(self, value) {
     let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        Array<i32>::grow(self);
+    };
+    builtin::array_set<i32>(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn Array<i32>::grow(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref array<i32>;
     let old_repr: ref array<i32>;
+    let used: i32;
     let i: i32;
-    let __local_8: i32;
-    used = self.used;
+    let __local_7: i32;
     capacity = builtin::array_len(self.repr);
-    if builtin::unlikely(used >= capacity) {
-        new_capacity = __inline_i32_max_0: block -> i32 {
-            __local_8 = capacity * 2;
-            break __inline_i32_max_0: select i32(__local_8 > 4, __local_8, 4);
-        };
-        new_repr = builtin::array_new<i32>(new_capacity);
-        old_repr = self.repr;
-        __for_0: block {
-            i = 0;
-            block {
-                l29: loop {
-                    if (i < used) == 0 {
-                        break __for_0;
-                    };
-                    builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                    i = i + 1;
-                    continue l29;
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<i32>(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l29: loop {
+                if (i < used) == 0 {
+                    break __for_0;
                 };
+                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
+                i = i + 1;
+                continue l29;
             };
         };
-        self.repr = ref.as_non_null(new_repr);
     };
-    builtin::array_set<i32>(self.repr, used, value);
-    self.used = used + 1;
+    self.repr = ref.as_non_null(new_repr);
 }
 
 fn Formatter::write_char_n(self, c, n) {

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -4133,28 +4133,33 @@ fn "Array<u64>^SequenceLiteralBuilder::push_literal"(self: &mut Array<u64>, valu
 
 pub fn "Array<u64>::append"(self: &mut Array<u64>, value: u64) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = __inline_i32_max_0: {
-            let a: i32 = (capacity * 2);
-            break __inline_i32_max_0: "core::prelude/array.wado::core/builtin/select<i32>"((a > 4), a, 4);
-        };
-        let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-        let old_repr: builtin::array<u64> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u64>::grow"();
     }
     core::builtin::array_set::<u64>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = __inline_i32_max_0: {
+        let a: i32 = (capacity * 2);
+        break __inline_i32_max_0: "core::prelude/array.wado::core/builtin/select<i32>"((a > 4), a, 4);
+    };
+    let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
+    let old_repr: builtin::array<u64> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u64>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<u64> {
@@ -8589,27 +8594,32 @@ pub fn "Tuple<Tuple<String,i32>,Tuple<String,i32>,Tuple<String,i32>,Tuple<String
 
 pub fn "Array<char>::append"(self: &mut Array<char>, value: char) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-        let old_repr: builtin::array<char> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<char>::grow"();
     }
     core::builtin::array_set::<char>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<char>::grow"(self: &mut Array<char>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
+    let old_repr: builtin::array<char> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<char>^SequenceLiteralBuilder::build"(self: &Array<char>) -> Array<char> {
@@ -8626,27 +8636,32 @@ pub fn "Array<char>::with_capacity"(capacity: i32) -> Array<char> {
 
 pub fn "Array<u8>::append"(self: &mut Array<u8>, value: u8) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
-        let old_repr: builtin::array<u8> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u8>::grow"();
     }
     core::builtin::array_set::<u8>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
+    let old_repr: builtin::array<u8> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u8>^SequenceLiteralBuilder::build"(self: &Array<u8>) -> Array<u8> {
@@ -9968,27 +9983,32 @@ export fn __cm_export__run() {
 
 pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        let old_repr: builtin::array<String> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<String>::grow"();
     }
     core::builtin::array_set::<String>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<String>::grow"(self: &mut Array<String>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+    let old_repr: builtin::array<String> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 pub fn "Array<String>::with_capacity"(capacity: i32) -> Array<String> {
@@ -9997,27 +10017,32 @@ pub fn "Array<String>::with_capacity"(capacity: i32) -> Array<String> {
 
 pub fn "Array<Tuple<String,String>>::append"(self: &mut Array<[String, String]>, value: [String, String]) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
-        let old_repr: builtin::array<[String, String]> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<[String, String]>(new_repr, i, core::builtin::array_get::<[String, String]>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<Tuple<String,String>>::grow"();
     }
     core::builtin::array_set::<[String, String]>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<Tuple<String,String>>::grow"(self: &mut Array<[String, String]>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
+    let old_repr: builtin::array<[String, String]> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<[String, String]>(new_repr, i, core::builtin::array_get::<[String, String]>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 pub fn "Array<Tuple<String,String>>::with_capacity"(capacity: i32) -> Array<[String, String]> {
@@ -10059,27 +10084,32 @@ fn "Array<Array<i32>>^SequenceLiteralBuilder::push_literal"(self: &mut Array<Arr
 
 pub fn "Array<Array<i32>>::append"(self: &mut Array<Array<i32>>, value: Array<i32>) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<Array<i32>> = core::builtin::array_new::<Array<i32>>(new_capacity);
-        let old_repr: builtin::array<Array<i32>> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<Array<i32>>(new_repr, i, core::builtin::array_get::<Array<i32>>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<Array<i32>>::grow"();
     }
     core::builtin::array_set::<Array<i32>>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<Array<i32>>::grow"(self: &mut Array<Array<i32>>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<Array<i32>> = core::builtin::array_new::<Array<i32>>(new_capacity);
+    let old_repr: builtin::array<Array<i32>> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<Array<i32>>(new_repr, i, core::builtin::array_get::<Array<i32>>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<Array<i32>>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<Array<i32>> {
@@ -10100,27 +10130,32 @@ fn "Array<i32>^SequenceLiteralBuilder::push_literal"(self: &mut Array<i32>, valu
 
 pub fn "Array<i32>::append"(self: &mut Array<i32>, value: i32) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<i32> = core::builtin::array_new::<i32>(new_capacity);
-        let old_repr: builtin::array<i32> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<i32>(new_repr, i, core::builtin::array_get::<i32>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<i32>::grow"();
     }
     core::builtin::array_set::<i32>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<i32>::grow"(self: &mut Array<i32>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<i32> = core::builtin::array_new::<i32>(new_capacity);
+    let old_repr: builtin::array<i32> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<i32>(new_repr, i, core::builtin::array_get::<i32>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<i32>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<i32> {

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -3355,28 +3355,33 @@ fn "Array<u64>^SequenceLiteralBuilder::push_literal"(self: &mut Array<u64>, valu
 
 pub fn "Array<u64>::append"(self: &mut Array<u64>, value: u64) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = __inline_i32_max_0: {
-            let a: i32 = (capacity * 2);
-            break __inline_i32_max_0: "core::prelude/array.wado::core/builtin/select<i32>"((a > 4), a, 4);
-        };
-        let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-        let old_repr: builtin::array<u64> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u64>::grow"();
     }
     core::builtin::array_set::<u64>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = __inline_i32_max_0: {
+        let a: i32 = (capacity * 2);
+        break __inline_i32_max_0: "core::prelude/array.wado::core/builtin/select<i32>"((a > 4), a, 4);
+    };
+    let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
+    let old_repr: builtin::array<u64> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u64>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<u64> {
@@ -7481,27 +7486,32 @@ pub fn "Fn<1,i32>^Display::fmt"(self: &fn(i32) -> i32, f: &mut Formatter) {
 
 pub fn "Array<char>::append"(self: &mut Array<char>, value: char) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-        let old_repr: builtin::array<char> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<char>::grow"();
     }
     core::builtin::array_set::<char>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<char>::grow"(self: &mut Array<char>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
+    let old_repr: builtin::array<char> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<char>^SequenceLiteralBuilder::build"(self: &Array<char>) -> Array<char> {
@@ -7518,27 +7528,32 @@ pub fn "Array<char>::with_capacity"(capacity: i32) -> Array<char> {
 
 pub fn "Array<u8>::append"(self: &mut Array<u8>, value: u8) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
-        let old_repr: builtin::array<u8> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u8>::grow"();
     }
     core::builtin::array_set::<u8>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
+    let old_repr: builtin::array<u8> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u8>^SequenceLiteralBuilder::build"(self: &Array<u8>) -> Array<u8> {
@@ -10209,27 +10224,32 @@ export fn __cm_export__run() {
 
 pub fn "Array<String>::append"(self: &mut Array<String>, value: String) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-        let old_repr: builtin::array<String> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<String>::grow"();
     }
     core::builtin::array_set::<String>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<String>::grow"(self: &mut Array<String>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
+    let old_repr: builtin::array<String> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 pub fn "Array<String>::with_capacity"(capacity: i32) -> Array<String> {
@@ -10238,27 +10258,32 @@ pub fn "Array<String>::with_capacity"(capacity: i32) -> Array<String> {
 
 pub fn "Array<Tuple<String,String>>::append"(self: &mut Array<[String, String]>, value: [String, String]) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
-        let old_repr: builtin::array<[String, String]> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<[String, String]>(new_repr, i, core::builtin::array_get::<[String, String]>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<Tuple<String,String>>::grow"();
     }
     core::builtin::array_set::<[String, String]>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<Tuple<String,String>>::grow"(self: &mut Array<[String, String]>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
+    let old_repr: builtin::array<[String, String]> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<[String, String]>(new_repr, i, core::builtin::array_get::<[String, String]>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 pub fn "Array<Tuple<String,String>>::with_capacity"(capacity: i32) -> Array<[String, String]> {

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -2896,27 +2896,32 @@ fn "Array<u64>^SequenceLiteralBuilder::push_literal"(self: &mut Array<u64>, valu
 
 pub fn "Array<u64>::append"(self: &mut Array<u64>, value: u64) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-        let old_repr: builtin::array<u64> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u64>::grow"();
     }
     core::builtin::array_set::<u64>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
+    let old_repr: builtin::array<u64> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u64>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<u64> {
@@ -6949,27 +6954,32 @@ pub fn "Tuple<i128,i128>^Display::fmt"(self: &[i128, i128], f: &mut Formatter) {
 
 pub fn "Array<char>::append"(self: &mut Array<char>, value: char) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-        let old_repr: builtin::array<char> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<char>::grow"();
     }
     core::builtin::array_set::<char>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<char>::grow"(self: &mut Array<char>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
+    let old_repr: builtin::array<char> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<char>^SequenceLiteralBuilder::build"(self: &Array<char>) -> Array<char> {
@@ -6986,27 +6996,32 @@ pub fn "Array<char>::with_capacity"(capacity: i32) -> Array<char> {
 
 pub fn "Array<u8>::append"(self: &mut Array<u8>, value: u8) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
-        let old_repr: builtin::array<u8> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u8>::grow"();
     }
     core::builtin::array_set::<u8>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
+    let old_repr: builtin::array<u8> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u8>^SequenceLiteralBuilder::build"(self: &Array<u8>) -> Array<u8> {

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -2896,27 +2896,32 @@ fn "Array<u64>^SequenceLiteralBuilder::push_literal"(self: &mut Array<u64>, valu
 
 pub fn "Array<u64>::append"(self: &mut Array<u64>, value: u64) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-        let old_repr: builtin::array<u64> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u64>::grow"();
     }
     core::builtin::array_set::<u64>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
+    let old_repr: builtin::array<u64> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u64>^SequenceLiteralBuilder::new_literal"(capacity: i32) -> Array<u64> {
@@ -6949,27 +6954,32 @@ pub fn "Tuple<i128,i128>^Display::fmt"(self: &[i128, i128], f: &mut Formatter) {
 
 pub fn "Array<char>::append"(self: &mut Array<char>, value: char) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-        let old_repr: builtin::array<char> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<char>::grow"();
     }
     core::builtin::array_set::<char>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<char>::grow"(self: &mut Array<char>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
+    let old_repr: builtin::array<char> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<char>^SequenceLiteralBuilder::build"(self: &Array<char>) -> Array<char> {
@@ -6986,27 +6996,32 @@ pub fn "Array<char>::with_capacity"(capacity: i32) -> Array<char> {
 
 pub fn "Array<u8>::append"(self: &mut Array<u8>, value: u8) {
     let used: i32 = self.used;
-    let capacity: i32 = core::builtin::array_len(self.repr);
-    if core::builtin::unlikely((used >= capacity)) {
-        let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
-        let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
-        let old_repr: builtin::array<u8> = self.repr;
-        __for_0: {
-            let mut i: i32 = 0;
-            loop {
-                if !(i < used) {
-                    break __for_0;
-                }
-                __for_0_body: {
-                    core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-                }
-                i = (i + 1);
-            }
-        }
-        self.repr = new_repr;
+    if core::builtin::unlikely((used >= core::builtin::array_len(self.repr))) {
+        self."Array<u8>::grow"();
     }
     core::builtin::array_set::<u8>(self.repr, used, value);
     self.used = (used + 1);
+}
+
+pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
+    let capacity: i32 = core::builtin::array_len(self.repr);
+    let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
+    let new_repr: builtin::array<u8> = "core::prelude/string.wado::core/builtin/array_new<u8>"(new_capacity);
+    let old_repr: builtin::array<u8> = self.repr;
+    let used: i32 = self.used;
+    __for_0: {
+        let mut i: i32 = 0;
+        loop {
+            if !(i < used) {
+                break __for_0;
+            }
+            __for_0_body: {
+                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
+            }
+            i = (i + 1);
+        }
+    }
+    self.repr = new_repr;
 }
 
 fn "Array<u8>^SequenceLiteralBuilder::build"(self: &Array<u8>) -> Array<u8> {


### PR DESCRIPTION
## Summary
This PR optimizes array deserialization by deferring memory allocation until the first element is encountered, avoiding unnecessary allocations for empty arrays which are common in practice.

## Key Changes

- **Lazy allocation in `Deserialize` for `Array<T>`**: Modified the deserialization logic to peek at the first element before allocating backing storage. Empty arrays now avoid any capacity allocation, while non-empty arrays start with capacity 2 (growing to 4 as needed).

- **Extracted `grow()` method**: Refactored the array growth logic from `append()` into a dedicated `grow()` method in `array.wado` for better code reuse and maintainability.

- **Simplified `append()` implementation**: The `append()` method now delegates to the new `grow()` method, reducing code duplication while maintaining the same performance characteristics.

- **Updated `.gitignore`**: Added patterns for JIT dump files (`*.jitdump` and `jit-*.dump`) to exclude profiling artifacts from version control.

## Implementation Details

The deserialization optimization restructures the control flow to:
1. Attempt to read the first element without pre-allocating
2. If empty (first element is `None`), return an empty array immediately
3. If non-empty, allocate with `with_capacity(2)` and continue reading remaining elements

This approach is particularly beneficial for APIs that frequently return empty collections, eliminating unnecessary memory overhead while maintaining efficient growth for larger arrays.

https://claude.ai/code/session_01SnFPAtMg4nbtGNVvMBQj2M