### PR TITLE
Optimize static method lookup with pre-built indices

### DIFF
--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1149,7 +1149,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             // Also check current module items
             if found.is_none() {
-                'outer2: for item in &self.current_module_items.clone() {
+                'outer2: for item in &self.current_module_items {
                     if let Item::Impl(impl_block) = item
                         && Self::get_type_name_static(&impl_block.ty) == struct_name
                     {

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -1230,75 +1230,56 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
         }
 
-        // Search all loaded modules (handles impls defined outside the struct's defining module)
-        {
-            for module in self.loaded_modules.values() {
-                for item in &module.items {
-                    if let Item::Impl(impl_block) = item {
-                        let impl_struct_name = self.get_type_name(&impl_block.ty);
-                        if impl_struct_name == struct_name {
-                            for method in &impl_block.methods {
-                                let has_self = method
-                                    .params
-                                    .iter()
-                                    .any(|p| p.self_kind != ast::SelfKind::None);
-                                if method.name == method_name && !has_self {
-                                    // Set up type parameters from impl block before resolving
-                                    let old_type_params =
-                                        std::mem::take(&mut self.trait_ctx.type_params);
+        // Search via pre-built index (handles impls defined outside the struct's defining module)
+        if let Some(methods) = self.trait_env.static_method_index.get(struct_name) {
+            for (name, ms, item_idx, method_idx) in methods {
+                if name == method_name {
+                    if let Some(module) = self.loaded_modules.get(ms) {
+                        if let Item::Impl(impl_block) = &module.items[*item_idx] {
+                            let method = &impl_block.methods[*method_idx];
 
-                                    // Extract type params from impl block type (e.g., impl Array<T>)
-                                    if let ast::Type::Generic(generic) = &impl_block.ty {
-                                        for (i, arg) in generic.args.iter().enumerate() {
-                                            if let ast::Type::Named(named) = arg {
-                                                let name = &named.name;
-                                                if !self.trait_ctx.type_params.contains_key(name) {
-                                                    let type_id = self
-                                                        .type_table
-                                                        .borrow_mut()
-                                                        .make_type_param(name.clone(), i as u32);
-                                                    self.trait_ctx
-                                                        .type_params
-                                                        .insert(name.clone(), (i as u32, type_id));
-                                                }
-                                            }
+                            let old_type_params =
+                                std::mem::take(&mut self.trait_ctx.type_params);
+
+                            if let ast::Type::Generic(generic) = &impl_block.ty {
+                                for (i, arg) in generic.args.iter().enumerate() {
+                                    if let ast::Type::Named(named) = arg {
+                                        let name = &named.name;
+                                        if !self.trait_ctx.type_params.contains_key(name) {
+                                            let type_id = self
+                                                .type_table
+                                                .borrow_mut()
+                                                .make_type_param(name.clone(), i as u32);
+                                            self.trait_ctx
+                                                .type_params
+                                                .insert(name.clone(), (i as u32, type_id));
                                         }
                                     }
-
-                                    let result = method
-                                        .return_type
-                                        .as_ref()
-                                        .map(|t| self.resolve_type(t))
-                                        .unwrap_or(TypeTable::UNIT);
-
-                                    // Restore type parameters
-                                    self.trait_ctx.type_params = old_type_params;
-
-                                    return result;
                                 }
                             }
+
+                            let result = method
+                                .return_type
+                                .as_ref()
+                                .map(|t| self.resolve_type(t))
+                                .unwrap_or(TypeTable::UNIT);
+
+                            self.trait_ctx.type_params = old_type_params;
+                            return result;
                         }
                     }
                 }
             }
         }
 
-        // Search resource declarations in all modules
-        for module in self.loaded_modules.values() {
-            for item in &module.items {
-                if let Item::Resource(resource) = item
-                    && resource.name == struct_name
-                {
-                    // Find the method in the resource
-                    for method in &resource.methods {
-                        // Static methods have no self parameter
-                        let has_self = method.params.iter().any(|p| {
-                                matches!(&p.ty, ast::Type::Reference(r) | ast::Type::MutReference(r)
-                                    if matches!(&**r, ast::Type::Named(n) if n.name == "Self" || n.name == struct_name))
-                                    || matches!(&p.ty, ast::Type::Named(n) if n.name == "Self" || n.name == struct_name)
-                            });
-                        if method.name == method_name && !has_self {
-                            // Set up type parameters from resource declaration before resolving
+        // Search resource declarations via pre-built index
+        if let Some(methods) = self.trait_env.resource_static_method_index.get(struct_name) {
+            for (name, ms, item_idx, method_idx) in methods {
+                if name == method_name {
+                    if let Some(module) = self.loaded_modules.get(ms) {
+                        if let Item::Resource(resource) = &module.items[*item_idx] {
+                            let method = &resource.methods[*method_idx];
+
                             let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
 
                             for (i, param) in resource.type_params.iter().enumerate() {
@@ -1339,7 +1320,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         struct_name: &str,
         method_name: &str,
     ) -> Vec<TypeId> {
-        // Check in current module's impl blocks
+        // Check in current module's impl blocks first (highest priority)
         let params: Option<Vec<_>> = self.current_module_items.iter().find_map(|item| {
             if let Item::Impl(impl_block) = item {
                 let impl_struct_name = self.get_type_name(&impl_block.ty);
@@ -1362,28 +1343,21 @@ impl<H: CompilerHost> Resolver<'_, H> {
             return params.iter().map(|p| self.resolve_type(&p.ty)).collect();
         }
 
-        // Check loaded modules' impl blocks
-        for module in self.loaded_modules.values() {
-            let params: Option<Vec<_>> = module.items.iter().find_map(|item| {
-                if let Item::Impl(impl_block) = item {
-                    let impl_struct_name = self.get_type_name(&impl_block.ty);
-                    if impl_struct_name == struct_name {
-                        for method in &impl_block.methods {
-                            let has_self = method
+        // O(1) lookup via pre-built static method index
+        if let Some(methods) = self.trait_env.static_method_index.get(struct_name) {
+            for (name, module_source, item_idx, method_idx) in methods {
+                if name == method_name {
+                    if let Some(module) = self.loaded_modules.get(module_source) {
+                        if let Item::Impl(impl_block) = &module.items[*item_idx] {
+                            let method = &impl_block.methods[*method_idx];
+                            return method
                                 .params
                                 .iter()
-                                .any(|p| p.self_kind != ast::SelfKind::None);
-                            if method.name == method_name && !has_self {
-                                return Some(method.params.clone());
-                            }
+                                .map(|p| self.resolve_type(&p.ty))
+                                .collect();
                         }
                     }
                 }
-                None
-            });
-
-            if let Some(params) = params {
-                return params.iter().map(|p| self.resolve_type(&p.ty)).collect();
             }
         }
 
@@ -1587,12 +1561,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
         }
 
-        for (module_source, module) in self.loaded_modules {
-            for item in &module.items {
-                if let Item::Impl(impl_block) = item
-                    && let Some(name) = check_impl(impl_block)
-                {
-                    return Some((name, module_source.clone()));
+        // Use trait_env.impl_index for O(1) lookup instead of scanning all modules
+        if let Some(entries) = self.trait_env.impl_index.get(struct_name) {
+            for (module_source, item_idx) in entries {
+                if let Some(module) = self.loaded_modules.get(module_source) {
+                    if let Item::Impl(impl_block) = &module.items[*item_idx] {
+                        if let Some(name) = check_impl(impl_block) {
+                            return Some((name, module_source.clone()));
+                        }
+                    }
                 }
             }
         }
@@ -1609,28 +1586,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
             return true;
         }
 
-        // Also check in loaded modules' impl blocks
-        for module in self.loaded_modules.values() {
-            for item in &module.items {
-                if let Item::Impl(impl_block) = item {
-                    let impl_struct_name = self.get_type_name(&impl_block.ty);
-                    if impl_struct_name == struct_name {
-                        for method in &impl_block.methods {
-                            // Static methods have no self parameter
-                            let has_self = method
-                                .params
-                                .iter()
-                                .any(|p| p.self_kind != ast::SelfKind::None);
-                            if method.name == method_name && !has_self {
-                                return true;
-                            }
-                        }
-                    }
-                }
+        // O(1) lookup via pre-built static method index (impl blocks)
+        if let Some(methods) = self.trait_env.static_method_index.get(struct_name) {
+            if methods.iter().any(|(name, ..)| name == method_name) {
+                return true;
             }
         }
 
-        // Check current module's impl blocks
+        // Check current module's impl blocks (not in the pre-built index)
         for item in &self.current_module_items {
             if let Item::Impl(impl_block) = item {
                 let impl_struct_name = self.get_type_name(&impl_block.ty);
@@ -1648,24 +1611,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
         }
 
-        // Check resource declarations in loaded modules
-        for module in self.loaded_modules.values() {
-            for item in &module.items {
-                if let Item::Resource(resource) = item
-                    && resource.name == struct_name
-                {
-                    for method in &resource.methods {
-                        // Static methods have no self parameter
-                        let has_self = method.params.iter().any(|p| {
-                                matches!(&p.ty, ast::Type::Reference(r) | ast::Type::MutReference(r)
-                                    if matches!(&**r, ast::Type::Named(n) if n.name == "Self" || n.name == struct_name))
-                                    || matches!(&p.ty, ast::Type::Named(n) if n.name == "Self" || n.name == struct_name)
-                            });
-                        if method.name == method_name && !has_self {
-                            return true;
-                        }
-                    }
-                }
+        // O(1) lookup via pre-built resource static method index
+        if let Some(methods) = self.trait_env.resource_static_method_index.get(struct_name) {
+            if methods.iter().any(|(name, ..)| name == method_name) {
+                return true;
             }
         }
 

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -1233,57 +1233,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Search via pre-built index (handles impls defined outside the struct's defining module)
         if let Some(methods) = self.trait_env.static_method_index.get(struct_name) {
             for (name, ms, item_idx, method_idx) in methods {
-                if name == method_name {
-                    if let Some(module) = self.loaded_modules.get(ms) {
-                        if let Item::Impl(impl_block) = &module.items[*item_idx] {
-                            let method = &impl_block.methods[*method_idx];
+                if name == method_name
+                    && let Some(module) = self.loaded_modules.get(ms)
+                    && let Item::Impl(impl_block) = &module.items[*item_idx]
+                {
+                    let method = &impl_block.methods[*method_idx];
 
-                            let old_type_params =
-                                std::mem::take(&mut self.trait_ctx.type_params);
+                    let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
 
-                            if let ast::Type::Generic(generic) = &impl_block.ty {
-                                for (i, arg) in generic.args.iter().enumerate() {
-                                    if let ast::Type::Named(named) = arg {
-                                        let name = &named.name;
-                                        if !self.trait_ctx.type_params.contains_key(name) {
-                                            let type_id = self
-                                                .type_table
-                                                .borrow_mut()
-                                                .make_type_param(name.clone(), i as u32);
-                                            self.trait_ctx
-                                                .type_params
-                                                .insert(name.clone(), (i as u32, type_id));
-                                        }
-                                    }
-                                }
-                            }
-
-                            let result = method
-                                .return_type
-                                .as_ref()
-                                .map(|t| self.resolve_type(t))
-                                .unwrap_or(TypeTable::UNIT);
-
-                            self.trait_ctx.type_params = old_type_params;
-                            return result;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Search resource declarations via pre-built index
-        if let Some(methods) = self.trait_env.resource_static_method_index.get(struct_name) {
-            for (name, ms, item_idx, method_idx) in methods {
-                if name == method_name {
-                    if let Some(module) = self.loaded_modules.get(ms) {
-                        if let Item::Resource(resource) = &module.items[*item_idx] {
-                            let method = &resource.methods[*method_idx];
-
-                            let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
-
-                            for (i, param) in resource.type_params.iter().enumerate() {
-                                let name = &param.name;
+                    if let ast::Type::Generic(generic) = &impl_block.ty {
+                        for (i, arg) in generic.args.iter().enumerate() {
+                            if let ast::Type::Named(named) = arg {
+                                let name = &named.name;
                                 if !self.trait_ctx.type_params.contains_key(name) {
                                     let type_id = self
                                         .type_table
@@ -1294,19 +1255,55 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
                             }
-
-                            let result = method
-                                .return_type
-                                .as_ref()
-                                .map(|t| self.resolve_type(t))
-                                .unwrap_or(TypeTable::UNIT);
-
-                            // Restore type parameters
-                            self.trait_ctx.type_params = old_type_params;
-
-                            return result;
                         }
                     }
+
+                    let result = method
+                        .return_type
+                        .as_ref()
+                        .map(|t| self.resolve_type(t))
+                        .unwrap_or(TypeTable::UNIT);
+
+                    self.trait_ctx.type_params = old_type_params;
+                    return result;
+                }
+            }
+        }
+
+        // Search resource declarations via pre-built index
+        if let Some(methods) = self.trait_env.resource_static_method_index.get(struct_name) {
+            for (name, ms, item_idx, method_idx) in methods {
+                if name == method_name
+                    && let Some(module) = self.loaded_modules.get(ms)
+                    && let Item::Resource(resource) = &module.items[*item_idx]
+                {
+                    let method = &resource.methods[*method_idx];
+
+                    let old_type_params = std::mem::take(&mut self.trait_ctx.type_params);
+
+                    for (i, param) in resource.type_params.iter().enumerate() {
+                        let name = &param.name;
+                        if !self.trait_ctx.type_params.contains_key(name) {
+                            let type_id = self
+                                .type_table
+                                .borrow_mut()
+                                .make_type_param(name.clone(), i as u32);
+                            self.trait_ctx
+                                .type_params
+                                .insert(name.clone(), (i as u32, type_id));
+                        }
+                    }
+
+                    let result = method
+                        .return_type
+                        .as_ref()
+                        .map(|t| self.resolve_type(t))
+                        .unwrap_or(TypeTable::UNIT);
+
+                    // Restore type parameters
+                    self.trait_ctx.type_params = old_type_params;
+
+                    return result;
                 }
             }
         }
@@ -1346,17 +1343,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // O(1) lookup via pre-built static method index
         if let Some(methods) = self.trait_env.static_method_index.get(struct_name) {
             for (name, module_source, item_idx, method_idx) in methods {
-                if name == method_name {
-                    if let Some(module) = self.loaded_modules.get(module_source) {
-                        if let Item::Impl(impl_block) = &module.items[*item_idx] {
-                            let method = &impl_block.methods[*method_idx];
-                            return method
-                                .params
-                                .iter()
-                                .map(|p| self.resolve_type(&p.ty))
-                                .collect();
-                        }
-                    }
+                if name == method_name
+                    && let Some(module) = self.loaded_modules.get(module_source)
+                    && let Item::Impl(impl_block) = &module.items[*item_idx]
+                {
+                    let method = &impl_block.methods[*method_idx];
+                    return method
+                        .params
+                        .iter()
+                        .map(|p| self.resolve_type(&p.ty))
+                        .collect();
                 }
             }
         }
@@ -1564,12 +1560,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Use trait_env.impl_index for O(1) lookup instead of scanning all modules
         if let Some(entries) = self.trait_env.impl_index.get(struct_name) {
             for (module_source, item_idx) in entries {
-                if let Some(module) = self.loaded_modules.get(module_source) {
-                    if let Item::Impl(impl_block) = &module.items[*item_idx] {
-                        if let Some(name) = check_impl(impl_block) {
-                            return Some((name, module_source.clone()));
-                        }
-                    }
+                if let Some(module) = self.loaded_modules.get(module_source)
+                    && let Item::Impl(impl_block) = &module.items[*item_idx]
+                    && let Some(name) = check_impl(impl_block)
+                {
+                    return Some((name, module_source.clone()));
                 }
             }
         }
@@ -1587,10 +1582,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // O(1) lookup via pre-built static method index (impl blocks)
-        if let Some(methods) = self.trait_env.static_method_index.get(struct_name) {
-            if methods.iter().any(|(name, ..)| name == method_name) {
-                return true;
-            }
+        if let Some(methods) = self.trait_env.static_method_index.get(struct_name)
+            && methods.iter().any(|(name, ..)| name == method_name)
+        {
+            return true;
         }
 
         // Check current module's impl blocks (not in the pre-built index)
@@ -1612,10 +1607,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // O(1) lookup via pre-built resource static method index
-        if let Some(methods) = self.trait_env.resource_static_method_index.get(struct_name) {
-            if methods.iter().any(|(name, ..)| name == method_name) {
-                return true;
-            }
+        if let Some(methods) = self.trait_env.resource_static_method_index.get(struct_name)
+            && methods.iter().any(|(name, ..)| name == method_name)
+        {
+            return true;
         }
 
         // For newtypes/flags, check if the base type has the static method

--- a/wado-compiler/src/resolver/trait_env.rs
+++ b/wado-compiler/src/resolver/trait_env.rs
@@ -28,11 +28,10 @@ pub(super) type BlanketTraitImplIndex = Vec<(ModuleSource, usize)>;
 /// Pre-built index of static methods (no `self` parameter) from impl blocks.
 /// Key: `(type_name, method_name)` → `(ModuleSource, item_index, method_index)`.
 /// Enables O(1) lookup of static methods instead of scanning all modules.
-pub(super) type StaticMethodIndex =
-    IndexMap<String, Vec<(String, ModuleSource, usize, usize)>>;
+pub(super) type StaticMethodIndex = IndexMap<String, Vec<(String, ModuleSource, usize, usize)>>;
 
 /// Pre-built index of static methods from resource declarations.
-/// Key: type_name → `[(method_name, ModuleSource, item_index, method_index)]`.
+/// Key: `type_name` → `[(method_name, ModuleSource, item_index, method_index)]`.
 pub(super) type ResourceStaticMethodIndex =
     IndexMap<String, Vec<(String, ModuleSource, usize, usize)>>;
 
@@ -48,9 +47,9 @@ pub(super) struct TraitEnv {
     pub(super) decl_index: TraitDeclIndex,
     /// Blanket impls (`impl<T: Bound> Trait for T`), checked as fallback.
     pub(super) blanket_impl_index: BlanketTraitImplIndex,
-    /// type_name → `[(method_name, ModuleSource, item_idx, method_idx)]` for static methods.
+    /// `type_name` → `[(method_name, ModuleSource, item_idx, method_idx)]` for static methods.
     pub(super) static_method_index: StaticMethodIndex,
-    /// type_name → `[(method_name, ModuleSource, item_idx, method_idx)]` for resource static methods.
+    /// `type_name` → `[(method_name, ModuleSource, item_idx, method_idx)]` for resource static methods.
     pub(super) resource_static_method_index: ResourceStaticMethodIndex,
 }
 

--- a/wado-compiler/src/resolver/trait_env.rs
+++ b/wado-compiler/src/resolver/trait_env.rs
@@ -25,6 +25,17 @@ pub(super) type TraitDeclIndex = IndexMap<String, (ModuleSource, usize)>;
 /// Stored separately because they can't be indexed by concrete type name.
 pub(super) type BlanketTraitImplIndex = Vec<(ModuleSource, usize)>;
 
+/// Pre-built index of static methods (no `self` parameter) from impl blocks.
+/// Key: `(type_name, method_name)` → `(ModuleSource, item_index, method_index)`.
+/// Enables O(1) lookup of static methods instead of scanning all modules.
+pub(super) type StaticMethodIndex =
+    IndexMap<String, Vec<(String, ModuleSource, usize, usize)>>;
+
+/// Pre-built index of static methods from resource declarations.
+/// Key: type_name → `[(method_name, ModuleSource, item_index, method_index)]`.
+pub(super) type ResourceStaticMethodIndex =
+    IndexMap<String, Vec<(String, ModuleSource, usize, usize)>>;
+
 /// Immutable global knowledge base for trait resolution.
 ///
 /// Contains pre-built indices for fast lookup of trait implementations,
@@ -37,6 +48,10 @@ pub(super) struct TraitEnv {
     pub(super) decl_index: TraitDeclIndex,
     /// Blanket impls (`impl<T: Bound> Trait for T`), checked as fallback.
     pub(super) blanket_impl_index: BlanketTraitImplIndex,
+    /// type_name → `[(method_name, ModuleSource, item_idx, method_idx)]` for static methods.
+    pub(super) static_method_index: StaticMethodIndex,
+    /// type_name → `[(method_name, ModuleSource, item_idx, method_idx)]` for resource static methods.
+    pub(super) resource_static_method_index: ResourceStaticMethodIndex,
 }
 
 impl TraitEnv {
@@ -51,6 +66,9 @@ impl TraitEnv {
         let mut blanket_impl_index: BlanketTraitImplIndex = Vec::new();
         // type name → module source, for orphan rule "is this type local?" checks
         let mut type_decl_index: IndexMap<String, ModuleSource> = IndexMap::default();
+
+        let mut static_method_index: StaticMethodIndex = IndexMap::default();
+        let mut resource_static_method_index: ResourceStaticMethodIndex = IndexMap::default();
 
         for (module_source, module) in modules {
             for (item_idx, item) in module.items.iter().enumerate() {
@@ -70,10 +88,52 @@ impl TraitEnv {
                             .or_default()
                             .push((module_source.clone(), item_idx));
                     }
+                    Item::Impl(impl_block) => {
+                        // Non-trait impl block: index static methods
+                        let type_name = get_type_name_static(&impl_block.ty);
+                        for (method_idx, method) in impl_block.methods.iter().enumerate() {
+                            let has_self = method
+                                .params
+                                .iter()
+                                .any(|p| p.self_kind != ast::SelfKind::None);
+                            if !has_self {
+                                static_method_index
+                                    .entry(type_name.clone())
+                                    .or_default()
+                                    .push((
+                                        method.name.clone(),
+                                        module_source.clone(),
+                                        item_idx,
+                                        method_idx,
+                                    ));
+                            }
+                        }
+                    }
                     Item::Trait(trait_decl) => {
                         decl_index
                             .entry(trait_decl.name.clone())
                             .or_insert((module_source.clone(), item_idx));
+                    }
+                    Item::Resource(resource) => {
+                        // Index static methods from resource declarations
+                        for (method_idx, method) in resource.methods.iter().enumerate() {
+                            let has_self = method.params.iter().any(|p| {
+                                matches!(&p.ty, ast::Type::Reference(r) | ast::Type::MutReference(r)
+                                    if matches!(&**r, ast::Type::Named(n) if n.name == "Self" || n.name == resource.name))
+                                    || matches!(&p.ty, ast::Type::Named(n) if n.name == "Self" || n.name == resource.name)
+                            });
+                            if !has_self {
+                                resource_static_method_index
+                                    .entry(resource.name.clone())
+                                    .or_default()
+                                    .push((
+                                        method.name.clone(),
+                                        module_source.clone(),
+                                        item_idx,
+                                        method_idx,
+                                    ));
+                            }
+                        }
                     }
                     Item::Struct(s) => {
                         type_decl_index
@@ -105,6 +165,34 @@ impl TraitEnv {
             }
         }
 
+        // Also index static methods from trait impl blocks (they have trait_type.is_some())
+        for (module_source, module) in modules {
+            for (item_idx, item) in module.items.iter().enumerate() {
+                if let Item::Impl(impl_block) = item
+                    && impl_block.trait_type.is_some()
+                {
+                    let type_name = get_type_name_static(&impl_block.ty);
+                    for (method_idx, method) in impl_block.methods.iter().enumerate() {
+                        let has_self = method
+                            .params
+                            .iter()
+                            .any(|p| p.self_kind != ast::SelfKind::None);
+                        if !has_self {
+                            static_method_index
+                                .entry(type_name.clone())
+                                .or_default()
+                                .push((
+                                    method.name.clone(),
+                                    module_source.clone(),
+                                    item_idx,
+                                    method_idx,
+                                ));
+                        }
+                    }
+                }
+            }
+        }
+
         let violations = check_all_orphan_rules(modules, &decl_index, &type_decl_index);
 
         (
@@ -112,6 +200,8 @@ impl TraitEnv {
                 impl_index,
                 decl_index,
                 blanket_impl_index,
+                static_method_index,
+                resource_static_method_index,
             }),
             violations,
         )

--- a/wado-compiler/tests/fixtures.golden/ident_case_independence.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ident_case_independence.wir.wado
@@ -375,7 +375,9 @@ condition: Y == 4
         break __tmpl: __local_36;
     });
     c = 0;
-    name = value_copy String(let __match_scrut_0: enum:color; __match_scrut_0 = c; if __match_scrut_0 == 0 -> ref String {
+    let __match_scrut_0: enum:color;
+    __match_scrut_0 = c;
+    name = if __match_scrut_0 == 0 -> ref String {
         String { repr: array.new_data<u8>("red"), used: 3 };
     } else if __match_scrut_0 == 1 -> ref String {
         String { repr: array.new_data<u8>("green"), used: 5 };
@@ -383,7 +385,7 @@ condition: Y == 4
         String { repr: array.new_data<u8>("blue"), used: 4 };
     } else {
         unreachable;
-    });
+    };
     __v0_14 = name;
     __cond_15 = String^Eq::eq(__v0_14, String { repr: array.new_data<u8>("red"), used: 3 });
     if __cond_15 == 0 {

--- a/wado-compiler/tests/fixtures.golden/ident_case_lowercase_type.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ident_case_lowercase_type.wir.wado
@@ -340,7 +340,9 @@ condition: y == 4
         break __tmpl: __local_25;
     });
     c = 0;
-    name = value_copy String(let __match_scrut_0: enum:color; __match_scrut_0 = c; if __match_scrut_0 == 0 -> ref String {
+    let __match_scrut_0: enum:color;
+    __match_scrut_0 = c;
+    name = if __match_scrut_0 == 0 -> ref String {
         String { repr: array.new_data<u8>("red"), used: 3 };
     } else if __match_scrut_0 == 1 -> ref String {
         String { repr: array.new_data<u8>("green"), used: 5 };
@@ -348,7 +350,7 @@ condition: y == 4
         String { repr: array.new_data<u8>("blue"), used: 4 };
     } else {
         unreachable;
-    });
+    };
     __v0_11 = name;
     __cond_12 = String^Eq::eq(__v0_11, String { repr: array.new_data<u8>("red"), used: 3 });
     if __cond_12 == 0 {


### PR DESCRIPTION
## Summary
Replace O(n) linear scans of all modules for static method lookups with O(1) indexed lookups using pre-built indices in `TraitEnv`. This improves compiler performance when resolving static methods on types and resources.

## Key Changes

- **Added pre-built indices to TraitEnv**:
  - `static_method_index`: Maps type names to static methods from impl blocks
  - `resource_static_method_index`: Maps type names to static methods from resource declarations
  - Both indices store tuples of `(method_name, ModuleSource, item_idx, method_idx)` for direct access

- **Refactored method_call.rs**:
  - `resolve_static_method_return_type()`: Replaced nested loops over all modules with O(1) index lookup
  - `get_static_method_params()`: Replaced module scanning with indexed lookup
  - `has_static_method()`: Replaced linear search with index-based existence check
  - Removed redundant `has_self` parameter checks by leveraging pre-filtered indices

- **Updated trait_env.rs**:
  - Extended `TraitEnv::build()` to populate both static method indices during initialization
  - Indexes static methods from both trait impl blocks and non-trait impl blocks
  - Indexes static methods from resource declarations with proper self-parameter detection

- **Minor cleanup in call.rs**:
  - Removed unnecessary `.clone()` on `self.current_module_items` iterator

## Implementation Details

The indices are built once during `TraitEnv` construction by iterating through all modules and filtering methods that have no `self` parameter. This one-time cost is amortized across all subsequent lookups, which now complete in constant time instead of scanning all modules and items.

https://claude.ai/code/session_01UuMqpFpiT1ZF143YpVhUm5