### PR TITLE
Document wasmtime profiler characteristics and jitdump workflow

### DIFF
--- a/.claude/skills/profiler/SKILL.md
+++ b/.claude/skills/profiler/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: profiler
+description: Profile Wado programs using wasmtime's jitdump profiler and Linux perf.
+---
+
+# Profiling Wado Programs
+
+Profile Wado programs with `--profile jitdump` and Linux `perf` to identify hot functions and instructions.
+
+## Why jitdump?
+
+Wado aggressively inlines functions, so hot functions are often large inlined blobs. Function-level profiling ("run is hot") is not actionable. JitDump enables instruction-level annotation via `perf annotate`, revealing which inlined callee is the actual bottleneck.
+
+The guest profiler (`--profile guest`) does not work with the current CM-async runtime (produces 0 samples).
+
+## Workflow
+
+### 1. Record
+
+```sh
+perf record -k mono wado run --profile jitdump prog.wado
+```
+
+Or with cargo during development:
+
+```sh
+perf record -k mono cargo run --release --bin wado -- run --profile jitdump prog.wado
+```
+
+### 2. Inject JIT symbols
+
+```sh
+perf inject --jit -i perf.data -o perf.jit.data
+```
+
+### 3. Report (function-level)
+
+```sh
+perf report -i perf.jit.data
+```
+
+This shows which functions consume the most samples. Look for `wasm[1]::function[N]::name` entries — these are user Wasm functions compiled from Wado source.
+
+### 4. Annotate (instruction-level)
+
+```sh
+perf annotate -i perf.jit.data -s <function_name>
+```
+
+For example:
+
+```sh
+perf annotate -i perf.jit.data -s run
+perf annotate -i perf.jit.data -s inflate_raw_ex
+```
+
+This disassembles the function and shows per-instruction sample percentages. Use this to identify hot loops within inlined code.
+
+## Symbol naming
+
+Symbols include full monomorphization detail:
+
+```
+wasm[1]::function[78]::Status^Deserialize::deserialize<JsonDeserializer>
+wasm[1]::function[48]::deflate_with_level
+```
+
+Each function has both a long form (`wasm[1]::function[N]::name`) and a short alias (`name`).
+
+## Cleanup
+
+JitDump creates `jit-<pid>.dump` files (500-600 KB each) in the current working directory. Remove after analysis:
+
+```sh
+rm -f jit-*.dump perf.data perf.jit.data
+```
+
+## Notes
+
+- Runtime overhead is ~1% — measurements are not significantly distorted.
+- `perf record` requires Linux. There is no macOS equivalent for jitdump.
+- For background, see `docs/research/wasmtime-profiler-characteristics.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ cargo run --bin wado -- compile -o file.wasm file.wado    # generates Wasm
 cargo run --bin wado -- compile -o file.wat file.wado     # generates WAT
 cargo run --bin wado -- compile --wat-to-stdout file.wado # outputs WAT to stdout
 cargo run --bin wado -- run file.wado                     # run CLI program using wasmtime
-cargo run --bin wado -- run --profile MODE file.wado      # run with profiling
+cargo run --bin wado -- run --profile jitdump file.wado   # run with jitdump profiling (see below)
 cargo run --bin wado -- serve file.wado                   # serve HTTP service using wasmtime
 ```
 
@@ -183,6 +183,19 @@ Use `wado serve` to run a Wado HTTP service (wasi:http/service world):
 wado serve file.wado                        # serve on 0.0.0.0:8080 (default)
 wado serve --addr 127.0.0.1:3000 file.wado  # serve on custom address
 ```
+
+### Profiling with JitDump
+
+Use `--profile jitdump` with Linux `perf` for instruction-level profiling. This is necessary because Wado aggressively inlines functions, making function-level profiling insufficient.
+
+```sh
+perf record -k mono wado run --profile jitdump file.wado
+perf inject --jit -i perf.data -o perf.jit.data
+perf report -i perf.jit.data                        # function-level
+perf annotate -i perf.jit.data -s <function_name>   # instruction-level
+```
+
+See `docs/research/wasmtime-profiler-characteristics.md` for detailed comparison of profiling modes.
 
 ### Dump Command
 

--- a/docs/research/wasmtime-profiler-characteristics.md
+++ b/docs/research/wasmtime-profiler-characteristics.md
@@ -1,0 +1,173 @@
+# Wasmtime Profiler Characteristics Research
+
+Date: 2026-03-20
+
+## Overview
+
+Wasmtime provides 3 profiling modes. This document summarizes the characteristics
+of each based on running `zlib` (compress+decompress) and `json-twitter` (JSON parsing)
+benchmarks in the Wado project (wasmtime 42, component-model-async enabled).
+
+## Benchmark Results
+
+### zlib (100KB x 10 iterations, compress + decompress)
+
+| Mode     | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median | Overhead |
+|----------|-------|-------|-------|-------|-------|--------|----------|
+| none     | 360   | 362   | 363   | 361   | 387   | 362 ms | baseline |
+| guest    | 380   | 405   | 418   | 391   | 386   | 391 ms | +8.0%    |
+| jitdump  | 367   | 363   | 396   | 363   | 389   | 367 ms | +1.4%    |
+| perfmap  | 356   | 355   | 356   | 392   | 365   | 356 ms | -1.7%*  |
+
+\* Within measurement noise — effectively zero overhead.
+
+### json-twitter (631KB JSON, 100 statuses)
+
+| Mode     | Run 1  | Run 2  | Run 3  | Run 4  | Run 5  | Median  | Overhead |
+|----------|--------|--------|--------|--------|--------|---------|----------|
+| none     | 41.5   | 41.4   | 41.4   | 45.3   | 43.1   | 41.5 ms | baseline |
+| guest    | 47.9   | 43.4   | 44.3   | 42.4   | 42.6   | 43.4 ms | +4.6%    |
+| jitdump  | 41.8   | 41.8   | 44.6   | 41.5   | 41.5   | 41.8 ms | +0.7%    |
+| perfmap  | 42.7   | 41.1   | 41.4   | 42.7   | 44.6   | 42.7 ms | +2.9%    |
+
+## Profiler Characteristics
+
+### 1. Guest Profiler (`--profile guest`)
+
+**Mechanism:** Epoch-based sampling profiler built into wasmtime. A background thread
+increments the engine's epoch counter at a configurable interval (default: 10ms).
+When the epoch deadline is reached, a callback invokes `GuestProfiler::sample()` to
+capture the Wasm call stack.
+
+**Output:** Firefox Profiler JSON format (`profile.json`). Can be viewed at
+`https://profiler.firefox.com/`.
+
+**Strengths:**
+- Cross-platform (works on Linux, macOS, Windows)
+- Self-contained — no external tools required
+- Configurable sampling interval (down to 1ms)
+- Output includes call stacks with function names
+
+**Weaknesses:**
+- **Does not work with component-model-async (CM-async):** In the current Wado
+  runtime (wasmtime 42 with `component_model_async`, `component_model_async_builtins`,
+  `component_model_async_stackful` enabled), the guest profiler consistently produces
+  **0 samples**. The epoch deadline callback (`store.epoch_deadline_callback`) appears
+  to conflict with the concurrent execution model used by CM-async's `call_async` path,
+  which uses a different task scheduling mechanism than the traditional fiber-based async.
+- Highest runtime overhead (~5-8%) due to epoch interruption instrumentation
+- Sampling resolution limited to function entry points and loop headers
+- Function names may appear as `wasm function N` without debug info
+
+**Output files:** ~5-7 KB (empty due to 0 samples in CM-async mode)
+
+**Verdict:** Currently **non-functional** for Wado's CM-async runtime. Would need
+wasmtime fixes or a different integration approach to work with CM-async.
+
+### 2. JitDump Profiler (`--profile jitdump`)
+
+**Mechanism:** Writes a JIT dump file (`jit-<pid>.dump`) containing JIT-compiled code
+regions with their memory addresses, sizes, and symbol names. Designed to integrate
+with Linux `perf` via `perf inject --jit`.
+
+**Output:** Binary `jit-<pid>.dump` file in the current working directory.
+
+**Usage workflow:**
+```sh
+perf record -k mono wado run --profile jitdump prog.wado
+perf inject --jit --input perf.data --output perf.jit.data
+perf report --input perf.jit.data
+```
+
+**Strengths:**
+- Extremely low runtime overhead (~1%) — only writes symbol info at JIT time
+- Full system-level profiling (guest Wasm + host runtime + kernel)
+- Instruction-level precision when combined with `perf`
+- Rich symbol information: 69 functions for zlib, 148 for json-twitter
+- Includes function names from Wado source (e.g., `inflate_raw_ex`, `_status_field_lookup`)
+- Works correctly with CM-async
+
+**Weaknesses:**
+- Linux-only (requires `perf`)
+- Requires post-processing with `perf inject --jit`
+- Largest output files (~550-615 KB) because it includes JIT machine code
+- Requires `perf record` wrapper — can't profile standalone
+
+**Output files:** 553 KB (zlib), 615 KB (json-twitter)
+
+**Verdict:** Best choice for detailed performance analysis on Linux. The `perf inject`
+step adds complexity but provides the richest profiling data.
+
+### 3. PerfMap Profiler (`--profile perfmap`)
+
+**Mechanism:** Writes a `/tmp/perf-<pid>.map` text file mapping JIT-compiled code
+addresses to symbol names. This is the simplest integration with Linux `perf` —
+`perf report` can read these map files directly without the `perf inject` step.
+
+**Output:** Text file `/tmp/perf-<pid>.map` with format: `<address> <size> <name>`.
+
+**Usage workflow:**
+```sh
+perf record -k mono wado run --profile perfmap prog.wado
+perf report --input perf.data
+# Or with samply:
+samply record wado run --profile perfmap prog.wado
+```
+
+**Strengths:**
+- Effectively zero runtime overhead (within measurement noise)
+- Simpler workflow than jitdump — no `perf inject` step needed
+- Compatible with `samply` for Firefox Profiler visualization
+- Works correctly with CM-async
+- Small output files (~15-27 KB)
+- Rich symbol information: 258 entries for zlib, 446 for json-twitter
+  (more entries than jitdump because it includes component trampolines)
+
+**Weaknesses:**
+- Linux-only (requires `perf` or `samply`)
+- Less precise than jitdump — no machine code embedded in the map file
+- Map files accumulate in `/tmp` and are not auto-cleaned
+
+**Output files:** 15 KB (zlib), 27 KB (json-twitter)
+
+**Verdict:** Best choice for quick, low-overhead profiling on Linux. Simpler workflow
+than jitdump with comparable symbol quality.
+
+## Comparison Summary
+
+| Feature              | guest            | jitdump           | perfmap          |
+|----------------------|------------------|-------------------|------------------|
+| Platform             | Cross-platform   | Linux only        | Linux only       |
+| External tool needed | None             | `perf`            | `perf`/`samply`  |
+| Runtime overhead     | ~5-8%            | ~1%               | ~0%              |
+| CM-async compatible  | **No** (0 samps) | Yes               | Yes              |
+| Output format        | JSON             | Binary dump       | Text map         |
+| Output size (zlib)   | 5 KB (empty)     | 553 KB            | 15 KB            |
+| Post-processing      | None             | `perf inject`     | None             |
+| Profiling scope      | Guest only       | Guest + host + OS | Guest + host + OS|
+| Symbol quality       | N/A (broken)     | Good (69/148 fns) | Good (258/446)   |
+| Visualization        | Firefox Profiler | `perf report`     | `perf`/`samply`  |
+
+## Key Finding: Guest Profiler Incompatibility with CM-async
+
+The guest profiler is architecturally incompatible with wasmtime's component-model-async
+execution mode used in Wado. The root cause:
+
+1. The guest profiler uses `epoch_deadline_callback` to sample Wasm call stacks
+2. With CM-async (`wasm_component_model_async + async_builtins + async_stackful`),
+   `TypedFunc::call_async` enters the concurrent execution path (`concurrency_support()`)
+3. This concurrent path manages tasks differently from the traditional async fiber model
+4. The epoch callback either never fires or fires when no Wasm frames are on the stack
+
+This means the guest profiler requires either:
+- Wasmtime-side fixes to support profiling in CM-async mode
+- A separate profiling approach that doesn't rely on epoch interruption
+
+## Recommendations
+
+1. **For production profiling:** Use `perfmap` — zero overhead, simple workflow,
+   works with CM-async
+2. **For deep analysis:** Use `jitdump` — negligible overhead, instruction-level
+   precision with `perf`
+3. **For cross-platform:** The guest profiler needs fixes before it can be used
+   with Wado's CM-async runtime. Consider filing an issue upstream with wasmtime.

--- a/docs/research/wasmtime-profiler-characteristics.md
+++ b/docs/research/wasmtime-profiler-characteristics.md
@@ -77,26 +77,27 @@ with Linux `perf` via `perf inject --jit`.
 perf record -k mono wado run --profile jitdump prog.wado
 perf inject --jit --input perf.data --output perf.jit.data
 perf report --input perf.jit.data
+# Instruction-level annotation:
+perf annotate --input perf.jit.data -s <function_name>
 ```
 
 **Strengths:**
 - Extremely low runtime overhead (~1%) — only writes symbol info at JIT time
 - Full system-level profiling (guest Wasm + host runtime + kernel)
-- Instruction-level precision when combined with `perf`
-- Rich symbol information: 69 functions for zlib, 148 for json-twitter
-- Includes function names from Wado source (e.g., `inflate_raw_ex`, `_status_field_lookup`)
+- Instruction-level precision when combined with `perf annotate`
+- Rich symbol information with full monomorphized names
 - Works correctly with CM-async
 
 **Weaknesses:**
 - Linux-only (requires `perf`)
 - Requires post-processing with `perf inject --jit`
 - Largest output files (~550-615 KB) because it includes JIT machine code
-- Requires `perf record` wrapper — can't profile standalone
+- `jit-<pid>.dump` files created in the current working directory (need manual cleanup)
 
 **Output files:** 553 KB (zlib), 615 KB (json-twitter)
 
-**Verdict:** Best choice for detailed performance analysis on Linux. The `perf inject`
-step adds complexity but provides the richest profiling data.
+**Verdict:** Use when you need instruction-level hot-spot analysis within a specific
+function.
 
 ### 3. PerfMap Profiler (`--profile perfmap`)
 
@@ -110,7 +111,7 @@ addresses to symbol names. This is the simplest integration with Linux `perf` �
 ```sh
 perf record -k mono wado run --profile perfmap prog.wado
 perf report --input perf.data
-# Or with samply:
+# Or with samply (best UX — Firefox Profiler auto-opens):
 samply record wado run --profile perfmap prog.wado
 ```
 
@@ -120,33 +121,137 @@ samply record wado run --profile perfmap prog.wado
 - Compatible with `samply` for Firefox Profiler visualization
 - Works correctly with CM-async
 - Small output files (~15-27 KB)
-- Rich symbol information: 258 entries for zlib, 446 for json-twitter
-  (more entries than jitdump because it includes component trampolines)
 
 **Weaknesses:**
 - Linux-only (requires `perf` or `samply`)
-- Less precise than jitdump — no machine code embedded in the map file
+- Function-level granularity only — no instruction-level annotation
 - Map files accumulate in `/tmp` and are not auto-cleaned
 
 **Output files:** 15 KB (zlib), 27 KB (json-twitter)
 
-**Verdict:** Best choice for quick, low-overhead profiling on Linux. Simpler workflow
-than jitdump with comparable symbol quality.
+**Verdict:** Best default choice. Start here for any profiling task.
 
-## Comparison Summary
+## Deep Comparison: PerfMap vs JitDump
 
-| Feature              | guest            | jitdump           | perfmap          |
-|----------------------|------------------|-------------------|------------------|
-| Platform             | Cross-platform   | Linux only        | Linux only       |
-| External tool needed | None             | `perf`            | `perf`/`samply`  |
-| Runtime overhead     | ~5-8%            | ~1%               | ~0%              |
-| CM-async compatible  | **No** (0 samps) | Yes               | Yes              |
-| Output format        | JSON             | Binary dump       | Text map         |
-| Output size (zlib)   | 5 KB (empty)     | 553 KB            | 15 KB            |
-| Post-processing      | None             | `perf inject`     | None             |
-| Profiling scope      | Guest only       | Guest + host + OS | Guest + host + OS|
-| Symbol quality       | N/A (broken)     | Good (69/148 fns) | Good (258/446)   |
-| Visualization        | Firefox Profiler | `perf report`     | `perf`/`samply`  |
+Since the guest profiler is non-functional with CM-async, the practical choice is
+between PerfMap and JitDump. Both produce **identical symbol sets** (same function
+names, same monomorphization detail), but differ in what analysis they enable.
+
+### Symbol Quality (Identical)
+
+Both formats provide the same 258 symbols for zlib (129 unique functions × 2
+because each function has both a `wasm[1]::function[N]::name` and a short alias).
+Symbol names include full monomorphization detail:
+
+```
+wasm[1]::function[72]::TwitterResponse^Deserialize::deserialize<JsonDeserializer>
+wasm[1]::function[78]::Status^Deserialize::deserialize<JsonDeserializer>
+wasm[1]::function[84]::UserMention^Deserialize::deserialize<JsonDeserializer>
+```
+
+This means `perf report` can distinguish different monomorphized instances of
+the same generic function (e.g., `deserialize` for `Status` vs `UserMention`).
+
+### Data Granularity
+
+| Capability                    | PerfMap              | JitDump                        |
+|-------------------------------|----------------------|--------------------------------|
+| Function-level profiling      | Yes                  | Yes                            |
+| Which function is hot         | Yes                  | Yes                            |
+| Call graph (flat)             | Yes                  | Yes                            |
+| Call graph (with `--call-graph=dwarf`) | Host frames only | Host frames only       |
+| Instruction-level annotation  | **No**               | **Yes** (`perf annotate`)      |
+| Machine code disassembly      | **No**               | **Yes** (code embedded in dump)|
+| Source-line mapping (DWARF)   | No                   | No (no DEBUG_INFO records)     |
+
+Key difference: JitDump embeds the actual x86-64 machine code for every JIT-compiled
+function. This enables `perf annotate` to disassemble the function and attribute
+sample counts to individual instructions:
+
+```
+perf annotate --input perf.jit.data -s inflate_raw_ex
+```
+
+This tells you not just "inflate_raw_ex is hot" but *which loop or instruction
+within inflate_raw_ex* is the bottleneck.
+
+PerfMap only maps address ranges to function names. `perf report` shows which function
+is hot, but cannot zoom in further.
+
+Note: Neither format includes DWARF debug info (JitDump has CODE_LOAD records only,
+no DEBUG_INFO records), so neither can map back to Wado source lines. Attribution
+is at the machine-code instruction level (jitdump) or function level (perfmap).
+
+### Function Coverage
+
+For json-twitter (a real-world JSON parsing workload):
+
+| Category                    | Count | Example                                             |
+|-----------------------------|-------|------------------------------------------------------|
+| User Wasm functions         | 124   | `Status^Deserialize::deserialize<JsonDeserializer>` |
+| Internal Wasm (grow/realloc)| 2     | `grow_memory`, `realloc`                            |
+| Trampolines                 | 176   | `wasm_to_array_trampoline`, `native_to_wasm`        |
+| Wasmtime builtins           | 18    | `wasmtime_builtin_gc_alloc_raw`                     |
+| Component trampolines       | 48    | `component-trampolines[N]-array-call-*`             |
+
+Function size distribution (user Wasm, json-twitter):
+
+```
+  < 100 bytes:    17 functions
+  100-500 bytes:  33 functions
+  500-2KB:        35 functions
+  2KB-10KB:       36 functions
+  > 10KB:          3 functions (largest: 20.2 KB)
+```
+
+Both profilers cover all these categories equally.
+
+### Workflow Complexity
+
+| Step                        | PerfMap                                    | JitDump                                    |
+|-----------------------------|--------------------------------------------|--------------------------------------------|
+| 1. Record                   | `perf record -k mono wado run --profile perfmap ...` | `perf record -k mono wado run --profile jitdump ...` |
+| 2. Post-process             | —                                          | `perf inject --jit -i perf.data -o perf.jit.data` |
+| 3. Report                   | `perf report`                              | `perf report -i perf.jit.data`            |
+| 4. Annotate (optional)      | N/A                                        | `perf annotate -i perf.jit.data -s func`  |
+| Alternative                 | `samply record wado run --profile perfmap ...` | —                                     |
+| Cleanup                     | `/tmp/perf-*.map` (small)                  | `jit-*.dump` in CWD (550-615 KB each)    |
+
+### Output Size
+
+| Benchmark     | PerfMap | JitDump | Ratio  |
+|---------------|---------|---------|--------|
+| zlib          | 15 KB   | 553 KB  | 37×    |
+| json-twitter  | 27 KB   | 615 KB  | 23×    |
+
+JitDump files are 23-37× larger because they contain actual machine code bytes.
+
+## Decision Guide: Which Profiler to Use First?
+
+```
+Is the guest profiler working? (CM-async disabled)
+├── Yes → Use guest (cross-platform, self-contained, Firefox Profiler UI)
+└── No (CM-async enabled, as in Wado) →
+    │
+    Do you need instruction-level hot-spot analysis?
+    ├── No → Use perfmap (simplest, zero overhead, samply-compatible)
+    └── Yes → Use jitdump (enables perf annotate)
+```
+
+**Recommendation: Start with `perfmap`, escalate to `jitdump` when needed.**
+
+1. **First pass — `perfmap`:** Identify which functions are hot. Zero overhead means
+   your measurements are not distorted. Works with `samply` for a great UI.
+   This answers "where is time being spent?" at the function level.
+
+2. **Second pass — `jitdump`:** Once you've identified the hot function(s), re-run
+   with jitdump to get instruction-level annotation. `perf annotate` shows exactly
+   which loop or instruction is the bottleneck within that function.
+
+In practice, for Wado compiler optimization work, `perfmap` alone is usually sufficient
+because the actionable insight is at the function level (which Wado function to optimize,
+whether to inline, etc.). JitDump's instruction-level detail is most useful when
+optimizing Cranelift codegen quality for a specific hot function.
 
 ## Key Finding: Guest Profiler Incompatibility with CM-async
 
@@ -162,12 +267,3 @@ execution mode used in Wado. The root cause:
 This means the guest profiler requires either:
 - Wasmtime-side fixes to support profiling in CM-async mode
 - A separate profiling approach that doesn't rely on epoch interruption
-
-## Recommendations
-
-1. **For production profiling:** Use `perfmap` — zero overhead, simple workflow,
-   works with CM-async
-2. **For deep analysis:** Use `jitdump` — negligible overhead, instruction-level
-   precision with `perf`
-3. **For cross-platform:** The guest profiler needs fixes before it can be used
-   with Wado's CM-async runtime. Consider filing an issue upstream with wasmtime.

--- a/docs/research/wasmtime-profiler-characteristics.md
+++ b/docs/research/wasmtime-profiler-characteristics.md
@@ -226,32 +226,46 @@ Both profilers cover all these categories equally.
 
 JitDump files are 23-37× larger because they contain actual machine code bytes.
 
-## Decision Guide: Which Profiler to Use First?
+## Decision Guide: Which Profiler to Use?
 
 ```
 Is the guest profiler working? (CM-async disabled)
 ├── Yes → Use guest (cross-platform, self-contained, Firefox Profiler UI)
-└── No (CM-async enabled, as in Wado) →
-    │
-    Do you need instruction-level hot-spot analysis?
-    ├── No → Use perfmap (simplest, zero overhead, samply-compatible)
-    └── Yes → Use jitdump (enables perf annotate)
+└── No (CM-async enabled, as in Wado) → Use jitdump
 ```
 
-**Recommendation: Start with `perfmap`, escalate to `jitdump` when needed.**
+**Recommendation: Use `jitdump` as the default profiler for Wado.**
 
-1. **First pass — `perfmap`:** Identify which functions are hot. Zero overhead means
-   your measurements are not distorted. Works with `samply` for a great UI.
-   This answers "where is time being spent?" at the function level.
+Wado's compiler aggressively inlines functions (`#[inline]`, `#[inline(always)]`,
+and optimizer-driven inlining). This means the "hot function" in a profile is often
+a large inlined blob (e.g., `run` at 7.6 KB containing dozens of inlined callees).
+Function-level attribution (perfmap) would only tell you "run is hot" — not *which
+inlined callee* within `run` is the actual bottleneck.
 
-2. **Second pass — `jitdump`:** Once you've identified the hot function(s), re-run
-   with jitdump to get instruction-level annotation. `perf annotate` shows exactly
-   which loop or instruction is the bottleneck within that function.
+JitDump solves this because `perf annotate` shows instruction-level sample attribution
+within the inlined function body. Even without DWARF debug info, you can identify
+hot loops and correlate instruction patterns back to specific Wado source operations.
 
-In practice, for Wado compiler optimization work, `perfmap` alone is usually sufficient
-because the actionable insight is at the function level (which Wado function to optimize,
-whether to inline, etc.). JitDump's instruction-level detail is most useful when
-optimizing Cranelift codegen quality for a specific hot function.
+**When to use perfmap instead:**
+- Quick sanity checks where you only need "is this function hot at all?"
+- When using `samply` for Firefox Profiler visualization (samply reads perfmap but
+  not jitdump)
+- When output file size matters (perfmap is 23-37× smaller)
+
+**Typical workflow:**
+```sh
+# 1. Record with jitdump
+perf record -k mono wado run --profile jitdump prog.wado
+
+# 2. Inject JIT symbols
+perf inject --jit -i perf.data -o perf.jit.data
+
+# 3. See which functions are hot
+perf report -i perf.jit.data
+
+# 4. Drill into a hot function's instructions
+perf annotate -i perf.jit.data -s run
+```
 
 ## Key Finding: Guest Profiler Incompatibility with CM-async
 

--- a/docs/research/wasmtime-profiler-characteristics.md
+++ b/docs/research/wasmtime-profiler-characteristics.md
@@ -12,23 +12,23 @@ benchmarks in the Wado project (wasmtime 42, component-model-async enabled).
 
 ### zlib (100KB x 10 iterations, compress + decompress)
 
-| Mode     | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median | Overhead |
-|----------|-------|-------|-------|-------|-------|--------|----------|
-| none     | 360   | 362   | 363   | 361   | 387   | 362 ms | baseline |
-| guest    | 380   | 405   | 418   | 391   | 386   | 391 ms | +8.0%    |
-| jitdump  | 367   | 363   | 396   | 363   | 389   | 367 ms | +1.4%    |
-| perfmap  | 356   | 355   | 356   | 392   | 365   | 356 ms | -1.7%*  |
+| Mode    | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median | Overhead |
+| ------- | ----- | ----- | ----- | ----- | ----- | ------ | -------- |
+| none    | 360   | 362   | 363   | 361   | 387   | 362 ms | baseline |
+| guest   | 380   | 405   | 418   | 391   | 386   | 391 ms | +8.0%    |
+| jitdump | 367   | 363   | 396   | 363   | 389   | 367 ms | +1.4%    |
+| perfmap | 356   | 355   | 356   | 392   | 365   | 356 ms | -1.7%*   |
 
 \* Within measurement noise — effectively zero overhead.
 
 ### json-twitter (631KB JSON, 100 statuses)
 
-| Mode     | Run 1  | Run 2  | Run 3  | Run 4  | Run 5  | Median  | Overhead |
-|----------|--------|--------|--------|--------|--------|---------|----------|
-| none     | 41.5   | 41.4   | 41.4   | 45.3   | 43.1   | 41.5 ms | baseline |
-| guest    | 47.9   | 43.4   | 44.3   | 42.4   | 42.6   | 43.4 ms | +4.6%    |
-| jitdump  | 41.8   | 41.8   | 44.6   | 41.5   | 41.5   | 41.8 ms | +0.7%    |
-| perfmap  | 42.7   | 41.1   | 41.4   | 42.7   | 44.6   | 42.7 ms | +2.9%    |
+| Mode    | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median  | Overhead |
+| ------- | ----- | ----- | ----- | ----- | ----- | ------- | -------- |
+| none    | 41.5  | 41.4  | 41.4  | 45.3  | 43.1  | 41.5 ms | baseline |
+| guest   | 47.9  | 43.4  | 44.3  | 42.4  | 42.6  | 43.4 ms | +4.6%    |
+| jitdump | 41.8  | 41.8  | 44.6  | 41.5  | 41.5  | 41.8 ms | +0.7%    |
+| perfmap | 42.7  | 41.1  | 41.4  | 42.7  | 44.6  | 42.7 ms | +2.9%    |
 
 ## Profiler Characteristics
 
@@ -43,12 +43,14 @@ capture the Wasm call stack.
 `https://profiler.firefox.com/`.
 
 **Strengths:**
+
 - Cross-platform (works on Linux, macOS, Windows)
 - Self-contained — no external tools required
 - Configurable sampling interval (down to 1ms)
 - Output includes call stacks with function names
 
 **Weaknesses:**
+
 - **Does not work with component-model-async (CM-async):** In the current Wado
   runtime (wasmtime 42 with `component_model_async`, `component_model_async_builtins`,
   `component_model_async_stackful` enabled), the guest profiler consistently produces
@@ -73,6 +75,7 @@ with Linux `perf` via `perf inject --jit`.
 **Output:** Binary `jit-<pid>.dump` file in the current working directory.
 
 **Usage workflow:**
+
 ```sh
 perf record -k mono wado run --profile jitdump prog.wado
 perf inject --jit --input perf.data --output perf.jit.data
@@ -82,6 +85,7 @@ perf annotate --input perf.jit.data -s <function_name>
 ```
 
 **Strengths:**
+
 - Extremely low runtime overhead (~1%) — only writes symbol info at JIT time
 - Full system-level profiling (guest Wasm + host runtime + kernel)
 - Instruction-level precision when combined with `perf annotate`
@@ -89,6 +93,7 @@ perf annotate --input perf.jit.data -s <function_name>
 - Works correctly with CM-async
 
 **Weaknesses:**
+
 - Linux-only (requires `perf`)
 - Requires post-processing with `perf inject --jit`
 - Largest output files (~550-615 KB) because it includes JIT machine code
@@ -108,6 +113,7 @@ addresses to symbol names. This is the simplest integration with Linux `perf` �
 **Output:** Text file `/tmp/perf-<pid>.map` with format: `<address> <size> <name>`.
 
 **Usage workflow:**
+
 ```sh
 perf record -k mono wado run --profile perfmap prog.wado
 perf report --input perf.data
@@ -116,6 +122,7 @@ samply record wado run --profile perfmap prog.wado
 ```
 
 **Strengths:**
+
 - Effectively zero runtime overhead (within measurement noise)
 - Simpler workflow than jitdump — no `perf inject` step needed
 - Compatible with `samply` for Firefox Profiler visualization
@@ -123,6 +130,7 @@ samply record wado run --profile perfmap prog.wado
 - Small output files (~15-27 KB)
 
 **Weaknesses:**
+
 - Linux-only (requires `perf` or `samply`)
 - Function-level granularity only — no instruction-level annotation
 - Map files accumulate in `/tmp` and are not auto-cleaned
@@ -154,15 +162,15 @@ the same generic function (e.g., `deserialize` for `Status` vs `UserMention`).
 
 ### Data Granularity
 
-| Capability                    | PerfMap              | JitDump                        |
-|-------------------------------|----------------------|--------------------------------|
-| Function-level profiling      | Yes                  | Yes                            |
-| Which function is hot         | Yes                  | Yes                            |
-| Call graph (flat)             | Yes                  | Yes                            |
-| Call graph (with `--call-graph=dwarf`) | Host frames only | Host frames only       |
-| Instruction-level annotation  | **No**               | **Yes** (`perf annotate`)      |
-| Machine code disassembly      | **No**               | **Yes** (code embedded in dump)|
-| Source-line mapping (DWARF)   | No                   | No (no DEBUG_INFO records)     |
+| Capability                             | PerfMap          | JitDump                         |
+| -------------------------------------- | ---------------- | ------------------------------- |
+| Function-level profiling               | Yes              | Yes                             |
+| Which function is hot                  | Yes              | Yes                             |
+| Call graph (flat)                      | Yes              | Yes                             |
+| Call graph (with `--call-graph=dwarf`) | Host frames only | Host frames only                |
+| Instruction-level annotation           | **No**           | **Yes** (`perf annotate`)       |
+| Machine code disassembly               | **No**           | **Yes** (code embedded in dump) |
+| Source-line mapping (DWARF)            | No               | No (no DEBUG_INFO records)      |
 
 Key difference: JitDump embeds the actual x86-64 machine code for every JIT-compiled
 function. This enables `perf annotate` to disassemble the function and attribute
@@ -172,8 +180,8 @@ sample counts to individual instructions:
 perf annotate --input perf.jit.data -s inflate_raw_ex
 ```
 
-This tells you not just "inflate_raw_ex is hot" but *which loop or instruction
-within inflate_raw_ex* is the bottleneck.
+This tells you not just "inflate_raw_ex is hot" but _which loop or instruction
+within inflate_raw_ex_ is the bottleneck.
 
 PerfMap only maps address ranges to function names. `perf report` shows which function
 is hot, but cannot zoom in further.
@@ -186,43 +194,43 @@ is at the machine-code instruction level (jitdump) or function level (perfmap).
 
 For json-twitter (a real-world JSON parsing workload):
 
-| Category                    | Count | Example                                             |
-|-----------------------------|-------|------------------------------------------------------|
-| User Wasm functions         | 124   | `Status^Deserialize::deserialize<JsonDeserializer>` |
-| Internal Wasm (grow/realloc)| 2     | `grow_memory`, `realloc`                            |
-| Trampolines                 | 176   | `wasm_to_array_trampoline`, `native_to_wasm`        |
-| Wasmtime builtins           | 18    | `wasmtime_builtin_gc_alloc_raw`                     |
-| Component trampolines       | 48    | `component-trampolines[N]-array-call-*`             |
+| Category                     | Count | Example                                             |
+| ---------------------------- | ----- | --------------------------------------------------- |
+| User Wasm functions          | 124   | `Status^Deserialize::deserialize<JsonDeserializer>` |
+| Internal Wasm (grow/realloc) | 2     | `grow_memory`, `realloc`                            |
+| Trampolines                  | 176   | `wasm_to_array_trampoline`, `native_to_wasm`        |
+| Wasmtime builtins            | 18    | `wasmtime_builtin_gc_alloc_raw`                     |
+| Component trampolines        | 48    | `component-trampolines[N]-array-call-*`             |
 
 Function size distribution (user Wasm, json-twitter):
 
 ```
-  < 100 bytes:    17 functions
-  100-500 bytes:  33 functions
-  500-2KB:        35 functions
-  2KB-10KB:       36 functions
-  > 10KB:          3 functions (largest: 20.2 KB)
+< 100 bytes:    17 functions
+100-500 bytes:  33 functions
+500-2KB:        35 functions
+2KB-10KB:       36 functions
+> 10KB:          3 functions (largest: 20.2 KB)
 ```
 
 Both profilers cover all these categories equally.
 
 ### Workflow Complexity
 
-| Step                        | PerfMap                                    | JitDump                                    |
-|-----------------------------|--------------------------------------------|--------------------------------------------|
-| 1. Record                   | `perf record -k mono wado run --profile perfmap ...` | `perf record -k mono wado run --profile jitdump ...` |
-| 2. Post-process             | —                                          | `perf inject --jit -i perf.data -o perf.jit.data` |
-| 3. Report                   | `perf report`                              | `perf report -i perf.jit.data`            |
-| 4. Annotate (optional)      | N/A                                        | `perf annotate -i perf.jit.data -s func`  |
-| Alternative                 | `samply record wado run --profile perfmap ...` | —                                     |
-| Cleanup                     | `/tmp/perf-*.map` (small)                  | `jit-*.dump` in CWD (550-615 KB each)    |
+| Step                   | PerfMap                                              | JitDump                                              |
+| ---------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| 1. Record              | `perf record -k mono wado run --profile perfmap ...` | `perf record -k mono wado run --profile jitdump ...` |
+| 2. Post-process        | —                                                    | `perf inject --jit -i perf.data -o perf.jit.data`    |
+| 3. Report              | `perf report`                                        | `perf report -i perf.jit.data`                       |
+| 4. Annotate (optional) | N/A                                                  | `perf annotate -i perf.jit.data -s func`             |
+| Alternative            | `samply record wado run --profile perfmap ...`       | —                                                    |
+| Cleanup                | `/tmp/perf-*.map` (small)                            | `jit-*.dump` in CWD (550-615 KB each)                |
 
 ### Output Size
 
-| Benchmark     | PerfMap | JitDump | Ratio  |
-|---------------|---------|---------|--------|
-| zlib          | 15 KB   | 553 KB  | 37×    |
-| json-twitter  | 27 KB   | 615 KB  | 23×    |
+| Benchmark    | PerfMap | JitDump | Ratio |
+| ------------ | ------- | ------- | ----- |
+| zlib         | 15 KB   | 553 KB  | 37×   |
+| json-twitter | 27 KB   | 615 KB  | 23×   |
 
 JitDump files are 23-37× larger because they contain actual machine code bytes.
 
@@ -239,20 +247,22 @@ Is the guest profiler working? (CM-async disabled)
 Wado's compiler aggressively inlines functions (`#[inline]`, `#[inline(always)]`,
 and optimizer-driven inlining). This means the "hot function" in a profile is often
 a large inlined blob (e.g., `run` at 7.6 KB containing dozens of inlined callees).
-Function-level attribution (perfmap) would only tell you "run is hot" — not *which
-inlined callee* within `run` is the actual bottleneck.
+Function-level attribution (perfmap) would only tell you "run is hot" — not _which
+inlined callee_ within `run` is the actual bottleneck.
 
 JitDump solves this because `perf annotate` shows instruction-level sample attribution
 within the inlined function body. Even without DWARF debug info, you can identify
 hot loops and correlate instruction patterns back to specific Wado source operations.
 
 **When to use perfmap instead:**
+
 - Quick sanity checks where you only need "is this function hot at all?"
 - When using `samply` for Firefox Profiler visualization (samply reads perfmap but
   not jitdump)
 - When output file size matters (perfmap is 23-37× smaller)
 
 **Typical workflow:**
+
 ```sh
 # 1. Record with jitdump
 perf record -k mono wado run --profile jitdump prog.wado
@@ -279,5 +289,6 @@ execution mode used in Wado. The root cause:
 4. The epoch callback either never fires or fires when no Wasm frames are on the stack
 
 This means the guest profiler requires either:
+
 - Wasmtime-side fixes to support profiling in CM-async mode
 - A separate profiling approach that doesn't rely on epoch interruption


### PR DESCRIPTION
## Summary

Add comprehensive profiling documentation for Wado, including research on wasmtime's three profiling modes and a practical guide for using jitdump with Linux perf.

## Key Changes

- **New research document** (`docs/research/wasmtime-profiler-characteristics.md`): Detailed analysis of wasmtime's three profiling modes (guest, jitdump, perfmap) with benchmark data showing runtime overhead, output characteristics, and a decision guide. Documents the critical finding that the guest profiler is incompatible with component-model-async (CM-async) in the current Wado runtime.

- **New profiler skill guide** (`.claude/skills/profiler/SKILL.md`): Quick-reference guide for profiling Wado programs with jitdump, including the complete workflow (record → inject → report → annotate) and explanation of why jitdump is necessary for Wado's aggressive inlining strategy.

- **Updated AGENTS.md**: Added profiling section with jitdump command examples and reference to the detailed research document.

## Notable Details

- **Guest profiler incompatibility**: The research identifies that wasmtime's epoch-based guest profiler produces 0 samples with CM-async due to architectural conflicts between epoch interruption and concurrent task scheduling. This is a key finding that explains why jitdump is the recommended approach.

- **Benchmark data**: Includes runtime overhead measurements for all three modes on real workloads (zlib and json-twitter), showing jitdump has ~1% overhead vs ~5-8% for guest profiler.

- **Instruction-level profiling rationale**: Documents why function-level profiling is insufficient for Wado due to aggressive inlining, and how jitdump's `perf annotate` capability solves this by showing per-instruction sample attribution.

- **Symbol quality**: Both jitdump and perfmap provide identical symbol sets with full monomorphization detail, enabling distinction between different instantiations of generic functions.

https://claude.ai/code/session_014LwixYCpZfAGhnNECPmSLF