### PR TITLE
Use dev-optimized profile for E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o0
+      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o0
 
   test-e2e-o1:
     name: Test (E2E O1)
@@ -108,9 +110,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o1
+      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o1
 
   test-e2e-o3:
     name: Test (E2E O3)
@@ -120,9 +124,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o3
+      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o3
 
   test-e2e-os:
     name: Test (E2E Os)
@@ -132,9 +138,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_os
+      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_os
 
   test-wado:
     name: Test (Wado)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o0
@@ -110,8 +108,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o1
@@ -124,8 +120,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o3
@@ -138,8 +132,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: e2e
       - uses: rui314/setup-mold@v1
 
       - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_os


### PR DESCRIPTION
## Summary
Updated all E2E test jobs in the CI workflow to use the `dev-optimized` Cargo profile instead of the default dev profile, improving test execution performance while maintaining faster compilation times compared to release builds.

## Changes
- Updated `test-e2e-o0` job to use `--profile dev-optimized`
- Updated `test-e2e-o1` job to use `--profile dev-optimized`
- Updated `test-e2e-o3` job to use `--profile dev-optimized`
- Updated `test-e2e-os` job to use `--profile dev-optimized`

## Details
The `dev-optimized` profile provides a balance between compilation speed and runtime performance, which is beneficial for E2E tests that may be sensitive to performance characteristics while still maintaining reasonable CI build times.

https://claude.ai/code/session_01HLfpUkyrV1yNMQqJCiYfgd