### PR TITLE
Update benchmark results with latest Wado version

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -112,7 +112,7 @@ mise run benchmark-json-catalog
 
 | Component  | Version      |
 | ---------- | ------------ |
-| Wado       | 2026-03-20   |
+| Wado       | 2026-03-21   |
 | wasmtime   | 42.0.1       |
 | Node.js    | v24.14.0     |
 | C compiler | gcc 13.3.0   |
@@ -144,9 +144,9 @@ All implementations produce the same result: 664,579 primes.
 
 | Runtime     | Time (ms) | Relative |
 | ----------- | --------- | -------- |
-| C (gcc -O3) | 46        | 1.00x    |
-| JavaScript  | 70        | 1.52x    |
-| **Wado**    | 140       | 3.04x    |
+| C (gcc -O3) | 39        | 1.00x    |
+| JavaScript  | 59        | 1.51x    |
+| **Wado**    | 92        | 2.36x    |
 
 All implementations produce the same result: 664,579 primes.
 


### PR DESCRIPTION
## Summary
Updated benchmark documentation to reflect the latest test results using Wado version 2026-03-21.

## Key Changes
- Updated Wado version from 2026-03-20 to 2026-03-21
- Refreshed prime number benchmark results showing improved performance:
  - C (gcc -O3): 46ms → 39ms
  - JavaScript: 70ms → 59ms
  - Wado: 140ms → 92ms
- Updated relative performance metrics accordingly (Wado improved from 3.04x to 2.36x relative to C baseline)

## Details
The benchmark results demonstrate performance improvements in the latest Wado release, with all implementations continuing to produce consistent results (664,579 primes).

https://claude.ai/code/session_01Q8kBaK4dppBBX5a8GrrNtv