### PR TITLE
Remove JitDump profiling documentation and clarify task completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,6 @@ cargo run --bin wado -- compile -o file.wasm file.wado    # generates Wasm
 cargo run --bin wado -- compile -o file.wat file.wado     # generates WAT
 cargo run --bin wado -- compile --wat-to-stdout file.wado # outputs WAT to stdout
 cargo run --bin wado -- run file.wado                     # run CLI program using wasmtime
-cargo run --bin wado -- run --profile jitdump file.wado   # run with jitdump profiling (see below)
 cargo run --bin wado -- serve file.wado                   # serve HTTP service using wasmtime
 ```
 
@@ -183,19 +182,6 @@ Use `wado serve` to run a Wado HTTP service (wasi:http/service world):
 wado serve file.wado                        # serve on 0.0.0.0:8080 (default)
 wado serve --addr 127.0.0.1:3000 file.wado  # serve on custom address
 ```
-
-### Profiling with JitDump
-
-Use `--profile jitdump` with Linux `perf` for instruction-level profiling. This is necessary because Wado aggressively inlines functions, making function-level profiling insufficient.
-
-```sh
-perf record -k mono wado run --profile jitdump file.wado
-perf inject --jit -i perf.data -o perf.jit.data
-perf report -i perf.jit.data                        # function-level
-perf annotate -i perf.jit.data -s <function_name>   # instruction-level
-```
-
-See `docs/research/wasmtime-profiler-characteristics.md` for detailed comparison of profiling modes.
 
 ### Dump Command
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,3 +355,4 @@ When you have completed a task, make sure everything is up-to-date and tested:
   - docs/compiler.md
   - docs/optimizer.md
 - Run `mise run on-task-done` to format, clippy-fix, update golden fixtures, regenerate stdlib docs, and test. It will take 15+ minutes.
+  - Run in foreground and commit the results. CI's integrity check fails if generated files are uncommitted.


### PR DESCRIPTION
## Summary
This PR removes documentation for the JitDump profiling feature and adds a clarification about committing generated files during task completion.

## Key Changes
- Removed the `--profile jitdump` command example from the run command documentation
- Deleted the entire "Profiling with JitDump" section, including:
  - Usage instructions for Linux `perf` with JitDump
  - Example commands for recording and analyzing profiling data
  - Reference to the detailed profiling comparison documentation
- Added clarification that generated files must be committed in the foreground during task completion, as CI's integrity check will fail otherwise

## Notes
These changes suggest that JitDump profiling support is being deprecated or removed from the Wado compiler toolchain. The documentation update ensures users are not directed to use unavailable features.

https://claude.ai/code/session_01BwBoWaQH4Azb3DARFVNUPe