### PR TITLE
Add support for extra arguments in WADO benchmark runner

### DIFF
--- a/.github/scripts/run_wado_benchmarks.ts
+++ b/.github/scripts/run_wado_benchmarks.ts
@@ -7,8 +7,8 @@ const WADO = './target/release/wado';
 
 type BenchResult = { name: string; unit: string; value: number };
 
-function runBench(src: string, optLevel: string): string {
-  return execFileSync(WADO, ['run', optLevel, src], { encoding: 'utf8' });
+function runBench(src: string, optLevel: string, extraArgs: string[] = []): string {
+  return execFileSync(WADO, ['run', optLevel, ...extraArgs, src], { encoding: 'utf8' });
 }
 
 function parseMs(output: string, pattern: RegExp = /Elapsed: ([\d.]+) ms/): number {
@@ -36,7 +36,7 @@ for (const opt of OPT_LEVELS) {
   output = runBench('benchmark/fts/fts.wado', opt);
   benchmarks.push({ name: `fts (${label})`, unit: 'ms', value: parseMs(output) });
 
-  output = runBench('benchmark/zlib/zlib_bench.wado', opt);
+  output = runBench('benchmark/zlib/zlib_bench.wado', opt, ['--dir', 'benchmark::.']);
   benchmarks.push({ name: `zlib/compress (${label})`, unit: 'ms', value: parseMs(output, /Compress: ([\d.]+) ms/) });
   benchmarks.push({ name: `zlib/decompress (${label})`, unit: 'ms', value: parseMs(output, /Decompress: ([\d.]+) ms/) });
 


### PR DESCRIPTION
## Summary
Enhanced the benchmark runner script to support passing additional command-line arguments to the WADO executable, enabling more flexible benchmark configurations.

## Key Changes
- Modified `runBench()` function to accept an optional `extraArgs` parameter (defaults to empty array)
- Updated the function to pass extra arguments to the WADO executable between the optimization level and source file
- Updated the zlib benchmark call to pass `['--dir', 'benchmark::.']` arguments, allowing the benchmark to access files in the benchmark directory

## Implementation Details
The `extraArgs` parameter is spread into the command array using the spread operator (`...extraArgs`), maintaining the correct argument order: `['run', optLevel, ...extraArgs, src]`. This allows the zlib benchmark to properly reference its input files while keeping the API backward compatible for other benchmarks that don't require extra arguments.

https://claude.ai/code/session_019vPYQmpoqRWaDvEgu8xWFK