### PR TITLE
Remove dev-optimized profile and use default dev profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run: mise run clippy-fix
       - run: mise run update-bundled
-      - run: cargo build --profile dev-optimized --bin wado --bin wado-dev-tools
+      - run: cargo build --bin wado --bin wado-dev-tools
       - run: mise run update-golden-fixtures
       - run: mise run update-golden-format-fixtures
       - run: mise run doc-stdlib
@@ -92,7 +92,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked --profile dev-optimized --all -- --skip fixture_test_
+      - run: cargo test --locked --all -- --skip fixture_test_
 
   test-e2e-o0:
     name: Test (E2E O0)
@@ -107,7 +107,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o0
+      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o0
 
   test-e2e-o1:
     name: Test (E2E O1)
@@ -122,7 +122,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o1
+      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o1
 
   test-e2e-o3:
     name: Test (E2E O3)
@@ -137,7 +137,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_o3
+      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o3
 
   test-e2e-os:
     name: Test (E2E Os)
@@ -152,7 +152,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - run: cargo test --locked --profile dev-optimized -p wado-compiler --test e2e -- fixture_test_os
+      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_os
 
   test-wado:
     name: Test (Wado)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,7 @@ adler = { version = "1" }
 toml = { version = "1", default-features = false, features = ["parse", "display", "serde"] }
 libc = { version = "0.2" }
 
-[profile.dev-optimized]
-inherits = "dev"
-
-[profile.dev-optimized.package.wado-compiler]
+[profile.dev.package.wado-compiler]
 opt-level = 1
 
 [workspace.lints.clippy]

--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,7 @@ run = """
 set -xe -o pipefail
 mise run clippy-fix
 mise run update-bundled
-cargo build --profile dev-optimized --bin wado --bin wado-dev-tools
+cargo build --bin wado --bin wado-dev-tools
 mise run update-golden-fixtures
 mise run update-golden-format-fixtures
 mise run update-gale-golden
@@ -86,12 +86,12 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 touch wado-compiler/tests/e2e.rs
-cargo test --profile dev-optimized
+cargo test
 """
 
 [tasks.test-wado]
 description = "Run Wado module tests"
-run = "cargo run --profile dev-optimized -p wado-cli -- test example/*.wado wado-compiler/lib/core benchmark/*/*.wado wasm-size/*/*.wado package-gale"
+run = "cargo run -p wado-cli -- test example/*.wado wado-compiler/lib/core benchmark/*/*.wado wasm-size/*/*.wado package-gale"
 
 [tasks.test-cov]
 description = "Run tests with coverage"
@@ -126,7 +126,7 @@ run = "cargo clippy --all --all-features -- -D warnings"
 
 [tasks.clippy-fix]
 description = "Run clippy auto-fix"
-run = "cargo clippy --all --all-features --profile dev-optimized --fix --allow-dirty --allow-staged"
+run = "cargo clippy --all --all-features --fix --allow-dirty --allow-staged"
 
 [tasks.update-golden-fixtures]
 description = "Regenerate WIR golden fixtures"
@@ -135,7 +135,7 @@ run = """
 set -xe -o pipefail
 mkdir -p wado-compiler/tests/fixtures.golden
 rm -rf wado-compiler/tests/fixtures.golden/*.*
-./target/dev-optimized/wado-dev-tools golden-dump \
+./target/debug/wado-dev-tools golden-dump \
     --in 'wado-compiler/tests/fixtures/{name}.wado' \
     --out 'wado-compiler/tests/fixtures.golden/{name}.wir.wado' \
     --phase wir -O2
@@ -147,16 +147,16 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 mkdir -p package-gale/tests/golden
-./target/dev-optimized/wado run package-gale/src/main.wado \
+./target/debug/wado run package-gale/src/main.wado \
     gen "package-gale/tests/grammars/sexpression.g4" \
     > "package-gale/tests/golden/sexpression.wado"
-./target/dev-optimized/wado run package-gale/src/main.wado \
+./target/debug/wado run package-gale/src/main.wado \
     gen "package-gale/tests/grammars/JSON.g4" \
     > "package-gale/tests/golden/json.wado"
-./target/dev-optimized/wado run package-gale/src/main.wado \
+./target/debug/wado run package-gale/src/main.wado \
     gen "package-gale/tests/grammars/calculator.g4" \
     > "package-gale/tests/golden/calculator.wado"
-./target/dev-optimized/wado run package-gale/src/main.wado \
+./target/debug/wado run package-gale/src/main.wado \
     gen "package-gale/tests/grammars/SQLite.g4" \
     > "package-gale/tests/golden/sqlite.wado"
 """
@@ -170,18 +170,18 @@ description = "Generate stdlib cheatsheet docs (core + wasi)"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-cargo build --bin wado --profile dev-optimized --quiet
+cargo build --bin wado --quiet
 
 CORE_MODULES="core:prelude core:cli core:collections core:base64 core:zlib"
 WASI_MODULES="wasi:cli wasi:filesystem wasi:http wasi:clocks wasi:random wasi:sockets"
 
-cargo run --bin wado --profile dev-optimized --quiet -- doc -f simple --title "Core Standard Library" \
+cargo run --bin wado --quiet -- doc -f simple --title "Core Standard Library" \
   $CORE_MODULES > docs/cheatsheet-stdlib-core.md
-cargo run --bin wado --profile dev-optimized --quiet -- doc -f simple --title "WASI Standard Library" \
+cargo run --bin wado --quiet -- doc -f simple --title "WASI Standard Library" \
   $WASI_MODULES > docs/cheatsheet-stdlib-wasi.md
-cargo run --bin wado --profile dev-optimized --quiet -- doc -f markdown --title "Core Standard Library" \
+cargo run --bin wado --quiet -- doc -f markdown --title "Core Standard Library" \
   $CORE_MODULES > docs/stdlib-core.md
-cargo run --bin wado --profile dev-optimized --quiet -- doc -f markdown --title "WASI Standard Library" \
+cargo run --bin wado --quiet -- doc -f markdown --title "WASI Standard Library" \
   $WASI_MODULES > docs/stdlib-wasi.md
 """
 

--- a/scripts/update-golden-format-fixtures.sh
+++ b/scripts/update-golden-format-fixtures.sh
@@ -11,8 +11,8 @@ FIXTURES_DIR="wado-compiler/tests/format.fixtures"
 GOLDEN_DIR="wado-compiler/tests/format.fixtures.golden"
 mkdir -p "$GOLDEN_DIR"
 
-WADO="./target/dev-optimized/wado"
-DUMP="./target/dev-optimized/wado-dev-tools"
+WADO="./target/debug/wado"
+DUMP="./target/debug/wado-dev-tools"
 
 # Generate formatted (clean) versions
 for f in "$FIXTURES_DIR"/*.dirty.wado; do


### PR DESCRIPTION
## Summary
This PR removes the custom `dev-optimized` Cargo profile and consolidates all development builds to use the standard `dev` profile. The `dev-optimized` profile is replaced with targeted optimizations only for the `wado-compiler` package within the default `dev` profile.

## Key Changes
- **Cargo.toml**: Removed the `[profile.dev-optimized]` section and moved the `opt-level = 1` optimization to `[profile.dev.package.wado-compiler]`
- **Build commands**: Removed `--profile dev-optimized` flag from all `cargo build`, `cargo test`, `cargo run`, and `cargo clippy` commands across:
  - `mise.toml` task definitions
  - `.github/workflows/ci.yml` CI workflow
  - `scripts/update-golden-format-fixtures.sh`
- **Binary paths**: Updated all references from `./target/dev-optimized/` to `./target/debug/` to match the standard dev profile output directory

## Implementation Details
The optimization strategy remains the same - `wado-compiler` still gets `opt-level = 1` during development builds for faster compilation while maintaining reasonable performance. However, this is now achieved through the standard Cargo profile inheritance mechanism rather than a custom profile, simplifying the build configuration and making it more maintainable.

https://claude.ai/code/session_01TsTDJb2yZpdzm11GE8LpFN