### PR TITLE
Optimize effect checking and resolver performance with caching

### DIFF
--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -20,7 +20,7 @@ use crate::token::Span;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// Lightweight signature extracted from TirFunction for effect checking.
+/// Lightweight signature extracted from `TirFunction` for effect checking.
 /// Avoids cloning the entire function body.
 struct EffectSignature {
     effects: Vec<EffectRef>,
@@ -153,7 +153,7 @@ struct EffectChecker<'a, H: CompilerHost> {
     type_table: Option<Rc<RefCell<TypeTable>>>,
     /// What this checker is checking
     mode: CheckMode,
-    /// Pre-built index: (module_source, func_name) -> EffectSignature
+    /// Pre-built index: (`module_source`, `func_name`) -> `EffectSignature`
     func_index: IndexMap<(ModuleSource, String), EffectSignature>,
 }
 
@@ -665,14 +665,12 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
             let tt = tt.borrow();
             // For method calls, args doesn't include the receiver (self), but params does.
             // Skip the self parameter when the function is a method.
-            let params_iter: Box<dyn Iterator<Item = _>> = if sig.is_method
-                && !sig.params.is_empty()
-                && sig.params[0].name == "self"
-            {
-                Box::new(sig.params.iter().skip(1))
-            } else {
-                Box::new(sig.params.iter())
-            };
+            let params_iter: Box<dyn Iterator<Item = _>> =
+                if sig.is_method && !sig.params.is_empty() && sig.params[0].name == "self" {
+                    Box::new(sig.params.iter().skip(1))
+                } else {
+                    Box::new(sig.params.iter())
+                };
             for (param, arg) in params_iter.zip(args.iter()) {
                 if let ResolvedType::Function {
                     effects: formal_effects,

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -14,11 +14,25 @@ use crate::logger::{Bail, Logger};
 use crate::name::ModuleSource;
 use crate::tir::{
     CallArg, EffectRef, FunctionRef, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction,
-    TirModule, TirStmt, TirStmtKind, TirTemplatePart, TypeTable,
+    TirModule, TirStmt, TirStmtKind, TirTemplatePart, TypeId, TypeTable,
 };
 use crate::token::Span;
 use std::cell::RefCell;
 use std::rc::Rc;
+
+/// Lightweight signature extracted from TirFunction for effect checking.
+/// Avoids cloning the entire function body.
+struct EffectSignature {
+    effects: Vec<EffectRef>,
+    params: Vec<EffectParam>,
+    is_method: bool,
+}
+
+/// Minimal parameter info needed for effect resolution.
+struct EffectParam {
+    name: String,
+    type_id: TypeId,
+}
 
 /// Error from effect checking
 #[derive(Debug, Clone)]
@@ -139,11 +153,53 @@ struct EffectChecker<'a, H: CompilerHost> {
     type_table: Option<Rc<RefCell<TypeTable>>>,
     /// What this checker is checking
     mode: CheckMode,
+    /// Pre-built index: (module_source, func_name) -> EffectSignature
+    func_index: IndexMap<(ModuleSource, String), EffectSignature>,
 }
 
 impl<'a, H: CompilerHost> EffectChecker<'a, H> {
     fn new(modules: &'a IndexMap<ModuleSource, TirModule>, logger: &'a Logger<'a, H>) -> Self {
         let type_table = modules.values().next().map(|m| Rc::clone(&m.type_table));
+        let mut func_index = IndexMap::default();
+        for (module_source, module) in modules {
+            for func_rc in &module.functions {
+                let func = func_rc.borrow();
+                func_index.insert(
+                    (module_source.clone(), func.name.clone()),
+                    EffectSignature {
+                        effects: func.effects.clone(),
+                        params: func
+                            .params
+                            .iter()
+                            .map(|p| EffectParam {
+                                name: p.name.clone(),
+                                type_id: p.type_id,
+                            })
+                            .collect(),
+                        is_method: func.is_method(),
+                    },
+                );
+            }
+            for impl_block in &module.impls {
+                for method in &impl_block.methods {
+                    func_index.insert(
+                        (module_source.clone(), method.name.clone()),
+                        EffectSignature {
+                            effects: method.effects.clone(),
+                            params: method
+                                .params
+                                .iter()
+                                .map(|p| EffectParam {
+                                    name: p.name.clone(),
+                                    type_id: p.type_id,
+                                })
+                                .collect(),
+                            is_method: method.is_method(),
+                        },
+                    );
+                }
+            }
+        }
         Self {
             modules,
             logger,
@@ -152,6 +208,7 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
             current_ref_params: IndexSet::default(),
             type_table,
             mode: CheckMode::EffectsOnly,
+            func_index,
         }
     }
 
@@ -602,25 +659,25 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
         }
 
         // Look at the callee's parameter types and actual argument types
-        if let Some(callee_func) = self.find_function(func_ref)
+        if let Some(sig) = self.find_effect_signature(func_ref)
             && let Some(tt) = &self.type_table
         {
             let tt = tt.borrow();
             // For method calls, args doesn't include the receiver (self), but params does.
             // Skip the self parameter when the function is a method.
-            let params_iter: Box<dyn Iterator<Item = _>> = if callee_func.is_method()
-                && !callee_func.params.is_empty()
-                && callee_func.params[0].name == "self"
+            let params_iter: Box<dyn Iterator<Item = _>> = if sig.is_method
+                && !sig.params.is_empty()
+                && sig.params[0].name == "self"
             {
-                Box::new(callee_func.params.iter().skip(1))
+                Box::new(sig.params.iter().skip(1))
             } else {
-                Box::new(callee_func.params.iter())
+                Box::new(sig.params.iter())
             };
             for (param, arg) in params_iter.zip(args.iter()) {
                 if let ResolvedType::Function {
                     effects: formal_effects,
                     ..
-                } = tt.get(param.type_id).clone()
+                } = tt.get(param.type_id)
                 {
                     let has_effect_params = formal_effects
                         .iter()
@@ -632,13 +689,13 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
                     if let ResolvedType::Function {
                         effects: actual_effects,
                         ..
-                    } = tt.get(arg.expr.type_id).clone()
+                    } = tt.get(arg.expr.type_id)
                     {
-                        for formal_effect in &formal_effects {
+                        for formal_effect in formal_effects {
                             if let EffectRef::Param { name } = formal_effect
                                 && let Some(concrete_set) = effect_param_concrete.get_mut(name)
                             {
-                                for actual in &actual_effects {
+                                for actual in actual_effects {
                                     concrete_set.insert(actual.clone());
                                 }
                             }
@@ -669,30 +726,18 @@ impl<'a, H: CompilerHost> EffectChecker<'a, H> {
 
     /// Get the effects for a function
     fn get_function_effects(&self, func_ref: &FunctionRef) -> Vec<EffectRef> {
-        if let Some(func) = self.find_function(func_ref) {
-            func.effects
+        let key = (func_ref.module_source.clone(), func_ref.name.clone());
+        if let Some(sig) = self.func_index.get(&key) {
+            sig.effects.clone()
         } else {
             Vec::new()
         }
     }
 
-    /// Find a function by reference
-    fn find_function(&self, func_ref: &FunctionRef) -> Option<TirFunction> {
-        let module = self.modules.get(&func_ref.module_source)?;
-        for func_rc in &module.functions {
-            let func = func_rc.borrow();
-            if func.name == func_ref.name {
-                return Some(func.clone());
-            }
-        }
-        for impl_block in &module.impls {
-            for method in &impl_block.methods {
-                if method.name == func_ref.name {
-                    return Some(method.clone());
-                }
-            }
-        }
-        None
+    /// Find the effect signature for a function by reference (O(1) lookup)
+    fn find_effect_signature(&self, func_ref: &FunctionRef) -> Option<&EffectSignature> {
+        let key = (func_ref.module_source.clone(), func_ref.name.clone());
+        self.func_index.get(&key)
     }
 }
 

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -149,6 +149,9 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// Recursion guard for `type_implements_trait` to avoid infinite recursion
     /// on recursive types (e.g., variant Elem containing struct `RepeatElem` with field Elem).
     trait_check_stack: RefCell<Vec<(TypeId, String)>>,
+    /// Cache for `lookup_method_info` results.
+    /// Key: (base_type_id, method_name) → cached MethodInfo
+    method_info_cache: IndexMap<(TypeId, String), Option<types::MethodInfo>>,
 }
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -204,6 +207,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             known_type_names_cache: IndexSet::default(),
             indexing_trait_cache: IndexMap::default(),
             trait_check_stack: RefCell::new(Vec::new()),
+            method_info_cache: IndexMap::default(),
         }
     }
 
@@ -287,10 +291,16 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         self.effect_sources = Self::build_effect_sources(module, &module_source);
 
         // First pass: collect type definitions
-        self.collect_types(module);
+        {
+            let _span = self.logger.span("resolve/collect_types");
+            self.collect_types(module);
+        }
 
         // Second pass: collect function signatures (for call resolution)
-        self.collect_function_signatures(module);
+        {
+            let _span = self.logger.span("resolve/collect_sigs");
+            self.collect_function_signatures(module);
+        }
 
         // Collect global variable names and types (before resolving functions that may reference them)
         self.current_module_globals.clear();
@@ -364,6 +374,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         }
 
         // Third pass: resolve functions
+        let _resolve_funcs_span = self.logger.span("resolve/resolve_funcs");
         let mut tir_module = TirModule::new(module_source);
 
         for item in &module.items {
@@ -658,6 +669,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
         }
 
+        drop(_resolve_funcs_span);
         // Share the type table via Rc::clone
         tir_module.type_table = Rc::clone(&self.type_table);
 

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -150,7 +150,7 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// on recursive types (e.g., variant Elem containing struct `RepeatElem` with field Elem).
     trait_check_stack: RefCell<Vec<(TypeId, String)>>,
     /// Cache for `lookup_method_info` results.
-    /// Key: (base_type_id, method_name) → cached MethodInfo
+    /// Key: (`base_type_id`, `method_name`) → cached `MethodInfo`
     method_info_cache: IndexMap<(TypeId, String), Option<types::MethodInfo>>,
 }
 

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -318,6 +318,23 @@ impl<H: CompilerHost> Resolver<'_, H> {
     ) -> Option<MethodInfo> {
         // First, get the base (non-reference) type for method lookup
         let base_type_id = self.get_base_type(receiver_type);
+
+        // Check cache
+        let cache_key = (base_type_id, method_name.to_string());
+        if let Some(cached) = self.method_info_cache.get(&cache_key) {
+            return cached.clone();
+        }
+
+        let result = self.lookup_method_info_uncached(base_type_id, method_name);
+        self.method_info_cache.insert(cache_key, result.clone());
+        result
+    }
+
+    fn lookup_method_info_uncached(
+        &mut self,
+        base_type_id: TypeId,
+        method_name: &str,
+    ) -> Option<MethodInfo> {
         let base_type = self.type_table.borrow().get(base_type_id).clone();
 
         // Get the struct name, module source, and type args from the base type

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -442,14 +442,23 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         let sorted_sources =
             Self::topological_sort_modules(modules, &all_struct_fields, &type_table.borrow());
 
-        let (wasi_registry, _) = WasiRegistry::build_from_stdlib();
-        let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
+        let (wasi_registry, _) = {
+            let _span = logger.span("resolve/wasi_registry");
+            WasiRegistry::build_from_stdlib()
+        };
+        let builtin_registry = {
+            let _span = logger.span("resolve/builtin_registry");
+            BuiltinRegistry::build_from_stdlib(&type_table)
+        };
 
         // Build trait lookup indices once for all modules.
         // This allows find_trait_method_for_type and find_indexing_trait_impl to do O(1)
         // lookups by type name instead of scanning all items in all modules per method call.
         // Also runs orphan rule checking; violations are emitted as errors.
-        let (trait_env, orphan_violations) = super::trait_env::TraitEnv::build(modules);
+        let (trait_env, orphan_violations) = {
+            let _span = logger.span("resolve/trait_env");
+            super::trait_env::TraitEnv::build(modules)
+        };
         for violation in orphan_violations {
             let _ = logger.error(violation);
         }
@@ -509,6 +518,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         };
 
         // Second pass: resolve each module with per-module function_return_types and imports
+        let _span = logger.span("resolve/modules");
         for module_source in &sorted_sources {
             let module = modules.get(module_source).expect("module should exist");
 
@@ -663,6 +673,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 known_type_names_cache: global_known_type_names.clone(),
                 indexing_trait_cache: IndexMap::default(),
                 trait_check_stack: RefCell::new(Vec::new()),
+                method_info_cache: IndexMap::default(),
             };
             // known_type_names_cache is pre-computed globally; no per-module rebuild needed
 
@@ -677,6 +688,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
         }
 
+        drop(_span);
         logger.ok_or_bail(result)
     }
 


### PR DESCRIPTION
## Summary
This PR improves compiler performance by introducing caching mechanisms in the effect checker and resolver, and adds performance instrumentation to track compilation time across different phases.

## Key Changes

### Effect Checker Optimization
- **Introduced `EffectSignature` struct**: A lightweight signature extracted from `TirFunction` that contains only the essential information needed for effect checking (effects, parameters, and method flag), avoiding expensive cloning of entire function bodies.
- **Added `EffectParam` struct**: Minimal parameter information (name and type_id) needed for effect resolution.
- **Pre-built function index**: The `EffectChecker` now builds a `func_index` during initialization that maps `(ModuleSource, function_name)` to `EffectSignature` for O(1) lookups instead of scanning modules on each lookup.
- **Replaced `find_function()` with `find_effect_signature()`**: Changed from returning full `TirFunction` clones to returning references to lightweight signatures.
- **Eliminated unnecessary clones**: Removed `.clone()` calls on effect and type references in the effect checking logic.

### Resolver Performance Improvements
- **Added method info caching**: Introduced `method_info_cache` in the `Resolver` struct to cache `lookup_method_info` results with key `(base_type_id, method_name)`.
- **Extracted `lookup_method_info_uncached()`**: Separated the uncached lookup logic to support caching without code duplication.
- **Added performance instrumentation**: Wrapped major compilation phases with logger spans to track execution time:
  - `resolve/wasi_registry`
  - `resolve/builtin_registry`
  - `resolve/trait_env`
  - `resolve/modules`
  - `resolve/collect_types`
  - `resolve/collect_sigs`
  - `resolve/resolve_funcs`

## Implementation Details
- The function index is built once during `EffectChecker::new()` by iterating through all modules and their functions/methods, eliminating repeated lookups during effect checking.
- Method info caching uses `IndexMap` for consistent ordering and is populated lazily as methods are looked up.
- Performance spans use RAII pattern (`_span` variables) to automatically measure time from creation to drop, providing accurate phase timing without manual instrumentation.

https://claude.ai/code/session_014gecjwoworSRai5n947sE9