### PR TITLE
Fix optimizer traversal wildcards and migrate passes to TirVisitor

### DIFF
--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -12,7 +12,7 @@
 //! and inclusive `<=` guard patterns.
 
 use crate::hashmap::IndexMap;
-use crate::optimize::visitor::{walk_expr, walk_stmt, TirVisitor};
+use crate::optimize::visitor::{TirVisitor, walk_expr, walk_stmt};
 use crate::project::Project;
 use crate::tir::{
     TirBinaryOp, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp,
@@ -457,7 +457,9 @@ fn record_defs_from_expr(expr: &TirExpr, defs: &mut DefMap) {
         | TirExprKind::FieldAccess { expr: inner, .. }
         | TirExprKind::GlobalVarSet { value: inner, .. }
         | TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TypePackExpansion { call_expr: inner, .. }
+        | TirExprKind::TypePackExpansion {
+            call_expr: inner, ..
+        }
         | TirExprKind::VariantTag { expr: inner }
         | TirExprKind::VariantTest { expr: inner, .. }
         | TirExprKind::VariantPayload { expr: inner, .. }
@@ -481,7 +483,10 @@ fn record_defs_from_expr(expr: &TirExpr, defs: &mut DefMap) {
                 }
             }
         }
-        TirExprKind::Match { expr: scrutinee, arms } => {
+        TirExprKind::Match {
+            expr: scrutinee,
+            arms,
+        } => {
             record_defs_from_expr(scrutinee, defs);
             for arm in arms {
                 if let Some(guard) = &arm.guard {
@@ -602,7 +607,12 @@ impl TirVisitor for ConditionEliminator<'_> {
 
         // For If stmts: extract a dominating guard from the condition to extend
         // elimination into the then-block.
-        if let TirStmtKind::If { condition, then_block, else_block } = &mut stmt.kind {
+        if let TirStmtKind::If {
+            condition,
+            then_block,
+            else_block,
+        } = &mut stmt.kind
+        {
             let mut changed = self.visit_expr(condition);
             let dom = extract_dominating_guard(condition, self.defs);
             let saved = self.dom_guards.clone();
@@ -622,7 +632,12 @@ impl TirVisitor for ConditionEliminator<'_> {
 
     fn visit_expr(&mut self, expr: &mut TirExpr) -> bool {
         // For If exprs: extract a dominating guard and propagate into then-branch.
-        if let TirExprKind::If { condition, then_branch, else_branch } = &mut expr.kind {
+        if let TirExprKind::If {
+            condition,
+            then_branch,
+            else_branch,
+        } = &mut expr.kind
+        {
             let mut changed = self.visit_expr(condition);
             let dom = extract_dominating_guard(condition, self.defs);
             let saved = self.dom_guards.clone();

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -12,6 +12,7 @@
 //! and inclusive `<=` guard patterns.
 
 use crate::hashmap::IndexMap;
+use crate::optimize::visitor::{walk_expr, walk_stmt, TirVisitor};
 use crate::project::Project;
 use crate::tir::{
     TirBinaryOp, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirUnaryOp,
@@ -86,7 +87,7 @@ fn process_block(block: &mut TirBlock, defs: &mut DefMap) -> bool {
     for stmt in &mut block.stmts {
         record_def_from_stmt(stmt, defs);
         record_defs_from_nested(stmt, defs);
-        changed |= eliminate_bitmask_bounded(stmt, defs);
+        changed |= BitmaskEliminator { defs }.visit_stmt(stmt);
         changed |= process_stmt(stmt, defs);
     }
     changed
@@ -142,14 +143,19 @@ fn process_loop(body: &mut TirBlock, defs: &mut DefMap) -> bool {
 
     if let Some(guard) = &guard {
         // Eliminate implied conditions in the loop body (skip the guard itself)
+        let mut condition_elim = ConditionEliminator {
+            guard,
+            dom_guards: vec![],
+            defs: &loop_defs,
+        };
         for stmt in body.stmts.iter_mut().skip(1) {
-            changed |= eliminate_in_stmt(stmt, guard, &[], &loop_defs);
+            changed |= condition_elim.visit_stmt(stmt);
         }
     }
 
     // Eliminate bitmask-bounded checks in the loop body
     for stmt in &mut body.stmts {
-        changed |= eliminate_bitmask_bounded(stmt, &loop_defs);
+        changed |= BitmaskEliminator { defs: &loop_defs }.visit_stmt(stmt);
     }
 
     // Recurse into nested loops
@@ -411,7 +417,18 @@ fn record_defs_from_nested(stmt: &TirStmt, defs: &mut DefMap) {
         } => {
             record_defs_from_expr(expr, defs);
         }
-        _ => {}
+        TirStmtKind::LetDestructure { value, .. } => {
+            record_defs_from_expr(value, defs);
+        }
+        // Loop bodies have their own scope handled via process_loop.
+        // Remaining kinds (Return/Break with None, Continue, TaskReturn, VariadicForOf)
+        // carry no expressions with nested definitions.
+        TirStmtKind::Loop { .. }
+        | TirStmtKind::Return { value: None }
+        | TirStmtKind::Break { value: None, .. }
+        | TirStmtKind::Continue
+        | TirStmtKind::TaskReturn { .. }
+        | TirStmtKind::VariadicForOf { .. } => {}
     }
 }
 
@@ -439,7 +456,12 @@ fn record_defs_from_expr(expr: &TirExpr, defs: &mut DefMap) {
         | TirExprKind::Cast { expr: inner, .. }
         | TirExprKind::FieldAccess { expr: inner, .. }
         | TirExprKind::GlobalVarSet { value: inner, .. }
-        | TirExprKind::TupleSpread { expr: inner, .. } => {
+        | TirExprKind::TupleSpread { expr: inner }
+        | TirExprKind::TypePackExpansion { call_expr: inner, .. }
+        | TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. }
+        | TirExprKind::ClosureToCanonical { functor: inner, .. } => {
             record_defs_from_expr(inner, defs);
         }
         TirExprKind::If {
@@ -459,9 +481,41 @@ fn record_defs_from_expr(expr: &TirExpr, defs: &mut DefMap) {
                 }
             }
         }
+        TirExprKind::Match { expr: scrutinee, arms } => {
+            record_defs_from_expr(scrutinee, defs);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    record_defs_from_expr(guard, defs);
+                }
+                record_defs_from_expr(&arm.body, defs);
+            }
+        }
+        TirExprKind::Switch {
+            scrutinee,
+            arms,
+            default,
+            ..
+        } => {
+            record_defs_from_expr(scrutinee, defs);
+            for arm in arms {
+                for s in &arm.stmts {
+                    record_def_from_stmt(s, defs);
+                    record_defs_from_nested(s, defs);
+                }
+            }
+            for s in &default.stmts {
+                record_def_from_stmt(s, defs);
+                record_defs_from_nested(s, defs);
+            }
+        }
         TirExprKind::Call { args, .. } => {
             for arg in args {
                 record_defs_from_expr(&arg.expr, defs);
+            }
+        }
+        TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                record_defs_from_expr(arg, defs);
             }
         }
         TirExprKind::MethodCall { receiver, args, .. } => {
@@ -470,354 +524,150 @@ fn record_defs_from_expr(expr: &TirExpr, defs: &mut DefMap) {
                 record_defs_from_expr(&arg.expr, defs);
             }
         }
+        TirExprKind::IndirectCall { callee, args } => {
+            record_defs_from_expr(callee, defs);
+            for arg in args {
+                record_defs_from_expr(arg, defs);
+            }
+        }
         TirExprKind::StructLiteral { fields, .. } => {
             for f in fields {
                 record_defs_from_expr(&f.value, defs);
             }
         }
-        TirExprKind::TupleLiteral { elements } | TirExprKind::CmRawCall { args: elements, .. } => {
+        TirExprKind::TupleLiteral { elements } => {
             for e in elements {
                 record_defs_from_expr(e, defs);
             }
         }
-        TirExprKind::VariantConstruct {
-            payload: Some(inner),
-            ..
-        } => {
-            record_defs_from_expr(inner, defs);
+        TirExprKind::VariantConstruct { payload, .. } => {
+            if let Some(inner) = payload {
+                record_defs_from_expr(inner, defs);
+            }
         }
-        _ => {}
+        // Defs inside closures are scoped to the closure body — don't record in outer scope.
+        TirExprKind::Closure { .. } => {}
+        // Leaf nodes carry no sub-expressions with definitions.
+        TirExprKind::Local { .. }
+        | TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => {}
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 
 /// Eliminate implied-false conditions within a statement.
-fn eliminate_in_stmt(
-    stmt: &mut TirStmt,
-    guard: &LoopGuard,
-    dom_guards: &[DominatingGuard],
-    defs: &DefMap,
-) -> bool {
-    // Check if this stmt itself is a bounds check pattern
-    if let TirStmtKind::If {
-        condition,
-        then_block,
-        else_block: None,
-    } = &mut stmt.kind
-        && is_panic_block(then_block)
-        && is_implied_false_by_any(condition, guard, dom_guards, defs)
-    {
-        *condition = TirExpr {
-            kind: TirExprKind::BoolLiteral(false),
-            type_id: condition.type_id,
-            span: condition.span,
-        };
-        return true;
-    }
-
-    // Recurse into sub-structures
-    match &mut stmt.kind {
-        TirStmtKind::Let { value, .. } => eliminate_in_expr(value, guard, dom_guards, defs),
-        TirStmtKind::Expr(expr) => eliminate_in_expr(expr, guard, dom_guards, defs),
-        TirStmtKind::Return { value: Some(expr) }
-        | TirStmtKind::Break {
-            value: Some(expr), ..
-        } => eliminate_in_expr(expr, guard, dom_guards, defs),
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            let mut changed = eliminate_in_expr(condition, guard, dom_guards, defs);
-            // If condition is `(var + offset) < bound`, create a dominating guard
-            // for the then-block to eliminate bounds checks on var+k for k <= offset.
-            let dom = extract_dominating_guard(condition, defs);
-            if let Some(dg) = dom {
-                let mut extended = dom_guards.to_vec();
-                extended.push(dg);
-                changed |= eliminate_in_block(then_block, guard, &extended, defs);
-            } else {
-                changed |= eliminate_in_block(then_block, guard, dom_guards, defs);
-            }
-            if let Some(eb) = else_block {
-                changed |= eliminate_in_block(eb, guard, dom_guards, defs);
-            }
-            changed
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            eliminate_in_block(block, guard, dom_guards, defs)
-        }
-        TirStmtKind::IfLet {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            let mut changed = eliminate_in_expr(scrutinee, guard, dom_guards, defs);
-            changed |= eliminate_in_block(then_block, guard, dom_guards, defs);
-            if let Some(eb) = else_block {
-                changed |= eliminate_in_block(eb, guard, dom_guards, defs);
-            }
-            changed
-        }
-        _ => false,
-    }
+/// TIR visitor that eliminates loop-guard-implied false bounds checks.
+///
+/// When a loop guard proves `i < bound`, inner conditions `i >= bound` are
+/// replaced with `false`. Dominating if-conditions are also tracked to extend
+/// the elimination into their then-blocks.
+struct ConditionEliminator<'a> {
+    guard: &'a LoopGuard,
+    dom_guards: Vec<DominatingGuard>,
+    defs: &'a DefMap,
 }
 
-fn eliminate_in_block(
-    block: &mut TirBlock,
-    guard: &LoopGuard,
-    dom_guards: &[DominatingGuard],
-    defs: &DefMap,
-) -> bool {
-    let mut changed = false;
-    for stmt in &mut block.stmts {
-        changed |= eliminate_in_stmt(stmt, guard, dom_guards, defs);
-    }
-    changed
-}
-
-fn eliminate_in_expr(
-    expr: &mut TirExpr,
-    guard: &LoopGuard,
-    dom_guards: &[DominatingGuard],
-    defs: &DefMap,
-) -> bool {
-    match &mut expr.kind {
-        TirExprKind::LabeledBlock { block, .. } | TirExprKind::Block(block) => {
-            eliminate_in_block(block, guard, dom_guards, defs)
-        }
-        TirExprKind::Binary { left, right, .. }
-        | TirExprKind::Assign {
-            target: left,
-            value: right,
-        }
-        | TirExprKind::Index {
-            expr: left,
-            index: right,
-        } => {
-            let mut c = eliminate_in_expr(left, guard, dom_guards, defs);
-            c |= eliminate_in_expr(right, guard, dom_guards, defs);
-            c
-        }
-        TirExprKind::Unary { expr: inner, .. }
-        | TirExprKind::Cast { expr: inner, .. }
-        | TirExprKind::FieldAccess { expr: inner, .. }
-        | TirExprKind::GlobalVarSet { value: inner, .. }
-        | TirExprKind::TupleSpread { expr: inner, .. } => {
-            eliminate_in_expr(inner, guard, dom_guards, defs)
-        }
-        TirExprKind::If {
+impl TirVisitor for ConditionEliminator<'_> {
+    fn visit_stmt(&mut self, stmt: &mut TirStmt) -> bool {
+        // Check if this statement is a bounds check that can be eliminated.
+        if let TirStmtKind::If {
             condition,
-            then_branch,
-            else_branch,
-        } => {
-            let mut c = eliminate_in_expr(condition, guard, dom_guards, defs);
-            let dom = extract_dominating_guard(condition, defs);
+            then_block,
+            else_block: None,
+        } = &mut stmt.kind
+            && is_panic_block(then_block)
+            && is_implied_false_by_any(condition, self.guard, &self.dom_guards, self.defs)
+        {
+            let type_id = condition.type_id;
+            let span = condition.span;
+            *condition = TirExpr {
+                kind: TirExprKind::BoolLiteral(false),
+                type_id,
+                span,
+            };
+            return true;
+        }
+
+        // For If stmts: extract a dominating guard from the condition to extend
+        // elimination into the then-block.
+        if let TirStmtKind::If { condition, then_block, else_block } = &mut stmt.kind {
+            let mut changed = self.visit_expr(condition);
+            let dom = extract_dominating_guard(condition, self.defs);
+            let saved = self.dom_guards.clone();
             if let Some(dg) = dom {
-                let mut extended = dom_guards.to_vec();
-                extended.push(dg);
-                c |= eliminate_in_block(then_branch, guard, &extended, defs);
-            } else {
-                c |= eliminate_in_block(then_branch, guard, dom_guards, defs);
+                self.dom_guards.push(dg);
             }
+            changed |= self.visit_block(then_block);
+            self.dom_guards = saved;
+            if let Some(eb) = else_block {
+                changed |= self.visit_block(eb);
+            }
+            return changed;
+        }
+
+        walk_stmt(self, stmt)
+    }
+
+    fn visit_expr(&mut self, expr: &mut TirExpr) -> bool {
+        // For If exprs: extract a dominating guard and propagate into then-branch.
+        if let TirExprKind::If { condition, then_branch, else_branch } = &mut expr.kind {
+            let mut changed = self.visit_expr(condition);
+            let dom = extract_dominating_guard(condition, self.defs);
+            let saved = self.dom_guards.clone();
+            if let Some(dg) = dom {
+                self.dom_guards.push(dg);
+            }
+            changed |= self.visit_block(then_branch);
+            self.dom_guards = saved;
             if let Some(eb) = else_branch {
-                c |= eliminate_in_block(eb, guard, dom_guards, defs);
+                changed |= self.visit_block(eb);
             }
-            c
+            return changed;
         }
-        TirExprKind::Call { args, .. } => {
-            let mut c = false;
-            for arg in args {
-                c |= eliminate_in_expr(&mut arg.expr, guard, dom_guards, defs);
-            }
-            c
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            let mut c = eliminate_in_expr(receiver, guard, dom_guards, defs);
-            for arg in args {
-                c |= eliminate_in_expr(&mut arg.expr, guard, dom_guards, defs);
-            }
-            c
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            let mut c = false;
-            for f in fields {
-                c |= eliminate_in_expr(&mut f.value, guard, dom_guards, defs);
-            }
-            c
-        }
-        TirExprKind::TupleLiteral { elements } => {
-            let mut c = false;
-            for e in elements {
-                c |= eliminate_in_expr(e, guard, dom_guards, defs);
-            }
-            c
-        }
-        TirExprKind::VariantConstruct {
-            payload: Some(inner),
-            ..
-        } => eliminate_in_expr(inner, guard, dom_guards, defs),
-        _ => false,
+        walk_expr(self, expr)
     }
 }
 
-/// Eliminate bounds checks where the index is masked by a bitmask and the bound
-/// exceeds the mask's maximum value.
+/// TIR visitor that eliminates bitmask-bounded false bounds checks.
 ///
 /// Pattern: `if (x & MASK) >= BOUND { panic(...) }` where `BOUND > MASK >= 0`
-/// Since `(x & MASK)` is always in `[0, MASK]`, `(x & MASK) >= BOUND` is always false.
-fn eliminate_bitmask_bounded(stmt: &mut TirStmt, defs: &DefMap) -> bool {
-    if let TirStmtKind::If {
-        condition,
-        then_block,
-        else_block: None,
-    } = &mut stmt.kind
-        && is_panic_block(then_block)
-        && is_bitmask_bounded(condition, defs)
-    {
-        *condition = TirExpr {
-            kind: TirExprKind::BoolLiteral(false),
-            type_id: condition.type_id,
-            span: condition.span,
-        };
-        return true;
-    }
-
-    // Recurse into sub-structures
-    match &mut stmt.kind {
-        TirStmtKind::Let { value, .. } => eliminate_bitmask_in_expr(value, defs),
-        TirStmtKind::Expr(expr) => eliminate_bitmask_in_expr(expr, defs),
-        TirStmtKind::Return { value: Some(expr) }
-        | TirStmtKind::Break {
-            value: Some(expr), ..
-        } => eliminate_bitmask_in_expr(expr, defs),
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            let mut changed = eliminate_bitmask_in_expr(condition, defs);
-            for s in &mut then_block.stmts {
-                changed |= eliminate_bitmask_bounded(s, defs);
-            }
-            if let Some(eb) = else_block {
-                for s in &mut eb.stmts {
-                    changed |= eliminate_bitmask_bounded(s, defs);
-                }
-            }
-            changed
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            let mut changed = false;
-            for s in &mut block.stmts {
-                changed |= eliminate_bitmask_bounded(s, defs);
-            }
-            changed
-        }
-        TirStmtKind::Loop { body } => {
-            let mut changed = false;
-            for s in &mut body.stmts {
-                changed |= eliminate_bitmask_bounded(s, defs);
-            }
-            changed
-        }
-        TirStmtKind::IfLet {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            let mut changed = eliminate_bitmask_in_expr(scrutinee, defs);
-            for s in &mut then_block.stmts {
-                changed |= eliminate_bitmask_bounded(s, defs);
-            }
-            if let Some(eb) = else_block {
-                for s in &mut eb.stmts {
-                    changed |= eliminate_bitmask_bounded(s, defs);
-                }
-            }
-            changed
-        }
-        _ => false,
-    }
+/// Since `(x & MASK)` is always in `[0, MASK]`, the condition is always false.
+struct BitmaskEliminator<'a> {
+    defs: &'a DefMap,
 }
 
-fn eliminate_bitmask_in_expr(expr: &mut TirExpr, defs: &DefMap) -> bool {
-    match &mut expr.kind {
-        TirExprKind::LabeledBlock { block, .. } | TirExprKind::Block(block) => {
-            let mut changed = false;
-            for s in &mut block.stmts {
-                changed |= eliminate_bitmask_bounded(s, defs);
-            }
-            changed
-        }
-        TirExprKind::Binary { left, right, .. }
-        | TirExprKind::Assign {
-            target: left,
-            value: right,
-        }
-        | TirExprKind::Index {
-            expr: left,
-            index: right,
-        } => {
-            let mut c = eliminate_bitmask_in_expr(left, defs);
-            c |= eliminate_bitmask_in_expr(right, defs);
-            c
-        }
-        TirExprKind::Unary { expr: inner, .. }
-        | TirExprKind::Cast { expr: inner, .. }
-        | TirExprKind::FieldAccess { expr: inner, .. }
-        | TirExprKind::GlobalVarSet { value: inner, .. }
-        | TirExprKind::TupleSpread { expr: inner, .. } => eliminate_bitmask_in_expr(inner, defs),
-        TirExprKind::If {
+impl TirVisitor for BitmaskEliminator<'_> {
+    fn visit_stmt(&mut self, stmt: &mut TirStmt) -> bool {
+        if let TirStmtKind::If {
             condition,
-            then_branch,
-            else_branch,
-        } => {
-            let mut c = eliminate_bitmask_in_expr(condition, defs);
-            for s in &mut then_branch.stmts {
-                c |= eliminate_bitmask_bounded(s, defs);
-            }
-            if let Some(eb) = else_branch {
-                for s in &mut eb.stmts {
-                    c |= eliminate_bitmask_bounded(s, defs);
-                }
-            }
-            c
+            then_block,
+            else_block: None,
+        } = &mut stmt.kind
+            && is_panic_block(then_block)
+            && is_bitmask_bounded(condition, self.defs)
+        {
+            let type_id = condition.type_id;
+            let span = condition.span;
+            *condition = TirExpr {
+                kind: TirExprKind::BoolLiteral(false),
+                type_id,
+                span,
+            };
+            return true;
         }
-        TirExprKind::Call { args, .. } => {
-            let mut c = false;
-            for arg in args {
-                c |= eliminate_bitmask_in_expr(&mut arg.expr, defs);
-            }
-            c
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            let mut c = eliminate_bitmask_in_expr(receiver, defs);
-            for arg in args {
-                c |= eliminate_bitmask_in_expr(&mut arg.expr, defs);
-            }
-            c
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            let mut c = false;
-            for f in fields {
-                c |= eliminate_bitmask_in_expr(&mut f.value, defs);
-            }
-            c
-        }
-        TirExprKind::TupleLiteral { elements } => {
-            let mut c = false;
-            for e in elements {
-                c |= eliminate_bitmask_in_expr(e, defs);
-            }
-            c
-        }
-        TirExprKind::VariantConstruct {
-            payload: Some(inner),
-            ..
-        } => eliminate_bitmask_in_expr(inner, defs),
-        _ => false,
+        walk_stmt(self, stmt)
     }
 }
 

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -271,6 +271,10 @@ fn fuse_in_expr(expr: &mut TirExpr, local_count: &mut u32, local_types: &mut Vec
             fuse_in_expr(functor, local_count, local_types)
         }
         TirExprKind::GlobalVarSet { value, .. } => fuse_in_expr(value, local_count, local_types),
+        TirExprKind::TupleSpread { expr: inner }
+        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
+            fuse_in_expr(inner, local_count, local_types)
+        }
         TirExprKind::Switch {
             scrutinee,
             arms,
@@ -295,7 +299,23 @@ fn fuse_in_expr(expr: &mut TirExpr, local_count: &mut u32, local_types: &mut Vec
             changed
         }
         TirExprKind::Closure { body, .. } => fuse_in_expr(body, local_count, local_types),
-        _ => false,
+        // Leaf nodes
+        TirExprKind::Local { .. }
+        | TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => false,
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 
@@ -740,7 +760,26 @@ fn count_local_uses_in_expr(expr: &TirExpr, local_idx: u32) -> usize {
                 + count_local_uses_in_block(default, local_idx)
         }
         TirExprKind::Closure { body, .. } => count_local_uses_in_expr(body, local_idx),
-        _ => 0,
+        TirExprKind::TupleSpread { expr: inner }
+        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
+            count_local_uses_in_expr(inner, local_idx)
+        }
+        // Leaf nodes
+        TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => 0,
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 
@@ -907,7 +946,26 @@ fn count_variant_payload_uses_in_expr(expr: &TirExpr, local_idx: u32, case_index
         TirExprKind::Closure { body, .. } => {
             count_variant_payload_uses_in_expr(body, local_idx, case_index)
         }
-        _ => 0,
+        TirExprKind::TupleSpread { expr: inner }
+        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
+            count_variant_payload_uses_in_expr(inner, local_idx, case_index)
+        }
+        // Leaf nodes
+        TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => 0,
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 
@@ -1297,7 +1355,14 @@ fn transform_lb_in_stmt_kind(
                 );
             }
         }
-        _ => {}
+        // If/Loop/LabeledBlock/IfLet are handled before this function is called (in
+        // transform_lb_stmt). The remaining kinds carry no expressions to transform.
+        TirStmtKind::If { .. }
+        | TirStmtKind::Loop { .. }
+        | TirStmtKind::LabeledBlock { .. }
+        | TirStmtKind::IfLet { .. }
+        | TirStmtKind::Continue
+        | TirStmtKind::VariadicForOf { .. } => {}
     }
 }
 
@@ -1482,7 +1547,44 @@ fn transform_lb_in_expr(
                 span,
             );
         }
-        _ => {}
+        // These expression kinds cannot contain `break orig_label` that reaches the outer
+        // scope, because check_lb_breaks_in_expr conservatively rejects fusion when a
+        // break to the target label is found inside any of these expressions.
+        TirExprKind::Binary { .. }
+        | TirExprKind::Unary { .. }
+        | TirExprKind::Cast { .. }
+        | TirExprKind::FieldAccess { .. }
+        | TirExprKind::TupleSpread { .. }
+        | TirExprKind::TypePackExpansion { .. }
+        | TirExprKind::Assign { .. }
+        | TirExprKind::Index { .. }
+        | TirExprKind::Call { .. }
+        | TirExprKind::CmRawCall { .. }
+        | TirExprKind::MethodCall { .. }
+        | TirExprKind::IndirectCall { .. }
+        | TirExprKind::StructLiteral { .. }
+        | TirExprKind::TupleLiteral { .. }
+        | TirExprKind::VariantConstruct { .. }
+        | TirExprKind::VariantTag { .. }
+        | TirExprKind::VariantTest { .. }
+        | TirExprKind::VariantPayload { .. }
+        | TirExprKind::Closure { .. }
+        | TirExprKind::ClosureToCanonical { .. }
+        | TirExprKind::GlobalVarSet { .. }
+        | TirExprKind::Local { .. }
+        | TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. }
+        | TirExprKind::TemplateString { .. } => {}
     }
 }
 
@@ -1607,9 +1709,7 @@ fn subst_variant_payload_in_expr(
 
     // Recurse into sub-expressions.
     match &mut expr.kind {
-        TirExprKind::Local { .. }
-        | TirExprKind::FuncRef { .. }
-        | TirExprKind::GlobalVarGet { .. } => {}
+        TirExprKind::Local { .. } => {}
         TirExprKind::Binary { left, right, .. } => {
             subst_variant_payload_in_expr(left, temp_local, case_index, payload_local);
             subst_variant_payload_in_expr(right, temp_local, case_index, payload_local);
@@ -1707,7 +1807,26 @@ fn subst_variant_payload_in_expr(
         TirExprKind::Closure { body, .. } => {
             subst_variant_payload_in_expr(body, temp_local, case_index, payload_local);
         }
-        _ => {}
+        TirExprKind::TupleSpread { expr: inner }
+        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
+            subst_variant_payload_in_expr(inner, temp_local, case_index, payload_local);
+        }
+        // Leaf nodes carry no sub-expressions to substitute into.
+        TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => {}
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -272,9 +272,9 @@ fn fuse_in_expr(expr: &mut TirExpr, local_count: &mut u32, local_types: &mut Vec
         }
         TirExprKind::GlobalVarSet { value, .. } => fuse_in_expr(value, local_count, local_types),
         TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
-            fuse_in_expr(inner, local_count, local_types)
-        }
+        | TirExprKind::TypePackExpansion {
+            call_expr: inner, ..
+        } => fuse_in_expr(inner, local_count, local_types),
         TirExprKind::Switch {
             scrutinee,
             arms,
@@ -761,9 +761,9 @@ fn count_local_uses_in_expr(expr: &TirExpr, local_idx: u32) -> usize {
         }
         TirExprKind::Closure { body, .. } => count_local_uses_in_expr(body, local_idx),
         TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
-            count_local_uses_in_expr(inner, local_idx)
-        }
+        | TirExprKind::TypePackExpansion {
+            call_expr: inner, ..
+        } => count_local_uses_in_expr(inner, local_idx),
         // Leaf nodes
         TirExprKind::FuncRef { .. }
         | TirExprKind::GlobalVarGet { .. }
@@ -947,9 +947,9 @@ fn count_variant_payload_uses_in_expr(expr: &TirExpr, local_idx: u32, case_index
             count_variant_payload_uses_in_expr(body, local_idx, case_index)
         }
         TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
-            count_variant_payload_uses_in_expr(inner, local_idx, case_index)
-        }
+        | TirExprKind::TypePackExpansion {
+            call_expr: inner, ..
+        } => count_variant_payload_uses_in_expr(inner, local_idx, case_index),
         // Leaf nodes
         TirExprKind::FuncRef { .. }
         | TirExprKind::GlobalVarGet { .. }
@@ -1808,7 +1808,9 @@ fn subst_variant_payload_in_expr(
             subst_variant_payload_in_expr(body, temp_local, case_index, payload_local);
         }
         TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TypePackExpansion { call_expr: inner, .. } => {
+        | TirExprKind::TypePackExpansion {
+            call_expr: inner, ..
+        } => {
             subst_variant_payload_in_expr(inner, temp_local, case_index, payload_local);
         }
         // Leaf nodes carry no sub-expressions to substitute into.

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -252,7 +252,33 @@ fn mark_ref_fields_in_stmt(
         TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
             mark_ref_field_locals_as_aliased(body, decomposed, stores_aliased);
         }
-        _ => {}
+        TirStmtKind::IfLet {
+            scrutinee,
+            then_block,
+            else_block,
+            ..
+        } => {
+            mark_ref_fields_in_expr(scrutinee, decomposed, stores_aliased);
+            mark_ref_field_locals_as_aliased(then_block, decomposed, stores_aliased);
+            if let Some(eb) = else_block {
+                mark_ref_field_locals_as_aliased(eb, decomposed, stores_aliased);
+            }
+        }
+        TirStmtKind::Break { value, .. } => {
+            if let Some(v) = value {
+                mark_ref_fields_in_expr(v, decomposed, stores_aliased);
+            }
+        }
+        TirStmtKind::LetDestructure { value, .. } => {
+            mark_ref_fields_in_expr(value, decomposed, stores_aliased);
+        }
+        TirStmtKind::Continue => {}
+        TirStmtKind::TaskReturn { .. } => {
+            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
+        }
+        TirStmtKind::VariadicForOf { .. } => {
+            unreachable!("VariadicForOf should be expanded during monomorphization")
+        }
     }
 }
 
@@ -276,7 +302,112 @@ fn mark_ref_fields_in_expr(
                 mark_ref_field_locals_as_aliased(eb, decomposed, stores_aliased);
             }
         }
-        _ => {}
+        TirExprKind::Match { expr: inner, arms } => {
+            mark_ref_fields_in_expr(inner, decomposed, stores_aliased);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    mark_ref_fields_in_expr(guard, decomposed, stores_aliased);
+                }
+                mark_ref_fields_in_expr(&arm.body, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::Switch {
+            scrutinee,
+            arms,
+            default,
+            ..
+        } => {
+            mark_ref_fields_in_expr(scrutinee, decomposed, stores_aliased);
+            for arm in arms {
+                mark_ref_field_locals_as_aliased(arm, decomposed, stores_aliased);
+            }
+            mark_ref_field_locals_as_aliased(default, decomposed, stores_aliased);
+        }
+        TirExprKind::Binary { left, right, .. } => {
+            mark_ref_fields_in_expr(left, decomposed, stores_aliased);
+            mark_ref_fields_in_expr(right, decomposed, stores_aliased);
+        }
+        TirExprKind::Unary { expr: inner, .. }
+        | TirExprKind::FieldAccess { expr: inner, .. }
+        | TirExprKind::TupleSpread { expr: inner }
+        | TirExprKind::TypePackExpansion {
+            call_expr: inner, ..
+        }
+        | TirExprKind::Cast { expr: inner, .. }
+        | TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. }
+        | TirExprKind::ClosureToCanonical { functor: inner, .. } => {
+            mark_ref_fields_in_expr(inner, decomposed, stores_aliased);
+        }
+        TirExprKind::Assign { target, value } => {
+            mark_ref_fields_in_expr(target, decomposed, stores_aliased);
+            mark_ref_fields_in_expr(value, decomposed, stores_aliased);
+        }
+        TirExprKind::Index { expr: inner, index } => {
+            mark_ref_fields_in_expr(inner, decomposed, stores_aliased);
+            mark_ref_fields_in_expr(index, decomposed, stores_aliased);
+        }
+        TirExprKind::Call { args, .. } => {
+            for arg in args {
+                mark_ref_fields_in_expr(&arg.expr, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                mark_ref_fields_in_expr(arg, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::MethodCall { receiver, args, .. } => {
+            mark_ref_fields_in_expr(receiver, decomposed, stores_aliased);
+            for arg in args {
+                mark_ref_fields_in_expr(&arg.expr, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::IndirectCall { callee, args } => {
+            mark_ref_fields_in_expr(callee, decomposed, stores_aliased);
+            for arg in args {
+                mark_ref_fields_in_expr(arg, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::StructLiteral { fields, .. } => {
+            for field in fields {
+                mark_ref_fields_in_expr(&field.value, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                mark_ref_fields_in_expr(elem, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::VariantConstruct { payload, .. } => {
+            if let Some(p) = payload {
+                mark_ref_fields_in_expr(p, decomposed, stores_aliased);
+            }
+        }
+        TirExprKind::Closure { body, .. } => {
+            mark_ref_fields_in_expr(body, decomposed, stores_aliased);
+        }
+        TirExprKind::GlobalVarSet { value, .. } => {
+            mark_ref_fields_in_expr(value, decomposed, stores_aliased);
+        }
+        // Leaf nodes
+        TirExprKind::Local { .. }
+        | TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => {}
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 
@@ -915,7 +1046,99 @@ fn check_has_field_access_expr(
                 check_has_field_access(eb, candidates, has_access);
             }
         }
-        _ => {}
+        TirExprKind::Match { expr: inner, arms } => {
+            check_has_field_access_expr(inner, candidates, has_access);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    check_has_field_access_expr(guard, candidates, has_access);
+                }
+                check_has_field_access_expr(&arm.body, candidates, has_access);
+            }
+        }
+        TirExprKind::Switch {
+            scrutinee,
+            arms,
+            default,
+            ..
+        } => {
+            check_has_field_access_expr(scrutinee, candidates, has_access);
+            for arm in arms {
+                check_has_field_access(arm, candidates, has_access);
+            }
+            check_has_field_access(default, candidates, has_access);
+        }
+        TirExprKind::Unary { expr: inner, .. }
+        | TirExprKind::Cast { expr: inner, .. }
+        | TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. }
+        | TirExprKind::ClosureToCanonical { functor: inner, .. } => {
+            check_has_field_access_expr(inner, candidates, has_access);
+        }
+        TirExprKind::Index { expr: inner, index } => {
+            check_has_field_access_expr(inner, candidates, has_access);
+            check_has_field_access_expr(index, candidates, has_access);
+        }
+        TirExprKind::Call { args, .. } => {
+            for arg in args {
+                check_has_field_access_expr(&arg.expr, candidates, has_access);
+            }
+        }
+        TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                check_has_field_access_expr(arg, candidates, has_access);
+            }
+        }
+        TirExprKind::MethodCall { receiver, args, .. } => {
+            check_has_field_access_expr(receiver, candidates, has_access);
+            for arg in args {
+                check_has_field_access_expr(&arg.expr, candidates, has_access);
+            }
+        }
+        TirExprKind::IndirectCall { callee, args } => {
+            check_has_field_access_expr(callee, candidates, has_access);
+            for arg in args {
+                check_has_field_access_expr(arg, candidates, has_access);
+            }
+        }
+        TirExprKind::StructLiteral { fields, .. } => {
+            for field in fields {
+                check_has_field_access_expr(&field.value, candidates, has_access);
+            }
+        }
+        TirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                check_has_field_access_expr(elem, candidates, has_access);
+            }
+        }
+        TirExprKind::VariantConstruct { payload, .. } => {
+            if let Some(p) = payload {
+                check_has_field_access_expr(p, candidates, has_access);
+            }
+        }
+        TirExprKind::Closure { body, .. } => {
+            check_has_field_access_expr(body, candidates, has_access);
+        }
+        TirExprKind::GlobalVarSet { value, .. } => {
+            check_has_field_access_expr(value, candidates, has_access);
+        }
+        // Leaf nodes
+        TirExprKind::Local { .. }
+        | TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => {}
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -243,7 +243,22 @@ fn collect_escaping_in_stmt(stmt: &TirStmt, escaping: &mut IndexSet<u32>) {
                 collect_escaping_in_stmt(s, escaping);
             }
         }
-        _ => {}
+        TirStmtKind::Return { value: None } | TirStmtKind::Continue => {}
+        TirStmtKind::Break { value, .. } => {
+            if let Some(v) = value {
+                collect_local_refs(v, escaping);
+                collect_escaping_in_expr(v, escaping);
+            }
+        }
+        TirStmtKind::LetDestructure { value, .. } => {
+            collect_escaping_in_expr(value, escaping);
+        }
+        TirStmtKind::TaskReturn { .. } => {
+            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
+        }
+        TirStmtKind::VariadicForOf { .. } => {
+            unreachable!("VariadicForOf should be expanded during monomorphization")
+        }
     }
 }
 
@@ -332,7 +347,80 @@ fn collect_escaping_in_expr(expr: &TirExpr, escaping: &mut IndexSet<u32>) {
                 collect_escaping_in_stmt(s, escaping);
             }
         }
-        _ => {}
+        TirExprKind::Match { expr: inner, arms } => {
+            collect_escaping_in_expr(inner, escaping);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    collect_escaping_in_expr(guard, escaping);
+                }
+                collect_escaping_in_expr(&arm.body, escaping);
+            }
+        }
+        TirExprKind::Switch {
+            scrutinee,
+            arms,
+            default,
+            ..
+        } => {
+            collect_escaping_in_expr(scrutinee, escaping);
+            for arm in arms {
+                for s in &arm.stmts {
+                    collect_escaping_in_stmt(s, escaping);
+                }
+            }
+            for s in &default.stmts {
+                collect_escaping_in_stmt(s, escaping);
+            }
+        }
+        TirExprKind::Closure { body, captures, .. } => {
+            // Closure captures: the captured variables escape
+            for capture in captures {
+                escaping.insert(capture.outer_index);
+            }
+            collect_escaping_in_expr(body, escaping);
+        }
+        TirExprKind::CmRawCall { args, .. } => {
+            for arg in args {
+                collect_local_refs(arg, escaping);
+                collect_escaping_in_expr(arg, escaping);
+            }
+        }
+        TirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                collect_escaping_in_expr(elem, escaping);
+            }
+        }
+        TirExprKind::VariantConstruct { payload, .. } => {
+            if let Some(p) = payload {
+                collect_escaping_in_expr(p, escaping);
+            }
+        }
+        TirExprKind::VariantTag { expr: inner }
+        | TirExprKind::VariantTest { expr: inner, .. }
+        | TirExprKind::VariantPayload { expr: inner, .. }
+        | TirExprKind::ClosureToCanonical { functor: inner, .. } => {
+            collect_escaping_in_expr(inner, escaping);
+        }
+        TirExprKind::GlobalVarSet { value, .. } => {
+            collect_escaping_in_expr(value, escaping);
+        }
+        // Leaf nodes
+        TirExprKind::Local { .. }
+        | TirExprKind::FuncRef { .. }
+        | TirExprKind::GlobalVarGet { .. }
+        | TirExprKind::Capture { .. }
+        | TirExprKind::IntLiteral { .. }
+        | TirExprKind::FloatLiteral { .. }
+        | TirExprKind::StringLiteral(_)
+        | TirExprKind::BytesLiteral(_)
+        | TirExprKind::BoolLiteral(_)
+        | TirExprKind::CharLiteral(_)
+        | TirExprKind::Null
+        | TirExprKind::Unit
+        | TirExprKind::EnumConstruct { .. } => {}
+        TirExprKind::TemplateString { .. } => {
+            unreachable!("TemplateString should be expanded before this phase")
+        }
     }
 }
 

--- a/wado-compiler/src/optimize/visitor.rs
+++ b/wado-compiler/src/optimize/visitor.rs
@@ -15,6 +15,15 @@ use crate::tir::{TirBlock, TirExpr, TirExprKind, TirStmt, TirStmtKind};
 /// All methods return `true` if any changes were made.
 /// Default implementations walk children recursively.
 pub(crate) trait TirVisitor {
+    /// Visit a statement. Override to add statement-level transformation logic.
+    /// Call `walk_stmt(self, stmt)` to recurse into children.
+    fn visit_stmt(&mut self, stmt: &mut TirStmt) -> bool
+    where
+        Self: Sized,
+    {
+        walk_stmt(self, stmt)
+    }
+
     /// Visit an expression. Override to add custom transformation logic.
     /// Call `walk_expr(self, expr)` to recurse into children.
     fn visit_expr(&mut self, expr: &mut TirExpr) -> bool
@@ -38,13 +47,13 @@ pub(crate) trait TirVisitor {
 pub(crate) fn walk_block(visitor: &mut impl TirVisitor, block: &mut TirBlock) -> bool {
     let mut changed = false;
     for stmt in &mut block.stmts {
-        changed |= walk_stmt(visitor, stmt);
+        changed |= visitor.visit_stmt(stmt);
     }
     changed
 }
 
 /// Walk a statement's children.
-fn walk_stmt(visitor: &mut impl TirVisitor, stmt: &mut TirStmt) -> bool {
+pub(crate) fn walk_stmt(visitor: &mut impl TirVisitor, stmt: &mut TirStmt) -> bool {
     match &mut stmt.kind {
         TirStmtKind::Let { value, .. } | TirStmtKind::LetDestructure { value, .. } => {
             visitor.visit_expr(value)

--- a/wado-compiler/tests/fixtures.golden/array_index_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_index_2.wir.wado
@@ -155,7 +155,6 @@ import fn subtask-drop from "wasi/subtask-drop";
 fn array_index_inline_multi() with Stdout {
     let __local_0: ref Array<bool>;
     let __local_1: ref Array<String>;
-    let c: ref Container<String>;
     let item0: ref String;
     let item1: ref String;
     let item2: ref String;
@@ -167,61 +166,54 @@ fn array_index_inline_multi() with Stdout {
     let __local_11: ref Formatter;
     let __local_12: ref String;
     let __local_13: ref Formatter;
-    let __local_34: ref Array<String>;
-    let __local_38: ref Array<String>;
-    let __local_42: ref Array<String>;
-    let __local_46: ref Array<bool>;
-    let __local_50: ref Array<bool>;
     let __local_56: ref Formatter;
     let __local_61: ref Formatter;
-    c = Container<String> { items: ref.as_non_null(__seq_lit: block -> ref Array<String> {
+    let __sroa_c_items: ref Array<String>;
+    let __sroa_c_markers: ref Array<bool>;
+    __sroa_c_items = __seq_lit: block -> ref Array<String> {
         __local_1 = Array<String> { repr: array.new_fixed<ref String>(String { repr: array.new_data<u8>("apple"), used: 5 }, String { repr: array.new_data<u8>("banana"), used: 6 }, String { repr: array.new_data<u8>("cherry"), used: 6 }), used: 3 };
         break __seq_lit: __local_1;
-    }), markers: ref.as_non_null(__seq_lit: block -> ref Array<bool> {
+    };
+    __sroa_c_markers = __seq_lit: block -> ref Array<bool> {
         __local_0 = Array<bool> { repr: array.new_fixed<bool>(1, 0, 1), used: 3 };
         break __seq_lit: __local_0;
-    }) };
+    };
     item0 = __inline_Array_String__IndexValue__index_value_13: block -> ref String {
-        __local_34 = c.items;
-        if 0 >= __local_34.used {
+        if 0 >= __sroa_c_items.used {
             "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
             unreachable;
         };
-        break __inline_Array_String__IndexValue__index_value_13: builtin::array_get<ref String>(__local_34.repr, 0);
+        break __inline_Array_String__IndexValue__index_value_13: builtin::array_get<ref String>(__sroa_c_items.repr, 0);
     };
     item1 = __inline_Array_String__IndexValue__index_value_15: block -> ref String {
-        __local_38 = c.items;
-        if 1 >= __local_38.used {
+        if 1 >= __sroa_c_items.used {
             "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
             unreachable;
         };
-        break __inline_Array_String__IndexValue__index_value_15: builtin::array_get<ref String>(__local_38.repr, 1);
+        break __inline_Array_String__IndexValue__index_value_15: builtin::array_get<ref String>(__sroa_c_items.repr, 1);
     };
     item2 = __inline_Array_String__IndexValue__index_value_17: block -> ref String {
-        __local_42 = c.items;
-        if 2 >= __local_42.used {
+        if 2 >= __sroa_c_items.used {
             "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
             unreachable;
         };
-        break __inline_Array_String__IndexValue__index_value_17: builtin::array_get<ref String>(__local_42.repr, 2);
+        break __inline_Array_String__IndexValue__index_value_17: builtin::array_get<ref String>(__sroa_c_items.repr, 2);
     };
     flag0 = __inline_Array_bool__IndexValue__index_value_19: block -> bool {
-        __local_46 = c.markers;
-        if 0 >= __local_46.used {
+        if 0 >= __sroa_c_markers.used {
             "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
             unreachable;
         };
-        break __inline_Array_bool__IndexValue__index_value_19: builtin::array_get<bool>(__local_46.repr, 0);
+        break __inline_Array_bool__IndexValue__index_value_19: builtin::array_get<bool>(__sroa_c_markers.repr, 0);
     };
     flag1 = __inline_Array_bool__IndexValue__index_value_21: block -> bool {
-        __local_50 = c.markers;
-        if 1 >= __local_50.used {
+        if 1 >= __sroa_c_markers.used {
             "core:internal/panic"(String { repr: array.new_data<u8>("index out of bounds"), used: 19 });
             unreachable;
         };
-        break __inline_Array_bool__IndexValue__index_value_21: builtin::array_get<bool>(__local_50.repr, 1);
+        break __inline_Array_bool__IndexValue__index_value_21: builtin::array_get<bool>(__sroa_c_markers.repr, 1);
     };
-    count = Container<String>::count_flagged(c);
+    count = Container<String>::count_flagged(Container<String> { items: ref.as_non_null(__sroa_c_items), markers: ref.as_non_null(__sroa_c_markers) });
     "core:cli/println"(__tmpl: block -> ref String {
         __local_9 = String { repr: builtin::array_new<u8>(59), used: 0 };
         String::append_char(__local_9, 105);

--- a/wado-compiler/tests/fixtures.golden/trait_default.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_default.wir.wado
@@ -25,10 +25,6 @@ struct Article {
     mut content: ref String,
 }
 
-struct Item {
-    mut name: ref String,
-}
-
 array array<i32> (mut i32);
 
 struct ArrayIter<i32> {  // from core:allocator  // ArrayIter<T> with T=i32
@@ -154,15 +150,15 @@ import fn stream-new from "wasi/stream-new";
 import fn subtask-drop from "wasi/subtask-drop";
 
 fn trait_default_calls_default() with Stdout {
-    let item: ref Item;
     let __local_3: ref String;
-    item = Item { name: String { repr: array.new_data<u8>("Widget"), used: 6 } };
-    "core:cli/println"(item.name);
-    "core:cli/println"(Item^Describable::short_desc(item.name));
+    let __sroa_item_name: ref String;
+    __sroa_item_name = String { repr: array.new_data<u8>("Widget"), used: 6 };
+    "core:cli/println"(__sroa_item_name);
+    "core:cli/println"(Item^Describable::short_desc(ref.as_non_null(__sroa_item_name)));
     "core:cli/println"(__tmpl: block -> ref String {
         __local_3 = String { repr: builtin::array_new<u8>(29), used: 0 };
         String::append(__local_3, String { repr: array.new_data<u8>("Description: "), used: 13 });
-        String::append(__local_3, Item^Describable::short_desc(item.name));
+        String::append(__local_3, Item^Describable::short_desc(ref.as_non_null(__sroa_item_name)));
         break __tmpl: __local_3;
     });
 }


### PR DESCRIPTION
## Summary

- **Stage 1**: Replace `_ => {}` wildcards in optimizer traversal functions with exhaustive match arms. New TIR node kinds now cause a compile error instead of silently being skipped, preventing the class of bugs (HFS stale cache, LICM infinite loop, variant SROA crash) caused by passes silently ignoring `Match`/`Switch` nodes.
- **Stage 2**: Migrate `condition_implication.rs` elimination passes to `TirVisitor`, removing ~100 lines of hand-rolled traversal code that duplicated `walk_expr`/`walk_stmt`.

### Files changed

**`visitor.rs`**
- Add `visit_stmt` to `TirVisitor` trait (default impl calls `walk_stmt`)
- Update `walk_block` to call `visitor.visit_stmt` so overrides propagate through block traversal
- Make `walk_stmt` `pub(crate)`

**`condition_implication.rs`**
- Replace `eliminate_in_stmt/block/expr` with `ConditionEliminator` struct implementing `TirVisitor`; dominating guard propagation handled via `visit_stmt`/`visit_expr` overrides for `If` nodes
- Replace `eliminate_bitmask_bounded/eliminate_bitmask_in_expr` with `BitmaskEliminator` struct
- Make `record_defs_from_expr` and `record_defs_from_nested` exhaustive (previously `_ => {}` silently missed `Match`, `Switch`, `CmRawCall`, `TypePackExpansion`, etc.)

**`labeled_block_fusion.rs`**
- Add `TupleSpread`/`TypePackExpansion` recursion to 4 traversal functions
- Replace `_ => {}` in `transform_lb_in_expr` with explicit exhaustive arms

**`sroa.rs`**
- `mark_ref_fields_in_stmt`: add `IfLet`, `Break`, `LetDestructure`, `Continue`, `TaskReturn`, `VariadicForOf` (missing `IfLet` could cause incorrect SROA when candidate struct with reference fields is initialized inside an `if let` branch)
- `mark_ref_fields_in_expr`: expand from only handling `Block`/`LabeledBlock`/`If` to all expression kinds including `Match`, `Switch`, `Binary`, `Call`, etc.
- `check_has_field_access_expr`: add `Match`, `Switch`, and all compound expression types

**`tmpl_hoist.rs`**
- `collect_escaping_in_stmt`: add `Break`, `LetDestructure`, `Continue`, `Return{None}`, `TaskReturn`, `VariadicForOf`
- `collect_escaping_in_expr`: add `Match`, `Switch`, `Closure`, `CmRawCall`, `TupleLiteral`, `VariantConstruct`, `VariantTag/Test/Payload`, `ClosureToCanonical`, `GlobalVarSet`, and explicit leaf nodes

## Test plan

- [x] `cargo build -p wado-compiler` — clean build
- [x] `cargo test -p wado-compiler --lib` — 317 unit tests pass
- [x] `cargo test -p wado-compiler --test e2e` — 4205 E2E tests pass

https://claude.ai/code/session_01XogcrGEw3tsADHovHA63aX