### PR TITLE
Add support for 'of' as a contextual keyword

### DIFF
--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -2244,22 +2244,23 @@ RFC 1950 (zlib format) is supported except for preset dictionaries (FDICT);
 streams with FDICT set will return `ZlibError::PresetDictionaryNotSupported`.
 
 Features:
-  - Adler-32 and CRC-32 checksums (with combine operations)
-  - DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
-  - DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
-  - Compression levels 0-9 with strategy selection
-  - zlib and gzip format support
-  - Streaming deflate/inflate API
+
+- Adler-32 and CRC-32 checksums (with combine operations)
+- DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
+- DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
+- Compression levels 0-9 with strategy selection
+- zlib and gzip format support
+- Streaming deflate/inflate API
 
 Usage - Compression:
-  let input: Array<u8> = [...];
-  let compressed = zlib_compress(&input);
-  let compressed_fast = compress2(&input, Z_BEST_SPEED);
-  let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
+let input: Array<u8> = [...];
+let compressed = zlib_compress(&input);
+let compressed_fast = compress2(&input, Z_BEST_SPEED);
+let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
 
 Usage - Decompression:
-  let decompressed = inflate_zlib(&compressed);
-  let decompressed_gz = inflate_gzip(&gzipped_data);
+let decompressed = inflate_zlib(&compressed);
+let decompressed_gz = inflate_gzip(&gzipped_data);
 
 ### Globals
 

--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -2244,23 +2244,22 @@ RFC 1950 (zlib format) is supported except for preset dictionaries (FDICT);
 streams with FDICT set will return `ZlibError::PresetDictionaryNotSupported`.
 
 Features:
-
-- Adler-32 and CRC-32 checksums (with combine operations)
-- DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
-- DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
-- Compression levels 0-9 with strategy selection
-- zlib and gzip format support
-- Streaming deflate/inflate API
+  - Adler-32 and CRC-32 checksums (with combine operations)
+  - DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
+  - DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
+  - Compression levels 0-9 with strategy selection
+  - zlib and gzip format support
+  - Streaming deflate/inflate API
 
 Usage - Compression:
-let input: Array<u8> = [...];
-let compressed = zlib_compress(&input);
-let compressed_fast = compress2(&input, Z_BEST_SPEED);
-let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
+  let input: Array<u8> = [...];
+  let compressed = zlib_compress(&input);
+  let compressed_fast = compress2(&input, Z_BEST_SPEED);
+  let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
 
 Usage - Decompression:
-let decompressed = inflate_zlib(&compressed);
-let decompressed_gz = inflate_gzip(&gzipped_data);
+  let decompressed = inflate_zlib(&compressed);
+  let decompressed_gz = inflate_gzip(&gzipped_data);
 
 ### Globals
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -115,6 +115,34 @@ name123
 
 Identifiers are case-sensitive.
 
+### Contextual Keywords
+
+The following keywords are **contextual** — they act as keywords only in specific syntactic positions and can be used as variable names, field names, and function parameters elsewhere:
+
+| Keyword | Keyword context | Identifier elsewhere |
+|---------|----------------|---------------------|
+| `flags` | `flags` declaration | Variable, field, parameter |
+| `type`  | `type` declaration | Variable, field, parameter |
+| `of`    | `for let <pattern> of <expr>` | Variable, field, parameter |
+| `from`  | `use { ... } from "..."` | Variable, field, parameter, type name |
+| `test`  | `test "name" { ... }` block | Variable, field, parameter |
+
+```wado
+// 'of' as a variable name
+let of = 42;
+println(`{of}`);
+
+// 'of' as a struct field
+struct Item { of: i32 }
+let item = Item { of: 10 };
+
+// 'of' as a for-of binding
+let arr: Array<i32> = [1, 2, 3];
+for let of of arr {
+    println(`{of}`);
+}
+```
+
 ### Statements and Expressions
 
 - `expr;` makes a statement. A semicolon is required for every statement including the last one.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -119,13 +119,13 @@ Identifiers are case-sensitive.
 
 The following keywords are **contextual** — they act as keywords only in specific syntactic positions and can be used as variable names, field names, and function parameters elsewhere:
 
-| Keyword | Keyword context | Identifier elsewhere |
-|---------|----------------|---------------------|
-| `flags` | `flags` declaration | Variable, field, parameter |
-| `type`  | `type` declaration | Variable, field, parameter |
-| `of`    | `for let <pattern> of <expr>` | Variable, field, parameter |
-| `from`  | `use { ... } from "..."` | Variable, field, parameter, type name |
-| `test`  | `test "name" { ... }` block | Variable, field, parameter |
+| Keyword | Keyword context               | Identifier elsewhere                  |
+| ------- | ----------------------------- | ------------------------------------- |
+| `flags` | `flags` declaration           | Variable, field, parameter            |
+| `type`  | `type` declaration            | Variable, field, parameter            |
+| `of`    | `for let <pattern> of <expr>` | Variable, field, parameter            |
+| `from`  | `use { ... } from "..."`      | Variable, field, parameter, type name |
+| `test`  | `test "name" { ... }` block   | Variable, field, parameter            |
 
 ```wado
 // 'of' as a variable name

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -124,7 +124,7 @@ pub enum TokenKind {
 
 impl TokenKind {
     /// Returns the identifier name for tokens that can act as identifiers.
-    /// This includes regular identifiers and contextual keywords (`flags`, `type`)
+    /// This includes regular identifiers and contextual keywords (`flags`, `type`, `of`)
     /// which are only keywords at declaration start but can be used as identifiers elsewhere.
     #[must_use]
     pub fn as_ident_name(&self) -> Option<&str> {
@@ -133,6 +133,8 @@ impl TokenKind {
             // Contextual keywords: only keywords at declaration start
             Self::Flags => Some("flags"),
             Self::Type => Some("type"),
+            // `of` is only a keyword after `for let <pattern>`, valid as identifier elsewhere
+            Self::Of => Some("of"),
             // `from` appears in `use { x } from "mod"` but is also valid as a type/trait name
             Self::From => Some("from"),
             _ => None,

--- a/wado-compiler/tests/fixtures.golden/contextual_keyword.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/contextual_keyword.wir.wado
@@ -117,53 +117,87 @@ import fn stream-new from "wasi/stream-new";
 import fn subtask-drop from "wasi/subtask-drop";
 
 fn run() with Stdout {
-    let __local_4: ref Array<i32>;
+    let __local_6: ref Array<i32>;
     let arr: ref Array<i32>;
-    let __iter_6: ref "core:allocator/ArrayIter<i32>";
+    let __iter_8: ref "core:allocator/ArrayIter<i32>";
     let flags: i32;
-    let __local_8: ref String;
-    let __local_9: ref Formatter;
-    let __local_10: ref String;
-    let __local_11: ref Formatter;
+    let __iter_10: ref "core:allocator/ArrayIter<i32>";
+    let of: i32;
     let __local_12: ref String;
     let __local_13: ref Formatter;
+    let __local_14: ref String;
+    let __local_15: ref Formatter;
+    let __local_16: ref String;
+    let __local_17: ref Formatter;
+    let __local_18: ref String;
+    let __local_19: ref Formatter;
+    let __local_20: ref String;
+    let __local_21: ref Formatter;
     "core:cli/println"(__tmpl: block -> ref String {
-        __local_8 = String { repr: builtin::array_new<u8>(31), used: 0 };
-        String::append(__local_8, String { repr: array.new_data<u8>("flags + type = "), used: 15 });
-        __local_9 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_8) };
-        i32::fmt_decimal(30, __local_9);
-        break __tmpl: __local_8;
+        __local_12 = String { repr: builtin::array_new<u8>(36), used: 0 };
+        String::append(__local_12, String { repr: array.new_data<u8>("flags + type + of = "), used: 20 });
+        __local_13 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_12) };
+        i32::fmt_decimal(60, __local_13);
+        break __tmpl: __local_12;
     });
     "core:cli/println"(__tmpl: block -> ref String {
-        __local_10 = String { repr: builtin::array_new<u8>(36), used: 0 };
-        String::append(__local_10, String { repr: array.new_data<u8>("test_param result = "), used: 20 });
-        __local_11 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_10) };
-        i32::fmt_decimal(30, __local_11);
-        break __tmpl: __local_10;
+        __local_14 = String { repr: builtin::array_new<u8>(36), used: 0 };
+        String::append(__local_14, String { repr: array.new_data<u8>("test_param result = "), used: 20 });
+        __local_15 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_14) };
+        i32::fmt_decimal(60, __local_15);
+        break __tmpl: __local_14;
+    });
+    "core:cli/println"(__tmpl: block -> ref String {
+        __local_16 = String { repr: builtin::array_new<u8>(26), used: 0 };
+        String::append(__local_16, String { repr: array.new_data<u8>("item.of = "), used: 10 });
+        __local_17 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_16) };
+        i32::fmt_decimal(42, __local_17);
+        break __tmpl: __local_16;
     });
     arr = __seq_lit: block -> ref Array<i32> {
-        __local_4 = Array<i32> { repr: array.new_fixed<i32>(1, 2, 3), used: 3 };
-        break __seq_lit: __local_4;
+        __local_6 = Array<i32> { repr: array.new_fixed<i32>(1, 2, 3), used: 3 };
+        break __seq_lit: __local_6;
     };
-    __iter_6 = "core:allocator/ArrayIter<i32>" { repr: ref.as_non_null(arr.repr), used: 3, index: 0 };
+    __iter_8 = "core:allocator/ArrayIter<i32>" { repr: ref.as_non_null(arr.repr), used: 3, index: 0 };
     b0: block {
         l1: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: i32;
-            multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = ArrayIter<i32>^Iterator::next(__iter_6);
+            multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = ArrayIter<i32>^Iterator::next(__iter_8);
             if __sroa___pattern_temp_0_discriminant == 0 {
                 flags = __sroa___pattern_temp_0_payload_0;
                 "core:cli/println"(__tmpl: block -> ref String {
-                    __local_12 = String { repr: builtin::array_new<u8>(31), used: 0 };
-                    String::append(__local_12, String { repr: array.new_data<u8>("for-of flags = "), used: 15 });
-                    __local_13 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_12) };
-                    i32::fmt_decimal(flags, __local_13);
-                    break __tmpl: __local_12;
+                    __local_18 = String { repr: builtin::array_new<u8>(31), used: 0 };
+                    String::append(__local_18, String { repr: array.new_data<u8>("for-of flags = "), used: 15 });
+                    __local_19 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_18) };
+                    i32::fmt_decimal(flags, __local_19);
+                    break __tmpl: __local_18;
                 });
             } else {
                 break b0;
             };
             continue l1;
+        };
+    };
+    __iter_10 = "core:allocator/ArrayIter<i32>" { repr: ref.as_non_null(arr.repr), used: 3, index: 0 };
+    b3: block {
+        l4: loop {
+            let __sroa___pattern_temp_1_discriminant: i32;
+            let __sroa___pattern_temp_1_payload_0: i32;
+            multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = ArrayIter<i32>^Iterator::next(__iter_10);
+            if __sroa___pattern_temp_1_discriminant == 0 {
+                of = __sroa___pattern_temp_1_payload_0;
+                "core:cli/println"(__tmpl: block -> ref String {
+                    __local_20 = String { repr: builtin::array_new<u8>(28), used: 0 };
+                    String::append(__local_20, String { repr: array.new_data<u8>("for-of of = "), used: 12 });
+                    __local_21 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: ref.as_non_null(__local_20) };
+                    i32::fmt_decimal(of, __local_21);
+                    break __tmpl: __local_20;
+                });
+            } else {
+                break b3;
+            };
+            continue l4;
         };
     };
 }
@@ -214,13 +248,13 @@ fn "core:internal/gc_array_to_memory"(arr, ptr, len) {  // from core:internal
     __for_1: block {
         i = 0;
         block {
-            l5: loop {
+            l8: loop {
                 if (i < len) == 0 {
                     break __for_1;
                 };
                 builtin::store_u8(ptr + i, builtin::array_get_u8(arr, i));
                 i = i + 1;
-                continue l5;
+                continue l8;
             };
         };
     };
@@ -300,13 +334,13 @@ fn count_digits_i64(val) {
     __for_1: block {
         t = val;
         block {
-            l11: loop {
+            l14: loop {
                 if (t > 0_i64) == 0 {
                     break __for_1;
                 };
                 n = n + 1;
                 t = t / 10_i64;
-                continue l11;
+                continue l14;
             };
         };
     };
@@ -323,14 +357,14 @@ fn write_decimal_digits(arr, offset, abs_val, digit_count) {
         __for_2: block {
             temp = abs_val;
             block {
-                l15: loop {
+                l18: loop {
                     if (temp > 0_i64) == 0 {
                         break __for_2;
                     };
                     pos = pos - 1;
                     builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     temp = temp / 10_i64;
-                    continue l15;
+                    continue l18;
                 };
             };
         };
@@ -472,13 +506,13 @@ fn Array<i32>::grow(self) {
     __for_0: block {
         i = 0;
         block {
-            l29: loop {
+            l32: loop {
                 if (i < used) == 0 {
                     break __for_0;
                 };
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l29;
+                continue l32;
             };
         };
     };
@@ -492,13 +526,13 @@ fn Formatter::write_char_n(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l32: loop {
+            l35: loop {
                 if (i < n) == 0 {
                     break __for_0;
                 };
                 String::append_char(_licm_buf_4, c);
                 i = i + 1;
-                continue l32;
+                continue l35;
             };
         };
     };

--- a/wado-compiler/tests/fixtures/contextual_keyword.wado
+++ b/wado-compiler/tests/fixtures/contextual_keyword.wado
@@ -1,31 +1,45 @@
-// Test contextual keywords (flags, type) used as identifiers
+// Test contextual keywords (flags, type, of) used as identifiers
 // These are only keywords at declaration start, allowed as identifiers elsewhere
 
 use { println, Stdout } from "core:cli";
 
-fn test_param(flags: i32, type: i32) -> i32 {
-    return flags + type;
+fn test_param(flags: i32, type: i32, of: i32) -> i32 {
+    return flags + type + of;
+}
+
+struct Item {
+    of: i32,
 }
 
 export fn run() with Stdout {
     // Test as local variable names
     let flags = 10;
     let type = 20;
+    let of = 30;
 
     // Test in expressions
-    let sum = flags + type;
-    println(`flags + type = {sum}`);
+    let sum = flags + type + of;
+    println(`flags + type + of = {sum}`);
 
     // Test as function parameters
-    let result = test_param(flags, type);
+    let result = test_param(flags, type, of);
     println(`test_param result = {result}`);
+
+    // Test as struct field
+    let item = Item { of: 42 };
+    println(`item.of = {item.of}`);
 
     // Test in for-of binding
     let arr: Array<i32> = [1, 2, 3];
     for let flags of arr {
         println(`for-of flags = {flags}`);
     }
+
+    // Test 'of' as for-of binding variable
+    for let of of arr {
+        println(`for-of of = {of}`);
+    }
 }
 
 __DATA__
-{"stdout": "flags + type = 30\ntest_param result = 30\nfor-of flags = 1\nfor-of flags = 2\nfor-of flags = 3\n"}
+{"stdout": "flags + type + of = 60\ntest_param result = 60\nitem.of = 42\nfor-of flags = 1\nfor-of flags = 2\nfor-of flags = 3\nfor-of of = 1\nfor-of of = 2\nfor-of of = 3\n"}


### PR DESCRIPTION
## Summary
Extended the contextual keyword system to support `of` as a keyword only in `for-of` loop bindings, while allowing it to be used as a variable name, field name, and function parameter elsewhere.

## Key Changes
- **Token support**: Added `of` to the `as_ident_name()` method in `token.rs` to recognize it as a contextual keyword that can function as an identifier outside of `for-of` contexts
- **Language specification**: Updated `docs/spec.md` with a comprehensive table of contextual keywords (`flags`, `type`, `of`, `from`, `test`) and their specific keyword contexts, including code examples demonstrating usage as variable names, struct fields, and loop bindings
- **Test coverage**: Enhanced `contextual_keyword.wado` test to comprehensively validate `of` usage:
  - As a function parameter
  - As a struct field name
  - As a local variable
  - As a `for-of` loop binding variable
- **Golden file**: Updated the compiled IR output to reflect the new test cases and variable numbering adjustments

## Implementation Details
The change maintains consistency with the existing contextual keyword pattern where `flags` and `type` are only keywords at declaration start. Similarly, `of` is only treated as a keyword in the specific syntactic position of `for let <pattern> of <expr>`, allowing it to be freely used as an identifier in all other contexts.

https://claude.ai/code/session_013j8rQSjQv2o3D6J5wnZBB6