### PR TITLE
Add ANTLR4 grammar files for e2e testing

### DIFF
--- a/docs/wep-2026-03-02-gale.md
+++ b/docs/wep-2026-03-02-gale.md
@@ -32,7 +32,7 @@ ANTLR4's `.g4` format is adopted as Gale's primary input. Key reasons:
 - Rule labels (`# LabelName`) map naturally to Wado variant cases
 - Widely used; existing grammars (SQL, JSON, etc.) can be adapted with minimal changes
 
-Gale processes `.g4` files but **rejects any embedded action code**. A `.g4` file with `{...}` action blocks is a Gale error — the grammar must be pure structure.
+Gale processes `.g4` files but **ignores any target-language-dependent elements** — action blocks (`{...}`), semantic predicates (`{...}?`), `options { superClass = ... }`, and `@header`/`@members` sections are parsed, warned, and skipped. This lets Gale consume real-world `.g4` grammars (which often contain these elements) while keeping the generated output purely structural.
 
 #### Phase 1 Scope
 
@@ -55,13 +55,18 @@ Supported:
 | Skip channel             | `-> skip`                        |
 | Rule labels              | `# LabelName`                    |
 
+Parsed but ignored (warned and skipped):
+
+- Embedded action blocks (`{ code }`) — skipped with warning
+- Semantic predicates (`{condition}?`) — skipped with warning
+- `options { superClass = ...; }` — parsed, `superClass` ignored with warning; `tokenVocab` recognized for future lexer/parser split support
+- `@header`, `@members`, and other named actions — skipped with warning
+
 Not in Phase 1:
 
-- Semantic predicates (`{condition}?`)
 - Lexer modes (`mode INSIDE;`)
 - Grammar imports (`import BaseGrammar;`)
-- `options {}`, `tokens {}` blocks
-- Any embedded action code (rejected with error)
+- `tokens {}` blocks
 - Syntactic predicates
 - Error recovery customization
 
@@ -386,7 +391,7 @@ pub struct LexerRule {
 - Generated Wado code is human-readable and debuggable
 - Runtime is independently testable as plain Wado source
 - `package-gale/` is a concrete pilot for `wado.toml`
-- ANTLR4 `.g4` grammars (without actions) are directly usable
+- ANTLR4 `.g4` grammars are directly usable — action blocks and semantic predicates are warned and skipped, so real-world grammars work without manual cleanup
 
 ### Negative
 

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -54,24 +54,22 @@ mise run update-gale-golden
 
 ### Test Grammars (`tests/grammars/`)
 
-| File | Language | License | Notes |
-| --- | --- | --- | --- |
-| `JSON.g4` | JSON | | Combined grammar. Clean (no actions). |
-| `sexpression.g4` | S-expression | | Combined grammar. Clean. |
-| `calculator.g4` | Calculator | | Combined grammar. Clean. |
-| `SQLite.g4` | SQLite | | Combined grammar. Large, clean. |
-| `css3Lexer.g4` | CSS3 | MIT | Split lexer. Clean. |
-| `css3Parser.g4` | CSS3 | MIT | Split parser. Clean. |
-| `HTMLLexer.g4` | HTML | BSD 3-Clause | Split lexer. Clean. |
-| `HTMLParser.g4` | HTML | BSD 3-Clause | Split parser. Clean. |
-| `ANTLRv4Lexer.g4` | ANTLR4 | BSD 3-Clause | Split lexer. Has action blocks and `superClass`. |
-| `ANTLRv4Parser.g4` | ANTLR4 | BSD 3-Clause | Split parser. Clean. |
-| `RustLexer.g4` | Rust | MIT | Split lexer. Has semantic predicates and `superClass`. |
-| `RustParser.g4` | Rust | MIT | Split parser. Has semantic predicates and `superClass`. |
-| `TypeScriptLexer.g4` | TypeScript | MIT | Split lexer. Has semantic predicates and `superClass`. |
-| `TypeScriptParser.g4` | TypeScript | MIT | Split parser. Has many semantic predicates and `superClass`. |
-
-All files sourced from [antlr/grammars-v4](https://github.com/antlr/grammars-v4). Each file has a `// Source:` and `// License:` header.
+| File | Language | Notes |
+| --- | --- | --- |
+| `JSON.g4` | JSON | Combined grammar. Clean (no actions). |
+| `sexpression.g4` | S-expression | Combined grammar. Clean. |
+| `calculator.g4` | Calculator | Combined grammar. Clean. |
+| `SQLite.g4` | SQLite | Combined grammar. Large, clean. |
+| `css3Lexer.g4` | CSS3 | Split lexer. Clean. |
+| `css3Parser.g4` | CSS3 | Split parser. Clean. |
+| `HTMLLexer.g4` | HTML | Split lexer. Clean. |
+| `HTMLParser.g4` | HTML | Split parser. Clean. |
+| `ANTLRv4Lexer.g4` | ANTLR4 | Split lexer. Has action blocks and `superClass`. |
+| `ANTLRv4Parser.g4` | ANTLR4 | Split parser. Clean. |
+| `RustLexer.g4` | Rust | Split lexer. Has semantic predicates and `superClass`. |
+| `RustParser.g4` | Rust | Split parser. Has semantic predicates and `superClass`. |
+| `TypeScriptLexer.g4` | TypeScript | Split lexer. Has semantic predicates and `superClass`. |
+| `TypeScriptParser.g4` | TypeScript | Split parser. Has many semantic predicates and `superClass`. |
 
 **Clean** grammars (JSON, sexpression, calculator, SQLite, CSS3, HTML) contain no target-language-dependent elements and should be fully parseable and code-generatable.
 

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -54,22 +54,22 @@ mise run update-gale-golden
 
 ### Test Grammars (`tests/grammars/`)
 
-| File | Language | Notes |
-| --- | --- | --- |
-| `JSON.g4` | JSON | Combined grammar. Clean (no actions). |
-| `sexpression.g4` | S-expression | Combined grammar. Clean. |
-| `calculator.g4` | Calculator | Combined grammar. Clean. |
-| `SQLite.g4` | SQLite | Combined grammar. Large, clean. |
-| `css3Lexer.g4` | CSS3 | Split lexer. Clean. |
-| `css3Parser.g4` | CSS3 | Split parser. Clean. |
-| `HTMLLexer.g4` | HTML | Split lexer. Clean. |
-| `HTMLParser.g4` | HTML | Split parser. Clean. |
-| `ANTLRv4Lexer.g4` | ANTLR4 | Split lexer. Has action blocks and `superClass`. |
-| `ANTLRv4Parser.g4` | ANTLR4 | Split parser. Clean. |
-| `RustLexer.g4` | Rust | Split lexer. Has semantic predicates and `superClass`. |
-| `RustParser.g4` | Rust | Split parser. Has semantic predicates and `superClass`. |
-| `TypeScriptLexer.g4` | TypeScript | Split lexer. Has semantic predicates and `superClass`. |
-| `TypeScriptParser.g4` | TypeScript | Split parser. Has many semantic predicates and `superClass`. |
+| File                  | Language     | Notes                                                        |
+| --------------------- | ------------ | ------------------------------------------------------------ |
+| `JSON.g4`             | JSON         | Combined grammar. Clean (no actions).                        |
+| `sexpression.g4`      | S-expression | Combined grammar. Clean.                                     |
+| `calculator.g4`       | Calculator   | Combined grammar. Clean.                                     |
+| `SQLite.g4`           | SQLite       | Combined grammar. Large, clean.                              |
+| `css3Lexer.g4`        | CSS3         | Split lexer. Clean.                                          |
+| `css3Parser.g4`       | CSS3         | Split parser. Clean.                                         |
+| `HTMLLexer.g4`        | HTML         | Split lexer. Clean.                                          |
+| `HTMLParser.g4`       | HTML         | Split parser. Clean.                                         |
+| `ANTLRv4Lexer.g4`     | ANTLR4       | Split lexer. Has action blocks and `superClass`.             |
+| `ANTLRv4Parser.g4`    | ANTLR4       | Split parser. Clean.                                         |
+| `RustLexer.g4`        | Rust         | Split lexer. Has semantic predicates and `superClass`.       |
+| `RustParser.g4`       | Rust         | Split parser. Has semantic predicates and `superClass`.      |
+| `TypeScriptLexer.g4`  | TypeScript   | Split lexer. Has semantic predicates and `superClass`.       |
+| `TypeScriptParser.g4` | TypeScript   | Split parser. Has many semantic predicates and `superClass`. |
 
 **Clean** grammars (JSON, sexpression, calculator, SQLite, CSS3, HTML) contain no target-language-dependent elements and should be fully parseable and code-generatable.
 

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -17,11 +17,26 @@ wado test package-gale/src/generator_test.wado
 mise run test-wado
 ```
 
-## Golden Fixtures
+## E2E Test Architecture
 
-Golden fixtures live in `tests/golden/` and contain the expected `.wado` output generated from the `.g4` grammars in `tests/grammars/`.
+Gale has two layers of e2e testing, both driven by `.g4` files in `tests/grammars/`.
 
-They are tested by `generator_test.wado` using `#include_str`:
+### Layer 1: G4 Parse Tests (`g4/integration_test.wado`)
+
+Verify that the g4 parser can parse real-world `.g4` files into `Grammar` IR without errors. Each test uses `#include_str` to load the `.g4` file and calls `parse()`.
+
+```wado
+test "parse JSON.g4" {
+    let input = #include_str("../../tests/grammars/JSON.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "JSON";
+    assert g.parser_rules.len() == 5;
+}
+```
+
+### Layer 2: Golden Tests (`generator_test.wado`)
+
+Verify that code generation from `Grammar` IR produces the expected `.wado` output. Each test compares `generate(parse(...))` against a golden file in `tests/golden/`.
 
 ```wado
 test "generate json golden" {
@@ -31,20 +46,54 @@ test "generate json golden" {
 }
 ```
 
-**When to regenerate**: whenever `generator.wado` or `runtime.wado` changes in a way that affects generated output, regenerate all golden fixtures:
+Golden fixtures are regenerated with:
 
 ```sh
 mise run update-gale-golden
 ```
 
-This runs `gale gen` against each `.g4` in `tests/grammars/` and overwrites the corresponding file in `tests/golden/`. Commit the updated golden files.
+### Test Grammars (`tests/grammars/`)
 
-**Adding a new golden test**:
+| File | Language | License | Notes |
+| --- | --- | --- | --- |
+| `JSON.g4` | JSON | | Combined grammar. Clean (no actions). |
+| `sexpression.g4` | S-expression | | Combined grammar. Clean. |
+| `calculator.g4` | Calculator | | Combined grammar. Clean. |
+| `SQLite.g4` | SQLite | | Combined grammar. Large, clean. |
+| `css3Lexer.g4` | CSS3 | MIT | Split lexer. Clean. |
+| `css3Parser.g4` | CSS3 | MIT | Split parser. Clean. |
+| `HTMLLexer.g4` | HTML | BSD 3-Clause | Split lexer. Clean. |
+| `HTMLParser.g4` | HTML | BSD 3-Clause | Split parser. Clean. |
+| `ANTLRv4Lexer.g4` | ANTLR4 | BSD 3-Clause | Split lexer. Has action blocks and `superClass`. |
+| `ANTLRv4Parser.g4` | ANTLR4 | BSD 3-Clause | Split parser. Clean. |
+| `RustLexer.g4` | Rust | MIT | Split lexer. Has semantic predicates and `superClass`. |
+| `RustParser.g4` | Rust | MIT | Split parser. Has semantic predicates and `superClass`. |
+| `TypeScriptLexer.g4` | TypeScript | MIT | Split lexer. Has semantic predicates and `superClass`. |
+| `TypeScriptParser.g4` | TypeScript | MIT | Split parser. Has many semantic predicates and `superClass`. |
 
-1. Add the `.g4` file to `tests/grammars/`
-2. Add a `mise run update-gale-golden` entry in `mise.toml` for it
-3. Run `mise run update-gale-golden` to generate the initial golden file
-4. Add a test case in `generator_test.wado` using `#include_str`
+All files sourced from [antlr/grammars-v4](https://github.com/antlr/grammars-v4). Each file has a `// Source:` and `// License:` header.
+
+**Clean** grammars (JSON, sexpression, calculator, SQLite, CSS3, HTML) contain no target-language-dependent elements and should be fully parseable and code-generatable.
+
+**Grammars with actions/predicates** (ANTLR4, Rust, TypeScript) contain `{...}` action blocks and/or `{...}?` semantic predicates. These must be warned and skipped during parsing (see WEP). They serve as e2e tests for Gale's ability to consume real-world grammars without manual cleanup.
+
+### Adding a New E2E Test Grammar
+
+1. Add the `.g4` file to `tests/grammars/` (include `// Source:` and `// License:` headers)
+2. Add a parse test in `g4/integration_test.wado`
+3. For golden tests: add an entry in `mise.toml` under `[tasks.update-gale-golden]`, run `mise run update-gale-golden`, and add a test case in `generator_test.wado`
+
+## Golden Fixtures
+
+Golden fixtures live in `tests/golden/` and contain the expected `.wado` output generated from the `.g4` grammars in `tests/grammars/`.
+
+**When to regenerate**: whenever `generator.wado`, `lexer_gen.wado`, `parser_gen.wado`, or `runtime.wado` changes in a way that affects generated output:
+
+```sh
+mise run update-gale-golden
+```
+
+Commit the updated golden files.
 
 ## Inlined Runtime
 

--- a/package-gale/README.md
+++ b/package-gale/README.md
@@ -61,17 +61,6 @@ package-gale/
       parser_test.wado
       integration_test.wado — parse real-world .g4 grammars
 ```
-
-## Implementation Status
-
-| Phase | Description | Status |
-| ----- | --- | --- |
-| 0 | Project scaffold, runtime types | Done |
-| 1 | G4 lexer and parser | Done |
-| 2 | Code generation (CST types, visitor, walk functions) | Done |
-| 2 | Lexer function generation (`fn tokenize`) | In progress |
-| 2 | Recursive descent parser function generation | Planned |
-
 ## Related WEPs
 
 - [WEP: Gale](../docs/wep-2026-03-02-gale.md) — full design and architecture

--- a/package-gale/README.md
+++ b/package-gale/README.md
@@ -12,27 +12,21 @@ Existing parser generators couple grammar and runtime in ways that cause mainten
 
 Gale's answer: generate a **single self-contained `.wado` file** that inlines the runtime. No external dependency, no version drift. Each generated file carries the exact runtime snapshot used at generation time.
 
+Target-language-dependent elements in `.g4` files (action blocks, semantic predicates, `superClass`, `@header`/`@members`) are warned and skipped, so real-world grammars work without manual cleanup.
+
 See [WEP: Gale — Grammar Adaptive LL Engine](../docs/wep-2026-03-02-gale.md) for full design rationale.
-
-## Related WEPs
-
-- [WEP: Gale](../docs/wep-2026-03-02-gale.md) — full design and architecture
-- [WEP: Compile-Time File Inclusion](../docs/wep-2026-03-02-include-str.md) — `#include_str` used to inline the runtime
 
 ## Usage
 
 ```sh
 # Generate parser from grammar (outputs to stdout)
-wado run src/main.wado gen grammar.g4
+gale gen grammar.g4
 
 # Write to file
-wado run src/main.wado gen grammar.g4 --output grammar_parser.wado
+gale gen grammar.g4 --output grammar_parser.wado
 
-# Inspect grammar IR (debugging)
-wado run src/main.wado dump grammar.g4
-
-# Inspect .g4 token stream
-wado run src/main.wado dump grammar.g4 --tokens
+# Run via wado (development)
+wado run package-gale/src/main.wado gen grammar.g4
 ```
 
 ## Project Structure
@@ -40,32 +34,45 @@ wado run src/main.wado dump grammar.g4 --tokens
 ```
 package-gale/
   wado.toml              — package manifest
+  docs/
+    antlr4-grammars.md   — ANTLR4 grammar format reference
   tests/
-    grammars/            — real-world .g4 input grammars for integration/golden tests
+    grammars/            — .g4 input grammars for e2e/golden tests
     golden/              — expected generated output (golden fixtures)
   src/
-    main.wado            — CLI entry point
+    main.wado            — CLI entry point (gen subcommand)
     main_test.wado       — smoke test for the public API
     ir.wado              — GrammarIR: typed grammar representation
     ir_test.wado
     runtime.wado         — Span, Token, ParseError (inlined into generated files)
     runtime_test.wado
     generator.wado       — GrammarIR → .wado source (inlines runtime via #include_str)
-    generator_test.wado  — includes golden tests
+    generator_test.wado  — golden tests against tests/golden/
+    lexer_gen.wado       — lexer function code generation
+    parser_gen.wado      — parser function code generation
+    gen_util.wado        — shared code generation utilities
+    wadopoet.wado        — Wado source code builder (like JavaPoet)
+    wadopoet_test.wado
     g4/
       token.wado         — G4Token enum and helpers
       lexer.wado         — tokenize .g4 source text
       lexer_test.wado
       parser.wado        — recursive descent parser: tokens → GrammarIR
       parser_test.wado
+      integration_test.wado — parse real-world .g4 grammars
 ```
 
 ## Implementation Status
 
-| Phase | Description                                          | Status      |
-| ----- | ---------------------------------------------------- | ----------- |
-| 0     | Project scaffold, runtime types                      | Done        |
-| 1     | G4 lexer and parser                                  | Done        |
-| 2     | Code generation (CST types, visitor, walk functions) | In progress |
-| 2     | Lexer function generation (`fn tokenize`)            | Planned     |
-| 2     | Recursive descent parser function generation         | Planned     |
+| Phase | Description | Status |
+| ----- | --- | --- |
+| 0 | Project scaffold, runtime types | Done |
+| 1 | G4 lexer and parser | Done |
+| 2 | Code generation (CST types, visitor, walk functions) | Done |
+| 2 | Lexer function generation (`fn tokenize`) | In progress |
+| 2 | Recursive descent parser function generation | Planned |
+
+## Related WEPs
+
+- [WEP: Gale](../docs/wep-2026-03-02-gale.md) — full design and architecture
+- [WEP: Compile-Time File Inclusion](../docs/wep-2026-03-02-include-str.md) — `#include_str` used to inline the runtime

--- a/package-gale/README.md
+++ b/package-gale/README.md
@@ -61,6 +61,7 @@ package-gale/
       parser_test.wado
       integration_test.wado — parse real-world .g4 grammars
 ```
+
 ## Related WEPs
 
 - [WEP: Gale](../docs/wep-2026-03-02-gale.md) — full design and architecture

--- a/package-gale/docs/antlr4-grammars.md
+++ b/package-gale/docs/antlr4-grammars.md
@@ -1,0 +1,193 @@
+---
+source: https://github.com/antlr/antlr4/blob/dev/doc/grammars.md
+license: |
+  BSD 3-Clause License
+  Copyright (c) 2012 Terence Parr and Sam Harwell
+  All rights reserved.
+  See https://github.com/antlr/antlr4/blob/dev/LICENSE.txt
+retrieved: 2026-03-26
+---
+
+# Grammar Structure
+
+A grammar is essentially a grammar declaration followed by a list of rules, but has the general form:
+
+```
+/** Optional javadoc style comment */
+grammar Name; ①
+options {...}
+import ... ;
+
+tokens {...}
+channels {...} // lexer only
+@actionName {...}
+
+rule1 // parser and lexer rules, possibly intermingled
+...
+ruleN
+```
+
+The file name containing grammar `X` must be called `X.g4`. You can specify options, imports, token specifications, and actions in any order. There can be at most one each of options, imports, and token specifications. All of those elements are optional except for the header ① and at least one rule. Rules take the basic form:
+
+```
+ruleName : alternative1 | ... | alternativeN ;
+```
+
+Parser rule names must start with a lowercase letter and lexer rules must start with a capital letter.
+
+Grammars defined without a prefix on the `grammar` header are combined grammars that can contain both lexical and parser rules. To make a parser grammar that only allows parser rules, use the following header.
+
+```
+parser grammar Name;
+...
+```
+
+And, naturally, a pure lexer grammar looks like this:
+
+```
+lexer grammar Name;
+...
+```
+
+Only lexer grammars can contain `mode` specifications.
+
+Only lexer grammars can contain custom channels specifications
+
+```
+channels {
+  WHITESPACE_CHANNEL,
+  COMMENTS_CHANNEL
+}
+```
+
+Those channels can then be used like enums within lexer rules:
+
+```
+WS : [ \r\t\n]+ -> channel(WHITESPACE_CHANNEL) ;
+```
+
+Sections 15.5, [Lexer Rules](http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference) and Section 15.3, [Parser Rules](http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference) contain details on rule syntax. Section 15.8, Options describes grammar options and Section 15.4, Actions and Attributes has information on grammar-level actions.
+
+## Grammar Imports
+
+Grammar `imports` let you break up a grammar into logical and reusable chunks, as we saw in [Importing Grammars](http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference). ANTLR treats imported grammars very much like object-oriented programming languages treat superclasses. A grammar inherits all of the rules, tokens specifications, and named actions from the imported grammar. Rules in the "main grammar" override rules from imported grammars to implement inheritance.
+
+Think of `import` as more like a smart include statement (which does not include rules that are already defined). The result of all imports is a single combined grammar; the ANTLR code generator sees a complete grammar and has no idea there were imported grammars.
+
+To process a main grammar, the ANTLR tool loads all of the imported grammars into subordinate grammar objects. It then merges the rules, token types, and named actions from the imported grammars into the main grammar. In the diagram below, the grammar on the right illustrates the effect of grammar `MyELang` importing grammar `ELang`.
+
+`MyELang` inherits rules `stat`, `WS`, and `ID`, but overrides rule `expr` and adds `INT`. Here's a sample build and test run that shows `MyELang` can recognize integer expressions whereas the original `ELang` can't. The third, erroneous input statement triggers an error message that also demonstrates the parser was looking for `MyELang`'s expr not `ELang`'s.
+
+```
+$ antlr4 MyELang.g4
+$ javac MyELang*.java
+$ grun MyELang stat
+=> 	34;
+=> 	a;
+=> 	;
+=> 	EOF
+<= 	line 3:0 extraneous input ';' expecting {INT, ID}
+```
+
+If there are modes in the main grammar or any of the imported grammars then the import process will import those modes and merge their rules where they are not overridden. In the event any mode becomes empty as all its
+rules have been overridden by rules outside the mode this mode will be discarded.
+
+If there were any `tokens` specifications, the main grammar would merge the token sets. If there were any `channel` specifications, the main grammar would merge the channel sets. Any named actions such as `@members` would be merged. In general, you should avoid named actions and actions within rules in imported grammars since that limits their reuse. ANTLR also ignores any options in imported grammars.
+
+Imported grammars can also import other grammars. ANTLR pursues all imported grammars in a depth-first fashion. If two or more imported grammars define rule `r`, ANTLR chooses the first version of `r` it finds. In the following diagram, ANTLR examines grammars in the following order `Nested`, `G1`, `G3`, `G2`.
+
+`Nested` includes the `r` rule from `G3` because it sees that version before the `r` in `G2`.
+
+Not every kind of grammar can import every other kind of grammar:
+
+* Lexer grammars can import lexers, including lexers containing modes.
+* Parsers can import parsers.
+* Combined grammars can import parsers or lexers without modes.
+
+ANTLR adds imported rules to the end of the rule list in a main lexer grammar. That means lexer rules in the main grammar get precedence over imported rules. For example, if a main grammar defines rule `IF : 'if' ;` and an imported grammar defines rule `ID : [a-z]+ ;` (which also recognizes `if`), the imported `ID` won't hide the main grammar's `IF` token definition.
+
+## Tokens Section
+
+The purpose of the `tokens` section is to define token types needed by a grammar for which there is no associated lexical rule. The basic syntax is:
+
+```
+tokens { Token1, ..., TokenN }
+```
+
+Most of the time, the tokens section is used to define token types needed by actions in the grammar as shown in Section 10.3, [Recognizing Languages whose Keywords Aren't Fixed](http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference):
+
+```
+// explicitly define keyword token types to avoid implicit definition warnings
+tokens { BEGIN, END, IF, THEN, WHILE }
+
+@lexer::members { // keywords map used in lexer to assign token types
+Map<String,Integer> keywords = new HashMap<String,Integer>() {{
+	put("begin", KeywordsParser.BEGIN);
+	put("end", KeywordsParser.END);
+	...
+}};
+}
+```
+
+The `tokens` section really just defines a set of tokens to add to the overall set.
+
+```
+$ cat Tok.g4
+grammar Tok;
+tokens { A, B, C }
+a : X ;
+$ antlr4 Tok.g4
+warning(125): Tok.g4:3:4: implicit definition of token X in parser
+$ cat Tok.tokens
+A=1
+B=2
+C=3
+X=4
+```
+
+## Actions at the Grammar Level
+
+Currently there are only two defined named actions (for the Java target) used outside of grammar rules: `header` and `members`. The former injects code into the generated recognizer class file, before the recognizer class definition, and the latter injects code into the recognizer class definition, as fields and methods.
+
+For combined grammars, ANTLR injects the actions into both the parser and the lexer. To restrict an action to the generated parser or lexer, use `@parser::name` or `@lexer::name`.
+
+Here's an example where the grammar specifies a package for the generated code:
+
+```
+grammar Count;
+
+@header {
+package foo;
+}
+
+@members {
+int count = 0;
+}
+
+list
+@after {System.out.println(count+" ints");}
+: INT {count++;} (',' INT {count++;} )*
+;
+
+INT : [0-9]+ ;
+WS : [ \r\t\n]+ -> skip ;
+```
+
+The grammar itself then should be in directory `foo` so that ANTLR generates code in that same `foo` directory (at least when not using the `-o` ANTLR tool option):
+
+```
+$ cd foo
+$ antlr4 Count.g4 # generates code in the current directory (foo)
+$ ls
+Count.g4		CountLexer.java	CountParser.java
+Count.tokens	CountLexer.tokens
+CountBaseListener.java CountListener.java
+$ javac *.java
+$ cd ..
+$ grun foo.Count list
+=> 	9, 10, 11
+=> 	EOF
+<= 	3 ints
+```
+
+The Java compiler expects classes in package `foo` to be in directory `foo`.

--- a/package-gale/docs/antlr4-grammars.md
+++ b/package-gale/docs/antlr4-grammars.md
@@ -100,9 +100,9 @@ Imported grammars can also import other grammars. ANTLR pursues all imported gra
 
 Not every kind of grammar can import every other kind of grammar:
 
-* Lexer grammars can import lexers, including lexers containing modes.
-* Parsers can import parsers.
-* Combined grammars can import parsers or lexers without modes.
+- Lexer grammars can import lexers, including lexers containing modes.
+- Parsers can import parsers.
+- Combined grammars can import parsers or lexers without modes.
 
 ANTLR adds imported rules to the end of the rule list in a main lexer grammar. That means lexer rules in the main grammar get precedence over imported rules. For example, if a main grammar defines rule `IF : 'if' ;` and an imported grammar defines rule `ID : [a-z]+ ;` (which also recognizes `if`), the imported `ID` won't hide the main grammar's `IF` token definition.
 

--- a/package-gale/tests/grammars/ANTLRv4Lexer.g4
+++ b/package-gale/tests/grammars/ANTLRv4Lexer.g4
@@ -1,0 +1,463 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012-2015 Terence Parr
+ *  Copyright (c) 2012-2015 Sam Harwell
+ *  Copyright (c) 2015 Gerald Rosenberg
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ *	A grammar for ANTLR v4 implemented using v4 syntax
+ *
+ *	Modified 2015.06.16 gbr
+ *	-- update for compatibility with Antlr v4.5
+ */
+
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons hanging
+// $antlr-format alignColons hanging
+
+// ======================================================
+// Lexer specification
+// ======================================================
+
+lexer grammar ANTLRv4Lexer;
+
+options {
+    superClass = LexerAdaptor;
+
+    // Using a predefined list of tokens here to ensure the same order of the tokens as they were defined
+    // in the old ANTLR3 tree parsers (to avoid having to change the tree parsers code).
+    // The actual values of the tokens doesn't matter, but the order does.
+    // tokenVocab = predefined;
+    //
+    // Instead of declaring predefined.tokens, which messes up the Maven tester for grammars-v4,
+    // we define the total order of token type values. This should work because it was stated
+    // that the "actual values of the tokens doesn't matter, but the order does." Declaring them
+    // in the tokensSpec section preserves the total order.
+}
+
+// Insert here @header for lexer.
+
+// Standard set of fragments
+tokens {
+    ACTION,
+    ARG_ACTION,
+    ARG_OR_CHARSET,
+    ASSIGN,
+    LEXER_CHAR_SET,
+    RULE_REF,
+    SEMPRED,
+    STRING_LITERAL,
+    TOKEN_REF,
+    UNICODE_ESC,
+    UNICODE_EXTENDED_ESC,
+    WS,
+    ALT,
+    BLOCK,
+    CLOSURE,
+    ELEMENT_OPTIONS,
+    EPSILON,
+    LEXER_ACTION_CALL,
+    LEXER_ALT_ACTION,
+    OPTIONAL,
+    POSITIVE_CLOSURE,
+    RULE,
+    RULEMODIFIERS,
+    RULES,
+    SET,
+    WILDCARD
+}
+
+channels {
+    OFF_CHANNEL,
+    COMMENT
+}
+
+// -------------------------
+// Comments
+
+DOC_COMMENT
+    : '/**' .*? ('*/' | EOF) -> channel (COMMENT)
+    ;
+
+BLOCK_COMMENT
+    : '/*' .*? ('*/' | EOF) -> channel (COMMENT)
+    ;
+
+LINE_COMMENT
+    : '//' ~ [\r\n]* -> channel (COMMENT)
+    ;
+
+// -------------------------
+// Integer
+
+INT
+    : '0'
+    | [1-9] [0-9]*
+    ;
+
+// -------------------------
+// Literal string
+//
+// ANTLR makes no distinction between a single character literal and a
+// multi-character string. All literals are single quote delimited and
+// may contain unicode escape sequences of the form \uxxxx, where x
+// is a valid hexadecimal number (per Unicode standard).
+STRING_LITERAL
+    : '\'' (ESC_SEQUENCE | ~ ['\r\n\\])* '\''
+    ;
+
+UNTERMINATED_STRING_LITERAL
+    : '\'' (ESC_SEQUENCE | ~ ['\r\n\\])*
+    ;
+
+// -------------------------
+// Arguments
+//
+// Certain argument lists, such as those specifying call parameters
+// to a rule invocation, or input parameters to a rule specification
+// are contained within square brackets.
+BEGIN_ARGUMENT
+    : '[' { this.handleBeginArgument(); }
+    ;
+
+// Many language targets use {} as block delimiters and so we
+// must recursively match {} delimited blocks to balance the
+// braces. Additionally, we must make some assumptions about
+// literal string representation in the target language. We assume
+// that they are delimited by ' or " and so consume these
+// in their own alts so as not to inadvertently match {}.
+ACTION
+    : NESTED_ACTION
+    ;
+
+fragment NESTED_ACTION
+    : // Action and other blocks start with opening {
+    '{' (
+        NESTED_ACTION          // embedded {} block
+        | STRING_LITERAL       // single quoted string
+        | DoubleQuoteLiteral   // double quoted string
+        | TripleQuoteLiteral   // string literal with triple quotes
+        | BacktickQuoteLiteral // backtick quoted string
+        | '/*' .*? '*/'        // block comment
+        | '//' ~[\r\n]*        // line comment
+        | '\\' .               // Escape sequence
+        | ~(
+            '\\'
+            | '"'
+            | '\''
+            | '`'
+            | '{'
+        ) // Some other single character that is not handled above
+    )*? '}'
+    ;
+
+// -------------------------
+// Keywords
+//
+// 'options', 'tokens', and 'channels' are considered keywords
+// but only when followed by '{', and considered as a single token.
+// Otherwise, the symbols are tokenized as RULE_REF and allowed as
+// an identifier in a labeledElement.
+OPTIONS
+    : 'options' WS* '{'
+    ;
+
+TOKENS
+    : 'tokens' WS* '{'
+    ;
+
+CHANNELS
+    : 'channels' WS* '{'
+    ;
+
+IMPORT
+    : 'import'
+    ;
+
+FRAGMENT
+    : 'fragment'
+    ;
+
+LEXER
+    : 'lexer'
+    ;
+
+PARSER
+    : 'parser'
+    ;
+
+GRAMMAR
+    : 'grammar'
+    ;
+
+PROTECTED
+    : 'protected'
+    ;
+
+PUBLIC
+    : 'public'
+    ;
+
+PRIVATE
+    : 'private'
+    ;
+
+RETURNS
+    : 'returns'
+    ;
+
+LOCALS
+    : 'locals'
+    ;
+
+THROWS
+    : 'throws'
+    ;
+
+CATCH
+    : 'catch'
+    ;
+
+FINALLY
+    : 'finally'
+    ;
+
+MODE
+    : 'mode'
+    ;
+
+// -------------------------
+// Punctuation
+
+COLON
+    : ':'
+    ;
+
+COLONCOLON
+    : '::'
+    ;
+
+COMMA
+    : ','
+    ;
+
+SEMI
+    : ';'
+    ;
+
+LPAREN
+    : '('
+    ;
+
+RPAREN
+    : ')'
+    ;
+
+RBRACE
+    : '}'
+    ;
+
+RARROW
+    : '->'
+    ;
+
+LT
+    : '<'
+    ;
+
+GT
+    : '>'
+    ;
+
+ASSIGN
+    : '='
+    ;
+
+QUESTION
+    : '?'
+    ;
+
+STAR
+    : '*'
+    ;
+
+PLUS_ASSIGN
+    : '+='
+    ;
+
+PLUS
+    : '+'
+    ;
+
+OR
+    : '|'
+    ;
+
+DOLLAR
+    : '$'
+    ;
+
+RANGE
+    : '..'
+    ;
+
+DOT
+    : '.'
+    ;
+
+AT
+    : '@'
+    ;
+
+POUND
+    : '#'
+    ;
+
+NOT
+    : '~'
+    ;
+
+// -------------------------
+// Identifiers - allows unicode rule/token names
+
+ID
+    : NameStartChar NameChar*
+    ;
+
+// -------------------------
+// Whitespace
+
+WS
+    : [ \t\r\n\f]+ -> channel (OFF_CHANNEL)
+    ;
+
+// ======================================================
+// Lexer modes
+// -------------------------
+// Arguments
+mode Argument;
+
+// E.g., [int x, List<String> a[]]
+NESTED_ARGUMENT
+    : '[' -> type (ARGUMENT_CONTENT), pushMode (Argument)
+    ;
+
+ARGUMENT_ESCAPE
+    : '\\' . -> type (ARGUMENT_CONTENT)
+    ;
+
+ARGUMENT_STRING_LITERAL
+    : DoubleQuoteLiteral -> type (ARGUMENT_CONTENT)
+    ;
+
+ARGUMENT_CHAR_LITERAL
+    : STRING_LITERAL -> type (ARGUMENT_CONTENT)
+    ;
+
+END_ARGUMENT
+    : ']' { this.handleEndArgument(); }
+    ;
+
+// added this to return non-EOF token type here. EOF does something weird
+UNTERMINATED_ARGUMENT
+    : EOF -> popMode
+    ;
+
+ARGUMENT_CONTENT
+    : .
+    ;
+
+// -------------------------
+mode LexerCharSet;
+
+LEXER_CHAR_SET_BODY
+    : (~ [\]\\] | '\\' .)+ -> more
+    ;
+
+LEXER_CHAR_SET
+    : ']' -> popMode
+    ;
+
+UNTERMINATED_CHAR_SET
+    : EOF -> popMode
+    ;
+
+// ------------------------------------------------------------------------------
+// Grammar specific Keywords, Punctuation, etc.
+
+fragment ESC_SEQUENCE
+    : '\\' ([btnfr"'\\] | UnicodeESC | . | EOF)
+    ;
+
+fragment HexDigit
+    : [0-9a-fA-F]
+    ;
+
+fragment UnicodeESC
+    : 'u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?
+    ;
+
+fragment DoubleQuoteLiteral
+    : '"' (ESC_SEQUENCE | ~["\r\n\\])*? '"'
+    ;
+
+fragment TripleQuoteLiteral
+    : '"""' (ESC_SEQUENCE | .)*? '"""'
+    ;
+
+fragment BacktickQuoteLiteral
+    : '`' (ESC_SEQUENCE | ~["\r\n\\])*? '`'
+    ;
+
+// -----------------------------------
+// Character ranges
+
+fragment NameChar
+    : NameStartChar
+    | '0' .. '9'
+    | '_'
+    | '\u00B7'
+    | '\u0300' .. '\u036F'
+    | '\u203F' .. '\u2040'
+    ;
+
+fragment NameStartChar
+    : 'A' .. 'Z'
+    | 'a' .. 'z'
+    | '\u00C0' .. '\u00D6'
+    | '\u00D8' .. '\u00F6'
+    | '\u00F8' .. '\u02FF'
+    | '\u0370' .. '\u037D'
+    | '\u037F' .. '\u1FFF'
+    | '\u200C' .. '\u200D'
+    | '\u2070' .. '\u218F'
+    | '\u2C00' .. '\u2FEF'
+    | '\u3001' .. '\uD7FF'
+    | '\uF900' .. '\uFDCF'
+    | '\uFDF0' .. '\uFFFD'
+    // ignores | ['\u10000-'\uEFFFF]
+    ;

--- a/package-gale/tests/grammars/ANTLRv4Lexer.g4
+++ b/package-gale/tests/grammars/ANTLRv4Lexer.g4
@@ -1,3 +1,6 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/antlr/antlr4/ANTLRv4Lexer.g4
+// License: BSD 3-Clause (see below)
+
 /*
  * [The "BSD license"]
  *  Copyright (c) 2012-2015 Terence Parr

--- a/package-gale/tests/grammars/ANTLRv4Parser.g4
+++ b/package-gale/tests/grammars/ANTLRv4Parser.g4
@@ -1,0 +1,416 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012-2014 Terence Parr
+ *  Copyright (c) 2012-2014 Sam Harwell
+ *  Copyright (c) 2015 Gerald Rosenberg
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*	A grammar for ANTLR v4 written in ANTLR v4.
+ *
+ *	Modified 2015.06.16 gbr
+ *	-- update for compatibility with Antlr v4.5
+ *	-- add mode for channels
+ *	-- moved members to LexerAdaptor
+ * 	-- move fragments to imports
+ */
+
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons hanging
+// $antlr-format alignColons hanging
+
+parser grammar ANTLRv4Parser;
+
+options {
+    tokenVocab = ANTLRv4Lexer;
+}
+
+// The main entry point for parsing a v4 grammar.
+grammarSpec
+    : grammarDecl prequelConstruct* rules modeSpec* EOF
+    ;
+
+grammarDecl
+    : grammarType identifier SEMI
+    ;
+
+grammarType
+    : LEXER GRAMMAR
+    | PARSER GRAMMAR
+    | GRAMMAR
+    ;
+
+// This is the list of all constructs that can be declared before
+// the set of rules that compose the grammar, and is invoked 0..n
+// times by the grammarPrequel rule.
+
+prequelConstruct
+    : optionsSpec
+    | delegateGrammars
+    | tokensSpec
+    | channelsSpec
+    | action_
+    ;
+
+// ------------
+// Options - things that affect analysis and/or code generation
+
+optionsSpec
+    : OPTIONS (option SEMI)* RBRACE
+    ;
+
+option
+    : identifier ASSIGN optionValue
+    ;
+
+optionValue
+    : identifier (DOT identifier)*
+    | STRING_LITERAL
+    | actionBlock
+    | INT
+    ;
+
+// ------------
+// Delegates
+
+delegateGrammars
+    : IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
+    ;
+
+delegateGrammar
+    : identifier ASSIGN identifier
+    | identifier
+    ;
+
+// ------------
+// Tokens & Channels
+
+tokensSpec
+    : TOKENS idList? RBRACE
+    ;
+
+channelsSpec
+    : CHANNELS idList? RBRACE
+    ;
+
+idList
+    : identifier (COMMA identifier)* COMMA?
+    ;
+
+// Match stuff like @parser::members {int i;}
+
+action_
+    : AT (actionScopeName COLONCOLON)? identifier actionBlock
+    ;
+
+// Scope names could collide with keywords; allow them as ids for action scopes
+
+actionScopeName
+    : identifier
+    | LEXER
+    | PARSER
+    ;
+
+actionBlock
+    : ACTION
+    ;
+
+argActionBlock
+    : BEGIN_ARGUMENT ARGUMENT_CONTENT*? END_ARGUMENT
+    ;
+
+modeSpec
+    : MODE identifier SEMI lexerRuleSpec*
+    ;
+
+rules
+    : ruleSpec*
+    ;
+
+ruleSpec
+    : parserRuleSpec
+    | lexerRuleSpec
+    ;
+
+parserRuleSpec
+    : ruleModifiers? RULE_REF argActionBlock? ruleReturns? throwsSpec? localsSpec? rulePrequel* COLON ruleBlock SEMI
+        exceptionGroup
+    ;
+
+exceptionGroup
+    : exceptionHandler* finallyClause?
+    ;
+
+exceptionHandler
+    : CATCH argActionBlock actionBlock
+    ;
+
+finallyClause
+    : FINALLY actionBlock
+    ;
+
+rulePrequel
+    : optionsSpec
+    | ruleAction
+    ;
+
+ruleReturns
+    : RETURNS argActionBlock
+    ;
+
+// --------------
+// Exception spec
+throwsSpec
+    : THROWS qualifiedIdentifier (COMMA qualifiedIdentifier)*
+    ;
+
+localsSpec
+    : LOCALS argActionBlock
+    ;
+
+/** Match stuff like @init {int i;} */
+ruleAction
+    : AT identifier actionBlock
+    ;
+
+ruleModifiers
+    : ruleModifier+
+    ;
+
+// An individual access modifier for a rule. The 'fragment' modifier
+// is an internal indication for lexer rules that they do not match
+// from the input but are like subroutines for other lexer rules to
+// reuse for certain lexical patterns. The other modifiers are passed
+// to the code generation templates and may be ignored by the template
+// if they are of no use in that language.
+
+ruleModifier
+    : PUBLIC
+    | PRIVATE
+    | PROTECTED
+    | FRAGMENT
+    ;
+
+ruleBlock
+    : ruleAltList
+    ;
+
+ruleAltList
+    : labeledAlt (OR labeledAlt)*
+    ;
+
+labeledAlt
+    : alternative (POUND identifier)?
+    ;
+
+// --------------------
+// Lexer rules
+
+lexerRuleSpec
+    : FRAGMENT? TOKEN_REF optionsSpec? COLON lexerRuleBlock SEMI
+    ;
+
+lexerRuleBlock
+    : lexerAltList
+    ;
+
+lexerAltList
+    : lexerAlt (OR lexerAlt)*
+    ;
+
+lexerAlt
+    : lexerElements lexerCommands?
+    |
+    // explicitly allow empty alts
+    ;
+
+lexerElements
+    : lexerElement+
+    |
+    ;
+
+lexerElement
+    : lexerAtom ebnfSuffix?
+    | lexerBlock ebnfSuffix?
+    | actionBlock QUESTION?
+    ;
+
+// but preds can be anywhere
+
+lexerBlock
+    : LPAREN lexerAltList RPAREN
+    ;
+
+// E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
+
+lexerCommands
+    : RARROW lexerCommand (COMMA lexerCommand)*
+    ;
+
+lexerCommand
+    : lexerCommandName LPAREN lexerCommandExpr RPAREN
+    | lexerCommandName
+    ;
+
+lexerCommandName
+    : identifier
+    | MODE
+    ;
+
+lexerCommandExpr
+    : identifier
+    | INT
+    ;
+
+// --------------------
+// Rule Alts
+
+altList
+    : alternative (OR alternative)*
+    ;
+
+alternative
+    : elementOptions? element+
+    |
+    // explicitly allow empty alts
+    ;
+
+element
+    : labeledElement (ebnfSuffix |)
+    | atom (ebnfSuffix |)
+    | ebnf
+    | actionBlock QUESTION? predicateOptions?
+    ;
+
+predicateOptions
+    : LT predicateOption (COMMA predicateOption)* GT
+    ;
+
+predicateOption
+    : elementOption
+    | identifier ASSIGN (actionBlock | INT | STRING_LITERAL)
+    ;
+
+labeledElement
+    : identifier (ASSIGN | PLUS_ASSIGN) (atom | block)
+    ;
+
+// --------------------
+// EBNF and blocks
+
+ebnf
+    : block blockSuffix?
+    ;
+
+blockSuffix
+    : ebnfSuffix
+    ;
+
+ebnfSuffix
+    : QUESTION QUESTION?
+    | STAR QUESTION?
+    | PLUS QUESTION?
+    ;
+
+lexerAtom
+    : characterRange
+    | terminalDef
+    | notSet
+    | LEXER_CHAR_SET
+    | wildcard
+    ;
+
+atom
+    : terminalDef
+    | ruleref
+    | notSet
+    | wildcard
+    ;
+
+wildcard
+    : DOT elementOptions?
+    ;
+
+// --------------------
+// Inverted element set
+notSet
+    : NOT setElement
+    | NOT blockSet
+    ;
+
+blockSet
+    : LPAREN setElement (OR setElement)* RPAREN
+    ;
+
+setElement
+    : TOKEN_REF elementOptions?
+    | STRING_LITERAL elementOptions?
+    | characterRange
+    | LEXER_CHAR_SET
+    ;
+
+// -------------
+// Grammar Block
+block
+    : LPAREN (optionsSpec? ruleAction* COLON)? altList RPAREN
+    ;
+
+// ----------------
+// Parser rule ref
+ruleref
+    : RULE_REF argActionBlock? elementOptions?
+    ;
+
+// ---------------
+// Character Range
+characterRange
+    : STRING_LITERAL RANGE STRING_LITERAL
+    ;
+
+terminalDef
+    : TOKEN_REF elementOptions?
+    | STRING_LITERAL elementOptions?
+    ;
+
+// Terminals may be adorned with certain options when
+// reference in the grammar: TOK<,,,>
+elementOptions
+    : LT elementOption (COMMA elementOption)* GT
+    ;
+
+elementOption
+    : qualifiedIdentifier
+    | identifier ASSIGN (qualifiedIdentifier | STRING_LITERAL | INT)
+    ;
+
+identifier
+    : RULE_REF
+    | TOKEN_REF
+    ;
+
+qualifiedIdentifier
+    : identifier (DOT identifier)*
+    ;

--- a/package-gale/tests/grammars/ANTLRv4Parser.g4
+++ b/package-gale/tests/grammars/ANTLRv4Parser.g4
@@ -1,3 +1,6 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/antlr/antlr4/ANTLRv4Parser.g4
+// License: BSD 3-Clause (see below)
+
 /*
  * [The "BSD license"]
  *  Copyright (c) 2012-2014 Terence Parr

--- a/package-gale/tests/grammars/HTMLLexer.g4
+++ b/package-gale/tests/grammars/HTMLLexer.g4
@@ -1,0 +1,137 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/html/HTMLLexer.g4
+// License: BSD 3-Clause (see below)
+
+/*
+ [The "BSD licence"]
+ Copyright (c) 2013 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
+// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
+lexer grammar HTMLLexer;
+
+HTML_COMMENT: '<!--' .*? '-->';
+
+HTML_CONDITIONAL_COMMENT: '<![' .*? ']>';
+
+XML: '<?xml' .*? '>';
+
+CDATA: '<![CDATA[' .*? ']]>';
+
+DTD: '<!' .*? '>';
+
+SCRIPTLET: '<?' .*? '?>' | '<%' .*? '%>';
+
+SEA_WS: (' ' | '\t' | '\r'? '\n')+;
+
+SCRIPT_OPEN: '<script' .*? '>' -> pushMode(SCRIPT);
+
+STYLE_OPEN: '<style' .*? '>' -> pushMode(STYLE);
+
+TAG_OPEN: '<' -> pushMode(TAG);
+
+HTML_TEXT: ~'<'+;
+
+// tag declarations
+
+mode TAG;
+
+TAG_CLOSE: '>' -> popMode;
+
+TAG_SLASH_CLOSE: '/>' -> popMode;
+
+TAG_SLASH: '/';
+
+// lexing mode for attribute values
+
+TAG_EQUALS: '=' -> pushMode(ATTVALUE);
+
+TAG_NAME: TAG_NameStartChar TAG_NameChar*;
+
+TAG_WHITESPACE: [ \t\r\n] -> channel(HIDDEN);
+
+fragment HEXDIGIT: [a-fA-F0-9];
+
+fragment DIGIT: [0-9];
+
+fragment TAG_NameChar:
+    TAG_NameStartChar
+    | '-'
+    | '_'
+    | '.'
+    | DIGIT
+    | '\u00B7'
+    | '\u0300' ..'\u036F'
+    | '\u203F' ..'\u2040'
+;
+
+fragment TAG_NameStartChar:
+    [:a-zA-Z]
+    | '\u2070' ..'\u218F'
+    | '\u2C00' ..'\u2FEF'
+    | '\u3001' ..'\uD7FF'
+    | '\uF900' ..'\uFDCF'
+    | '\uFDF0' ..'\uFFFD'
+;
+
+// <scripts>
+
+mode SCRIPT;
+
+SCRIPT_BODY: .*? '</script>' -> popMode;
+
+SCRIPT_SHORT_BODY: .*? '</>' -> popMode;
+
+// <styles>
+
+mode STYLE;
+
+STYLE_BODY: .*? '</style>' -> popMode;
+
+STYLE_SHORT_BODY: .*? '</>' -> popMode;
+
+// attribute values
+
+mode ATTVALUE;
+
+// an attribute value may have spaces b/t the '=' and the value
+ATTVALUE_VALUE: ' '* ATTRIBUTE -> popMode;
+
+ATTRIBUTE: DOUBLE_QUOTE_STRING | SINGLE_QUOTE_STRING | ATTCHARS | HEXCHARS | DECCHARS;
+
+fragment ATTCHARS: ATTCHAR+ ' '?;
+
+fragment ATTCHAR: '-' | '_' | '.' | '/' | '+' | ',' | '?' | '=' | ':' | ';' | '#' | [0-9a-zA-Z];
+
+fragment HEXCHARS: '#' [0-9a-fA-F]+;
+
+fragment DECCHARS: [0-9]+ '%'?;
+
+fragment DOUBLE_QUOTE_STRING: '"' ~[<"]* '"';
+
+fragment SINGLE_QUOTE_STRING: '\'' ~[<']* '\'';

--- a/package-gale/tests/grammars/HTMLParser.g4
+++ b/package-gale/tests/grammars/HTMLParser.g4
@@ -1,0 +1,93 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/html/HTMLParser.g4
+// License: BSD 3-Clause (see below)
+
+/*
+ [The "BSD licence"]
+ Copyright (c) 2013 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+parser grammar HTMLParser;
+
+options {
+    tokenVocab = HTMLLexer;
+}
+
+htmlDocument
+    : scriptletOrSeaWs* XML? scriptletOrSeaWs* DTD? scriptletOrSeaWs* htmlElements*
+    ;
+
+scriptletOrSeaWs
+    : SCRIPTLET
+    | SEA_WS
+    ;
+
+htmlElements
+    : htmlMisc* htmlElement htmlMisc*
+    ;
+
+htmlElement
+    : TAG_OPEN TAG_NAME htmlAttribute* (
+        TAG_CLOSE (htmlContent TAG_OPEN TAG_SLASH TAG_NAME TAG_CLOSE)?
+        | TAG_SLASH_CLOSE
+    )
+    | SCRIPTLET
+    | script
+    | style
+    ;
+
+htmlContent
+    : htmlChardata? ((htmlElement | CDATA | htmlComment) htmlChardata?)*
+    ;
+
+htmlAttribute
+    : TAG_NAME (TAG_EQUALS ATTVALUE_VALUE)?
+    ;
+
+htmlChardata
+    : HTML_TEXT
+    | SEA_WS
+    ;
+
+htmlMisc
+    : htmlComment
+    | SEA_WS
+    ;
+
+htmlComment
+    : HTML_COMMENT
+    | HTML_CONDITIONAL_COMMENT
+    ;
+
+script
+    : SCRIPT_OPEN (SCRIPT_BODY | SCRIPT_SHORT_BODY)
+    ;
+
+style
+    : STYLE_OPEN (STYLE_BODY | STYLE_SHORT_BODY)
+    ;

--- a/package-gale/tests/grammars/RustLexer.g4
+++ b/package-gale/tests/grammars/RustLexer.g4
@@ -1,0 +1,273 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/rust/RustLexer.g4
+// License: MIT (see below)
+
+/*
+Copyright (c) 2010 The Rust Project Developers
+Copyright (c) 2020-2022 Student Main
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
+// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
+lexer grammar RustLexer;
+
+// Insert here @header for C++ lexer.
+
+options
+{
+    superClass = RustLexerBase;
+}
+
+// https://doc.rust-lang.org/reference/keywords.html strict
+KW_AS        : 'as';
+KW_BREAK     : 'break';
+KW_CONST     : 'const';
+KW_CONTINUE  : 'continue';
+KW_CRATE     : 'crate';
+KW_ELSE      : 'else';
+KW_ENUM      : 'enum';
+KW_EXTERN    : 'extern';
+KW_FALSE     : 'false';
+KW_FN        : 'fn';
+KW_FOR       : 'for';
+KW_IF        : 'if';
+KW_IMPL      : 'impl';
+KW_IN        : 'in';
+KW_LET       : 'let';
+KW_LOOP      : 'loop';
+KW_MATCH     : 'match';
+KW_MOD       : 'mod';
+KW_MOVE      : 'move';
+KW_MUT       : 'mut';
+KW_PUB       : 'pub';
+KW_REF       : 'ref';
+KW_RETURN    : 'return';
+KW_SELFVALUE : 'self';
+KW_SELFTYPE  : 'Self';
+KW_STATIC    : 'static';
+KW_STRUCT    : 'struct';
+KW_SUPER     : 'super';
+KW_TRAIT     : 'trait';
+KW_TRUE      : 'true';
+KW_TYPE      : 'type';
+KW_UNSAFE    : 'unsafe';
+KW_USE       : 'use';
+KW_WHERE     : 'where';
+KW_WHILE     : 'while';
+
+// 2018+
+KW_ASYNC : 'async';
+KW_AWAIT : 'await';
+KW_DYN   : 'dyn';
+
+// reserved
+KW_ABSTRACT : 'abstract';
+KW_BECOME   : 'become';
+KW_BOX      : 'box';
+KW_DO       : 'do';
+KW_FINAL    : 'final';
+KW_MACRO    : 'macro';
+KW_OVERRIDE : 'override';
+KW_PRIV     : 'priv';
+KW_TYPEOF   : 'typeof';
+KW_UNSIZED  : 'unsized';
+KW_VIRTUAL  : 'virtual';
+KW_YIELD    : 'yield';
+
+// reserved 2018+
+KW_TRY: 'try';
+
+// weak
+KW_UNION          : 'union';
+KW_STATICLIFETIME : '\'static';
+
+KW_MACRORULES        : 'macro_rules';
+KW_UNDERLINELIFETIME : '\'_';
+KW_DOLLARCRATE       : '$crate';
+
+// rule itself allow any identifier, but keyword has been matched before
+NON_KEYWORD_IDENTIFIER: XID_Start XID_Continue* | '_' XID_Continue+;
+
+// [\p{L}\p{Nl}\p{Other_ID_Start}-\p{Pattern_Syntax}-\p{Pattern_White_Space}]
+fragment XID_Start: [\p{L}\p{Nl}] | UNICODE_OIDS;
+
+// [\p{ID_Start}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Other_ID_Continue}-\p{Pattern_Syntax}-\p{Pattern_White_Space}]
+fragment XID_Continue: XID_Start | [\p{Mn}\p{Mc}\p{Nd}\p{Pc}] | UNICODE_OIDC;
+
+fragment UNICODE_OIDS: '\u1885' ..'\u1886' | '\u2118' | '\u212e' | '\u309b' ..'\u309c';
+
+fragment UNICODE_OIDC: '\u00b7' | '\u0387' | '\u1369' ..'\u1371' | '\u19da';
+
+RAW_IDENTIFIER: 'r#' NON_KEYWORD_IDENTIFIER;
+// comments https://doc.rust-lang.org/reference/comments.html
+LINE_COMMENT: ('//' (~[/!] | '//') ~[\r\n]* | '//') -> channel (HIDDEN);
+
+BLOCK_COMMENT:
+    (
+        '/*' (~[*!] | '**' | BLOCK_COMMENT_OR_DOC) (BLOCK_COMMENT_OR_DOC | ~[*])*? '*/'
+        | '/**/'
+        | '/***/'
+    ) -> channel (HIDDEN)
+;
+
+INNER_LINE_DOC: '//!' ~[\n\r]* -> channel (HIDDEN); // isolated cr
+
+INNER_BLOCK_DOC: '/*!' ( BLOCK_COMMENT_OR_DOC | ~[*])*? '*/' -> channel (HIDDEN);
+
+OUTER_LINE_DOC: '///' (~[/] ~[\n\r]*)? -> channel (HIDDEN); // isolated cr
+
+OUTER_BLOCK_DOC:
+    '/**' (~[*] | BLOCK_COMMENT_OR_DOC) (BLOCK_COMMENT_OR_DOC | ~[*])*? '*/' -> channel (HIDDEN)
+;
+
+BLOCK_COMMENT_OR_DOC: ( BLOCK_COMMENT | INNER_BLOCK_DOC | OUTER_BLOCK_DOC) -> channel (HIDDEN);
+
+SHEBANG: {this.SOF()}? '\ufeff'? '#!' ~[\r\n]* -> channel(HIDDEN);
+
+// whitespace https://doc.rust-lang.org/reference/whitespace.html
+WHITESPACE : [\p{Zs}]          -> channel(HIDDEN);
+NEWLINE    : ('\r\n' | [\r\n]) -> channel(HIDDEN);
+
+// tokens char and string
+CHAR_LITERAL: '\'' ( ~['\\\n\r\t] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE) '\'';
+
+STRING_LITERAL: '"' ( ~["] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE | ESC_NEWLINE)* '"';
+
+RAW_STRING_LITERAL: 'r' RAW_STRING_CONTENT;
+
+fragment RAW_STRING_CONTENT: '#' RAW_STRING_CONTENT '#' | '"' .*? '"';
+
+BYTE_LITERAL: 'b\'' (. | QUOTE_ESCAPE | BYTE_ESCAPE) '\'';
+
+BYTE_STRING_LITERAL: 'b"' (~["] | QUOTE_ESCAPE | BYTE_ESCAPE)* '"';
+
+RAW_BYTE_STRING_LITERAL: 'br' RAW_STRING_CONTENT;
+
+fragment ASCII_ESCAPE: '\\x' OCT_DIGIT HEX_DIGIT | COMMON_ESCAPE;
+
+fragment BYTE_ESCAPE: '\\x' HEX_DIGIT HEX_DIGIT | COMMON_ESCAPE;
+
+fragment COMMON_ESCAPE: '\\' [nrt\\0];
+
+fragment UNICODE_ESCAPE:
+    '\\u{' HEX_DIGIT HEX_DIGIT? HEX_DIGIT? HEX_DIGIT? HEX_DIGIT? HEX_DIGIT? '}'
+;
+
+fragment QUOTE_ESCAPE: '\\' ['"];
+
+fragment ESC_NEWLINE: '\\' '\n';
+
+// number
+
+INTEGER_LITERAL: ( DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL) INTEGER_SUFFIX?;
+
+DEC_LITERAL: DEC_DIGIT (DEC_DIGIT | '_')*;
+
+HEX_LITERAL: '0x' '_'* HEX_DIGIT (HEX_DIGIT | '_')*;
+
+OCT_LITERAL: '0o' '_'* OCT_DIGIT (OCT_DIGIT | '_')*;
+
+BIN_LITERAL: '0b' '_'* [01] [01_]*;
+
+FLOAT_LITERAL:
+    {this.FloatLiteralPossible()}?
+    (
+        DEC_LITERAL '.' {this.FloatDotPossible()}?
+        | DEC_LITERAL ( '.' DEC_LITERAL)? FLOAT_EXPONENT? FLOAT_SUFFIX?
+    )
+;
+
+fragment INTEGER_SUFFIX:
+    'u8'
+    | 'u16'
+    | 'u32'
+    | 'u64'
+    | 'u128'
+    | 'usize'
+    | 'i8'
+    | 'i16'
+    | 'i32'
+    | 'i64'
+    | 'i128'
+    | 'isize'
+;
+
+fragment FLOAT_SUFFIX: 'f32' | 'f64';
+
+fragment FLOAT_EXPONENT: [eE] [+-]? '_'* DEC_LITERAL;
+
+fragment OCT_DIGIT: [0-7];
+
+fragment DEC_DIGIT: [0-9];
+
+fragment HEX_DIGIT: [0-9a-fA-F];
+
+// LIFETIME_TOKEN: '\'' IDENTIFIER_OR_KEYWORD | '\'_';
+
+LIFETIME_OR_LABEL: '\'' NON_KEYWORD_IDENTIFIER;
+
+PLUS    : '+';
+MINUS   : '-';
+STAR    : '*';
+SLASH   : '/';
+PERCENT : '%';
+CARET   : '^';
+NOT     : '!';
+AND     : '&';
+OR      : '|';
+ANDAND  : '&&';
+OROR    : '||';
+//SHL: '<<'; SHR: '>>'; removed to avoid confusion in type parameter
+PLUSEQ     : '+=';
+MINUSEQ    : '-=';
+STAREQ     : '*=';
+SLASHEQ    : '/=';
+PERCENTEQ  : '%=';
+CARETEQ    : '^=';
+ANDEQ      : '&=';
+OREQ       : '|=';
+SHLEQ      : '<<=';
+SHREQ      : '>>=';
+EQ         : '=';
+EQEQ       : '==';
+NE         : '!=';
+GT         : '>';
+LT         : '<';
+GE         : '>=';
+LE         : '<=';
+AT         : '@';
+UNDERSCORE : '_';
+DOT        : '.';
+DOTDOT     : '..';
+DOTDOTDOT  : '...';
+DOTDOTEQ   : '..=';
+COMMA      : ',';
+SEMI       : ';';
+COLON      : ':';
+PATHSEP    : '::';
+RARROW     : '->';
+FATARROW   : '=>';
+POUND      : '#';
+DOLLAR     : '$';
+QUESTION   : '?';
+
+LCURLYBRACE    : '{';
+RCURLYBRACE    : '}';
+LSQUAREBRACKET : '[';
+RSQUAREBRACKET : ']';
+LPAREN         : '(';
+RPAREN         : ')';

--- a/package-gale/tests/grammars/RustParser.g4
+++ b/package-gale/tests/grammars/RustParser.g4
@@ -1,0 +1,1201 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/rust/RustParser.g4
+// License: MIT (see below)
+
+/*
+Copyright (c) 2010 The Rust Project Developers
+Copyright (c) 2020-2022 Student Main
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+parser grammar RustParser;
+
+// Insert here @header for C++ parser.
+
+options
+{
+    tokenVocab = RustLexer;
+    superClass = RustParserBase;
+}
+
+// entry point
+// 4
+crate
+    : innerAttribute* item* EOF
+    ;
+
+// 3
+macroInvocation
+    : simplePath NOT delimTokenTree
+    ;
+
+delimTokenTree
+    : LPAREN tokenTree* RPAREN
+    | LSQUAREBRACKET tokenTree* RSQUAREBRACKET
+    | LCURLYBRACE tokenTree* RCURLYBRACE
+    ;
+
+tokenTree
+    : tokenTreeToken+
+    | delimTokenTree
+    ;
+
+tokenTreeToken
+    : macroIdentifierLikeToken
+    | macroLiteralToken
+    | macroPunctuationToken
+    | macroRepOp
+    | DOLLAR
+    ;
+
+macroInvocationSemi
+    : simplePath NOT LPAREN tokenTree* RPAREN SEMI
+    | simplePath NOT LSQUAREBRACKET tokenTree* RSQUAREBRACKET SEMI
+    | simplePath NOT LCURLYBRACE tokenTree* RCURLYBRACE
+    ;
+
+// 3.1
+macroRulesDefinition
+    : KW_MACRORULES NOT identifier macroRulesDef
+    ;
+
+macroRulesDef
+    : LPAREN macroRules RPAREN SEMI
+    | LSQUAREBRACKET macroRules RSQUAREBRACKET SEMI
+    | LCURLYBRACE macroRules RCURLYBRACE
+    ;
+
+macroRules
+    : macroRule (SEMI macroRule)* SEMI?
+    ;
+
+macroRule
+    : macroMatcher FATARROW macroTranscriber
+    ;
+
+macroMatcher
+    : LPAREN macroMatch* RPAREN
+    | LSQUAREBRACKET macroMatch* RSQUAREBRACKET
+    | LCURLYBRACE macroMatch* RCURLYBRACE
+    ;
+
+macroMatch
+    : macroMatchToken+
+    | macroMatcher
+    | DOLLAR (identifier | KW_SELFVALUE) COLON macroFragSpec
+    | DOLLAR LPAREN macroMatch+ RPAREN macroRepSep? macroRepOp
+    ;
+
+macroMatchToken
+    : macroIdentifierLikeToken
+    | macroLiteralToken
+    | macroPunctuationToken
+    | macroRepOp
+    ;
+
+macroFragSpec
+    : identifier // do validate here is wasting token
+    ;
+
+macroRepSep
+    : macroIdentifierLikeToken
+    | macroLiteralToken
+    | macroPunctuationToken
+    | DOLLAR
+    ;
+
+macroRepOp
+    : STAR
+    | PLUS
+    | QUESTION
+    ;
+
+macroTranscriber
+    : delimTokenTree
+    ;
+
+//configurationPredicate
+// : configurationOption | configurationAll | configurationAny | configurationNot ; configurationOption: identifier (
+// EQ (STRING_LITERAL | RAW_STRING_LITERAL))?; configurationAll: 'all' LPAREN configurationPredicateList? RPAREN;
+// configurationAny: 'any' LPAREN configurationPredicateList? RPAREN; configurationNot: 'not' LPAREN configurationPredicate RPAREN;
+
+//configurationPredicateList
+// : configurationPredicate (COMMA configurationPredicate)* COMMA? ; cfgAttribute: 'cfg' LPAREN configurationPredicate RPAREN;
+// cfgAttrAttribute: 'cfg_attr' LPAREN configurationPredicate COMMA cfgAttrs? RPAREN; cfgAttrs: attr (COMMA attr)* COMMA?;
+
+// 6
+item
+    : outerAttribute* (visItem | macroItem)
+    ;
+
+visItem
+    : visibility? (
+        module
+        | externCrate
+        | useDeclaration
+        | function_
+        | typeAlias
+        | struct_
+        | enumeration
+        | union_
+        | constantItem
+        | staticItem
+        | trait_
+        | implementation
+        | externBlock
+    )
+    ;
+
+macroItem
+    : macroInvocationSemi
+    | macroRulesDefinition
+    ;
+
+// 6.1
+module
+    : KW_UNSAFE? KW_MOD identifier (SEMI | LCURLYBRACE innerAttribute* item* RCURLYBRACE)
+    ;
+
+// 6.2
+externCrate
+    : KW_EXTERN KW_CRATE crateRef asClause? SEMI
+    ;
+
+crateRef
+    : identifier
+    | KW_SELFVALUE
+    ;
+
+asClause
+    : KW_AS (identifier | UNDERSCORE)
+    ;
+
+// 6.3
+useDeclaration
+    : KW_USE useTree SEMI
+    ;
+
+useTree
+    : (simplePath? PATHSEP)? (STAR | LCURLYBRACE ( useTree (COMMA useTree)* COMMA?)? RCURLYBRACE)
+    | simplePath (KW_AS (identifier | UNDERSCORE))?
+    ;
+
+// 6.4
+function_
+    : functionQualifiers KW_FN identifier genericParams? LPAREN functionParameters? RPAREN functionReturnType? whereClause? (
+        blockExpression
+        | SEMI
+    )
+    ;
+
+functionQualifiers
+    : KW_CONST? KW_ASYNC? KW_UNSAFE? (KW_EXTERN abi?)?
+    ;
+
+abi
+    : STRING_LITERAL
+    | RAW_STRING_LITERAL
+    ;
+
+functionParameters
+    : selfParam COMMA?
+    | (selfParam COMMA)? functionParam (COMMA functionParam)* COMMA?
+    ;
+
+selfParam
+    : outerAttribute* (shorthandSelf | typedSelf)
+    ;
+
+shorthandSelf
+    : (AND lifetime?)? KW_MUT? KW_SELFVALUE
+    ;
+
+typedSelf
+    : KW_MUT? KW_SELFVALUE COLON type_
+    ;
+
+functionParam
+    : outerAttribute* (functionParamPattern | DOTDOTDOT | type_)
+    ;
+
+functionParamPattern
+    : pattern COLON (type_ | DOTDOTDOT)
+    ;
+
+functionReturnType
+    : RARROW type_
+    ;
+
+// 6.5
+typeAlias
+    : KW_TYPE identifier genericParams? whereClause? (EQ type_)? SEMI
+    ;
+
+// 6.6
+struct_
+    : structStruct
+    | tupleStruct
+    ;
+
+structStruct
+    : KW_STRUCT identifier genericParams? whereClause? (LCURLYBRACE structFields? RCURLYBRACE | SEMI)
+    ;
+
+tupleStruct
+    : KW_STRUCT identifier genericParams? LPAREN tupleFields? RPAREN whereClause? SEMI
+    ;
+
+structFields
+    : structField (COMMA structField)* COMMA?
+    ;
+
+structField
+    : outerAttribute* visibility? identifier COLON type_
+    ;
+
+tupleFields
+    : tupleField (COMMA tupleField)* COMMA?
+    ;
+
+tupleField
+    : outerAttribute* visibility? type_
+    ;
+
+// 6.7
+enumeration
+    : KW_ENUM identifier genericParams? whereClause? LCURLYBRACE enumItems? RCURLYBRACE
+    ;
+
+enumItems
+    : enumItem (COMMA enumItem)* COMMA?
+    ;
+
+enumItem
+    : outerAttribute* visibility? identifier (
+        enumItemTuple
+        | enumItemStruct
+        | enumItemDiscriminant
+    )?
+    ;
+
+enumItemTuple
+    : LPAREN tupleFields? RPAREN
+    ;
+
+enumItemStruct
+    : LCURLYBRACE structFields? RCURLYBRACE
+    ;
+
+enumItemDiscriminant
+    : EQ expression
+    ;
+
+// 6.8
+union_
+    : KW_UNION identifier genericParams? whereClause? LCURLYBRACE structFields RCURLYBRACE
+    ;
+
+// 6.9
+constantItem
+    : KW_CONST (identifier | UNDERSCORE) COLON type_ (EQ expression)? SEMI
+    ;
+
+// 6.10
+staticItem
+    : KW_STATIC KW_MUT? identifier COLON type_ (EQ expression)? SEMI
+    ;
+
+// 6.11
+trait_
+    : KW_UNSAFE? KW_TRAIT identifier genericParams? (COLON typeParamBounds?)? whereClause? LCURLYBRACE innerAttribute* associatedItem* RCURLYBRACE
+    ;
+
+// 6.12
+implementation
+    : inherentImpl
+    | traitImpl
+    ;
+
+inherentImpl
+    : KW_IMPL genericParams? type_ whereClause? LCURLYBRACE innerAttribute* associatedItem* RCURLYBRACE
+    ;
+
+traitImpl
+    : KW_UNSAFE? KW_IMPL genericParams? NOT? typePath KW_FOR type_ whereClause? LCURLYBRACE innerAttribute* associatedItem* RCURLYBRACE
+    ;
+
+// 6.13
+externBlock
+    : KW_UNSAFE? KW_EXTERN abi? LCURLYBRACE innerAttribute* externalItem* RCURLYBRACE
+    ;
+
+externalItem
+    : outerAttribute* (macroInvocationSemi | visibility? ( staticItem | function_))
+    ;
+
+// 6.14
+genericParams
+    : LT ((genericParam COMMA)* genericParam COMMA?)? GT
+    ;
+
+genericParam
+    : outerAttribute* (lifetimeParam | typeParam | constParam)
+    ;
+
+lifetimeParam
+    : outerAttribute? LIFETIME_OR_LABEL (COLON lifetimeBounds)?
+    ;
+
+typeParam
+    : outerAttribute? identifier (COLON typeParamBounds?)? (EQ type_)?
+    ;
+
+constParam
+    : KW_CONST identifier COLON type_
+    ;
+
+whereClause
+    : KW_WHERE (whereClauseItem COMMA)* whereClauseItem?
+    ;
+
+whereClauseItem
+    : lifetimeWhereClauseItem
+    | typeBoundWhereClauseItem
+    ;
+
+lifetimeWhereClauseItem
+    : lifetime COLON lifetimeBounds
+    ;
+
+typeBoundWhereClauseItem
+    : forLifetimes? type_ COLON typeParamBounds?
+    ;
+
+forLifetimes
+    : KW_FOR genericParams
+    ;
+
+// 6.15
+associatedItem
+    : outerAttribute* (macroInvocationSemi | visibility? ( typeAlias | constantItem | function_))
+    ;
+
+// 7
+innerAttribute
+    : POUND NOT LSQUAREBRACKET attr RSQUAREBRACKET
+    ;
+
+outerAttribute
+    : POUND LSQUAREBRACKET attr RSQUAREBRACKET
+    ;
+
+attr
+    : simplePath attrInput?
+    ;
+
+attrInput
+    : delimTokenTree
+    | EQ literalExpression
+    ; // w/o suffix
+
+//metaItem
+// : simplePath ( EQ literalExpression //w | LPAREN metaSeq RPAREN )? ; metaSeq: metaItemInner (COMMA metaItemInner)* COMMA?;
+// metaItemInner: metaItem | literalExpression; // w
+
+//metaWord: identifier; metaNameValueStr: identifier EQ ( STRING_LITERAL | RAW_STRING_LITERAL); metaListPaths:
+// identifier LPAREN ( simplePath (COMMA simplePath)* COMMA?)? RPAREN; metaListIdents: identifier LPAREN ( identifier (COMMA
+// identifier)* COMMA?)? RPAREN; metaListNameValueStr : identifier LPAREN (metaNameValueStr ( COMMA metaNameValueStr)* COMMA?)? RPAREN
+// ;
+
+// 8
+statement
+    : SEMI
+    | item
+    | letStatement
+    | expressionStatement
+    | macroInvocationSemi
+    ;
+
+letStatement
+    : outerAttribute* KW_LET patternNoTopAlt (COLON type_)? (EQ expression)? SEMI
+    ;
+
+expressionStatement
+    : expression SEMI
+    | expressionWithBlock SEMI?
+    ;
+
+// 8.2
+expression
+    : outerAttribute+ expression                                     # AttributedExpression // technical, remove left recursive
+    | literalExpression                                              # LiteralExpression_
+    | pathExpression                                                 # PathExpression_
+    | expression DOT pathExprSegment LPAREN callParams? RPAREN       # MethodCallExpression          // 8.2.10
+    | expression DOT identifier                                      # FieldExpression               // 8.2.11
+    | expression DOT tupleIndex                                      # TupleIndexingExpression       // 8.2.7
+    | expression DOT KW_AWAIT                                        # AwaitExpression               // 8.2.18
+    | expression LPAREN callParams? RPAREN                           # CallExpression                // 8.2.9
+    | expression LSQUAREBRACKET expression RSQUAREBRACKET            # IndexExpression               // 8.2.6
+    | expression QUESTION                                            # ErrorPropagationExpression    // 8.2.4
+    | (AND | ANDAND) KW_MUT? expression                              # BorrowExpression              // 8.2.4
+    | STAR expression                                                # DereferenceExpression         // 8.2.4
+    | (MINUS | NOT) expression                                         # NegationExpression            // 8.2.4
+    | expression KW_AS typeNoBounds                                  # TypeCastExpression            // 8.2.4
+    | expression (STAR | SLASH | PERCENT) expression                  # ArithmeticOrLogicalExpression // 8.2.4
+    | expression (PLUS | MINUS) expression                            # ArithmeticOrLogicalExpression // 8.2.4
+    | expression (shl | shr) expression                              # ArithmeticOrLogicalExpression // 8.2.4
+    | expression AND expression                                      # ArithmeticOrLogicalExpression // 8.2.4
+    | expression CARET expression                                    # ArithmeticOrLogicalExpression // 8.2.4
+    | expression OR expression                                       # ArithmeticOrLogicalExpression // 8.2.4
+    | expression comparisonOperator expression                       # ComparisonExpression          // 8.2.4
+    | expression ANDAND expression                                   # LazyBooleanExpression         // 8.2.4
+    | expression OROR expression                                     # LazyBooleanExpression         // 8.2.4
+    | expression DOTDOT expression?                                  # RangeExpression               // 8.2.14
+    | DOTDOT expression?                                             # RangeExpression               // 8.2.14
+    | DOTDOTEQ expression                                            # RangeExpression               // 8.2.14
+    | expression DOTDOTEQ expression                                 # RangeExpression               // 8.2.14
+    | expression EQ expression                                       # AssignmentExpression          // 8.2.4
+    | expression compoundAssignOperator expression                   # CompoundAssignmentExpression  // 8.2.4
+    | KW_CONTINUE LIFETIME_OR_LABEL? expression?                     # ContinueExpression            // 8.2.13
+    | KW_BREAK LIFETIME_OR_LABEL? expression?                        # BreakExpression               // 8.2.13
+    | KW_RETURN expression?                                          # ReturnExpression              // 8.2.17
+    | LPAREN innerAttribute* expression RPAREN                       # GroupedExpression             // 8.2.5
+    | LSQUAREBRACKET innerAttribute* arrayElements? RSQUAREBRACKET   # ArrayExpression               // 8.2.6
+    | LPAREN innerAttribute* tupleElements? RPAREN                   # TupleExpression               // 8.2.7
+    | structExpression                                               # StructExpression_             // 8.2.8
+    | enumerationVariantExpression                                   # EnumerationVariantExpression_
+    | closureExpression                                              # ClosureExpression_            // 8.2.12
+    | expressionWithBlock                                            # ExpressionWithBlock_
+    | macroInvocation                                                # MacroInvocationAsExpression
+    ;
+
+comparisonOperator
+    : EQEQ
+    | NE
+    | GT
+    | LT
+    | GE
+    | LE
+    ;
+
+compoundAssignOperator
+    : PLUSEQ
+    | MINUSEQ
+    | STAREQ
+    | SLASHEQ
+    | PERCENTEQ
+    | ANDEQ
+    | OREQ
+    | CARETEQ
+    | SHLEQ
+    | SHREQ
+    ;
+
+expressionWithBlock
+    : outerAttribute+ expressionWithBlock // technical
+    | blockExpression
+    | asyncBlockExpression
+    | unsafeBlockExpression
+    | loopExpression
+    | ifExpression
+    | ifLetExpression
+    | matchExpression
+    ;
+
+// 8.2.1
+literalExpression
+    : CHAR_LITERAL
+    | STRING_LITERAL
+    | RAW_STRING_LITERAL
+    | BYTE_LITERAL
+    | BYTE_STRING_LITERAL
+    | RAW_BYTE_STRING_LITERAL
+    | INTEGER_LITERAL
+    | FLOAT_LITERAL
+    | KW_TRUE
+    | KW_FALSE
+    ;
+
+// 8.2.2
+pathExpression
+    : pathInExpression
+    | qualifiedPathInExpression
+    ;
+
+// 8.2.3
+blockExpression
+    : LCURLYBRACE innerAttribute* statements? RCURLYBRACE
+    ;
+
+statements
+    : statement+ expression?
+    | expression
+    ;
+
+asyncBlockExpression
+    : KW_ASYNC KW_MOVE? blockExpression
+    ;
+
+unsafeBlockExpression
+    : KW_UNSAFE blockExpression
+    ;
+
+// 8.2.6
+arrayElements
+    : expression (COMMA expression)* COMMA?
+    | expression SEMI expression
+    ;
+
+// 8.2.7
+tupleElements
+    : (expression COMMA)+ expression?
+    ;
+
+tupleIndex
+    : INTEGER_LITERAL
+    ;
+
+// 8.2.8
+structExpression
+    : structExprStruct
+    | structExprTuple
+    | structExprUnit
+    ;
+
+structExprStruct
+    : pathInExpression LCURLYBRACE innerAttribute* (structExprFields | structBase)? RCURLYBRACE
+    ;
+
+structExprFields
+    : structExprField (COMMA structExprField)* (COMMA structBase | COMMA?)
+    ;
+
+// outerAttribute here is not in doc
+structExprField
+    : outerAttribute* (identifier | (identifier | tupleIndex) COLON expression)
+    ;
+
+structBase
+    : DOTDOT expression
+    ;
+
+structExprTuple
+    : pathInExpression LPAREN innerAttribute* (expression ( COMMA expression)* COMMA?)? RPAREN
+    ;
+
+structExprUnit
+    : pathInExpression
+    ;
+
+enumerationVariantExpression
+    : enumExprStruct
+    | enumExprTuple
+    | enumExprFieldless
+    ;
+
+enumExprStruct
+    : pathInExpression LCURLYBRACE enumExprFields? RCURLYBRACE
+    ;
+
+enumExprFields
+    : enumExprField (COMMA enumExprField)* COMMA?
+    ;
+
+enumExprField
+    : identifier
+    | (identifier | tupleIndex) COLON expression
+    ;
+
+enumExprTuple
+    : pathInExpression LPAREN (expression (COMMA expression)* COMMA?)? RPAREN
+    ;
+
+enumExprFieldless
+    : pathInExpression
+    ;
+
+// 8.2.9
+callParams
+    : expression (COMMA expression)* COMMA?
+    ;
+
+// 8.2.12
+closureExpression
+    : KW_MOVE? (OROR | OR closureParameters? OR) (expression | RARROW typeNoBounds blockExpression)
+    ;
+
+closureParameters
+    : closureParam (COMMA closureParam)* COMMA?
+    ;
+
+closureParam
+    : outerAttribute* pattern (COLON type_)?
+    ;
+
+// 8.2.13
+loopExpression
+    : loopLabel? (
+        infiniteLoopExpression
+        | predicateLoopExpression
+        | predicatePatternLoopExpression
+        | iteratorLoopExpression
+    )
+    ;
+
+infiniteLoopExpression
+    : KW_LOOP blockExpression
+    ;
+
+predicateLoopExpression
+    : KW_WHILE expression /*except structExpression*/ blockExpression
+    ;
+
+predicatePatternLoopExpression
+    : KW_WHILE KW_LET pattern EQ expression blockExpression
+    ;
+
+iteratorLoopExpression
+    : KW_FOR pattern KW_IN expression blockExpression
+    ;
+
+loopLabel
+    : LIFETIME_OR_LABEL COLON
+    ;
+
+// 8.2.15
+ifExpression
+    : KW_IF expression blockExpression (KW_ELSE (blockExpression | ifExpression | ifLetExpression))?
+    ;
+
+ifLetExpression
+    : KW_IF KW_LET pattern EQ expression blockExpression (
+        KW_ELSE (blockExpression | ifExpression | ifLetExpression)
+    )?
+    ;
+
+// 8.2.16
+matchExpression
+    : KW_MATCH expression LCURLYBRACE innerAttribute* matchArms? RCURLYBRACE
+    ;
+
+matchArms
+    : (matchArm FATARROW matchArmExpression)* matchArm FATARROW expression COMMA?
+    ;
+
+matchArmExpression
+    : expression COMMA
+    | expressionWithBlock COMMA?
+    ;
+
+matchArm
+    : outerAttribute* pattern matchArmGuard?
+    ;
+
+matchArmGuard
+    : KW_IF expression
+    ;
+
+// 9
+pattern
+    : OR? patternNoTopAlt (OR patternNoTopAlt)*
+    ;
+
+patternNoTopAlt
+    : patternWithoutRange
+    | rangePattern
+    ;
+
+patternWithoutRange
+    : literalPattern
+    | identifierPattern
+    | wildcardPattern
+    | restPattern
+    | referencePattern
+    | structPattern
+    | tupleStructPattern
+    | tuplePattern
+    | groupedPattern
+    | slicePattern
+    | pathPattern
+    | macroInvocation
+    ;
+
+literalPattern
+    : KW_TRUE
+    | KW_FALSE
+    | CHAR_LITERAL
+    | BYTE_LITERAL
+    | STRING_LITERAL
+    | RAW_STRING_LITERAL
+    | BYTE_STRING_LITERAL
+    | RAW_BYTE_STRING_LITERAL
+    | MINUS? INTEGER_LITERAL
+    | MINUS? FLOAT_LITERAL
+    ;
+
+identifierPattern
+    : KW_REF? KW_MUT? identifier (AT pattern)?
+    ;
+
+wildcardPattern
+    : UNDERSCORE
+    ;
+
+restPattern
+    : DOTDOT
+    ;
+
+rangePattern
+    : rangePatternBound DOTDOTEQ rangePatternBound # InclusiveRangePattern
+    | rangePatternBound DOTDOT                    # HalfOpenRangePattern
+    | rangePatternBound DOTDOTDOT rangePatternBound # ObsoleteRangePattern
+    ;
+
+rangePatternBound
+    : CHAR_LITERAL
+    | BYTE_LITERAL
+    | MINUS? INTEGER_LITERAL
+    | MINUS? FLOAT_LITERAL
+    | pathPattern
+    ;
+
+referencePattern
+    : (AND | ANDAND) KW_MUT? patternWithoutRange
+    ;
+
+structPattern
+    : pathInExpression LCURLYBRACE structPatternElements? RCURLYBRACE
+    ;
+
+structPatternElements
+    : structPatternFields (COMMA structPatternEtCetera?)?
+    | structPatternEtCetera
+    ;
+
+structPatternFields
+    : structPatternField (COMMA structPatternField)*
+    ;
+
+structPatternField
+    : outerAttribute* (tupleIndex COLON pattern | identifier COLON pattern | KW_REF? KW_MUT? identifier)
+    ;
+
+structPatternEtCetera
+    : outerAttribute* DOTDOT
+    ;
+
+tupleStructPattern
+    : pathInExpression LPAREN tupleStructItems? RPAREN
+    ;
+
+tupleStructItems
+    : pattern (COMMA pattern)* COMMA?
+    ;
+
+tuplePattern
+    : LPAREN tuplePatternItems? RPAREN
+    ;
+
+tuplePatternItems
+    : pattern COMMA
+    | restPattern
+    | pattern (COMMA pattern)+ COMMA?
+    ;
+
+groupedPattern
+    : LPAREN pattern RPAREN
+    ;
+
+slicePattern
+    : LSQUAREBRACKET slicePatternItems? RSQUAREBRACKET
+    ;
+
+slicePatternItems
+    : pattern (COMMA pattern)* COMMA?
+    ;
+
+pathPattern
+    : pathInExpression
+    | qualifiedPathInExpression
+    ;
+
+// 10.1
+type_
+    : typeNoBounds
+    | implTraitType
+    | traitObjectType
+    ;
+
+typeNoBounds
+    : parenthesizedType
+    | implTraitTypeOneBound
+    | traitObjectTypeOneBound
+    | typePath
+    | tupleType
+    | neverType
+    | rawPointerType
+    | referenceType
+    | arrayType
+    | sliceType
+    | inferredType
+    | qualifiedPathInType
+    | bareFunctionType
+    | macroInvocation
+    ;
+
+parenthesizedType
+    : LPAREN type_ RPAREN
+    ;
+
+// 10.1.4
+neverType
+    : NOT
+    ;
+
+// 10.1.5
+tupleType
+    : LPAREN ((type_ COMMA)+ type_?)? RPAREN
+    ;
+
+// 10.1.6
+arrayType
+    : LSQUAREBRACKET type_ SEMI expression RSQUAREBRACKET
+    ;
+
+// 10.1.7
+sliceType
+    : LSQUAREBRACKET type_ RSQUAREBRACKET
+    ;
+
+// 10.1.13
+referenceType
+    : AND lifetime? KW_MUT? typeNoBounds
+    ;
+
+rawPointerType
+    : STAR (KW_MUT | KW_CONST) typeNoBounds
+    ;
+
+// 10.1.14
+bareFunctionType
+    : forLifetimes? functionTypeQualifiers KW_FN LPAREN functionParametersMaybeNamedVariadic? RPAREN bareFunctionReturnType?
+    ;
+
+functionTypeQualifiers
+    : KW_UNSAFE? (KW_EXTERN abi?)?
+    ;
+
+bareFunctionReturnType
+    : RARROW typeNoBounds
+    ;
+
+functionParametersMaybeNamedVariadic
+    : maybeNamedFunctionParameters
+    | maybeNamedFunctionParametersVariadic
+    ;
+
+maybeNamedFunctionParameters
+    : maybeNamedParam (COMMA maybeNamedParam)* COMMA?
+    ;
+
+maybeNamedParam
+    : outerAttribute* ((identifier | UNDERSCORE) COLON)? type_
+    ;
+
+maybeNamedFunctionParametersVariadic
+    : (maybeNamedParam COMMA)* maybeNamedParam COMMA outerAttribute* DOTDOTDOT
+    ;
+
+// 10.1.15
+traitObjectType
+    : KW_DYN? typeParamBounds
+    ;
+
+traitObjectTypeOneBound
+    : KW_DYN? traitBound
+    ;
+
+implTraitType
+    : KW_IMPL typeParamBounds
+    ;
+
+implTraitTypeOneBound
+    : KW_IMPL traitBound
+    ;
+
+// 10.1.18
+inferredType
+    : UNDERSCORE
+    ;
+
+// 10.6
+typeParamBounds
+    : typeParamBound (PLUS typeParamBound)* PLUS?
+    ;
+
+typeParamBound
+    : lifetime
+    | traitBound
+    ;
+
+traitBound
+    : QUESTION? forLifetimes? typePath
+    | LPAREN QUESTION? forLifetimes? typePath RPAREN
+    ;
+
+lifetimeBounds
+    : (lifetime PLUS)* lifetime?
+    ;
+
+lifetime
+    : LIFETIME_OR_LABEL
+    | KW_STATICLIFETIME
+    | KW_UNDERLINELIFETIME
+    ;
+
+// 12.4
+simplePath
+    : PATHSEP? simplePathSegment (PATHSEP simplePathSegment)*
+    ;
+
+simplePathSegment
+    : identifier
+    | KW_SUPER
+    | KW_SELFVALUE
+    | KW_CRATE
+    | KW_DOLLARCRATE
+    ;
+
+pathInExpression
+    : PATHSEP? pathExprSegment (PATHSEP pathExprSegment)*
+    ;
+
+pathExprSegment
+    : pathIdentSegment (PATHSEP genericArgs)?
+    ;
+
+pathIdentSegment
+    : identifier
+    | KW_SUPER
+    | KW_SELFVALUE
+    | KW_SELFTYPE
+    | KW_CRATE
+    | KW_DOLLARCRATE
+    ;
+
+//TODO: let x : T<_>=something;
+genericArgs
+    : LT GT
+    | LT genericArgsLifetimes (COMMA genericArgsTypes)? (COMMA genericArgsBindings)? COMMA? GT
+    | LT genericArgsTypes (COMMA genericArgsBindings)? COMMA? GT
+    | LT (genericArg COMMA)* genericArg COMMA? GT
+    ;
+
+genericArg
+    : lifetime
+    | type_
+    | genericArgsConst
+    | genericArgsBinding
+    ;
+
+genericArgsConst
+    : blockExpression
+    | MINUS? literalExpression
+    | simplePathSegment
+    ;
+
+genericArgsLifetimes
+    : lifetime (COMMA lifetime)*
+    ;
+
+genericArgsTypes
+    : type_ (COMMA type_)*
+    ;
+
+genericArgsBindings
+    : genericArgsBinding (COMMA genericArgsBinding)*
+    ;
+
+genericArgsBinding
+    : identifier EQ type_
+    ;
+
+qualifiedPathInExpression
+    : qualifiedPathType (PATHSEP pathExprSegment)+
+    ;
+
+qualifiedPathType
+    : LT type_ (KW_AS typePath)? GT
+    ;
+
+qualifiedPathInType
+    : qualifiedPathType (PATHSEP typePathSegment)+
+    ;
+
+typePath
+    : PATHSEP? typePathSegment (PATHSEP typePathSegment)*
+    ;
+
+typePathSegment
+    : pathIdentSegment PATHSEP? (genericArgs | typePathFn)?
+    ;
+
+typePathFn
+    : LPAREN typePathInputs? RPAREN (RARROW type_)?
+    ;
+
+typePathInputs
+    : type_ (COMMA type_)* COMMA?
+    ;
+
+// 12.6
+visibility
+    : KW_PUB (LPAREN ( KW_CRATE | KW_SELFVALUE | KW_SUPER | KW_IN simplePath) RPAREN)?
+    ;
+
+// technical
+identifier
+    : NON_KEYWORD_IDENTIFIER
+    | RAW_IDENTIFIER
+    | KW_MACRORULES
+    ;
+
+keyword
+    : KW_AS
+    | KW_BREAK
+    | KW_CONST
+    | KW_CONTINUE
+    | KW_CRATE
+    | KW_ELSE
+    | KW_ENUM
+    | KW_EXTERN
+    | KW_FALSE
+    | KW_FN
+    | KW_FOR
+    | KW_IF
+    | KW_IMPL
+    | KW_IN
+    | KW_LET
+    | KW_LOOP
+    | KW_MATCH
+    | KW_MOD
+    | KW_MOVE
+    | KW_MUT
+    | KW_PUB
+    | KW_REF
+    | KW_RETURN
+    | KW_SELFVALUE
+    | KW_SELFTYPE
+    | KW_STATIC
+    | KW_STRUCT
+    | KW_SUPER
+    | KW_TRAIT
+    | KW_TRUE
+    | KW_TYPE
+    | KW_UNSAFE
+    | KW_USE
+    | KW_WHERE
+    | KW_WHILE
+
+    // 2018+
+    | KW_ASYNC
+    | KW_AWAIT
+    | KW_DYN
+    // reserved
+    | KW_ABSTRACT
+    | KW_BECOME
+    | KW_BOX
+    | KW_DO
+    | KW_FINAL
+    | KW_MACRO
+    | KW_OVERRIDE
+    | KW_PRIV
+    | KW_TYPEOF
+    | KW_UNSIZED
+    | KW_VIRTUAL
+    | KW_YIELD
+    | KW_TRY
+    | KW_UNION
+    | KW_STATICLIFETIME
+    ;
+
+macroIdentifierLikeToken
+    : keyword
+    | identifier
+    | KW_MACRORULES
+    | KW_UNDERLINELIFETIME
+    | KW_DOLLARCRATE
+    | LIFETIME_OR_LABEL
+    ;
+
+macroLiteralToken
+    : literalExpression
+    ;
+
+// macroDelimiterToken: LCURLYBRACE | RCURLYBRACE | LSQUAREBRACKET | RSQUAREBRACKET | LPAREN | RPAREN;
+macroPunctuationToken
+    : MINUS
+    //| PLUS | STAR
+    | SLASH
+    | PERCENT
+    | CARET
+    | NOT
+    | AND
+    | OR
+    | ANDAND
+    | OROR
+    // already covered by LT and GT in macro | shl | shr
+    | PLUSEQ
+    | MINUSEQ
+    | STAREQ
+    | SLASHEQ
+    | PERCENTEQ
+    | CARETEQ
+    | ANDEQ
+    | OREQ
+    | SHLEQ
+    | SHREQ
+    | EQ
+    | EQEQ
+    | NE
+    | GT
+    | LT
+    | GE
+    | LE
+    | AT
+    | UNDERSCORE
+    | DOT
+    | DOTDOT
+    | DOTDOTDOT
+    | DOTDOTEQ
+    | COMMA
+    | SEMI
+    | COLON
+    | PATHSEP
+    | RARROW
+    | FATARROW
+    | POUND
+    //| DOLLAR | QUESTION
+    ;
+
+shl
+    : LT {this.NextLT()}? LT
+    ;
+
+shr
+    : GT {this.NextGT()}? GT
+    ;

--- a/package-gale/tests/grammars/TypeScriptLexer.g4
+++ b/package-gale/tests/grammars/TypeScriptLexer.g4
@@ -1,0 +1,318 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/javascript/typescript/TypeScriptLexer.g4
+// License: MIT (see below)
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 by Bart Kiers (original author) and Alexandre Vitorelli (contributor -> ported to CSharp)
+ * Copyright (c) 2017 by Ivan Kochurkin (Positive Technologies):
+    added ECMAScript 6 support, cleared and transformed to the universal grammar.
+ * Copyright (c) 2018 by Juan Alvarez (contributor -> ported to Go)
+ * Copyright (c) 2019 by Andrii Artiushok (contributor -> added TypeScript support)
+ * Copyright (c) 2024 by Andrew Leppard (www.wegrok.review)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
+// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
+lexer grammar TypeScriptLexer;
+
+channels {
+    ERROR
+}
+
+options {
+    superClass = TypeScriptLexerBase;
+}
+
+MultiLineComment  : '/*' .*? '*/'             -> channel(HIDDEN);
+SingleLineComment : '//' ~[\r\n\u2028\u2029]* -> channel(HIDDEN);
+RegularExpressionLiteral:
+    '/' RegularExpressionFirstChar RegularExpressionChar* {this.IsRegexPossible()}? '/' IdentifierPart*
+;
+
+OpenBracket                : '[';
+CloseBracket               : ']';
+OpenParen                  : '(';
+CloseParen                 : ')';
+OpenBrace                  : '{' {this.ProcessOpenBrace();};
+TemplateCloseBrace         :     {this.IsInTemplateString()}? '}' -> popMode;
+CloseBrace                 : '}' {this.ProcessCloseBrace();};
+SemiColon                  : ';';
+Comma                      : ',';
+Assign                     : '=';
+QuestionMark               : '?';
+QuestionMarkDot            : '?.';
+Colon                      : ':';
+Ellipsis                   : '...';
+Dot                        : '.';
+PlusPlus                   : '++';
+MinusMinus                 : '--';
+Plus                       : '+';
+Minus                      : '-';
+BitNot                     : '~';
+Not                        : '!';
+Multiply                   : '*';
+Divide                     : '/';
+Modulus                    : '%';
+Power                      : '**';
+NullCoalesce               : '??';
+Hashtag                    : '#';
+LeftShiftArithmetic        : '<<';
+// We can't match these in the lexer because it would cause issues when parsing
+// types like Map<string, Map<string, string>>
+// RightShiftArithmetic       : '>>';
+// RightShiftLogical          : '>>>';
+LessThan                   : '<';
+MoreThan                   : '>';
+LessThanEquals             : '<=';
+GreaterThanEquals          : '>=';
+Equals_                    : '==';
+NotEquals                  : '!=';
+IdentityEquals             : '===';
+IdentityNotEquals          : '!==';
+BitAnd                     : '&';
+BitXOr                     : '^';
+BitOr                      : '|';
+And                        : '&&';
+Or                         : '||';
+MultiplyAssign             : '*=';
+DivideAssign               : '/=';
+ModulusAssign              : '%=';
+PlusAssign                 : '+=';
+MinusAssign                : '-=';
+LeftShiftArithmeticAssign  : '<<=';
+RightShiftArithmeticAssign : '>>=';
+RightShiftLogicalAssign    : '>>>=';
+BitAndAssign               : '&=';
+BitXorAssign               : '^=';
+BitOrAssign                : '|=';
+PowerAssign                : '**=';
+NullishCoalescingAssign    : '??=';
+ARROW                      : '=>';
+
+/// Null Literals
+
+NullLiteral: 'null';
+
+/// Boolean Literals
+
+BooleanLiteral: 'true' | 'false';
+
+/// Numeric Literals
+
+DecimalLiteral:
+    DecimalIntegerLiteral '.' [0-9] [0-9_]* ExponentPart?
+    | '.' [0-9] [0-9_]* ExponentPart?
+    | DecimalIntegerLiteral ExponentPart?
+;
+
+/// Numeric Literals
+
+HexIntegerLiteral    : '0' [xX] [0-9a-fA-F] HexDigit*;
+OctalIntegerLiteral  : '0' [0-7]+ {!this.IsStrictMode()}?;
+OctalIntegerLiteral2 : '0' [oO] [0-7] [_0-7]*;
+BinaryIntegerLiteral : '0' [bB] [01] [_01]*;
+
+BigHexIntegerLiteral     : '0' [xX] [0-9a-fA-F] HexDigit* 'n';
+BigOctalIntegerLiteral   : '0' [oO] [0-7] [_0-7]* 'n';
+BigBinaryIntegerLiteral  : '0' [bB] [01] [_01]* 'n';
+BigDecimalIntegerLiteral : DecimalIntegerLiteral 'n';
+
+/// Keywords
+
+Break      : 'break';
+Do         : 'do';
+Instanceof : 'instanceof';
+Typeof     : 'typeof';
+Case       : 'case';
+Else       : 'else';
+New        : 'new';
+Var        : 'var';
+Catch      : 'catch';
+Finally    : 'finally';
+Return     : 'return';
+Void       : 'void';
+Continue   : 'continue';
+For        : 'for';
+Switch     : 'switch';
+While      : 'while';
+Debugger   : 'debugger';
+Function_  : 'function';
+This       : 'this';
+With       : 'with';
+Default    : 'default';
+If         : 'if';
+Throw      : 'throw';
+Delete     : 'delete';
+In         : 'in';
+Try        : 'try';
+As         : 'as';
+From       : 'from';
+ReadOnly   : 'readonly';
+Async      : 'async';
+Await      : 'await';
+Yield      : 'yield';
+YieldStar  : 'yield*';
+
+/// Future Reserved Words
+
+Class   : 'class';
+Enum    : 'enum';
+Extends : 'extends';
+Super   : 'super';
+Const   : 'const';
+Export  : 'export';
+Import  : 'import';
+
+/// The following tokens are also considered to be FutureReservedWords
+/// when parsing strict mode
+
+Implements : 'implements';
+Let        : 'let';
+Private    : 'private';
+Public     : 'public';
+Interface  : 'interface';
+Package    : 'package';
+Protected  : 'protected';
+Static     : 'static';
+
+//keywords:
+Any        : 'any';
+Number     : 'number';
+Never      : 'never';
+Boolean    : 'boolean';
+String     : 'string';
+Unique     : 'unique';
+Symbol     : 'symbol';
+Undefined  : 'undefined';
+Object     : 'object';
+
+Of      : 'of';
+KeyOf   : 'keyof';
+
+TypeAlias: 'type';
+
+Constructor : 'constructor';
+Namespace   : 'namespace';
+Require     : 'require';
+Module      : 'module';
+Declare     : 'declare';
+
+Abstract: 'abstract';
+
+Is: 'is';
+
+//
+// Ext.2 Additions to 1.8: Decorators
+//
+At: '@';
+
+/// Identifier Names and Identifiers
+
+Identifier: IdentifierStart IdentifierPart*;
+
+/// String Literals
+StringLiteral:
+    ('"' DoubleStringCharacter* '"' | '\'' SingleStringCharacter* '\'') {this.ProcessStringLiteral();}
+;
+
+BackTick: '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
+
+WhiteSpaces: [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
+
+LineTerminator: [\r\n\u2028\u2029] -> channel(HIDDEN);
+
+/// Comments
+
+HtmlComment         : '<!--' .*? '-->'      -> channel(HIDDEN);
+CDataComment        : '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
+UnexpectedCharacter : .                     -> channel(ERROR);
+
+mode TEMPLATE;
+
+TemplateStringEscapeAtom      : '\\' .;
+BackTickInside                : '`'  {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
+TemplateStringStartExpression : '${' {this.StartTemplateString();} -> pushMode(DEFAULT_MODE);
+TemplateStringAtom            : ~[`\\];
+
+// Fragment rules
+
+fragment DoubleStringCharacter: ~["\\\r\n] | '\\' EscapeSequence | LineContinuation;
+
+fragment SingleStringCharacter: ~['\\\r\n] | '\\' EscapeSequence | LineContinuation;
+
+fragment EscapeSequence:
+    CharacterEscapeSequence
+    | '0' // no digit ahead! TODO
+    | HexEscapeSequence
+    | UnicodeEscapeSequence
+    | ExtendedUnicodeEscapeSequence
+;
+
+fragment CharacterEscapeSequence: SingleEscapeCharacter | NonEscapeCharacter;
+
+fragment HexEscapeSequence: 'x' HexDigit HexDigit;
+
+fragment UnicodeEscapeSequence:
+    'u' HexDigit HexDigit HexDigit HexDigit
+    | 'u' '{' HexDigit HexDigit+ '}'
+;
+
+fragment ExtendedUnicodeEscapeSequence: 'u' '{' HexDigit+ '}';
+
+fragment SingleEscapeCharacter: ['"\\bfnrtv];
+
+fragment NonEscapeCharacter: ~['"\\bfnrtv0-9xu\r\n];
+
+fragment EscapeCharacter: SingleEscapeCharacter | [0-9] | [xu];
+
+fragment LineContinuation: '\\' [\r\n\u2028\u2029]+;
+
+fragment HexDigit: [_0-9a-fA-F];
+
+fragment DecimalIntegerLiteral: '0' | [1-9] [0-9_]*;
+
+fragment ExponentPart: [eE] [+-]? [0-9_]+;
+
+fragment IdentifierPart: IdentifierStart | [\p{Mn}] | [\p{Nd}] | [\p{Pc}] | '\u200C' | '\u200D';
+
+fragment IdentifierStart: [\p{L}] | [$_] | '\\' UnicodeEscapeSequence;
+
+fragment RegularExpressionFirstChar:
+    ~[*\r\n\u2028\u2029\\/[]
+    | RegularExpressionBackslashSequence
+    | '[' RegularExpressionClassChar* ']'
+;
+
+fragment RegularExpressionChar:
+    ~[\r\n\u2028\u2029\\/[]
+    | RegularExpressionBackslashSequence
+    | '[' RegularExpressionClassChar* ']'
+;
+
+fragment RegularExpressionClassChar: ~[\r\n\u2028\u2029\]\\] | RegularExpressionBackslashSequence;
+
+fragment RegularExpressionBackslashSequence: '\\' ~[\r\n\u2028\u2029];

--- a/package-gale/tests/grammars/TypeScriptParser.g4
+++ b/package-gale/tests/grammars/TypeScriptParser.g4
@@ -1,0 +1,987 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/javascript/typescript/TypeScriptParser.g4
+// License: MIT (see below)
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 by Bart Kiers (original author) and Alexandre Vitorelli (contributor -> ported to CSharp)
+ * Copyright (c) 2017 by Ivan Kochurkin (Positive Technologies):
+    added ECMAScript 6 support, cleared and transformed to the universal grammar.
+ * Copyright (c) 2018 by Juan Alvarez (contributor -> ported to Go)
+ * Copyright (c) 2019 by Andrii Artiushok (contributor -> added TypeScript support)
+ * Copyright (c) 2024 by Andrew Leppard (www.wegrok.review)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+parser grammar TypeScriptParser;
+
+options {
+    tokenVocab = TypeScriptLexer;
+    superClass = TypeScriptParserBase;
+}
+
+// SupportSyntax
+
+initializer
+    : '=' singleExpression
+    ;
+
+bindingPattern
+    : (arrayLiteral | objectLiteral)
+    ;
+
+// TypeScript SPart
+// A.1 Types
+typeParameters
+    : '<' typeParameterList? '>'
+    ;
+
+typeParameterList
+    : typeParameter (',' typeParameter)*
+    ;
+
+typeParameter
+    : identifier constraint?
+    | identifier '=' typeArgument
+    | typeParameters
+    ;
+
+constraint
+    : 'extends' type_
+    ;
+
+typeArguments
+    : '<' typeArgumentList? '>'
+    ;
+
+typeArgumentList
+    : typeArgument (',' typeArgument)*
+    ;
+
+typeArgument
+    : type_
+    ;
+
+// Union and intersection types can have a leading '|' or '&'
+// See https://github.com/microsoft/TypeScript/pull/12386
+type_
+    : ('|' | '&')? unionOrIntersectionOrPrimaryType
+    | functionType
+    | constructorType
+    | typeGeneric
+    ;
+
+unionOrIntersectionOrPrimaryType
+    : unionOrIntersectionOrPrimaryType '|' unionOrIntersectionOrPrimaryType # Union
+    | unionOrIntersectionOrPrimaryType '&' unionOrIntersectionOrPrimaryType # Intersection
+    | primaryType                                                           # Primary
+    ;
+
+primaryType
+    : '(' type_ ')'                              # ParenthesizedPrimType
+    | predefinedType                             # PredefinedPrimType
+    | typeReference                              # ReferencePrimType
+    | objectType                                 # ObjectPrimType
+    | primaryType {this.notLineTerminator()}? '[' primaryType? ']' # ArrayPrimType
+    | '[' tupleElementTypes ']'                  # TuplePrimType
+    | typeQuery                                  # QueryPrimType
+    | This                                       # ThisPrimType
+    | typeReference Is primaryType               # RedefinitionOfType
+    | KeyOf primaryType                          # KeyOfType
+    ;
+
+predefinedType
+    : Any
+    | NullLiteral
+    | Number
+    | DecimalLiteral
+    | Boolean
+    | BooleanLiteral
+    | String
+    | StringLiteral
+    | Unique? Symbol
+    | Never
+    | Undefined
+    | Object
+    | Void
+    ;
+
+typeReference
+    : typeName typeGeneric?
+    ;
+
+typeGeneric
+    : '<' typeArgumentList typeGeneric?'>'
+    ;
+
+typeName
+    : identifier
+    | namespaceName
+    ;
+
+objectType
+    : '{' typeBody? '}'
+    ;
+
+typeBody
+    : typeMemberList (SemiColon | ',')?
+    ;
+
+typeMemberList
+    : typeMember ((SemiColon | ',') typeMember)*
+    ;
+
+typeMember
+    : propertySignatur
+    | callSignature
+    | constructSignature
+    | indexSignature
+    | methodSignature ('=>' type_)?
+    ;
+
+arrayType
+    : primaryType {this.notLineTerminator()}? '[' ']'
+    ;
+
+tupleType
+    : '[' tupleElementTypes ']'
+    ;
+
+// Tuples can have a trailing comma. See https://github.com/Microsoft/TypeScript/issues/28893
+tupleElementTypes
+    : type_ (',' type_)* ','?
+    ;
+
+functionType
+    : typeParameters? '(' parameterList? ')' '=>' type_
+    ;
+
+constructorType
+    : 'new' typeParameters? '(' parameterList? ')' '=>' type_
+    ;
+
+typeQuery
+    : 'typeof' typeQueryExpression
+    ;
+
+typeQueryExpression
+    : identifier
+    | (identifierName '.')+ identifierName
+    ;
+
+propertySignatur
+    : ReadOnly? propertyName '?'? typeAnnotation? ('=>' type_)?
+    ;
+
+typeAnnotation
+    : ':' type_
+    ;
+
+callSignature
+    : typeParameters? '(' parameterList? ')' typeAnnotation?
+    ;
+
+// Function parameter list can have a trailing comma.
+// See https://github.com/Microsoft/TypeScript/issues/16152
+parameterList
+    : restParameter
+    | parameter (',' parameter)* (',' restParameter)? ','?
+    ;
+
+requiredParameterList
+    : requiredParameter (',' requiredParameter)*
+    ;
+
+parameter
+    : requiredParameter
+    | optionalParameter
+    ;
+
+optionalParameter
+    : decoratorList? (
+        accessibilityModifier? identifierOrPattern (
+            '?' typeAnnotation?
+            | typeAnnotation? initializer
+        )
+    )
+    ;
+
+restParameter
+    : '...' singleExpression typeAnnotation?
+    ;
+
+requiredParameter
+    : decoratorList? accessibilityModifier? identifierOrPattern typeAnnotation?
+    ;
+
+accessibilityModifier
+    : Public
+    | Private
+    | Protected
+    ;
+
+identifierOrPattern
+    : identifierName
+    | bindingPattern
+    ;
+
+constructSignature
+    : 'new' typeParameters? '(' parameterList? ')' typeAnnotation?
+    ;
+
+indexSignature
+    : '[' identifier ':' (Number | String) ']' typeAnnotation
+    ;
+
+methodSignature
+    : propertyName '?'? callSignature
+    ;
+
+typeAliasDeclaration
+    : Export? 'type' identifier typeParameters? '=' type_ eos
+    ;
+
+constructorDeclaration
+    : accessibilityModifier? Constructor '(' formalParameterList? ')' (
+        ('{' functionBody '}')
+        | SemiColon
+    )?
+    ;
+
+// A.5 Interface
+
+interfaceDeclaration
+    : Export? Declare? Interface identifier typeParameters? interfaceExtendsClause? objectType SemiColon?
+    ;
+
+interfaceExtendsClause
+    : Extends classOrInterfaceTypeList
+    ;
+
+classOrInterfaceTypeList
+    : typeReference (',' typeReference)*
+    ;
+
+// A.7 Interface
+
+enumDeclaration
+    : Const? Enum identifier '{' enumBody? '}'
+    ;
+
+enumBody
+    : enumMemberList ','?
+    ;
+
+enumMemberList
+    : enumMember (',' enumMember)*
+    ;
+
+enumMember
+    : propertyName ('=' singleExpression)?
+    ;
+
+// A.8 Namespaces
+
+namespaceDeclaration
+    : Declare? Namespace namespaceName '{' statementList? '}'
+    ;
+
+namespaceName
+    : identifier ('.'+ identifier)*
+    ;
+
+importAliasDeclaration
+    : identifier '=' namespaceName SemiColon
+    ;
+
+// Ext.2 Additions to 1.8: Decorators
+
+decoratorList
+    : decorator+
+    ;
+
+decorator
+    : '@' (decoratorMemberExpression | decoratorCallExpression)
+    ;
+
+decoratorMemberExpression
+    : identifier
+    | decoratorMemberExpression '.' identifierName
+    | '(' singleExpression ')'
+    ;
+
+decoratorCallExpression
+    : decoratorMemberExpression arguments
+    ;
+
+// ECMAPart
+program
+    : sourceElements? EOF
+    ;
+
+sourceElement
+    : Export? statement
+    ;
+
+statement
+    : block
+    | variableStatement
+    | importStatement
+    | exportStatement
+    | emptyStatement_
+    | abstractDeclaration //ADDED
+    | classDeclaration
+    | functionDeclaration
+    | expressionStatement
+    | interfaceDeclaration //ADDED
+    | namespaceDeclaration //ADDED
+    | ifStatement
+    | iterationStatement
+    | continueStatement
+    | breakStatement
+    | returnStatement
+    | yieldStatement
+    | withStatement
+    | labelledStatement
+    | switchStatement
+    | throwStatement
+    | tryStatement
+    | debuggerStatement
+    | arrowFunctionDeclaration
+    | generatorFunctionDeclaration
+    | typeAliasDeclaration //ADDED
+    | enumDeclaration      //ADDED
+    | Export statement
+    ;
+
+block
+    : '{' statementList? '}'
+    ;
+
+statementList
+    : statement+
+    ;
+
+abstractDeclaration
+    : Abstract (identifier callSignature | variableStatement) eos
+    ;
+
+importStatement
+    : Import importFromBlock
+    ;
+
+importFromBlock
+    : importDefault? (importNamespace | importModuleItems) importFrom eos
+    | StringLiteral eos
+    ;
+
+importModuleItems
+    : '{' (importAliasName ',')* (importAliasName ','?)? '}'
+    ;
+
+importAliasName
+    : moduleExportName (As importedBinding)?
+    ;
+
+moduleExportName
+    : identifierName
+    | StringLiteral
+    ;
+
+// yield and await are permitted as BindingIdentifier in the grammar
+importedBinding
+    : Identifier
+    | Yield
+    | Await
+    ;
+
+importDefault
+    : aliasName ','
+    ;
+
+importNamespace
+    : ('*' | identifierName) (As identifierName)?
+    ;
+
+importFrom
+    : From StringLiteral
+    ;
+
+aliasName
+    : identifierName (As identifierName)?
+    ;
+
+exportStatement
+    : Export Default? (exportFromBlock | declaration) eos # ExportDeclaration
+    | Export Default singleExpression eos                 # ExportDefaultDeclaration
+    ;
+
+exportFromBlock
+    : importNamespace importFrom eos
+    | exportModuleItems importFrom? eos
+    ;
+
+exportModuleItems
+    : '{' (exportAliasName ',')* (exportAliasName ','?)? '}'
+    ;
+
+exportAliasName
+    : moduleExportName (As moduleExportName)?
+    ;
+
+declaration
+    : variableStatement
+    | classDeclaration
+    | functionDeclaration
+    ;
+
+variableStatement
+    : bindingPattern typeAnnotation? initializer SemiColon?
+    | accessibilityModifier? varModifier? ReadOnly? variableDeclarationList SemiColon?
+    | Declare varModifier? variableDeclarationList SemiColon?
+    ;
+
+variableDeclarationList
+    : variableDeclaration (',' variableDeclaration)*
+    ;
+
+variableDeclaration
+    : (identifierOrKeyWord | arrayLiteral | objectLiteral) typeAnnotation? singleExpression? (
+        '=' typeParameters? singleExpression
+    )? // ECMAScript 6: Array & Object Matching
+    ;
+
+emptyStatement_
+    : SemiColon
+    ;
+
+expressionStatement
+    : {this.notOpenBraceAndNotFunctionAndNotInterface()}? expressionSequence SemiColon?
+    ;
+
+ifStatement
+    : If '(' expressionSequence ')' statement (Else statement)?
+    ;
+
+iterationStatement
+    : Do statement While '(' expressionSequence ')' eos                                                                     # DoStatement
+    | While '(' expressionSequence ')' statement                                                                            # WhileStatement
+    | For '(' expressionSequence? SemiColon expressionSequence? SemiColon expressionSequence? ')' statement                 # ForStatement
+    | For '(' varModifier variableDeclarationList SemiColon expressionSequence? SemiColon expressionSequence? ')' statement # ForVarStatement
+    | For '(' singleExpression In expressionSequence ')' statement                                                          # ForInStatement
+    | For '(' varModifier variableDeclaration In expressionSequence ')' statement                                           # ForVarInStatement
+    | For Await? '(' singleExpression identifier {this.p("of")}? expressionSequence (As type_)? ')' statement                            # ForOfStatement
+    | For Await? '(' varModifier variableDeclaration identifier {this.p("of")}? expressionSequence (As type_)? ')' statement             # ForVarOfStatement
+    ;
+
+varModifier
+    : Var
+    | Let
+    | Const
+    ;
+
+continueStatement
+    : Continue ({this.notLineTerminator()}? identifier)? eos
+    ;
+
+breakStatement
+    : Break ({this.notLineTerminator()}? identifier)? eos
+    ;
+
+returnStatement
+    : Return ({this.notLineTerminator()}? expressionSequence)? eos
+    ;
+
+yieldStatement
+    : (Yield | YieldStar) ({this.notLineTerminator()}? expressionSequence)? eos
+    ;
+
+withStatement
+    : With '(' expressionSequence ')' statement
+    ;
+
+switchStatement
+    : Switch '(' expressionSequence ')' caseBlock
+    ;
+
+caseBlock
+    : '{' caseClauses? (defaultClause caseClauses?)? '}'
+    ;
+
+caseClauses
+    : caseClause+
+    ;
+
+caseClause
+    : Case expressionSequence ':' statementList?
+    ;
+
+defaultClause
+    : Default ':' statementList?
+    ;
+
+labelledStatement
+    : identifier ':' statement
+    ;
+
+throwStatement
+    : Throw {this.notLineTerminator()}? expressionSequence eos
+    ;
+
+tryStatement
+    : Try block (catchProduction finallyProduction? | finallyProduction)
+    ;
+
+catchProduction
+    : Catch ('(' identifier typeAnnotation? ')')? block
+    ;
+
+finallyProduction
+    : Finally block
+    ;
+
+debuggerStatement
+    : Debugger eos
+    ;
+
+functionDeclaration
+    : Async? Function_ '*'? identifier callSignature (('{' functionBody '}') | SemiColon)
+    ;
+
+//Ovveride ECMA
+classDeclaration
+    : decoratorList? (Export Default?)? Abstract? Class identifier typeParameters? classHeritage classTail
+    ;
+
+classHeritage
+    : classExtendsClause? implementsClause?
+    ;
+
+classTail
+    : '{' classElement* '}'
+    ;
+
+classExtendsClause
+    : Extends typeReference
+    ;
+
+implementsClause
+    : Implements classOrInterfaceTypeList
+    ;
+
+// Classes modified
+classElement
+    : constructorDeclaration
+    | decoratorList? propertyMemberDeclaration
+    | indexMemberDeclaration
+    | statement
+    ;
+
+propertyMemberDeclaration
+    : propertyMemberBase propertyName '?'? typeAnnotation? initializer? SemiColon        # PropertyDeclarationExpression
+    | propertyMemberBase propertyName callSignature (('{' functionBody '}') | SemiColon) # MethodDeclarationExpression
+    | propertyMemberBase (getAccessor | setAccessor)                                     # GetterSetterDeclarationExpression
+    | abstractDeclaration                                                                # AbstractMemberDeclaration
+    ;
+
+propertyMemberBase
+    : accessibilityModifier? Async? Static? ReadOnly?
+    ;
+
+indexMemberDeclaration
+    : indexSignature SemiColon
+    ;
+
+generatorMethod
+    : (Async {this.notLineTerminator()}?)? '*'? propertyName '(' formalParameterList? ')' '{' functionBody '}'
+    ;
+
+generatorFunctionDeclaration
+    : Async? Function_ '*' identifier? '(' formalParameterList? ')' '{' functionBody '}'
+    ;
+
+generatorBlock
+    : '{' generatorDefinition (',' generatorDefinition)* ','? '}'
+    ;
+
+generatorDefinition
+    : '*' iteratorDefinition
+    ;
+
+iteratorBlock
+    : '{' iteratorDefinition (',' iteratorDefinition)* ','? '}'
+    ;
+
+iteratorDefinition
+    : '[' singleExpression ']' '(' formalParameterList? ')' '{' functionBody '}'
+    ;
+
+classElementName
+    : propertyName
+    | privateIdentifier
+    ;
+
+privateIdentifier
+    : '#' identifierName
+    ;
+
+formalParameterList
+    : formalParameterArg (',' formalParameterArg)* (',' lastFormalParameterArg)? ','?
+    | lastFormalParameterArg
+    | arrayLiteral                             // ECMAScript 6: Parameter Context Matching
+    | objectLiteral (':' formalParameterList)? // ECMAScript 6: Parameter Context Matching
+    ;
+
+formalParameterArg
+    : decorator? accessibilityModifier? assignable '?'? typeAnnotation? (
+        '=' singleExpression
+    )? // ECMAScript 6: Initialization
+    ;
+
+lastFormalParameterArg // ECMAScript 6: Rest Parameter
+    : Ellipsis identifier typeAnnotation?
+    ;
+
+functionBody
+    : sourceElements?
+    ;
+
+sourceElements
+    : sourceElement+
+    ;
+
+arrayLiteral
+    : ('[' elementList ']')
+    ;
+
+// JavaScript supports arrasys like [,,1,2,,].
+elementList
+    : ','* arrayElement? (','+ arrayElement) * ','* // Yes, everything is optional
+    ;
+
+arrayElement // ECMAScript 6: Spread Operator
+    : Ellipsis? (singleExpression | identifier) ','?
+    ;
+
+objectLiteral
+    : '{' (propertyAssignment (',' propertyAssignment)* ','?)? '}'
+    ;
+
+// MODIFIED
+propertyAssignment
+    : propertyName (':' | '=') singleExpression     # PropertyExpressionAssignment
+    | '[' singleExpression ']' ':' singleExpression # ComputedPropertyExpressionAssignment
+    | getAccessor                                   # PropertyGetter
+    | setAccessor                                   # PropertySetter
+    | generatorMethod                               # MethodProperty
+    | identifierOrKeyWord                           # PropertyShorthand
+    | Ellipsis? singleExpression                    # SpreadOperator
+    | restParameter                                 # RestParameterInObject
+    ;
+
+getAccessor
+    : getter '(' ')' typeAnnotation? '{' functionBody '}'
+    ;
+
+setAccessor
+    : setter '(' formalParameterList? ')' '{' functionBody '}'
+    ;
+
+propertyName
+    : identifierName
+    | StringLiteral
+    | numericLiteral
+    | '[' singleExpression ']'
+    ;
+
+arguments
+    : '(' (argumentList ','?)? ')'
+    ;
+
+argumentList
+    : argument (',' argument)*
+    ;
+
+argument // ECMAScript 6: Spread Operator
+    : Ellipsis? (singleExpression | identifier)
+    ;
+
+expressionSequence
+    : singleExpression (',' singleExpression)*
+    ;
+
+singleExpression
+    : anonymousFunction                                           # FunctionExpression
+    | Class identifier? typeParameters? classHeritage classTail   # ClassExpression
+    | singleExpression '?.'? '[' expressionSequence ']'           # MemberIndexExpression
+    | singleExpression '?.' singleExpression                      # OptionalChainExpression
+    | singleExpression '!'? '.' '#'? identifierName typeGeneric?  # MemberDotExpression
+    | singleExpression '?'? '.' '#'? identifierName typeGeneric?  # MemberDotExpression
+    // Split to try `new Date()` first, then `new Date`.
+    | New singleExpression typeArguments? arguments                   # NewExpression
+    | New singleExpression typeArguments?                             # NewExpression
+    | singleExpression arguments                                      # ArgumentsExpression
+    | singleExpression {this.notLineTerminator()}? '++'               # PostIncrementExpression
+    | singleExpression {this.notLineTerminator()}? '--'               # PostDecreaseExpression
+    | Delete singleExpression                                         # DeleteExpression
+    | Void singleExpression                                           # VoidExpression
+    | Typeof singleExpression                                         # TypeofExpression
+    | '++' singleExpression                                           # PreIncrementExpression
+    | '--' singleExpression                                           # PreDecreaseExpression
+    | '+' singleExpression                                            # UnaryPlusExpression
+    | '-' singleExpression                                            # UnaryMinusExpression
+    | '~' singleExpression                                            # BitNotExpression
+    | '!' singleExpression                                            # NotExpression
+    | Await singleExpression                                          # AwaitExpression
+    | <assoc = right> singleExpression '**' singleExpression          # PowerExpression
+    | singleExpression ('*' | '/' | '%') singleExpression             # MultiplicativeExpression
+    | singleExpression ('+' | '-') singleExpression                   # AdditiveExpression
+    | singleExpression '??' singleExpression                          # CoalesceExpression
+    | singleExpression ('<<' | '>' '>' | '>' '>' '>') singleExpression # BitShiftExpression
+    | singleExpression ('<' | '>' | '<=' | '>=') singleExpression     # RelationalExpression
+    | singleExpression Instanceof singleExpression                    # InstanceofExpression
+    | singleExpression In singleExpression                            # InExpression
+    | singleExpression ('==' | '!=' | '===' | '!==') singleExpression # EqualityExpression
+    | singleExpression '&' singleExpression                           # BitAndExpression
+    | singleExpression '^' singleExpression                           # BitXOrExpression
+    | singleExpression '|' singleExpression                           # BitOrExpression
+    | singleExpression '&&' singleExpression                          # LogicalAndExpression
+    | singleExpression '||' singleExpression                          # LogicalOrExpression
+    | singleExpression '?' singleExpression ':' singleExpression      # TernaryExpression
+    | singleExpression '=' singleExpression                           # AssignmentExpression
+    | singleExpression assignmentOperator singleExpression            # AssignmentOperatorExpression
+    | singleExpression templateStringLiteral                          # TemplateStringExpression     // ECMAScript 6
+    | iteratorBlock                                                   # IteratorsExpression          // ECMAScript 6
+    | generatorBlock                                                  # GeneratorsExpression         // ECMAScript 6
+    | generatorFunctionDeclaration                                    # GeneratorsFunctionExpression // ECMAScript 6
+    | yieldStatement                                                  # YieldExpression              // ECMAScript 6
+    | This                                                            # ThisExpression
+    | identifierName singleExpression?                                # IdentifierExpression
+    | Super                                                           # SuperExpression
+    | literal                                                         # LiteralExpression
+    | arrayLiteral                                                    # ArrayLiteralExpression
+    | objectLiteral                                                   # ObjectLiteralExpression
+    | '(' expressionSequence ')'                                      # ParenthesizedExpression
+    | typeArguments expressionSequence?                               # GenericTypes
+    | singleExpression As asExpression                                # CastAsExpression
+// TypeScript v2.0
+    | singleExpression '!'                                            # NonNullAssertionExpression
+    ;
+
+asExpression
+    : predefinedType ('[' ']')?
+    | singleExpression
+    ;
+
+assignable
+    : identifier
+    | keyword
+    | arrayLiteral
+    | objectLiteral
+    ;
+
+anonymousFunction
+    : functionDeclaration
+    | Async? Function_ '*'? '(' formalParameterList? ')' typeAnnotation? '{' functionBody '}'
+    | arrowFunctionDeclaration
+    ;
+
+arrowFunctionDeclaration
+    : Async? arrowFunctionParameters typeAnnotation? '=>' arrowFunctionBody
+    ;
+
+arrowFunctionParameters
+    : propertyName
+    | '(' formalParameterList? ')'
+    ;
+
+arrowFunctionBody
+    : singleExpression
+    | '{' functionBody '}'
+    ;
+
+assignmentOperator
+    : '*='
+    | '/='
+    | '%='
+    | '+='
+    | '-='
+    | '<<='
+    | '>>='
+    | '>>>='
+    | '&='
+    | '^='
+    | '|='
+    | '**='
+    | '??='
+    ;
+
+literal
+    : NullLiteral
+    | BooleanLiteral
+    | StringLiteral
+    | templateStringLiteral
+    | RegularExpressionLiteral
+    | numericLiteral
+    | bigintLiteral
+    ;
+
+templateStringLiteral
+    : BackTick templateStringAtom* BackTick
+    ;
+
+templateStringAtom
+    : TemplateStringAtom
+    | TemplateStringStartExpression singleExpression TemplateCloseBrace
+    | TemplateStringEscapeAtom
+    ;
+
+numericLiteral
+    : DecimalLiteral
+    | HexIntegerLiteral
+    | OctalIntegerLiteral
+    | OctalIntegerLiteral2
+    | BinaryIntegerLiteral
+    ;
+
+bigintLiteral
+    : BigDecimalIntegerLiteral
+    | BigHexIntegerLiteral
+    | BigOctalIntegerLiteral
+    | BigBinaryIntegerLiteral
+    ;
+
+getter
+    : {this.n("get")}? identifier classElementName
+    ;
+
+setter
+    : {this.n("set")}? identifier classElementName
+    ;
+
+identifierName
+    : identifier
+    | reservedWord
+    ;
+
+identifier
+    : Identifier
+    | Async
+    | As
+    | From
+    | Yield
+    | Of
+    | Any
+    | Any
+    | Number
+    | Boolean
+    | String
+    | Unique
+    | Symbol
+    | Never
+    | Undefined
+    | Object
+    | KeyOf
+    | TypeAlias
+    | Constructor
+    | Namespace
+    | Abstract
+    ;
+
+identifierOrKeyWord
+    : identifier
+    | TypeAlias
+    | Require
+    ;
+
+reservedWord
+    : keyword
+    | NullLiteral
+    | BooleanLiteral
+    ;
+
+keyword
+    : Break
+    | Do
+    | Instanceof
+    | Typeof
+    | Case
+    | Else
+    | New
+    | Var
+    | Catch
+    | Finally
+    | Return
+    | Void
+    | Continue
+    | For
+    | Switch
+    | While
+    | Debugger
+    | Function_
+    | This
+    | With
+    | Default
+    | If
+    | Throw
+    | Delete
+    | In
+    | Try
+    | Class
+    | Enum
+    | Extends
+    | Super
+    | Const
+    | Export
+    | Import
+    | Implements
+    | Let
+    | Private
+    | Public
+    | Interface
+    | Package
+    | Protected
+    | Static
+    | Yield
+    | Async
+    | Await
+    | ReadOnly
+    | From
+    | As
+    | Require
+    | TypeAlias
+    | String
+    | Boolean
+    | Number
+    | Module
+    ;
+
+eos
+    : SemiColon
+    | EOF
+    | {this.lineTerminatorAhead()}?
+    | {this.closeBrace()}?
+    ;

--- a/package-gale/tests/grammars/css3Lexer.g4
+++ b/package-gale/tests/grammars/css3Lexer.g4
@@ -1,0 +1,259 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/css3/css3Lexer.g4
+// License: MIT - Copyright (c) April 2017 Tom Everett
+
+// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
+// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
+lexer grammar css3Lexer;
+
+channels {
+    ERROR
+}
+
+OpenBracket  : '[';
+CloseBracket : ']';
+OpenParen    : '(';
+CloseParen   : ')';
+OpenBrace    : '{';
+CloseBrace   : '}';
+SemiColon    : ';';
+Equal        : '=';
+Colon        : ':';
+Dot          : '.';
+Multiply     : '*';
+Divide       : '/';
+Pipe         : '|';
+Underscore   : '_';
+
+fragment At: '@';
+
+fragment Hex: [0-9a-fA-F];
+
+fragment NewlineOrSpace: '\r\n' | [ \t\r\n\f] |;
+
+fragment Unicode: '\\' Hex Hex? Hex? Hex? Hex? Hex? NewlineOrSpace;
+
+fragment Escape: Unicode | '\\' ~[\r\n\f0-9a-fA-F];
+
+fragment Nmstart: [_a-zA-Z] | Nonascii | Escape;
+
+fragment Nmchar: [_a-zA-Z0-9\-] | Nonascii | Escape;
+
+// CSS2.2 Grammar defines the following, but I'm not sure how to add them to parser for error handling
+// BadString :
+// BadUri :
+// BadComment :
+// BadUri :
+
+Comment: '/*' ~'*'* '*'+ ( ~[/*] ~'*'* '*'+)* '/';
+
+fragment Name: Nmchar+;
+
+Url: U R L '(' Whitespace ( [!#$%&*-~] | Nonascii | Escape)* Whitespace ')';
+
+Space: [ \t\r\n\f]+;
+
+fragment Whitespace: Space |;
+
+fragment Newline: '\n' | '\r\n' | '\r' | '\f';
+
+fragment ZeroToFourZeros: '0'? '0'? '0'? '0'?;
+
+fragment A: 'a' | 'A' | '\\' ZeroToFourZeros ('41' | '61') NewlineOrSpace;
+
+fragment B: 'b' | 'B' | '\\' ZeroToFourZeros ('42' | '62') NewlineOrSpace;
+
+fragment C: 'c' | 'C' | '\\' ZeroToFourZeros ('43' | '63') NewlineOrSpace;
+
+fragment D: 'd' | 'D' | '\\' ZeroToFourZeros ('44' | '64') NewlineOrSpace;
+
+fragment E: 'e' | 'E' | '\\' ZeroToFourZeros ('45' | '65') NewlineOrSpace;
+
+fragment F: 'f' | 'F' | '\\' ZeroToFourZeros ('46' | '66') NewlineOrSpace;
+
+fragment G: 'g' | 'G' | '\\' ZeroToFourZeros ('47' | '67') NewlineOrSpace | '\\g' | '\\G';
+
+fragment H: 'h' | 'H' | '\\' ZeroToFourZeros ('48' | '68') NewlineOrSpace | '\\h' | '\\H';
+
+fragment I: 'i' | 'I' | '\\' ZeroToFourZeros ('49' | '69') NewlineOrSpace | '\\i' | '\\I';
+
+fragment K: 'k' | 'K' | '\\' ZeroToFourZeros ('4b' | '6b') NewlineOrSpace | '\\k' | '\\K';
+
+fragment L: 'l' | 'L' | '\\' ZeroToFourZeros ('4c' | '6c') NewlineOrSpace | '\\l' | '\\L';
+
+fragment M: 'm' | 'M' | '\\' ZeroToFourZeros ('4d' | '6d') NewlineOrSpace | '\\m' | '\\M';
+
+fragment N: 'n' | 'N' | '\\' ZeroToFourZeros ('4e' | '6e') NewlineOrSpace | '\\n' | '\\N';
+
+fragment O: 'o' | 'O' | '\\' ZeroToFourZeros ('4f' | '6f') NewlineOrSpace | '\\o' | '\\O';
+
+fragment P: 'p' | 'P' | '\\' ZeroToFourZeros ('50' | '70') NewlineOrSpace | '\\p' | '\\P';
+
+fragment Q: 'q' | 'Q' | '\\' ZeroToFourZeros ('51' | '71') NewlineOrSpace | '\\q' | '\\Q';
+
+fragment R: 'r' | 'R' | '\\' ZeroToFourZeros ('52' | '72') NewlineOrSpace | '\\r' | '\\R';
+
+fragment S: 's' | 'S' | '\\' ZeroToFourZeros ('53' | '73') NewlineOrSpace | '\\s' | '\\S';
+
+fragment T: 't' | 'T' | '\\' ZeroToFourZeros ('54' | '74') NewlineOrSpace | '\\t' | '\\T';
+
+fragment U: 'u' | 'U' | '\\' ZeroToFourZeros ('55' | '75') NewlineOrSpace | '\\u' | '\\U';
+
+fragment V: 'v' | 'V' | '\\' ZeroToFourZeros ('56' | '76') NewlineOrSpace | '\\v' | '\\V';
+
+fragment W: 'w' | 'W' | '\\' ZeroToFourZeros ('57' | '77') NewlineOrSpace | '\\w' | '\\W';
+
+fragment X: 'x' | 'X' | '\\' ZeroToFourZeros ('58' | '78') NewlineOrSpace | '\\x' | '\\X';
+
+fragment Y: 'y' | 'Y' | '\\' ZeroToFourZeros ('59' | '79') NewlineOrSpace | '\\y' | '\\Y';
+
+fragment Z: 'z' | 'Z' | '\\' ZeroToFourZeros ('5a' | '7a') NewlineOrSpace | '\\z' | '\\Z';
+
+fragment DashChar: '-' | '\\' ZeroToFourZeros '2d' NewlineOrSpace;
+
+Cdo: '<!--';
+
+Cdc: '-->';
+
+Includes: '~=';
+
+DashMatch: '|=';
+
+Hash: '#' Name;
+
+Import: At I M P O R T;
+
+Page: At P A G E;
+
+Media: At M E D I A;
+
+Namespace: At N A M E S P A C E;
+
+Charset: '@charset ';
+
+Important: '!' ( Space | Comment)* I M P O R T A N T;
+
+fragment FontRelative: Number E M | Number E X | Number C H | Number R E M;
+
+// https://www.w3.org/TR/css3-values/#viewport-relative-lengths
+fragment ViewportRelative: Number V W | Number V H | Number V M I N | Number V M A X;
+
+fragment AbsLength:
+    Number P X
+    | Number C M
+    | Number M M
+    | Number I N
+    | Number P T
+    | Number P C
+    | Number Q
+;
+
+fragment Angle: Number D E G | Number R A D | Number G R A D | Number T U R N;
+
+fragment Time: Number M S | Number S;
+
+fragment Freq: Number H Z | Number K H Z;
+
+Percentage: Number '%';
+
+Url_: 'url(';
+
+UnicodeRange:
+    [u|U] '+?' '?'? '?'? '?'? '?'? '?'?
+    | [u|U] '+' Hex '?'? '?'? '?'? '?'? '?'?
+    | [u|U] '+' Hex Hex '?'? '?'? '?'? '?'?
+    | [u|U] '+' Hex Hex Hex '?'? '?'? '?'?
+    | [u|U] '+' Hex Hex Hex Hex '?'? '?'?
+    | [u|U] '+' Hex Hex Hex Hex Hex '?'?
+;
+
+// https://www.w3.org/TR/css3-mediaqueries/
+MediaOnly: O N L Y;
+
+Not: N O T;
+
+And: A N D;
+
+fragment Resolution: Number D P I | Number D P C M | Number D P P X;
+
+fragment Length: AbsLength | FontRelative | ViewportRelative;
+
+Dimension: Length | Time | Freq | Resolution | Angle;
+
+UnknownDimension: Number Ident;
+
+// https://www.w3.org/TR/css3-selectors/
+fragment Nonascii: ~[\u0000-\u007f];
+
+Plus: '+';
+
+Minus: '-';
+
+Greater: '>';
+
+Comma: ',';
+
+Tilde: '~';
+
+PseudoNot: ':' N O T '(';
+
+Number: [0-9]+ | [0-9]* '.' [0-9]+;
+
+String_:
+    '"' (~[\n\r\f\\"] | '\\' Newline | Nonascii | Escape)* '"'
+    | '\'' ( ~[\n\r\f\\'] | '\\' Newline | Nonascii | Escape)* '\''
+;
+
+PrefixMatch: '^=';
+
+SuffixMatch: '$=';
+
+SubstringMatch: '*=';
+
+// https://www.w3.org/TR/css-fonts-3/#font-face-rule
+FontFace: At F O N T DashChar F A C E;
+
+// https://www.w3.org/TR/css3-conditional/
+Supports: At S U P P O R T S;
+
+Or: O R;
+
+// https://www.w3.org/TR/css3-animations/
+fragment VendorPrefix: '-' M O Z '-' | '-' W E B K I T '-' | '-' O '-';
+
+Keyframes: At VendorPrefix? K E Y F R A M E S;
+
+From: F R O M;
+
+To: T O;
+
+// https://www.w3.org/TR/css3-values/#calc-syntax
+Calc: 'calc(';
+
+// https://www.w3.org/TR/css-device-adapt-1/
+Viewport: At V I E W P O R T;
+
+// https://www.w3.org/TR/css-counter-styles-3/
+CounterStyle: At C O U N T E R DashChar S T Y L E;
+
+// https://www.w3.org/TR/css-fonts-3/
+FontFeatureValues: At F O N T DashChar F E A T U R E DashChar V A L U E S;
+
+// https://msdn.microsoft.com/en-us/library/ms532847.aspx
+DxImageTransform: 'progid:DXImageTransform.Microsoft.' Function_;
+
+AtKeyword: At Ident;
+
+// Variables
+// https://www.w3.org/TR/css-variables-1
+Variable: '--' Nmstart Nmchar*;
+
+Var: 'var(';
+
+// Give Ident least priority so that more specific rules matches first
+Ident: '-'? Nmstart Nmchar*;
+
+Function_: Ident '(';
+
+UnexpectedCharacter: . -> channel(ERROR);

--- a/package-gale/tests/grammars/css3Parser.g4
+++ b/package-gale/tests/grammars/css3Parser.g4
@@ -1,0 +1,452 @@
+// Source: https://github.com/antlr/grammars-v4/blob/master/css3/css3Parser.g4
+// License: MIT - Copyright (c) April 2017 Tom Everett
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+parser grammar css3Parser;
+
+options {
+    tokenVocab = css3Lexer;
+}
+
+stylesheet
+    : ws (charset ( Comment | Space | Cdo | Cdc)*)* (imports ( Comment | Space | Cdo | Cdc)*)* (
+        namespace_ ( Comment | Space | Cdo | Cdc)*
+    )* (nestedStatement ( Comment | Space | Cdo | Cdc)*)* EOF
+    ;
+
+charset
+    : Charset ws String_ ws ';' ws # goodCharset
+    | Charset ws String_ ws        # badCharset
+    ;
+
+imports
+    : Import ws (String_ | url) ws mediaQueryList ';' ws # goodImport
+    | Import ws ( String_ | url) ws ';' ws               # goodImport
+    | Import ws ( String_ | url) ws mediaQueryList       # badImport
+    | Import ws ( String_ | url) ws                      # badImport
+    ;
+
+// Namespaces
+// https://www.w3.org/TR/css-namespaces-3/
+namespace_
+    : Namespace ws (namespacePrefix ws)? (String_ | url) ws ';' ws # goodNamespace
+    | Namespace ws (namespacePrefix ws)? ( String_ | url) ws       # badNamespace
+    ;
+
+namespacePrefix
+    : ident
+    ;
+
+// Media queries
+// https://www.w3.org/TR/css3-mediaqueries/
+media
+    : Media ws mediaQueryList groupRuleBody ws
+    ;
+
+mediaQueryList
+    : (mediaQuery ( Comma ws mediaQuery)*)? ws
+    ;
+
+mediaQuery
+    : (MediaOnly | Not)? ws mediaType ws (And ws mediaExpression)*
+    | mediaExpression ( And ws mediaExpression)*
+    ;
+
+mediaType
+    : ident
+    ;
+
+mediaExpression
+    : '(' ws mediaFeature (':' ws expr)? ')' ws
+    // Grammar allows for 'and(', which gets tokenized as Function. In practice, people always insert space before '(' to have it work on Chrome.
+    ;
+
+mediaFeature
+    : ident ws
+    ;
+
+// Page
+page
+    : Page ws pseudoPage? '{' ws declaration? (';' ws declaration?)* '}' ws
+    ;
+
+pseudoPage
+    : ':' ident ws
+    ;
+
+// Selectors
+// https://www.w3.org/TR/css3-selectors/
+selectorGroup
+    : selector (Comma ws selector)*
+    ;
+
+selector
+    : simpleSelectorSequence ws (combinator simpleSelectorSequence ws)*
+    ;
+
+combinator
+    : Plus ws
+    | Greater ws
+    | Tilde ws
+    | Space ws
+    ;
+
+simpleSelectorSequence
+    : (typeSelector | universal) (Hash | className | attrib | pseudo | negation)*
+    | ( Hash | className | attrib | pseudo | negation)+
+    ;
+
+typeSelector
+    : typeNamespacePrefix? elementName
+    ;
+
+typeNamespacePrefix
+    : (ident | '*')? '|'
+    ;
+
+elementName
+    : ident
+    ;
+
+universal
+    : typeNamespacePrefix? '*'
+    ;
+
+className
+    : '.' ident
+    ;
+
+attrib
+    : '[' ws typeNamespacePrefix? ident ws (
+        (PrefixMatch | SuffixMatch | SubstringMatch | '=' | Includes | DashMatch) ws (
+            ident
+            | String_
+        ) ws
+    )? ']'
+    ;
+
+pseudo
+    /* '::' starts a pseudo-element, ':' a pseudo-class */
+    /* Exceptions: :first-line, :first-letter, :before And :after. */
+    /* Note that pseudo-elements are restricted to one per selector And */
+    /* occur MediaOnly in the last simple_selector_sequence. */
+    : ':' ':'? (ident | functionalPseudo)
+    ;
+
+functionalPseudo
+    : Function_ ws expression ')'
+    ;
+
+expression
+    /* In CSS3, the expressions are identifiers, strings, */
+    /* or of the form "an+b" */
+    : (( Plus | Minus | Dimension | UnknownDimension | Number | String_ | ident) ws)+
+    ;
+
+negation
+    : PseudoNot ws negationArg ws ')'
+    ;
+
+negationArg
+    : typeSelector
+    | universal
+    | Hash
+    | className
+    | attrib
+    | pseudo
+    ;
+
+// Rules
+operator_
+    : '/' ws   # goodOperator
+    | Comma ws # goodOperator
+    | Space ws # goodOperator
+    | '=' ws   # badOperator // IE filter and DXImageTransform function
+    ;
+
+property_
+    : ident ws    # goodProperty
+    | Variable ws # goodProperty
+    | '*' ident   # badProperty // IE hacks
+    | '_' ident   # badProperty // IE hacks
+    ;
+
+ruleset
+    : selectorGroup '{' ws declarationList? '}' ws # knownRuleset
+    | any_* '{' ws declarationList? '}' ws         # unknownRuleset
+    ;
+
+declarationList
+    : (';' ws)* declaration ws (';' ws declaration?)*
+    ;
+
+declaration
+    : property_ ':' ws expr prio? # knownDeclaration
+    | property_ ':' ws value      # unknownDeclaration
+    ;
+
+prio
+    : Important ws
+    ;
+
+value
+    : (any_ | block | AtKeyword ws)+
+    ;
+
+expr
+    : term (operator_? term)*
+    ;
+
+term
+    : number ws           # knownTerm
+    | percentage ws       # knownTerm
+    | dimension ws        # knownTerm
+    | String_ ws          # knownTerm
+    | UnicodeRange ws     # knownTerm
+    | ident ws            # knownTerm
+    | var_                # knownTerm
+    | url ws              # knownTerm
+    | hexcolor            # knownTerm
+    | calc                # knownTerm
+    | function_           # knownTerm
+    | unknownDimension ws # unknownTerm
+    | dxImageTransform    # badTerm
+    ;
+
+function_
+    : Function_ ws expr ')' ws
+    ;
+
+dxImageTransform
+    : DxImageTransform ws expr ')' ws // IE DXImageTransform function
+    ;
+
+hexcolor
+    : Hash ws
+    ;
+
+number
+    : (Plus | Minus)? Number
+    ;
+
+percentage
+    : (Plus | Minus)? Percentage
+    ;
+
+dimension
+    : (Plus | Minus)? Dimension
+    ;
+
+unknownDimension
+    : (Plus | Minus)? UnknownDimension
+    ;
+
+// Error handling
+any_
+    : ident ws
+    | number ws
+    | percentage ws
+    | dimension ws
+    | unknownDimension ws
+    | String_ ws
+    //| Delim ws    // Not implemented yet
+    | url ws
+    | Hash ws
+    | UnicodeRange ws
+    | Includes ws
+    | DashMatch ws
+    | ':' ws
+    | Function_ ws ( any_ | unused)* ')' ws
+    | '(' ws ( any_ | unused)* ')' ws
+    | '[' ws ( any_ | unused)* ']' ws
+    ;
+
+atRule
+    : AtKeyword ws any_* (block | ';' ws) # unknownAtRule
+    ;
+
+unused
+    : block
+    | AtKeyword ws
+    | ';' ws
+    | Cdo ws
+    | Cdc ws
+    ;
+
+block
+    : '{' ws (declarationList | nestedStatement | any_ | block | AtKeyword ws | ';' ws)* '}' ws
+    ;
+
+// Conditional
+// https://www.w3.org/TR/css3-conditional/
+nestedStatement
+    : ruleset
+    | media
+    | page
+    | fontFaceRule
+    | keyframesRule
+    | supportsRule
+    | viewport
+    | counterStyle
+    | fontFeatureValuesRule
+    | atRule
+    ;
+
+groupRuleBody
+    : '{' ws nestedStatement* '}' ws
+    ;
+
+supportsRule
+    : Supports ws supportsCondition ws groupRuleBody
+    ;
+
+supportsCondition
+    : supportsNegation
+    | supportsConjunction
+    | supportsDisjunction
+    | supportsConditionInParens
+    ;
+
+supportsConditionInParens
+    : '(' ws supportsCondition ws ')'
+    | supportsDeclarationCondition
+    | generalEnclosed
+    ;
+
+supportsNegation
+    : Not ws Space ws supportsConditionInParens
+    ;
+
+supportsConjunction
+    : supportsConditionInParens (ws Space ws And ws Space ws supportsConditionInParens)+
+    ;
+
+supportsDisjunction
+    : supportsConditionInParens (ws Space ws Or ws Space ws supportsConditionInParens)+
+    ;
+
+supportsDeclarationCondition
+    : '(' ws declaration ')'
+    ;
+
+generalEnclosed
+    : (Function_ | '(') (any_ | unused)* ')'
+    ;
+
+// Url
+// https://www.w3.org/TR/css3-values/#urls
+url
+    : Url_ ws String_ ws ')'
+    | Url
+    ;
+
+// Variable
+// https://www.w3.org/TR/css-variables-1
+var_
+    : Var ws Variable ws ')' ws
+    ;
+
+// Calc
+// https://www.w3.org/TR/css3-values/#calc-syntax
+calc
+    : Calc ws calcSum ')' ws
+    ;
+
+calcSum
+    : calcProduct (Space ws ( Plus | Minus) ws Space ws calcProduct)*
+    ;
+
+calcProduct
+    : calcValue ('*' ws calcValue | '/' ws number ws)*
+    ;
+
+calcValue
+    : number ws
+    | dimension ws
+    | unknownDimension ws
+    | percentage ws
+    | '(' ws calcSum ')' ws
+    ;
+
+// Font face
+// https://www.w3.org/TR/2013/CR-css-fonts-3-20131003/#font-face-rule
+fontFaceRule
+    : FontFace ws '{' ws fontFaceDeclaration? (';' ws fontFaceDeclaration?)* '}' ws
+    ;
+
+fontFaceDeclaration
+    : property_ ':' ws expr  # knownFontFaceDeclaration
+    | property_ ':' ws value # unknownFontFaceDeclaration
+    ;
+
+// Animations
+// https://www.w3.org/TR/css3-animations/
+keyframesRule
+    : Keyframes ws Space ws ident ws '{' ws keyframeBlock* '}' ws
+    ;
+
+keyframeBlock
+    : (keyframeSelector '{' ws declarationList? '}' ws)
+    ;
+
+keyframeSelector
+    : (From | To | Percentage) ws (Comma ws ( From | To | Percentage) ws)*
+    ;
+
+// Viewport
+// https://www.w3.org/TR/css-device-adapt-1/
+viewport
+    : Viewport ws '{' ws declarationList? '}' ws
+    ;
+
+// Counter style
+// https://www.w3.org/TR/css-counter-styles-3/
+counterStyle
+    : CounterStyle ws ident ws '{' ws declarationList? '}' ws
+    ;
+
+// Font feature values
+// https://www.w3.org/TR/css-fonts-3/
+fontFeatureValuesRule
+    : FontFeatureValues ws fontFamilyNameList ws '{' ws featureValueBlock* '}' ws
+    ;
+
+fontFamilyNameList
+    : fontFamilyName (ws Comma ws fontFamilyName)*
+    ;
+
+fontFamilyName
+    : String_
+    | ident ( ws ident)*
+    ;
+
+featureValueBlock
+    : featureType ws '{' ws featureValueDefinition? (ws ';' ws featureValueDefinition?)* '}' ws
+    ;
+
+featureType
+    : AtKeyword
+    ;
+
+featureValueDefinition
+    : ident ws ':' ws number (ws number)*
+    ;
+
+// The specific words can be identifiers too
+ident
+    : Ident
+    | MediaOnly
+    | Not
+    | And
+    | Or
+    | From
+    | To
+    ;
+
+// Comments might be part of CSS hacks, thus pass them to visitor to decide whether to skip
+// Spaces are significant around '+' '-' '(', thus they should not be skipped
+ws
+    : (Comment | Space)*
+    ;

--- a/wado-compiler/lib/builtins/wado-bundled-libm.wat
+++ b/wado-compiler/lib/builtins/wado-bundled-libm.wat
@@ -13,8 +13,8 @@
   (type (;11;) (func (param f64 f64 i32) (result f64)))
   (type (;12;) (func (param i32 i32 i32 i32 i32) (result i32)))
   (type (;13;) (func (param i32 f64 i32)))
-  (type (;14;) (func (param i32 i64 i64 i64 i64)))
-  (type (;15;) (func (param i32 i64 i64 i32)))
+  (type (;14;) (func (param i32 i64 i64 i32)))
+  (type (;15;) (func (param i32 i64 i64 i64 i64)))
   (memory (;0;) 17)
   (global $__stack_pointer (;0;) (mut i32) (i32.const 1048576))
   (global (;1;) i32 (i32.const 1053712))
@@ -150,7 +150,7 @@
                                   (f64.const -0x1.33a271c8a2d4bp+1 (;=-2.403394911734414;))))
                               (f64.const 0x1p+0 (;=1;))))
                           (local.tee 3
-                            (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                            (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                               (local.get 0))))
                         (f64.div
                           (f64.sub
@@ -175,7 +175,7 @@
                     (f64.const 0x1.921fb54442d18p+0 (;=1.5707963267948966;))
                     (f64.add
                       (local.tee 4
-                        (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                        (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                           (local.tee 0
                             (f64.mul
                               (f64.add
@@ -310,7 +310,7 @@
         (local.get 1)
         (i64.const -1)))
   )
-  (func $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E (;1;) (type 0) (param f64) (result f64)
+  (func $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E (;1;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 f64 i64 i32 i32 i32 i32 i64 i64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -380,7 +380,7 @@
         (local.set 8
           (local.tee 7
             (i32.shl
-              (i32.load16_u offset=1049200
+              (i32.load16_u offset=1053232
                 (i32.shl
                   (i32.and
                     (i32.wrap_i64
@@ -598,7 +598,7 @@
                                 (f32.const -0x1.69cb5cp-1 (;=-0.70662963;)))
                               (f32.const 0x1p+0 (;=1;))))
                           (local.tee 3
-                            (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+                            (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
                               (local.get 0))))
                         (f32.div
                           (f32.sub
@@ -623,7 +623,7 @@
                     (f32.const 0x1.921fb4p+0 (;=1.5707963;))
                     (f32.add
                       (local.tee 4
-                        (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+                        (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
                           (local.tee 0
                             (f32.mul
                               (f32.add
@@ -706,7 +706,7 @@
         (local.get 1)
         (i32.const -1)))
   )
-  (func $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E (;3;) (type 1) (param f32) (result f32)
+  (func $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE (;3;) (type 1) (param f32) (result f32)
     (local i32 f32 i32 i32 i32 i32 i32 i64)
     (block ;; label = @1
       (block ;; label = @2
@@ -748,7 +748,7 @@
         (local.set 5
           (local.tee 4
             (i32.shl
-              (i32.load16_u offset=1049200
+              (i32.load16_u offset=1053232
                 (i32.and
                   (i32.shr_u
                     (local.get 1)
@@ -883,11 +883,11 @@
             (i32.const 1049)))
         (return
           (f64.add
-            (call $_ZN4libm4math3log3log17h399efe6a27875d74E
+            (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
               (local.get 0))
             (f64.const 0x1.62e42fefa39efp-1 (;=0.6931471805599453;)))))
       (return
-        (call $_ZN4libm4math3log3log17h399efe6a27875d74E
+        (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
           (f64.add
             (f64.add
               (local.get 0)
@@ -896,7 +896,7 @@
               (f64.const -0x1p+0 (;=-1;))
               (f64.add
                 (local.get 0)
-                (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                   (f64.add
                     (f64.mul
                       (local.get 0)
@@ -906,10 +906,10 @@
       (f64.add
         (local.get 0)
         (f64.const -0x1p+0 (;=-1;))))
-    (call $_ZN4libm4math5log1p5log1p17h145bbb9e3e4ffa11E
+    (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
       (f64.add
         (local.get 0)
-        (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+        (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
           (f64.add
             (f64.mul
               (local.get 0)
@@ -918,7 +918,7 @@
               (local.get 0)
               (local.get 0))))))
   )
-  (func $_ZN4libm4math3log3log17h399efe6a27875d74E (;5;) (type 0) (param f64) (result f64)
+  (func $_ZN4libm4math3log3log17h781c40c93ff4fcfcE (;5;) (type 0) (param f64) (result f64)
     (local i64 i32 i64 i32 f64 f64)
     (block ;; label = @1
       (block ;; label = @2
@@ -1073,7 +1073,7 @@
           (f64.const 0x0p+0 (;=0;)))))
     (local.get 0)
   )
-  (func $_ZN4libm4math5log1p5log1p17h145bbb9e3e4ffa11E (;6;) (type 0) (param f64) (result f64)
+  (func $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E (;6;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 f64 f64 f64)
     (local.set 1
       (i32.sub
@@ -1288,11 +1288,11 @@
             (i32.const 1166016512)))
         (return
           (f32.add
-            (call $_ZN4libm4math4logf4logf17h5138a507fd2f2997E
+            (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
               (local.get 0))
             (f32.const 0x1.62e43p-1 (;=0.6931472;)))))
       (return
-        (call $_ZN4libm4math4logf4logf17h5138a507fd2f2997E
+        (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
           (f32.add
             (f32.add
               (local.get 0)
@@ -1301,7 +1301,7 @@
               (f32.const -0x1p+0 (;=-1;))
               (f32.add
                 (local.get 0)
-                (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+                (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
                   (f32.add
                     (f32.mul
                       (local.get 0)
@@ -1311,10 +1311,10 @@
       (f32.add
         (local.get 0)
         (f32.const -0x1p+0 (;=-1;))))
-    (call $_ZN4libm4math6log1pf6log1pf17h436c1394925bc1ffE
+    (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
       (f32.add
         (local.get 0)
-        (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+        (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
           (f32.add
             (f32.mul
               (local.get 0)
@@ -1323,7 +1323,7 @@
               (local.get 0)
               (local.get 0))))))
   )
-  (func $_ZN4libm4math4logf4logf17h5138a507fd2f2997E (;8;) (type 1) (param f32) (result f32)
+  (func $_ZN4libm4math4logf4logf17h7b88872ed73a994aE (;8;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32)
     (block ;; label = @1
       (block ;; label = @2
@@ -1444,7 +1444,7 @@
                       (f32.const 0x1.999c26p-2 (;=0.40000972;))))))))
           (local.get 4))))
   )
-  (func $_ZN4libm4math6log1pf6log1pf17h436c1394925bc1ffE (;9;) (type 1) (param f32) (result f32)
+  (func $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E (;9;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32)
     (local.set 1
       (i32.sub
@@ -1689,7 +1689,7 @@
                           (f64.const -0x1.33a271c8a2d4bp+1 (;=-2.403394911734414;))))
                       (f64.const 0x1p+0 (;=1;)))))
                 (local.set 4
-                  (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                  (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                     (local.get 0)))
                 (br_if 1 (;@5;)
                   (i32.gt_u
@@ -1857,7 +1857,7 @@
                           (local.tee 3
                             (f64.add
                               (local.tee 3
-                                (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                                (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                                   (f64.promote_f32
                                     (local.tee 1
                                       (f32.mul
@@ -1990,13 +1990,13 @@
               (local.get 0)
               (local.get 0)))
           (local.set 2
-            (call $_ZN4libm4math5log1p5log1p17h145bbb9e3e4ffa11E
+            (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
               (f64.add
                 (local.get 2)
                 (f64.div
                   (local.get 0)
                   (f64.add
-                    (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                    (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                       (f64.add
                         (local.get 0)
                         (f64.const 0x1p+0 (;=1;))))
@@ -2004,12 +2004,12 @@
           (br 2 (;@1;)))
         (local.set 2
           (f64.add
-            (call $_ZN4libm4math3log3log17h399efe6a27875d74E
+            (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
               (local.get 2))
             (f64.const 0x1.62e42fefa39efp-1 (;=0.6931471805599453;))))
         (br 1 (;@1;)))
       (local.set 2
-        (call $_ZN4libm4math3log3log17h399efe6a27875d74E
+        (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
           (f64.add
             (f64.add
               (local.get 2)
@@ -2018,7 +2018,7 @@
               (f64.const 0x1p+0 (;=1;))
               (f64.add
                 (local.get 2)
-                (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+                (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
                   (f64.add
                     (f64.mul
                       (local.get 0)
@@ -2077,13 +2077,13 @@
               (local.get 0)
               (local.get 0)))
           (local.set 2
-            (call $_ZN4libm4math6log1pf6log1pf17h436c1394925bc1ffE
+            (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
               (f32.add
                 (local.get 2)
                 (f32.div
                   (local.get 4)
                   (f32.add
-                    (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+                    (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
                       (f32.add
                         (local.get 4)
                         (f32.const 0x1p+0 (;=1;))))
@@ -2091,12 +2091,12 @@
           (br 2 (;@1;)))
         (local.set 2
           (f32.add
-            (call $_ZN4libm4math4logf4logf17h5138a507fd2f2997E
+            (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
               (local.get 2))
             (f32.const 0x1.62e43p-1 (;=0.6931472;))))
         (br 1 (;@1;)))
       (local.set 2
-        (call $_ZN4libm4math4logf4logf17h5138a507fd2f2997E
+        (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
           (f32.add
             (f32.add
               (local.get 2)
@@ -2105,7 +2105,7 @@
               (f32.const 0x1p+0 (;=1;))
               (f32.add
                 (local.get 2)
-                (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+                (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
                   (f32.add
                     (f32.mul
                       (local.get 0)
@@ -2125,10 +2125,10 @@
         (i32.const 0)))
   )
   (func $libm_atan (;14;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math4atan4atan17hf3c0d8eec3a91c10E
+    (call $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE
       (local.get 0))
   )
-  (func $_ZN4libm4math4atan4atan17hf3c0d8eec3a91c10E (;15;) (type 0) (param f64) (result f64)
+  (func $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE (;15;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 i32 f64 f64 f64)
     (local.set 1
       (i32.sub
@@ -2153,9 +2153,9 @@
                         (i32.const 2147483647)))
                     (i32.const 1141899263)))
                 (br_if 1 (;@5;)
-                  (i32.lt_u
+                  (i32.le_u
                     (local.get 3)
-                    (i32.const 1071382528)))
+                    (i32.const 1071382527)))
                 (local.set 0
                   (f64.abs
                     (local.get 0)))
@@ -2294,15 +2294,15 @@
             (f64.const 0x1.555555555550dp-2 (;=0.3333333333333293;)))))
       (block ;; label = @2
         (br_if 0 (;@2;)
-          (i32.lt_u
+          (i32.le_u
             (local.get 3)
-            (i32.const 1071382528)))
+            (i32.const 1071382527)))
         (return
           (select
             (f64.neg
               (local.tee 0
                 (f64.sub
-                  (f64.load offset=1048576
+                  (f64.load offset=1053536
                     (local.tee 3
                       (i32.shl
                         (local.get 4)
@@ -2314,7 +2314,7 @@
                         (f64.add
                           (local.get 7)
                           (local.get 6)))
-                      (f64.load offset=1048608
+                      (f64.load offset=1053568
                         (local.get 3)))
                     (local.get 0)))))
             (local.get 0)
@@ -2362,7 +2362,7 @@
             (i32.wrap_i64
               (local.get 2)))))
       (return
-        (call $_ZN4libm4math4atan4atan17hf3c0d8eec3a91c10E
+        (call $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE
           (local.get 0))))
     (local.set 6
       (i32.or
@@ -2450,7 +2450,7 @@
                       (i32.const 67108864))
                     (local.get 3))))
               (local.set 8
-                (call $_ZN4libm4math4atan4atan17hf3c0d8eec3a91c10E
+                (call $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE
                   (f64.abs
                     (f64.div
                       (local.get 0)
@@ -2513,7 +2513,7 @@
               (local.get 1)))
           (i32.const 1065353216)))
       (return
-        (call $_ZN4libm4math5atanf5atanf17h932b34dc897c95f3E
+        (call $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E
           (local.get 0))))
     (local.set 5
       (i32.or
@@ -2596,7 +2596,7 @@
                     (i32.const 218103808))
                   (local.get 2))))
             (local.set 6
-              (call $_ZN4libm4math5atanf5atanf17h932b34dc897c95f3E
+              (call $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E
                 (f32.abs
                   (f32.div
                     (local.get 0)
@@ -2632,7 +2632,7 @@
       (f32.const 0x1.921fb6p+0 (;=1.5707964;))
       (local.get 0))
   )
-  (func $_ZN4libm4math5atanf5atanf17h932b34dc897c95f3E (;18;) (type 1) (param f32) (result f32)
+  (func $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E (;18;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 i32 i32 f32 f32)
     (local.set 1
       (i32.sub
@@ -2770,7 +2770,7 @@
             (select
               (local.tee 0
                 (f32.sub
-                  (f32.load offset=1053584
+                  (f32.load offset=1048600
                     (local.tee 4
                       (i32.shl
                         (local.get 5)
@@ -2782,7 +2782,7 @@
                         (f32.add
                           (local.get 7)
                           (local.get 3)))
-                      (f32.load offset=1053600
+                      (f32.load offset=1048616
                         (local.get 4)))
                     (local.get 0))))
               (f32.neg
@@ -2813,7 +2813,7 @@
     (local.get 0)
   )
   (func $libm_atanf (;19;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math5atanf5atanf17h932b34dc897c95f3E
+    (call $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E
       (local.get 0))
   )
   (func $libm_atanh (;20;) (type 0) (param f64) (result f64)
@@ -2842,7 +2842,7 @@
             (i32.const 1022)))
         (local.set 2
           (f64.mul
-            (call $_ZN4libm4math5log1p5log1p17h145bbb9e3e4ffa11E
+            (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
               (f64.add
                 (local.tee 2
                   (f64.div
@@ -2860,7 +2860,7 @@
             (i32.const 991)))
         (local.set 2
           (f64.mul
-            (call $_ZN4libm4math5log1p5log1p17h145bbb9e3e4ffa11E
+            (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
               (f64.add
                 (local.tee 0
                   (f64.add
@@ -2915,7 +2915,7 @@
             (i32.const 1056964608)))
         (local.set 2
           (f32.mul
-            (call $_ZN4libm4math6log1pf6log1pf17h436c1394925bc1ffE
+            (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
               (f32.add
                 (local.tee 2
                   (f32.div
@@ -2933,7 +2933,7 @@
             (i32.const 796917760)))
         (local.set 2
           (f32.mul
-            (call $_ZN4libm4math6log1pf6log1pf17h436c1394925bc1ffE
+            (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
               (f32.add
                 (local.tee 4
                   (f32.add
@@ -3056,7 +3056,7 @@
                 (local.get 6)))
             (i32.const 12))))
       (local.set 11
-        (call $_ZN4libm4math3fma3fma17he2f3487cd27ca955E
+        (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
           (local.tee 7
             (f64.mul
               (f64.sub
@@ -3106,7 +3106,7 @@
                     (f64.const 0x1.5555555555555p-2 (;=0.3333333333333333;)))))
               (f64.reinterpret_i64
                 (i64.or
-                  (i64.load offset=1048656
+                  (i64.load offset=1052864
                     (i32.shl
                       (local.tee 10
                         (i32.and
@@ -3174,7 +3174,7 @@
                                           (local.get 9)))
                                       (f64.add
                                         (f64.add
-                                          (call $_ZN4libm4math3fma3fma17he2f3487cd27ca955E
+                                          (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
                                             (local.get 7)
                                             (local.get 8)
                                             (f64.neg
@@ -3210,7 +3210,7 @@
                     (f64.const -0x1.8p-52 (;=-0.00000000000000033306690738754696;))))
                 (f64.const 0x1p-75 (;=0.000000000000000000000026469779601696886;))))))
         (local.set 9
-          (call $_ZN4libm4math3fma3fma17he2f3487cd27ca955E
+          (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
             (local.get 8)
             (local.get 8)
             (f64.neg
@@ -3247,7 +3247,7 @@
                                               (local.get 7)))
                                           (local.get 13))
                                         (f64.add
-                                          (call $_ZN4libm4math3fma3fma17he2f3487cd27ca955E
+                                          (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
                                             (local.get 8)
                                             (local.get 7)
                                             (f64.neg
@@ -3338,7 +3338,7 @@
     (f64.reinterpret_i64
       (local.get 2))
   )
-  (func $_ZN4libm4math3fma3fma17he2f3487cd27ca955E (;23;) (type 4) (param f64 f64 f64) (result f64)
+  (func $_ZN4libm4math3fma3fma17hfec38a2f137b951cE (;23;) (type 4) (param f64 f64 f64) (result f64)
     (local i32 i64 i64 i32 i64 i64 i32 i32 i64 i64 i32 i64 i64 i64)
     (global.set $__stack_pointer
       (local.tee 3
@@ -4075,7 +4075,7 @@
                     (i32.gt_u
                       (local.get 2)
                       (i32.const 2146435071)))
-                  (call $_ZN4libm4math8rem_pio28rem_pio217h00100b53da492ea7E
+                  (call $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E
                     (i32.add
                       (local.get 1)
                       (i32.const 8))
@@ -4102,7 +4102,7 @@
                       (local.get 2)
                       (i32.const 1044816030))))
                 (local.set 3
-                  (call $_ZN4libm4math5k_cos5k_cos17ha6fdd81ea36304b4E.17
+                  (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
                     (local.get 0)
                     (f64.const 0x0p+0 (;=0;))))
                 (br 5 (;@1;)))
@@ -4157,7 +4157,7 @@
                     (local.get 3)))))
             (br 3 (;@1;)))
           (local.set 3
-            (call $_ZN4libm4math5k_cos5k_cos17ha6fdd81ea36304b4E.17
+            (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
               (local.get 0)
               (local.get 3)))
           (br 2 (;@1;)))
@@ -4209,7 +4209,7 @@
         (br 1 (;@1;)))
       (local.set 3
         (f64.neg
-          (call $_ZN4libm4math5k_cos5k_cos17ha6fdd81ea36304b4E.17
+          (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
             (local.get 0)
             (local.get 3)))))
     (global.set $__stack_pointer
@@ -4218,7 +4218,7 @@
         (i32.const 32)))
     (local.get 3)
   )
-  (func $_ZN4libm4math8rem_pio28rem_pio217h00100b53da492ea7E (;26;) (type 5) (param i32 f64)
+  (func $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E (;26;) (type 5) (param i32 f64)
     (local i32 i64 i32 i32 i32 i32 i32 f64 i32 i32)
     (global.set $__stack_pointer
       (local.tee 2
@@ -4351,7 +4351,7 @@
                     (local.get 2)
                     (i64.const 0))
                   (local.set 4
-                    (call $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hdfd962d741b4d37eE
+                    (call $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hd7141cf13a36ffbcE
                       (local.get 2)
                       (select
                         (local.get 11)
@@ -4411,7 +4411,7 @@
                       (i32.ne
                         (local.get 5)
                         (i32.const 1075388923)))
-                    (call $_ZN4libm4math8rem_pio28rem_pio26medium17h0e8f2d37b2c2a5b5E
+                    (call $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E
                       (local.get 0)
                       (local.get 1)
                       (i32.const 1075388923))
@@ -4623,12 +4623,12 @@
                 (local.get 9))
               (f64.const -0x1.0b4611a626331p-34 (;=-0.00000000006077100506506192;))))
           (br 2 (;@1;)))
-        (call $_ZN4libm4math8rem_pio28rem_pio26medium17h0e8f2d37b2c2a5b5E
+        (call $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E
           (local.get 0)
           (local.get 1)
           (local.get 5))
         (br 1 (;@1;)))
-      (call $_ZN4libm4math8rem_pio28rem_pio26medium17h0e8f2d37b2c2a5b5E
+      (call $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E
         (local.get 0)
         (local.get 1)
         (i32.const 1074977148)))
@@ -4637,7 +4637,7 @@
         (local.get 2)
         (i32.const 48)))
   )
-  (func $_ZN4libm4math5k_cos5k_cos17ha6fdd81ea36304b4E.17 (;27;) (type 2) (param f64 f64) (result f64)
+  (func $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E (;27;) (type 2) (param f64 f64) (result f64)
     (local f64 f64 f64)
     (f64.add
       (local.tee 4
@@ -4733,7 +4733,7 @@
                             (i32.gt_u
                               (local.get 4)
                               (i32.const 2139095039)))
-                          (call $_ZN4libm4math9rem_pio2f9rem_pio2f17hf69dfbea6bacc523E
+                          (call $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E
                             (local.get 1)
                             (local.get 0))
                           (local.set 2
@@ -5139,7 +5139,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math9rem_pio2f9rem_pio2f17hf69dfbea6bacc523E (;29;) (type 6) (param i32 f32)
+  (func $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E (;29;) (type 6) (param i32 f32)
     (local i32 f64 i32 i32 i32 f64)
     (global.set $__stack_pointer
       (local.tee 2
@@ -5183,7 +5183,7 @@
                         (i32.const -150)))
                     (i32.const 23))))))
           (local.set 5
-            (call $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hdfd962d741b4d37eE
+            (call $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hd7141cf13a36ffbcE
               (local.get 2)
               (i32.const 1)
               (i32.add
@@ -5272,7 +5272,7 @@
           (local.set 0
             (f64.mul
               (f64.mul
-                (call $_ZN4libm4math3exp3exp17h907b579aaaa6d23dE
+                (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
                   (f64.add
                     (local.get 0)
                     (f64.const -0x1.62066151add8bp+10 (;=-1416.0996898839683;))))
@@ -5283,7 +5283,7 @@
           (f64.mul
             (f64.add
               (local.tee 0
-                (call $_ZN4libm4math3exp3exp17h907b579aaaa6d23dE
+                (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
                   (local.get 0)))
               (f64.div
                 (f64.const 0x1p+0 (;=1;))
@@ -5300,7 +5300,7 @@
             (f64.div
               (f64.mul
                 (local.tee 0
-                  (call $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E
+                  (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
                     (local.get 0)))
                 (local.get 0))
               (f64.add
@@ -5327,7 +5327,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math3exp3exp17h907b579aaaa6d23dE (;31;) (type 0) (param f64) (result f64)
+  (func $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE (;31;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 i32 f64 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -5419,7 +5419,7 @@
                       (f64.mul
                         (local.get 0)
                         (f64.const 0x1.71547652b82fep+0 (;=1.4426950408889634;)))
-                      (f64.load offset=1048640
+                      (f64.load offset=1053600
                         (i32.shl
                           (local.get 3)
                           (i32.const 3))))))
@@ -5504,7 +5504,7 @@
         (i32.eqz
           (local.get 4)))
       (local.set 5
-        (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+        (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
           (local.get 5)
           (local.get 4))))
     (global.set $__stack_pointer
@@ -5513,7 +5513,7 @@
         (i32.const 16)))
     (local.get 5)
   )
-  (func $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E (;32;) (type 0) (param f64) (result f64)
+  (func $_ZN4libm4math5expm15expm117hf425b3a732f15702E (;32;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 f64 f64 f64 f64)
     (f64.store offset=8
       (local.tee 1
@@ -5836,7 +5836,7 @@
           (local.set 0
             (f32.mul
               (f32.mul
-                (call $_ZN4libm4math4expf4expf17h49d18e1ff0d69b78E
+                (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
                   (f32.add
                     (local.get 0)
                     (f32.const -0x1.45c778p+7 (;=-162.88959;))))
@@ -5847,7 +5847,7 @@
           (f32.mul
             (f32.add
               (local.tee 0
-                (call $_ZN4libm4math4expf4expf17h49d18e1ff0d69b78E
+                (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
                   (local.get 0)))
               (f32.div
                 (f32.const 0x1p+0 (;=1;))
@@ -5864,7 +5864,7 @@
             (f32.div
               (f32.mul
                 (local.tee 0
-                  (call $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E
+                  (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
                     (local.get 0)))
                 (local.get 0))
               (f32.add
@@ -5891,7 +5891,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math4expf4expf17h49d18e1ff0d69b78E (;34;) (type 1) (param f32) (result f32)
+  (func $_ZN4libm4math4expf4expf17hedd2067d7b29c452E (;34;) (type 1) (param f32) (result f32)
     (local i32 i32 i32 i32 f32 f32 f32)
     (global.set $__stack_pointer
       (local.tee 1
@@ -5995,7 +5995,7 @@
                     (f32.mul
                       (local.get 0)
                       (f32.const 0x1.715476p+0 (;=1.442695;)))
-                    (f32.load offset=1053552
+                    (f32.load offset=1052728
                       (i32.shl
                         (local.get 3)
                         (i32.const 2))))))
@@ -6063,7 +6063,7 @@
         (i32.eqz
           (local.get 4)))
       (local.set 5
-        (call $_ZN4libm4math6scalbn7scalbnf17h94814bd2ee5e97a4E
+        (call $_ZN4libm4math6scalbn7scalbnf17ha430054e259e38a4E
           (local.get 5)
           (local.get 4))))
     (global.set $__stack_pointer
@@ -6072,7 +6072,7 @@
         (i32.const 16)))
     (local.get 5)
   )
-  (func $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E (;35;) (type 1) (param f32) (result f32)
+  (func $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E (;35;) (type 1) (param f32) (result f32)
     (local i32 i32 i32 f32 f32 f32 f32)
     (local.set 1
       (i32.sub
@@ -6367,7 +6367,7 @@
     (local.get 0)
   )
   (func $libm_exp (;36;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math3exp3exp17h907b579aaaa6d23dE
+    (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
       (local.get 0))
   )
   (func $libm_exp2 (;37;) (type 0) (param f64) (result f64)
@@ -6468,10 +6468,10 @@
             (f64.const 0x1p+1023 (;=89884656743115800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;))))
         (br 1 (;@1;)))
       (local.set 0
-        (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+        (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
           (f64.add
             (local.tee 7
-              (f64.load offset=1049456
+              (f64.load offset=1048632
                 (local.tee 6
                   (i32.and
                     (i32.shl
@@ -6496,7 +6496,7 @@
                       (f64.add
                         (local.get 4)
                         (f64.const -0x1.8p+44 (;=-26388279066624;))))
-                    (f64.load offset=1049464
+                    (f64.load offset=1048640
                       (local.get 6)))))
               (f64.add
                 (f64.mul
@@ -6524,7 +6524,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E (;38;) (type 7) (param f64 i32) (result f64)
+  (func $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE (;38;) (type 7) (param f64 i32) (result f64)
     (block ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -6681,7 +6681,7 @@
         (f64.add
           (f64.add
             (local.tee 5
-              (f64.load offset=1048728
+              (f64.load offset=1052736
                 (i32.shl
                   (i32.and
                     (local.tee 3
@@ -6732,19 +6732,19 @@
             (i64.const 52)))))
   )
   (func $libm_expf (;40;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math4expf4expf17h49d18e1ff0d69b78E
+    (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
       (local.get 0))
   )
   (func $libm_expm1 (;41;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E
+    (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
       (local.get 0))
   )
   (func $libm_expm1f (;42;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E
+    (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
       (local.get 0))
   )
   (func $libm_fmod (;43;) (type 2) (param f64 f64) (result f64)
-    (local i32 i64 i64 i64 i64 i64 i64 i64 i64 i32 i32 i32 i64 i64)
+    (local i32 i64 i64 i64 i64 i64 i64 i64 i64 i32 i32 i32 i64)
     (global.set $__stack_pointer
       (local.tee 2
         (i32.sub
@@ -6915,7 +6915,7 @@
                       (local.get 1)))
                   (local.get 0)))
               (br 4 (;@1;)))
-            (call $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h01957a4744086374E)
+            (call $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h4d91c9c4a6b3b2e4E)
             (unreachable))
           (block ;; label = @4
             (block ;; label = @5
@@ -6924,171 +6924,164 @@
                   (block ;; label = @8
                     (block ;; label = @9
                       (block ;; label = @10
+                        (br_if 0 (;@10;)
+                          (i64.ge_u
+                            (local.get 5)
+                            (i64.const 4611686018427387904)))
+                        (br_if 1 (;@9;)
+                          (i64.ge_u
+                            (local.get 4)
+                            (local.get 10)))
                         (block ;; label = @11
                           (br_if 0 (;@11;)
+                            (i64.eqz
+                              (i64.and
+                                (local.get 5)
+                                (local.tee 6
+                                  (i64.add
+                                    (local.get 5)
+                                    (i64.const -1))))))
+                          (br_if 3 (;@8;)
+                            (i64.le_u
+                              (local.tee 7
+                                (i64.shl
+                                  (local.get 5)
+                                  (local.tee 10
+                                    (i64.extend_i32_u
+                                      (i32.and
+                                        (local.tee 13
+                                          (i32.add
+                                            (i32.wrap_i64
+                                              (i64.clz
+                                                (local.get 5)))
+                                            (i32.const -2)))
+                                        (i32.const 63))))))
+                              (i64.const 2305843009213693952)))
+                          (br_if 4 (;@7;)
                             (i64.ge_u
-                              (local.get 5)
+                              (local.get 7)
                               (i64.const 4611686018427387904)))
-                          (br_if 1 (;@10;)
+                          (br_if 5 (;@6;)
                             (i64.ge_u
                               (local.get 4)
-                              (local.get 10)))
+                              (local.tee 8
+                                (i64.shl
+                                  (local.get 7)
+                                  (i64.const 1)))))
+                          (call $__udivti3
+                            (i32.add
+                              (local.get 2)
+                              (i32.const 112))
+                            (i64.const 0)
+                            (local.tee 6
+                              (i64.sub
+                                (i64.const -9223372036854775808)
+                                (local.get 8)))
+                            (local.get 8)
+                            (i64.const 0))
+                          (call $__multi3
+                            (i32.add
+                              (local.get 2)
+                              (i32.const 96))
+                            (local.tee 5
+                              (i64.load offset=112
+                                (local.get 2)))
+                            (i64.load offset=120
+                              (local.get 2))
+                            (local.get 8)
+                            (i64.const 0))
+                          (call $__multi3
+                            (i32.add
+                              (local.get 2)
+                              (i32.const 80))
+                            (local.get 5)
+                            (i64.const 1)
+                            (local.tee 14
+                              (i64.shl
+                                (local.get 4)
+                                (i64.const 1)))
+                            (i64.const 0))
+                          (local.set 6
+                            (i64.sub
+                              (i64.sub
+                                (local.get 6)
+                                (i64.load offset=104
+                                  (local.get 2)))
+                              (i64.extend_i32_u
+                                (i64.ne
+                                  (local.tee 4
+                                    (i64.load offset=96
+                                      (local.get 2)))
+                                  (i64.const 0)))))
+                          (local.set 3
+                            (i64.sub
+                              (i64.const 0)
+                              (local.get 4)))
+                          (local.set 4
+                            (i64.load offset=88
+                              (local.get 2)))
                           (block ;; label = @12
                             (br_if 0 (;@12;)
-                              (i64.eqz
-                                (i64.and
-                                  (local.get 5)
-                                  (local.tee 6
-                                    (i64.add
-                                      (local.get 5)
-                                      (i64.const -1))))))
-                            (br_if 3 (;@9;)
-                              (i64.le_u
-                                (local.tee 8
-                                  (i64.shl
-                                    (local.get 5)
-                                    (local.tee 14
-                                      (i64.extend_i32_u
-                                        (i32.and
-                                          (local.tee 13
-                                            (i32.add
-                                              (i32.wrap_i64
-                                                (i64.clz
-                                                  (local.get 5)))
-                                              (i32.const -2)))
-                                          (i32.const 63))))))
-                                (i64.const 2305843009213693952)))
-                            (br_if 4 (;@8;)
-                              (i64.ge_u
-                                (local.get 8)
-                                (i64.const 4611686018427387904)))
-                            (br_if 5 (;@7;)
-                              (i64.ge_u
-                                (local.get 4)
-                                (local.tee 7
-                                  (i64.shl
-                                    (local.get 8)
-                                    (i64.const 1)))))
-                            (br_if 6 (;@6;)
-                              (i64.le_u
-                                (local.get 7)
-                                (local.tee 5
-                                  (i64.sub
-                                    (i64.const -9223372036854775808)
-                                    (local.get 7)))))
-                            (call $__udivti3
-                              (i32.add
-                                (local.get 2)
-                                (i32.const 112))
-                              (i64.const 0)
-                              (local.get 5)
-                              (local.get 7)
-                              (i64.const 0))
-                            (call $__multi3
-                              (i32.add
-                                (local.get 2)
-                                (i32.const 96))
-                              (local.tee 10
-                                (i64.load offset=112
-                                  (local.get 2)))
-                              (i64.load offset=120
-                                (local.get 2))
-                              (local.get 7)
-                              (i64.const 0))
-                            (call $__multi3
-                              (i32.add
-                                (local.get 2)
-                                (i32.const 80))
-                              (local.get 10)
-                              (i64.const 1)
-                              (local.tee 15
-                                (i64.shl
-                                  (local.get 4)
-                                  (i64.const 1)))
-                              (i64.const 0))
-                            (local.set 6
-                              (i64.sub
-                                (i64.sub
-                                  (local.get 5)
-                                  (i64.load offset=104
-                                    (local.get 2)))
-                                (i64.extend_i32_u
-                                  (i64.ne
-                                    (local.tee 4
-                                      (i64.load offset=96
-                                        (local.get 2)))
-                                    (i64.const 0)))))
-                            (local.set 3
-                              (i64.sub
-                                (i64.const 0)
-                                (local.get 4)))
-                            (local.set 4
-                              (i64.load offset=88
-                                (local.get 2)))
-                            (block ;; label = @13
-                              (br_if 0 (;@13;)
-                                (i32.gt_u
-                                  (local.tee 12
-                                    (i32.add
-                                      (local.get 13)
-                                      (local.get 12)))
-                                  (i32.const 62)))
-                              (local.set 5
-                                (i64.load offset=80
-                                  (local.get 2)))
-                              (br 9 (;@4;)))
+                              (i32.gt_u
+                                (local.tee 12
+                                  (i32.add
+                                    (local.get 13)
+                                    (local.get 12)))
+                                (i32.const 62)))
                             (local.set 5
-                              (i64.mul
-                                (local.get 15)
-                                (local.get 10)))
-                            (loop ;; label = @13
-                              (call $__multi3
-                                (i32.add
-                                  (local.get 2)
-                                  (i32.const 64))
-                                (local.get 3)
-                                (local.get 6)
-                                (local.get 4)
-                                (i64.const 0))
-                              (local.set 4
-                                (i64.add
-                                  (i64.load offset=72
-                                    (local.get 2))
-                                  (i64.shr_u
-                                    (local.get 5)
-                                    (i64.const 1))))
-                              (local.set 5
-                                (i64.load offset=64
-                                  (local.get 2)))
-                              (br_if 0 (;@13;)
-                                (i32.gt_u
-                                  (local.tee 12
-                                    (i32.add
-                                      (local.get 12)
-                                      (i32.const -63)))
-                                  (i32.const 62)))
-                              (br 9 (;@4;))))
-                          (br_if 6 (;@5;)
-                            (i32.lt_u
-                              (local.get 12)
-                              (i32.const 64)))
-                          (br 9 (;@2;)))
-                        (call $_ZN4core9panicking5panic17h19814263112256c0E
-                          (i32.const 34))
-                        (unreachable))
-                      (call $_ZN4core9panicking5panic17h19814263112256c0E
-                        (i32.const 30))
+                              (i64.load offset=80
+                                (local.get 2)))
+                            (br 8 (;@4;)))
+                          (local.set 5
+                            (i64.mul
+                              (local.get 14)
+                              (local.get 5)))
+                          (loop ;; label = @12
+                            (call $__multi3
+                              (i32.add
+                                (local.get 2)
+                                (i32.const 64))
+                              (local.get 3)
+                              (local.get 6)
+                              (local.get 4)
+                              (i64.const 0))
+                            (local.set 4
+                              (i64.add
+                                (i64.load offset=72
+                                  (local.get 2))
+                                (i64.shr_u
+                                  (local.get 5)
+                                  (i64.const 1))))
+                            (local.set 5
+                              (i64.load offset=64
+                                (local.get 2)))
+                            (br_if 0 (;@12;)
+                              (i32.gt_u
+                                (local.tee 12
+                                  (i32.add
+                                    (local.get 12)
+                                    (i32.const -63)))
+                                (i32.const 62)))
+                            (br 8 (;@4;))))
+                        (br_if 5 (;@5;)
+                          (i32.lt_u
+                            (local.get 12)
+                            (i32.const 64)))
+                        (br 8 (;@2;)))
+                      (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                        (i32.const 34))
                       (unreachable))
-                    (call $_ZN4core9panicking5panic17h19814263112256c0E
-                      (i32.const 43))
+                    (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                      (i32.const 30))
                     (unreachable))
-                  (call $_ZN4core9panicking5panic17h19814263112256c0E
+                  (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
                     (i32.const 43))
                   (unreachable))
-                (call $_ZN4core9panicking5panic17h19814263112256c0E
-                  (i32.const 23))
+                (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                  (i32.const 43))
                 (unreachable))
-              (call $_ZN4core6option13unwrap_failed17h8ebba99799176358E)
+              (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                (i32.const 23))
               (unreachable))
             (local.set 4
               (i64.and
@@ -7142,7 +7135,7 @@
                     (local.get 4))))
               (i64.const 2))
             (i64.const 0)
-            (local.get 7)
+            (local.get 8)
             (i64.const 0))
           (local.set 4
             (i64.shr_u
@@ -7152,11 +7145,11 @@
                     (local.get 2)))
                 (select
                   (i64.const 0)
-                  (local.get 8)
+                  (local.get 7)
                   (i64.gt_u
-                    (local.get 8)
+                    (local.get 7)
                     (local.get 4))))
-              (local.get 14))))
+              (local.get 10))))
         (br_if 0 (;@2;)
           (i64.eqz
             (local.get 4)))
@@ -7200,20 +7193,15 @@
         (i32.const 144)))
     (local.get 0)
   )
-  (func $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h01957a4744086374E (;44;) (type 8)
-    (call $_ZN4core9panicking9panic_fmt17hb8badb9a939ccf7aE)
+  (func $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h4d91c9c4a6b3b2e4E (;44;) (type 8)
+    (call $_ZN4core9panicking9panic_fmt17h6651313c3e2c6c2fE)
     (unreachable)
   )
-  (func $_ZN4core9panicking5panic17h19814263112256c0E (;45;) (type 9) (param i32)
-    (call $_ZN4core9panicking9panic_fmt17hb8badb9a939ccf7aE)
+  (func $_ZN4core9panicking5panic17h0149fc8f1656305aE (;45;) (type 9) (param i32)
+    (call $_ZN4core9panicking9panic_fmt17h6651313c3e2c6c2fE)
     (unreachable)
   )
-  (func $_ZN4core6option13unwrap_failed17h8ebba99799176358E (;46;) (type 8)
-    (call $_ZN4core9panicking5panic17h19814263112256c0E
-      (i32.const 43))
-    (unreachable)
-  )
-  (func $libm_fmodf (;47;) (type 3) (param f32 f32) (result f32)
+  (func $libm_fmodf (;46;) (type 3) (param f32 f32) (result f32)
     (local i32 i32 i32 i32 i32 i32 i32 i32 i64 i64 i64)
     (block ;; label = @1
       (block ;; label = @2
@@ -7333,7 +7321,7 @@
                       (local.get 0)
                       (local.get 1)))
                   (local.get 0))))
-            (call $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h01957a4744086374E)
+            (call $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h4d91c9c4a6b3b2e4E)
             (unreachable))
           (block ;; label = @4
             (block ;; label = @5
@@ -7425,10 +7413,10 @@
                                     (i64.const 31))
                                   (i64.const 9223372032559808512))
                                 (i64.mul
+                                  (local.get 12)
                                   (i64.shr_u
                                     (local.get 10)
-                                    (i64.const 32))
-                                  (local.get 12))))
+                                    (i64.const 32)))))
                             (br_if 0 (;@12;)
                               (i32.gt_u
                                 (local.tee 3
@@ -7482,19 +7470,19 @@
                           (local.get 2)
                           (i32.const 32)))
                       (br 7 (;@2;)))
-                    (call $_ZN4core9panicking5panic17h19814263112256c0E
+                    (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
                       (i32.const 34))
                     (unreachable))
-                  (call $_ZN4core9panicking5panic17h19814263112256c0E
+                  (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
                     (i32.const 30))
                   (unreachable))
-                (call $_ZN4core9panicking5panic17h19814263112256c0E
+                (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
                   (i32.const 43))
                 (unreachable))
-              (call $_ZN4core9panicking5panic17h19814263112256c0E
+              (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
                 (i32.const 43))
               (unreachable))
-            (call $_ZN4core9panicking5panic17h19814263112256c0E
+            (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
               (i32.const 23))
             (unreachable))
           (local.set 3
@@ -7536,7 +7524,7 @@
           (local.get 8))))
     (local.get 0)
   )
-  (func $libm_hypot (;48;) (type 2) (param f64 f64) (result f64)
+  (func $libm_hypot (;47;) (type 2) (param f64 f64) (result f64)
     (local i64 i64 i64 i64 f64 f64 f64 f64)
     (local.set 1
       (f64.reinterpret_i64
@@ -7630,7 +7618,7 @@
         (local.set 1
           (f64.mul
             (local.get 6)
-            (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+            (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
               (f64.add
                 (local.tee 7
                   (f64.mul
@@ -7698,7 +7686,7 @@
         (local.get 1)))
     (local.get 0)
   )
-  (func $libm_hypotf (;49;) (type 3) (param f32 f32) (result f32)
+  (func $libm_hypotf (;48;) (type 3) (param f32 f32) (result f32)
     (local i32 i32 i32 f32 f64)
     (local.set 1
       (f32.reinterpret_i32
@@ -7786,7 +7774,7 @@
       (local.set 1
         (f32.mul
           (local.get 5)
-          (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+          (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
             (f32.demote_f64
               (f64.add
                 (f64.mul
@@ -7801,11 +7789,11 @@
                   (local.get 6))))))))
     (local.get 1)
   )
-  (func $libm_log (;50;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math3log3log17h399efe6a27875d74E
+  (func $libm_log (;49;) (type 0) (param f64) (result f64)
+    (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
       (local.get 0))
   )
-  (func $libm_log10 (;51;) (type 0) (param f64) (result f64)
+  (func $libm_log10 (;50;) (type 0) (param f64) (result f64)
     (local i64 i32 i64 i32 f64 f64 f64 f64 f64 f64)
     (block ;; label = @1
       (block ;; label = @2
@@ -7991,7 +7979,7 @@
           (f64.const 0x0p+0 (;=0;)))))
     (local.get 0)
   )
-  (func $libm_log10f (;52;) (type 1) (param f32) (result f32)
+  (func $libm_log10f (;51;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32 f32)
     (block ;; label = @1
       (block ;; label = @2
@@ -8134,15 +8122,15 @@
                 (local.get 5))
               (f32.const -0x1.09d5b2p-15 (;=-0.00003168997;)))))))
   )
-  (func $libm_log1p (;53;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math5log1p5log1p17h145bbb9e3e4ffa11E
+  (func $libm_log1p (;52;) (type 0) (param f64) (result f64)
+    (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
       (local.get 0))
   )
-  (func $libm_log1pf (;54;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math6log1pf6log1pf17h436c1394925bc1ffE
+  (func $libm_log1pf (;53;) (type 1) (param f32) (result f32)
+    (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
       (local.get 0))
   )
-  (func $libm_log2 (;55;) (type 0) (param f64) (result f64)
+  (func $libm_log2 (;54;) (type 0) (param f64) (result f64)
     (local i64 i32 i64 i32 f64 f64 f64 f64 f64)
     (block ;; label = @1
       (block ;; label = @2
@@ -8321,7 +8309,7 @@
           (f64.const 0x0p+0 (;=0;)))))
     (local.get 0)
   )
-  (func $libm_log2f (;56;) (type 1) (param f32) (result f32)
+  (func $libm_log2f (;55;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32)
     (block ;; label = @1
       (block ;; label = @2
@@ -8457,11 +8445,11 @@
             (local.get 1)
             (i32.const 23)))))
   )
-  (func $libm_logf (;57;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math4logf4logf17h5138a507fd2f2997E
+  (func $libm_logf (;56;) (type 1) (param f32) (result f32)
+    (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
       (local.get 0))
   )
-  (func $libm_pow (;58;) (type 2) (param f64 f64) (result f64)
+  (func $libm_pow (;57;) (type 2) (param f64 f64) (result f64)
     (local f64 i64 i32 i32 i32 i64 i32 i64 i32 i32 i32 i32 i32 f64 f64 f64 f64)
     (local.set 2
       (f64.const 0x1p+0 (;=1;)))
@@ -8677,7 +8665,7 @@
               (local.get 7)
               (i64.const 0)))
           (return
-            (call $_ZN4libm4math4sqrt4sqrt17h75ceb3a6ef965b19E
+            (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
               (local.get 0))))
         (return
           (select
@@ -8810,7 +8798,7 @@
               (f64.sub
                 (local.tee 2
                   (f64.add
-                    (f64.load offset=1048696
+                    (f64.load offset=1053504
                       (local.tee 6
                         (i32.shl
                           (local.get 8)
@@ -8828,7 +8816,7 @@
                                         (f64.const 0x1p+0 (;=1;))
                                         (f64.add
                                           (local.tee 0
-                                            (f64.load offset=1048680
+                                            (f64.load offset=1053488
                                               (local.get 6)))
                                           (local.tee 16
                                             (f64.reinterpret_i64
@@ -8961,7 +8949,7 @@
                               (f64.add
                                 (f64.add
                                   (local.tee 17
-                                    (f64.load offset=1048712
+                                    (f64.load offset=1053520
                                       (local.get 6)))
                                   (f64.add
                                     (local.get 2)
@@ -9332,7 +9320,7 @@
                     (i64.const 4294967295)))))
             (br 1 (;@3;)))
           (local.set 1
-            (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+            (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
               (local.get 1)
               (local.get 8))))
         (return
@@ -9376,7 +9364,7 @@
             (i32.const 1)))))
     (local.get 2)
   )
-  (func $libm_powf (;59;) (type 3) (param f32 f32) (result f32)
+  (func $libm_powf (;58;) (type 3) (param f32 f32) (result f32)
     (local f32 i32 i32 i32 f32 i32 i32 i32 i32 f32 f32 f32)
     (local.set 2
       (f32.const 0x1p+0 (;=1;)))
@@ -9640,7 +9628,7 @@
                 (f32.sub
                   (local.tee 2
                     (f32.add
-                      (f32.load offset=1053568
+                      (f32.load offset=1048584
                         (local.tee 7
                           (i32.shl
                             (local.get 3)
@@ -9658,7 +9646,7 @@
                                           (f32.const 0x1p+0 (;=1;))
                                           (f32.add
                                             (local.tee 0
-                                              (f32.load offset=1053560
+                                              (f32.load offset=1048576
                                                 (local.get 7)))
                                             (local.tee 12
                                               (f32.reinterpret_i32
@@ -9782,7 +9770,7 @@
                                 (f32.add
                                   (f32.add
                                     (local.tee 6
-                                      (f32.load offset=1053576
+                                      (f32.load offset=1048592
                                         (local.get 7)))
                                     (f32.add
                                       (local.get 2)
@@ -9888,7 +9876,7 @@
             (f32.const 0x1p+0 (;=1;))
             (local.get 0))))
       (return
-        (call $_ZN4libm4math4sqrt5sqrtf17h3f74684b5a6fd261E
+        (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
           (local.get 0))))
     (block ;; label = @1
       (block ;; label = @2
@@ -10112,14 +10100,14 @@
             (local.get 5)))
         (br 1 (;@1;)))
       (local.set 0
-        (call $_ZN4libm4math6scalbn7scalbnf17h94814bd2ee5e97a4E
+        (call $_ZN4libm4math6scalbn7scalbnf17ha430054e259e38a4E
           (local.get 0)
           (local.get 3))))
     (f32.mul
       (local.get 11)
       (local.get 0))
   )
-  (func $_ZN4libm4math6scalbn7scalbnf17h94814bd2ee5e97a4E (;60;) (type 10) (param f32 i32) (result f32)
+  (func $_ZN4libm4math6scalbn7scalbnf17ha430054e259e38a4E (;59;) (type 10) (param f32 i32) (result f32)
     (block ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -10196,7 +10184,7 @@
             (i32.const 1065353216))
           (i32.const 2139095040))))
   )
-  (func $libm_sin (;61;) (type 0) (param f64) (result f64)
+  (func $libm_sin (;60;) (type 0) (param f64) (result f64)
     (local i32 i32 f64 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -10225,7 +10213,7 @@
                     (i32.gt_u
                       (local.get 2)
                       (i32.const 2146435071)))
-                  (call $_ZN4libm4math8rem_pio28rem_pio217h00100b53da492ea7E
+                  (call $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E
                     (i32.add
                       (local.get 1)
                       (i32.const 8))
@@ -10248,7 +10236,7 @@
                 (br 5 (;@1;)))
               (local.set 0
                 (f64.neg
-                  (call $_ZN4libm4math5k_cos5k_cos17ha6fdd81ea36304b4E.17
+                  (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
                     (local.get 0)
                     (local.get 3))))
               (br 4 (;@1;)))
@@ -10298,7 +10286,7 @@
                     (local.get 3)))))
             (br 3 (;@1;)))
           (local.set 0
-            (call $_ZN4libm4math5k_cos5k_cos17ha6fdd81ea36304b4E.17
+            (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
               (local.get 0)
               (local.get 3)))
           (br 2 (;@1;)))
@@ -10417,7 +10405,7 @@
         (i32.const 32)))
     (local.get 0)
   )
-  (func $libm_sinf (;62;) (type 1) (param f32) (result f32)
+  (func $libm_sinf (;61;) (type 1) (param f32) (result f32)
     (local i32 f64 i32 i32 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -10457,7 +10445,7 @@
                         (i32.gt_u
                           (local.get 4)
                           (i32.const 2139095039)))
-                      (call $_ZN4libm4math9rem_pio2f9rem_pio2f17hf69dfbea6bacc523E
+                      (call $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E
                         (local.get 1)
                         (local.get 0))
                       (local.set 2
@@ -10870,7 +10858,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $libm_sinh (;63;) (type 0) (param f64) (result f64)
+  (func $libm_sinh (;62;) (type 0) (param f64) (result f64)
     (local f64 f64 i64)
     (local.set 1
       (f64.copysign
@@ -10892,14 +10880,14 @@
             (local.get 1))
           (f64.mul
             (f64.mul
-              (call $_ZN4libm4math3exp3exp17h907b579aaaa6d23dE
+              (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
                 (f64.add
                   (local.get 2)
                   (f64.const -0x1.62066151add8bp+10 (;=-1416.0996898839683;))))
               (f64.const 0x1p+1021 (;=22471164185778950000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;)))
             (f64.const 0x1p+1021 (;=22471164185778950000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;))))))
     (local.set 2
-      (call $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E
+      (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
         (local.get 2)))
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -10937,7 +10925,7 @@
                 (f64.const 0x1p+0 (;=1;))))))))
     (local.get 0)
   )
-  (func $libm_sinhf (;64;) (type 1) (param f32) (result f32)
+  (func $libm_sinhf (;63;) (type 1) (param f32) (result f32)
     (local f32 f32 i32)
     (local.set 1
       (f32.copysign
@@ -10959,14 +10947,14 @@
             (local.get 1))
           (f32.mul
             (f32.mul
-              (call $_ZN4libm4math4expf4expf17h49d18e1ff0d69b78E
+              (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
                 (f32.add
                   (local.get 2)
                   (f32.const -0x1.45c778p+7 (;=-162.88959;))))
               (f32.const 0x1p+117 (;=166153500000000000000000000000000000;)))
             (f32.const 0x1p+117 (;=166153500000000000000000000000000000;))))))
     (local.set 2
-      (call $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E
+      (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
         (local.get 2)))
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -11004,7 +10992,7 @@
                 (f32.const 0x1p+0 (;=1;))))))))
     (local.get 0)
   )
-  (func $libm_tan (;65;) (type 0) (param f64) (result f64)
+  (func $libm_tan (;64;) (type 0) (param f64) (result f64)
     (local i32 i32)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11029,13 +11017,13 @@
             (i32.gt_u
               (local.get 2)
               (i32.const 2146435071)))
-          (call $_ZN4libm4math8rem_pio28rem_pio217h00100b53da492ea7E
+          (call $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E
             (i32.add
               (local.get 1)
               (i32.const 8))
             (local.get 0))
           (local.set 0
-            (call $_ZN4libm4math5k_tan5k_tan17h3b77a1233fdc8f5fE
+            (call $_ZN4libm4math5k_tan5k_tan17he70947e0d23fd5ccE
               (f64.load offset=8
                 (local.get 1))
               (f64.load offset=24
@@ -11056,7 +11044,7 @@
             (local.get 2)
             (i32.const 1044381696)))
         (local.set 0
-          (call $_ZN4libm4math5k_tan5k_tan17h3b77a1233fdc8f5fE
+          (call $_ZN4libm4math5k_tan5k_tan17he70947e0d23fd5ccE
             (local.get 0)
             (f64.const 0x0p+0 (;=0;))
             (i32.const 0)))
@@ -11082,7 +11070,7 @@
         (i32.const 32)))
     (local.get 0)
   )
-  (func $_ZN4libm4math5k_tan5k_tan17h3b77a1233fdc8f5fE (;66;) (type 11) (param f64 f64 i32) (result f64)
+  (func $_ZN4libm4math5k_tan5k_tan17he70947e0d23fd5ccE (;65;) (type 11) (param f64 f64 i32) (result f64)
     (local i64 i32 f64 f64 f64)
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -11252,7 +11240,7 @@
         (local.get 3)
         (i64.const 0)))
   )
-  (func $libm_tanf (;67;) (type 1) (param f32) (result f32)
+  (func $libm_tanf (;66;) (type 1) (param f32) (result f32)
     (local i32 f64 i32 i32 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11288,7 +11276,7 @@
                 (i32.gt_u
                   (local.get 4)
                   (i32.const 2139095039)))
-              (call $_ZN4libm4math9rem_pio2f9rem_pio2f17hf69dfbea6bacc523E
+              (call $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E
                 (local.get 1)
                 (local.get 0))
               (local.set 0
@@ -11613,7 +11601,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $libm_tanh (;68;) (type 0) (param f64) (result f64)
+  (func $libm_tanh (;67;) (type 0) (param f64) (result f64)
     (local i32 f64 i64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11652,7 +11640,7 @@
             (f64.div
               (f64.neg
                 (local.tee 2
-                  (call $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E
+                  (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
                     (f64.mul
                       (local.get 2)
                       (f64.const -0x1p+1 (;=-2;))))))
@@ -11671,7 +11659,7 @@
               (f64.div
                 (f64.const 0x1p+1 (;=2;))
                 (f64.add
-                  (call $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E
+                  (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
                     (f64.add
                       (local.get 2)
                       (local.get 2)))
@@ -11687,7 +11675,7 @@
       (local.set 2
         (f64.div
           (local.tee 2
-            (call $_ZN4libm4math5expm15expm117h62db3ad0cf147f82E
+            (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
               (f64.add
                 (local.get 2)
                 (local.get 2))))
@@ -11707,7 +11695,7 @@
           (local.get 0))
         (i64.const 0)))
   )
-  (func $libm_tanhf (;69;) (type 1) (param f32) (result f32)
+  (func $libm_tanhf (;68;) (type 1) (param f32) (result f32)
     (local i32 f32 i32)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11747,7 +11735,7 @@
             (f32.div
               (f32.neg
                 (local.tee 2
-                  (call $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E
+                  (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
                     (f32.mul
                       (local.get 2)
                       (f32.const -0x1p+1 (;=-2;))))))
@@ -11766,7 +11754,7 @@
               (f32.div
                 (f32.const 0x1p+1 (;=2;))
                 (f32.add
-                  (call $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E
+                  (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
                     (f32.add
                       (local.get 2)
                       (local.get 2)))
@@ -11782,7 +11770,7 @@
       (local.set 2
         (f32.div
           (local.tee 2
-            (call $_ZN4libm4math6expm1f6expm1f17hdf7d3c865d707583E
+            (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
               (f32.add
                 (local.get 2)
                 (local.get 2))))
@@ -11802,10 +11790,10 @@
           (local.get 0))
         (i32.const 0)))
   )
-  (func $_ZN4core9panicking9panic_fmt17hb8badb9a939ccf7aE (;70;) (type 8)
+  (func $_ZN4core9panicking9panic_fmt17h6651313c3e2c6c2fE (;69;) (type 8)
     (unreachable)
   )
-  (func $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hdfd962d741b4d37eE (;71;) (type 12) (param i32 i32 i32 i32 i32) (result i32)
+  (func $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hd7141cf13a36ffbcE (;70;) (type 12) (param i32 i32 i32 i32 i32) (result i32)
     (local i32 i32 i32 i32 i32 i32 i32 f64 i32 i32 i32 i32 i32 i32 i32 i32 i32 f64 f64 i64 i64 i64 i32 i32 i32)
     (global.set $__stack_pointer
       (local.tee 5
@@ -11854,7 +11842,7 @@
     (local.set 9
       (i32.add
         (local.tee 8
-          (i32.load offset=1048856
+          (i32.load offset=1052888
             (i32.shl
               (local.get 4)
               (i32.const 2))))
@@ -11886,7 +11874,7 @@
           (i32.shl
             (local.get 1)
             (i32.const 2)))
-        (i32.const 1048876)))
+        (i32.const 1052908)))
     (loop ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -12117,7 +12105,7 @@
                             (local.tee 23
                               (f64.mul
                                 (local.tee 22
-                                  (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+                                  (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
                                     (local.get 12)
                                     (local.get 18)))
                                 (f64.const 0x1p-3 (;=0.125;))))))
@@ -12344,7 +12332,7 @@
             (local.set 12
               (f64.sub
                 (local.get 12)
-                (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+                (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
                   (f64.const 0x1p+0 (;=1;))
                   (local.get 18))))
             (br 1 (;@3;)))
@@ -12465,7 +12453,7 @@
                       (local.get 7)))
                   (i32.const 3)))
               (f64.convert_i32_s
-                (i32.load offset=1048872
+                (i32.load offset=1052904
                   (i32.shl
                     (i32.add
                       (local.get 10)
@@ -12539,7 +12527,7 @@
           (br_if 0 (;@3;)
             (f64.ge
               (local.tee 12
-                (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+                (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
                   (local.get 12)
                   (i32.sub
                     (i32.const 0)
@@ -12600,7 +12588,7 @@
           (local.get 21)
           (i32.const 2))))
     (local.set 12
-      (call $_ZN4libm4math6scalbn6scalbn17h531a39b61a410142E
+      (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
         (f64.const 0x1p+0 (;=1;))
         (local.get 18)))
     (local.set 0
@@ -12670,7 +12658,7 @@
               (f64.load
                 (i32.add
                   (local.get 6)
-                  (i32.const 1049136)))
+                  (i32.const 1053168)))
               (f64.load
                 (i32.add
                   (local.get 0)
@@ -12832,7 +12820,7 @@
       (local.get 27)
       (i32.const 7))
   )
-  (func $_ZN4libm4math8rem_pio28rem_pio26medium17h0e8f2d37b2c2a5b5E (;72;) (type 13) (param i32 f64 i32)
+  (func $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E (;71;) (type 13) (param i32 f64 i32)
     (local f64 f64 f64 f64)
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -12936,7 +12924,119 @@
           (local.get 5))
         (local.get 4)))
   )
-  (func $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17hf8b03061c0b0ce49E (;73;) (type 14) (param i32 i64 i64 i64 i64)
+  (func $__ashlti3 (;72;) (type 14) (param i32 i64 i64 i32)
+    (local i64)
+    (block ;; label = @1
+      (block ;; label = @2
+        (br_if 0 (;@2;)
+          (i32.and
+            (local.get 3)
+            (i32.const 64)))
+        (br_if 1 (;@1;)
+          (i32.eqz
+            (local.get 3)))
+        (local.set 2
+          (i64.or
+            (i64.shl
+              (local.get 2)
+              (local.tee 4
+                (i64.extend_i32_u
+                  (i32.and
+                    (local.get 3)
+                    (i32.const 63)))))
+            (i64.shr_u
+              (local.get 1)
+              (i64.extend_i32_u
+                (i32.and
+                  (i32.sub
+                    (i32.const 0)
+                    (local.get 3))
+                  (i32.const 63))))))
+        (local.set 1
+          (i64.shl
+            (local.get 1)
+            (local.get 4)))
+        (br 1 (;@1;)))
+      (local.set 2
+        (i64.shl
+          (local.get 1)
+          (i64.extend_i32_u
+            (i32.and
+              (local.get 3)
+              (i32.const 63)))))
+      (local.set 1
+        (i64.const 0)))
+    (i64.store
+      (local.get 0)
+      (local.get 1))
+    (i64.store offset=8
+      (local.get 0)
+      (local.get 2))
+  )
+  (func $__multi3 (;73;) (type 15) (param i32 i64 i64 i64 i64)
+    (local i64 i64 i64 i64 i64 i64)
+    (i64.store
+      (local.get 0)
+      (local.tee 10
+        (i64.add
+          (local.tee 7
+            (i64.mul
+              (local.tee 5
+                (i64.and
+                  (local.get 3)
+                  (i64.const 4294967295)))
+              (local.tee 6
+                (i64.and
+                  (local.get 1)
+                  (i64.const 4294967295)))))
+          (i64.shl
+            (local.tee 5
+              (i64.add
+                (local.tee 6
+                  (i64.mul
+                    (local.tee 8
+                      (i64.shr_u
+                        (local.get 3)
+                        (i64.const 32)))
+                    (local.get 6)))
+                (i64.mul
+                  (local.get 5)
+                  (local.tee 9
+                    (i64.shr_u
+                      (local.get 1)
+                      (i64.const 32))))))
+            (i64.const 32)))))
+    (i64.store offset=8
+      (local.get 0)
+      (i64.add
+        (i64.add
+          (i64.add
+            (i64.mul
+              (local.get 8)
+              (local.get 9))
+            (i64.or
+              (i64.shl
+                (i64.extend_i32_u
+                  (i64.lt_u
+                    (local.get 5)
+                    (local.get 6)))
+                (i64.const 32))
+              (i64.shr_u
+                (local.get 5)
+                (i64.const 32))))
+          (i64.extend_i32_u
+            (i64.lt_u
+              (local.get 10)
+              (local.get 7))))
+        (i64.add
+          (i64.mul
+            (local.get 4)
+            (local.get 1))
+          (i64.mul
+            (local.get 3)
+            (local.get 2)))))
+  )
+  (func $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h8d9ba2662c058edeE (;74;) (type 15) (param i32 i64 i64 i64 i64)
     (local i32 i64 i32 i32 i32 i64 i64 i64 i64)
     (global.set $__stack_pointer
       (local.tee 5
@@ -13498,14 +13598,14 @@
         (local.get 5)
         (i32.const 176)))
   )
-  (func $__udivti3 (;74;) (type 14) (param i32 i64 i64 i64 i64)
+  (func $__udivti3 (;75;) (type 15) (param i32 i64 i64 i64 i64)
     (local i32)
     (global.set $__stack_pointer
       (local.tee 5
         (i32.sub
           (global.get $__stack_pointer)
           (i32.const 32))))
-    (call $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17hf8b03061c0b0ce49E
+    (call $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h8d9ba2662c058edeE
       (local.get 5)
       (local.get 1)
       (local.get 2)
@@ -13526,56 +13626,7 @@
         (local.get 5)
         (i32.const 32)))
   )
-  (func $__ashlti3 (;75;) (type 15) (param i32 i64 i64 i32)
-    (local i64)
-    (block ;; label = @1
-      (block ;; label = @2
-        (br_if 0 (;@2;)
-          (i32.and
-            (local.get 3)
-            (i32.const 64)))
-        (br_if 1 (;@1;)
-          (i32.eqz
-            (local.get 3)))
-        (local.set 2
-          (i64.or
-            (i64.shl
-              (local.get 2)
-              (local.tee 4
-                (i64.extend_i32_u
-                  (i32.and
-                    (local.get 3)
-                    (i32.const 63)))))
-            (i64.shr_u
-              (local.get 1)
-              (i64.extend_i32_u
-                (i32.and
-                  (i32.sub
-                    (i32.const 0)
-                    (local.get 3))
-                  (i32.const 63))))))
-        (local.set 1
-          (i64.shl
-            (local.get 1)
-            (local.get 4)))
-        (br 1 (;@1;)))
-      (local.set 2
-        (i64.shl
-          (local.get 1)
-          (i64.extend_i32_u
-            (i32.and
-              (local.get 3)
-              (i32.const 63)))))
-      (local.set 1
-        (i64.const 0)))
-    (i64.store
-      (local.get 0)
-      (local.get 1))
-    (i64.store offset=8
-      (local.get 0)
-      (local.get 2))
-  )
-  (func $__lshrti3 (;76;) (type 15) (param i32 i64 i64 i32)
+  (func $__lshrti3 (;76;) (type 14) (param i32 i64 i64 i32)
     (local i64)
     (block ;; label = @1
       (block ;; label = @2
@@ -13624,77 +13675,14 @@
       (local.get 0)
       (local.get 2))
   )
-  (func $__multi3 (;77;) (type 14) (param i32 i64 i64 i64 i64)
-    (local i64 i64 i64 i64 i64 i64)
-    (i64.store
-      (local.get 0)
-      (local.tee 10
-        (i64.add
-          (local.tee 7
-            (i64.mul
-              (local.tee 5
-                (i64.and
-                  (local.get 3)
-                  (i64.const 4294967295)))
-              (local.tee 6
-                (i64.and
-                  (local.get 1)
-                  (i64.const 4294967295)))))
-          (i64.shl
-            (local.tee 5
-              (i64.add
-                (local.tee 6
-                  (i64.mul
-                    (local.tee 8
-                      (i64.shr_u
-                        (local.get 3)
-                        (i64.const 32)))
-                    (local.get 6)))
-                (i64.mul
-                  (local.get 5)
-                  (local.tee 9
-                    (i64.shr_u
-                      (local.get 1)
-                      (i64.const 32))))))
-            (i64.const 32)))))
-    (i64.store offset=8
-      (local.get 0)
-      (i64.add
-        (i64.add
-          (i64.add
-            (i64.mul
-              (local.get 8)
-              (local.get 9))
-            (i64.or
-              (i64.shl
-                (i64.extend_i32_u
-                  (i64.lt_u
-                    (local.get 5)
-                    (local.get 6)))
-                (i64.const 32))
-              (i64.shr_u
-                (local.get 5)
-                (i64.const 32))))
-          (i64.extend_i32_u
-            (i64.lt_u
-              (local.get 10)
-              (local.get 7))))
-        (i64.add
-          (i64.mul
-            (local.get 4)
-            (local.get 1))
-          (i64.mul
-            (local.get 3)
-            (local.get 2)))))
-  )
-  (func $__umodti3 (;78;) (type 14) (param i32 i64 i64 i64 i64)
+  (func $__umodti3 (;77;) (type 15) (param i32 i64 i64 i64 i64)
     (local i32)
     (global.set $__stack_pointer
       (local.tee 5
         (i32.sub
           (global.get $__stack_pointer)
           (i32.const 32))))
-    (call $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17hf8b03061c0b0ce49E
+    (call $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h8d9ba2662c058edeE
       (local.get 5)
       (local.get 1)
       (local.get 2)
@@ -13715,10 +13703,10 @@
         (local.get 5)
         (i32.const 32)))
   )
-  (data $.rodata (;0;) (i32.const 1048576) "O\bba\05g\ac\dd?\18-DT\fb!\e9?\9b\f6\81\d2\0bs\ef?\18-DT\fb!\f9?\e2e/\22\7f+z<\07\5c\143&\a6\81<\bd\cb\f0z\88\07p<\07\5c\143&\a6\91<\00\00\00\00\00\00\e0?\00\00\00\00\00\00\e0\bf\00\00\00\00\00\00\f0?\8br\8d\f9\a2(\f4?=n=\a5\fee\f9?\00\00\00\00\00\00\f0?\00\00\00\00\00\00\f8?\00\00\00\00\00\00\00\00\06\d0\cfC\eb\fdL>\00\00\00\00\00\00\00\00\00\00\00@\03\b8\e2?\cd;\7ff\9e\a0\e6?\87\01\ebs\14\a1\e7?\db\a0*B\e5\ac\e8?\90\f0\a3\82\91\c4\e9?\ad\d3Z\99\9f\e8\ea?\9cR\85\dd\9b\19\ec?\87\a4\fb\dc\18X\ed?\da\90\a4\a2\af\a4\ee?\00\00\00\00\00\00\f0?\0f\89\f9lX\b5\f0?{Q}<\b8r\f1?8bunz8\f2?\15\b71\0a\fe\06\f3?\224\12L\a6\de\f3?'*6\d5\da\bf\f4?)TH\dd\07\ab\f5?\03\00\00\00\04\00\00\00\04\00\00\00\06\00\00\00\83\f9\a2\00DNn\00\fc)\15\00\d1W'\00\dd4\f5\00b\db\c0\00<\99\95\00A\90C\00cQ\fe\00\bb\de\ab\00\b7a\c5\00:n$\00\d2MB\00I\06\e0\00\09\ea.\00\1c\92\d1\00\eb\1d\fe\00)\b1\1c\00\e8>\a7\00\f55\82\00D\bb.\00\9c\e9\84\00\b4&p\00A~_\00\d6\919\00S\839\00\9c\f49\00\8b_\84\00(\f9\bd\00\f8\1f;\00\de\ff\97\00\0f\98\05\00\11/\ef\00\0aZ\8b\00m\1fm\00\cf~6\00\09\cb'\00FO\b7\00\9ef?\00-\ea_\00\ba'u\00\e5\eb\c7\00={\f1\00\f79\07\00\92R\8a\00\fbk\ea\00\1f\b1_\00\08]\8d\000\03V\00{\fcF\00\f0\abk\00 \bc\cf\006\f4\9a\00\e3\a9\1d\00^a\91\00\08\1b\e6\00\85\99e\00\a0\14_\00\8d@h\00\80\d8\ff\00'sM\00\06\061\00\caV\15\00\c9\a8s\00{\e2`\00k\8c\c0\00\00\00\00@\fb!\f9?\00\00\00\00-Dt>\00\00\00\80\98F\f8<\00\00\00`Q\ccx;\00\00\00\80\83\1b\f09\00\00\00@ %z8\00\00\00\80\22\82\e36\00\00\00\00\1d\f3i5Q\b4\f0\b2\96\b1D\b0\f9\ae\b6\ady\acC\ab\14\aa\eb\a8\c8\a7\aa\a6\92\a5\80\a4s\a3k\a2h\a1j\a0p\9f{\9e\8a\9d\9d\9c\b5\9b\d1\9a\f0\99\13\99:\98e\97\93\96\c4\95\f8\940\94k\93\a9\92\ea\91.\91u\90\be\8f\0a\8fY\8e\aa\8d\fe\8cT\8c\ac\8b\07\8bd\8a\c4\89%\89\89\88\ee\87V\87\c0\86+\86\99\85\08\85y\84\ec\83a\83\d8\82P\82\c9\81E\81\c2\80@\80\02\ff\0e\fd%\fbG\f9s\f7\aa\f5\ea\f34\f2\87\f0\e3\eeG\ed\b3\eb'\ea\a3\e8'\e7\b2\e5C\e4\dc\e2z\e1 \e0\cb\de}\dd4\dc\f1\da\b3\d9{\d8H\d7\1a\d6\f1\d4\cd\d3\ad\d2\92\d1{\d0i\cf[\ceQ\cdJ\ccH\cbJ\caO\c9X\c8d\c7t\c6\87\c5\9d\c4\b7\c3\d4\c2\f4\c1\16\c1<\c0e\bf\90\be\be\bd\ef\bc#\bcY\bb\91\ba\cc\b9\0a\b9J\b8\8c\b7\d0\b6\17\b6`\b5]=\7ff\9e\a0\e6?\00\00\00\00\00\889=D\17u\faR\b0\e6?\00\00\00\00\00\00\d8<\fe\d9\0bu\12\c0\e6?\00\00\00\00\00x(\bd\bfv\d4\dd\dc\cf\e6?\00\00\00\00\00\c0\1e=)\1ae<\b2\df\e6?\00\00\00\00\00\00\d8\bc\e3:Y\98\92\ef\e6?\00\00\00\00\00\00\bc\bc\86\93Q\f9}\ff\e6?\00\00\00\00\00\d8/\bd\a3-\f4ft\0f\e7?\00\00\00\00\00\88,\bd\c3_\ec\e8u\1f\e7?\00\00\00\00\00\c0\13=\05\cf\ea\86\82/\e7?\00\00\00\00\0008\bdR\81\a5H\9a?\e7?\00\00\00\00\00\c0\00\bd\fc\cc\d75\bdO\e7?\00\00\00\00\00\88/=\f1gBV\eb_\e7?\00\00\00\00\00\e0\03=Hm\ab\b1$p\e7?\00\00\00\00\00\d0'\bd8]\deOi\80\e7?\00\00\00\00\00\00\dd\bc\00\1d\ac8\b9\90\e7?\00\00\00\00\00\00\e3<x\01\ebs\14\a1\e7?\00\00\00\00\00\00\ed\bc`\d0v\09{\b1\e7?\00\00\00\00\00@ =3\c10\01\ed\c1\e7?\00\00\00\00\00\00\a0<6\86\ffbj\d2\e7?\00\00\00\00\00\90&\bd;N\cf6\f3\e2\e7?\00\00\00\00\00\e0\02\bd\e8\c3\91\84\87\f3\e7?\00\00\00\00\00X$\bdN\1b>T'\04\e8?\00\00\00\00\00\003=\1a\07\d1\ad\d2\14\e8?\00\00\00\00\00\00\0f=~\cdL\99\89%\e8?\00\00\00\00\00\c0!\bd\d0B\b9\1eL6\e8?\00\00\00\00\00\d0)=\b5\ca#F\1aG\e8?\00\00\00\00\00\10G=\bc[\9f\17\f4W\e8?\00\00\00\00\00`\22=\af\91D\9b\d9h\e8?\00\00\00\00\00\c42\bd\95\a31\d9\cay\e8?\00\00\00\00\00\00#\bd\b8e\8a\d9\c7\8a\e8?\00\00\00\00\00\80*\bd\00Xx\a4\d0\9b\e8?\00\00\00\00\00\00\ed\bc#\a2*B\e5\ac\e8?\00\00\00\00\00(3=\fa\19\d6\ba\05\be\e8?\00\00\00\00\00\b4B=\83C\b5\162\cf\e8?\00\00\00\00\00\d0.\bdLf\08^j\e0\e8?\00\00\00\00\00P \bd\07x\15\99\ae\f1\e8?\00\00\00\00\00((=\0e,(\d0\fe\02\e9?\00\00\00\00\00\b0\1c\bd\96\ff\91\0b[\14\e9?\00\00\00\00\00\e0\05\bd\f9/\aaS\c3%\e9?\00\00\00\00\00@\f5<J\c6\cd\b077\e9?\00\00\00\00\00 \17=\ae\98_+\b8H\e9?\00\00\00\00\00\00\09\bd\cbR\c8\cbDZ\e9?\00\00\00\00\00h%=!ov\9a\ddk\e9?\00\00\00\00\00\d06\bd*N\de\9f\82}\e9?\00\00\00\00\00\00\01\bd\a3#z\e43\8f\e9?\00\00\00\00\00\00-=\04\06\cap\f1\a0\e9?\00\00\00\00\00\a48\bd\89\ffSM\bb\b2\e9?\00\00\00\00\00\5c5=[\f1\a3\82\91\c4\e9?\00\00\00\00\00\b8&=\c5\b8K\19t\d6\e9?\00\00\00\00\00\00\ec\bc\8e#\e3\19c\e8\e9?\00\00\00\00\00\d0\17=\02\f3\07\8d^\fa\e9?\00\00\00\00\00@\16=M\e5]{f\0c\ea?\00\00\00\00\00\00\f5\bc\f6\b8\8e\edz\1e\ea?\00\00\00\00\00\e0\09='.J\ec\9b0\ea?\00\00\00\00\00\d8*=]\0aF\80\c9B\ea?\00\00\00\00\00\f0\1a\bd\9b%>\b2\03U\ea?\00\00\00\00\00`\0b=\13b\f4\8aJg\ea?\00\00\00\00\00\888=\a7\b30\13\9ey\ea?\00\00\00\00\00 \11=\8d.\c1S\fe\8b\ea?\00\00\00\00\00\c0\06=\d2\fcyUk\9e\ea?\00\00\00\00\00\b8)\bd\b8o5!\e5\b0\ea?\00\00\00\00\00p+=\81\f3\d3\bfk\c3\ea?\00\00\00\00\00\00\d9<\80'<:\ff\d5\ea?\00\00\00\00\00\00\e4<\a3\d2Z\99\9f\e8\ea?\00\00\00\00\00\90,\bdg\f3\22\e6L\fb\ea?\00\00\00\00\00P\16=\90\b7\8d)\07\0e\eb?\00\00\00\00\00\d4/=\a9\89\9al\ce \eb?\00\00\00\00\00p\12=K\1aO\b8\a23\eb?\00\00\00\00\00GM=\e7G\b7\15\84F\eb?\00\00\00\00\0088\bd:Y\e5\8drY\eb?\00\00\00\00\00\00\98<j\c5\f1)nl\eb?\00\00\00\00\00\d0\0a=P^\fb\f2v\7f\eb?\00\00\00\00\00\80\de<\b2I'\f2\8c\92\eb?\00\00\00\00\00\c0\04\bd\03\06\a10\b0\a5\eb?\00\00\00\00\00p\0d\bdfo\9a\b7\e0\b8\eb?\00\00\00\00\00\90\0d=\ff\c1K\90\1e\cc\eb?\00\00\00\00\00\a0\02=o\a1\f3\c3i\df\eb?\00\00\00\00\00x\1f\bd\b8\1d\d7[\c2\f2\eb?\00\00\00\00\00\a0\10\bd\e9\b2Aa(\06\ec?\00\00\00\00\00@\11\bd\e0R\85\dd\9b\19\ec?\00\00\00\00\00\e0\0b=\eed\fa\d9\1c-\ec?\00\00\00\00\00@\09\bd/\d0\ff_\ab@\ec?\00\00\00\00\00\d0\0e\bd\15\fd\faxGT\ec?\00\00\00\00\00f9=\cb\d0W.\f1g\ec?\00\00\00\00\00\10\1a\bd\b6\c1\88\89\a8{\ec?\00\00\00\00\80EX\bd3\e7\06\94m\8f\ec?\00\00\00\00\00H\1a\bd\df\c4QW@\a3\ec?\00\00\00\00\00\00\cb<\94\90\ef\dc \b7\ec?\00\00\00\00\00@\01=\89\16m.\0f\cb\ec?\00\00\00\00\00 \f0<\12\c4]U\0b\df\ec?\00\00\00\00\00`\f3<;\ab[[\15\f3\ec?\00\00\00\00\00\90\06\bd\bc\89\07J-\07\ed?\00\00\00\00\00\a0\09=\fa\c8\08+S\1b\ed?\00\00\00\00\00\e0\15\bd\85\8a\0d\08\87/\ed?\00\00\00\00\00(\1d=\03\a2\ca\ea\c8C\ed?\00\00\00\00\00\a0\01=\91\a4\fb\dc\18X\ed?\00\00\00\00\00\00\df<\a1\e6b\e8vl\ed?\00\00\00\00\00\a0\03\bdN\83\c9\16\e3\80\ed?\00\00\00\00\00\d8\0c\bd\90`\ffq]\95\ed?\00\00\00\00\00\c0\f4<\ae2\db\03\e6\a9\ed?\00\00\00\00\00\90\ff<%\83:\d6|\be\ed?\00\00\00\00\00\80\e9<E\b4\01\f3!\d3\ed?\00\00\00\00\00 \f5\bc\bf\05\1cd\d5\e7\ed?\00\00\00\00\00p\1d\bd\ec\9a{3\97\fc\ed?\00\00\00\00\00\14\16\bd^}\19kg\11\ee?\00\00\00\00\00H\0b=\e7\a3\f5\14F&\ee?\00\00\00\00\00\ce@=\5c\ee\16;3;\ee?\00\00\00\00\00h\0c=\b4?\8b\e7.P\ee?\00\00\00\00\000\09\bdhmg$9e\ee?\00\00\00\00\00\00\e5\bcDL\c7\fbQz\ee?\00\00\00\00\00\f8\07\bd&\b7\cdwy\8f\ee?\00\00\00\00\00p\f3\bc\e8\90\a4\a2\af\a4\ee?\00\00\00\00\00\d0\e5<\e4\ca|\86\f4\b9\ee?\00\00\00\00\00\1a\16=\0dh\8e-H\cf\ee?\00\00\00\00\00P\f5<\14\85\18\a2\aa\e4\ee?\00\00\00\00\00@\c6<\13Za\ee\1b\fa\ee?\00\00\00\00\00\80\ee\bc\06A\b6\1c\9c\0f\ef?\00\00\00\00\00\88\fa\bcc\b9k7+%\ef?\00\00\00\00\00\90,\bdur\ddH\c9:\ef?\00\00\00\00\00\00\aa<$En[vP\ef?\00\00\00\00\00\f0\f4\bc\fdD\88y2f\ef?\00\00\00\00\00\80\ca<8\be\9c\ad\fd{\ef?\00\00\00\00\00\bc\fa<\82<$\02\d8\91\ef?\00\00\00\00\00`\d4\bc\8e\90\9e\81\c1\a7\ef?\00\00\00\00\00\0c\0b\bd\11\d5\926\ba\bd\ef?\00\00\00\00\00\e0\c0\bc\94q\8f+\c2\d3\ef?\00\00\00\00\80\de\10\bd\ee#*k\d9\e9\ef?\00\00\00\00\00C\ee<\00\00\00\00\00\00\f0?\00\00\00\00\00\00\00\00\be\bcZ\fa\1a\0b\f0?\00\00\00\00\00@\b3\bc\033\fb\a9=\16\f0?\00\00\00\00\00\17\12\bd\82\02;\14h!\f0?\00\00\00\00\00@\ba<l\80w>\9a,\f0?\00\00\00\00\00\98\ef<\ca\bb\11.\d47\f0?\00\00\00\00\00@\c7\bc\89\7fn\e8\15C\f0?\00\00\00\00\000\d8<gT\f6r_N\f0?\00\00\00\00\00?\1a\bdZ\85\15\d3\b0Y\f0?\00\00\00\00\00\84\02\bd\95\1f<\0e\0ae\f0?\00\00\00\00\00`\f1<\1a\f7\dd)kp\f0?\00\00\00\00\00$\15=-\a8r+\d4{\f0?\00\00\00\00\00\a0\e9\bc\d0\9bu\18E\87\f0?\00\00\00\00\00@\e6<\c8\07f\f6\bd\92\f0?\00\00\00\00\00x\00\bd\83\f3\c6\ca>\9e\f0?\00\00\00\00\00\00\98\bc09\1f\9b\c7\a9\f0?\00\00\00\00\00\a0\ff<\fc\88\f9lX\b5\f0?\00\00\00\00\00\c8\fa\bc\8al\e4E\f1\c0\f0?\00\00\00\00\00\c0\d9<\16Hr+\92\cc\f0?\00\00\00\00\00 \05=\d8]9#;\d8\f0?\00\00\00\00\00\d0\fa\bc\f3\d1\d32\ec\e3\f0?\00\00\00\00\00\ac\1b=\a6\a9\df_\a5\ef\f0?\00\00\00\00\00\e8\04\bd\f0\d2\fe\aff\fb\f0?\00\00\00\00\000\0d\bdK#\d7(0\07\f1?\00\00\00\00\00P\f1<[[\12\d0\01\13\f1?\00\00\00\00\00\00\ec<\f9*^\ab\db\1e\f1?\00\00\00\00\00\bc\16=\d51l\c0\bd*\f1?\00\00\00\00\00@\e8<}\04\f2\14\a86\f1?\00\00\00\00\00\d0\0e\bd\e9-\a9\ae\9aB\f1?\00\00\00\00\00\e0\e8<81O\93\95N\f1?\00\00\00\00\00@\eb<q\8e\a5\c8\98Z\f1?\00\00\00\00\000\05=\df\c3qT\a4f\f1?\00\00\00\00\008\03=\11R}<\b8r\f1?\00\00\00\00\00\d4(=\9f\bb\95\86\d4~\f1?\00\00\00\00\00\d0\05\bd\93\8d\8c8\f9\8a\f1?\00\00\00\00\00\88\1c\bdf]7X&\97\f1?\00\00\00\00\00\f0\11=\a7\cbo\eb[\a3\f1?\00\00\00\00\00H\10=\e3\87\13\f8\99\af\f1?\00\00\00\00\009G\bdT]\04\84\e0\bb\f1?\00\00\00\00\00\e4$=C\1c(\95/\c8\f1?\00\00\00\00\00 \0a\bd\b2\b9h1\87\d4\f1?\00\00\00\00\00\80\e3<1@\b4^\e7\e0\f1?\00\00\00\00\00\c0\ea<8\d9\fc\22P\ed\f1?\00\00\00\00\00\90\01=\f7\cd8\84\c1\f9\f1?\00\00\00\00\00x\1b\bd\8f\8db\88;\06\f2?\00\00\00\00\00\94-=\1e\a8x5\be\12\f2?\00\00\00\00\00\00\d8<A\dd}\91I\1f\f2?\00\00\00\00\004+=#\13y\a2\dd+\f2?\00\00\00\00\00\f8\19=\e7aunz8\f2?\00\00\00\00\00\c8\19\bd'\14\82\fb\1fE\f2?\00\00\00\00\000\02=\02\a6\b2O\ceQ\f2?\00\00\00\00\00H\13\bd\b0\ce\1eq\85^\f2?\00\00\00\00\00p\12=\16}\e2eEk\f2?\00\00\00\00\00\d0\11=\0f\e0\1d4\0ex\f2?\00\00\00\00\00\ee1=>c\f5\e1\df\84\f2?\00\00\00\00\00\c0\14\bd0\bb\91u\ba\91\f2?\00\00\00\00\00\d8\13\bd\09\df\1f\f5\9d\9e\f2?\00\00\00\00\00\b0\08=\9b\0e\d1f\8a\ab\f2?\00\00\00\00\00|\22\bd:\da\da\d0\7f\b8\f2?\00\00\00\00\004*=\f9\1aw9~\c5\f2?\00\00\00\00\00\80\10\bd\d9\02\e4\a6\85\d2\f2?\00\00\00\00\00\d0\0e\bdy\15d\1f\96\df\f2?\00\00\00\00\00 \f4\bc\cf.>\a9\af\ec\f2?\00\00\00\00\00\98$\bd\22\88\bdJ\d2\f9\f2?\00\00\00\00\000\16\bd%\b61\0a\fe\06\f3?\00\00\00\00\0062\bd\0b\a5\ee\ed2\14\f3?\00\00\00\00\80\dfp\bd\b8\d7L\fcp!\f3?\00\00\00\00\00H\22\bd\a2\e9\a8;\b8.\f3?\00\00\00\00\00\98%\bdf\17d\b2\08<\f3?\00\00\00\00\00\d0\1e='\fa\e3fbI\f3?\00\00\00\00\00\00\dc\bc\0f\9f\92_\c5V\f3?\00\00\00\00\00\d80\bd\b9\88\de\a21d\f3?\00\00\00\00\00\c8\22=9\aa:7\a7q\f3?\00\00\00\00\00` =\fet\1e#&\7f\f3?\00\00\00\00\00`\16\bd8\d8\05m\ae\8c\f3?\00\00\00\00\00\e0\0a\bd\c3>q\1b@\9a\f3?\00\00\00\00\00rD\bd \a0\e54\db\a7\f3?\00\00\00\00\00 \08=\95n\ec\bf\7f\b5\f3?\00\00\00\00\00\80>=\f2\a8\13\c3-\c3\f3?\00\00\00\00\00\80\ef<\22\e1\edD\e5\d0\f3?\00\00\00\00\00\a0\17\bd\bb4\12L\a6\de\f3?\00\00\00\00\000&=\ccN\1c\dfp\ec\f3?\00\00\00\00\00\a6H\bd\8c~\ac\04E\fa\f3?\00\00\00\00\00\dc<\bd\bb\a0g\c3\22\08\f4?\00\00\00\00\00\b8%=\95.\f7!\0a\16\f4?\00\00\00\00\00\c0\1e=FF\09'\fb#\f4?\00\00\00\00\00`\13\bd \a9P\d9\f51\f4?\00\00\00\00\00\98#=\eb\b9\84?\fa?\f4?\00\00\00\00\00\00\fa<\19\89a`\08N\f4?\00\00\00\00\00\c0\f6\bc\01\d2\a7B \5c\f4?\00\00\00\00\00\c0\0b\bd\16\00\1d\edAj\f4?\00\00\00\00\00\80\12\bd&3\8bfmx\f4?\00\00\00\00\00\e00=\00<\c1\b5\a2\86\f4?\00\00\00\00\00@-\bd\04\af\92\e1\e1\94\f4?\00\00\00\00\00 \0c=r\d3\d7\f0*\a3\f4?\00\00\00\00\00P\1e\bd\01\b8m\ea}\b1\f4?\00\00\00\00\00\80\07=\e1)6\d5\da\bf\f4?\00\00\00\00\00\80\13\bd2\c1\17\b8A\ce\f4?\00\00\00\00\00\80\00=\db\dd\fd\99\b2\dc\f4?\00\00\00\00\00p,=\96\ab\d8\81-\eb\f4?\00\00\00\00\00\e0\1c\bd\02-\9dv\b2\f9\f4?\00\00\00\00\00 \19=\c11E\7fA\08\f5?\00\00\00\00\00\c0\08\bd*f\cf\a2\da\16\f5?\00\00\00\00\00\00\fa\bc\eaQ?\e8}%\f5?\00\00\00\00\00\08J=\daN\9dV+4\f5?\00\00\00\00\00\d8&\bd\1a\ac\f6\f4\e2B\f5?\00\00\00\00\00D2\bd\db\94]\ca\a4Q\f5?\00\00\00\00\00<H=k\11\e9\ddp`\f5?\00\00\00\00\00\b0$=\de)\b56Go\f5?\00\00\00\00\00ZA=\0e\c4\e2\db'~\f5?\00\00\00\00\00\e0)\bdo\c7\97\d4\12\8d\f5?\00\00\00\00\00\08#\bdL\0b\ff'\08\9c\f5?\00\00\00\00\00\ecM='TH\dd\07\ab\f5?\00\00\00\00\00\00\c4\bc\f4z\a8\fb\11\ba\f5?\00\00\00\00\00\080=\0bFY\8a&\c9\f5?\00\00\00\00\00\c8&\bd?\8e\99\90E\d8\f5?\00\00\00\00\00\9aF=\e1 \ad\15o\e7\f5?\00\00\00\00\00@\1b\bd\ca\eb\dc \a3\f6\f5?\00\00\00\00\00p\17=\b8\dcv\b9\e1\05\f6?\00\00\00\00\00\f8&=\15\f7\cd\e6*\15\f6?\00\00\00\00\00\00\01=1U:\b0~$\f6?\00\00\00\00\00\d0\15\bd\b5)\19\1d\dd3\f6?\00\00\00\00\00\d0\12\bd\13\c3\cc4FC\f6?\00\00\00\00\00\80\ea\bc\fa\8e\bc\fe\b9R\f6?\00\00\00\00\00`(\bd\973U\828b\f6?\00\00\00\00\00\feq=\8e2\08\c7\c1q\f6?\00\00\00\00\00 7\bd~\a9L\d4U\81\f6?\00\00\00\00\00\80\e6<q\94\9e\b1\f4\90\f6?\00\00\00\00\00x)\bd\00\00\00?\00\00\00\bf\00\00\80?\00\00\c0?\00\00\00\00\dc\cf\d15\00\00\00\00\00\c0\15?8c\ed>\da\0fI?^\98{?\da\0f\c9?i7\ac1h!\223\b4\0f\143h!\a23\18-DT\fb!\e9?\18-DT\fb!\e9\bf\d2!3\7f|\d9\02@\d2!3\7f|\d9\02\c0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\80\18-DT\fb!\09@\18-DT\fb!\09\c0\db\0fI?\db\0fI\bf\e4\cb\16@\e4\cb\16\c0\00\00\00\00\00\00\00\80\db\0fI@\db\0fI\c0")
+  (data $.rodata (;0;) (i32.const 1048576) "\00\00\80?\00\00\c0?\00\00\00\00\dc\cf\d15\00\00\00\00\00\c0\15?8c\ed>\da\0fI?^\98{?\da\0f\c9?i7\ac1h!\223\b4\0f\143h!\a23]=\7ff\9e\a0\e6?\00\00\00\00\00\889=D\17u\faR\b0\e6?\00\00\00\00\00\00\d8<\fe\d9\0bu\12\c0\e6?\00\00\00\00\00x(\bd\bfv\d4\dd\dc\cf\e6?\00\00\00\00\00\c0\1e=)\1ae<\b2\df\e6?\00\00\00\00\00\00\d8\bc\e3:Y\98\92\ef\e6?\00\00\00\00\00\00\bc\bc\86\93Q\f9}\ff\e6?\00\00\00\00\00\d8/\bd\a3-\f4ft\0f\e7?\00\00\00\00\00\88,\bd\c3_\ec\e8u\1f\e7?\00\00\00\00\00\c0\13=\05\cf\ea\86\82/\e7?\00\00\00\00\0008\bdR\81\a5H\9a?\e7?\00\00\00\00\00\c0\00\bd\fc\cc\d75\bdO\e7?\00\00\00\00\00\88/=\f1gBV\eb_\e7?\00\00\00\00\00\e0\03=Hm\ab\b1$p\e7?\00\00\00\00\00\d0'\bd8]\deOi\80\e7?\00\00\00\00\00\00\dd\bc\00\1d\ac8\b9\90\e7?\00\00\00\00\00\00\e3<x\01\ebs\14\a1\e7?\00\00\00\00\00\00\ed\bc`\d0v\09{\b1\e7?\00\00\00\00\00@ =3\c10\01\ed\c1\e7?\00\00\00\00\00\00\a0<6\86\ffbj\d2\e7?\00\00\00\00\00\90&\bd;N\cf6\f3\e2\e7?\00\00\00\00\00\e0\02\bd\e8\c3\91\84\87\f3\e7?\00\00\00\00\00X$\bdN\1b>T'\04\e8?\00\00\00\00\00\003=\1a\07\d1\ad\d2\14\e8?\00\00\00\00\00\00\0f=~\cdL\99\89%\e8?\00\00\00\00\00\c0!\bd\d0B\b9\1eL6\e8?\00\00\00\00\00\d0)=\b5\ca#F\1aG\e8?\00\00\00\00\00\10G=\bc[\9f\17\f4W\e8?\00\00\00\00\00`\22=\af\91D\9b\d9h\e8?\00\00\00\00\00\c42\bd\95\a31\d9\cay\e8?\00\00\00\00\00\00#\bd\b8e\8a\d9\c7\8a\e8?\00\00\00\00\00\80*\bd\00Xx\a4\d0\9b\e8?\00\00\00\00\00\00\ed\bc#\a2*B\e5\ac\e8?\00\00\00\00\00(3=\fa\19\d6\ba\05\be\e8?\00\00\00\00\00\b4B=\83C\b5\162\cf\e8?\00\00\00\00\00\d0.\bdLf\08^j\e0\e8?\00\00\00\00\00P \bd\07x\15\99\ae\f1\e8?\00\00\00\00\00((=\0e,(\d0\fe\02\e9?\00\00\00\00\00\b0\1c\bd\96\ff\91\0b[\14\e9?\00\00\00\00\00\e0\05\bd\f9/\aaS\c3%\e9?\00\00\00\00\00@\f5<J\c6\cd\b077\e9?\00\00\00\00\00 \17=\ae\98_+\b8H\e9?\00\00\00\00\00\00\09\bd\cbR\c8\cbDZ\e9?\00\00\00\00\00h%=!ov\9a\ddk\e9?\00\00\00\00\00\d06\bd*N\de\9f\82}\e9?\00\00\00\00\00\00\01\bd\a3#z\e43\8f\e9?\00\00\00\00\00\00-=\04\06\cap\f1\a0\e9?\00\00\00\00\00\a48\bd\89\ffSM\bb\b2\e9?\00\00\00\00\00\5c5=[\f1\a3\82\91\c4\e9?\00\00\00\00\00\b8&=\c5\b8K\19t\d6\e9?\00\00\00\00\00\00\ec\bc\8e#\e3\19c\e8\e9?\00\00\00\00\00\d0\17=\02\f3\07\8d^\fa\e9?\00\00\00\00\00@\16=M\e5]{f\0c\ea?\00\00\00\00\00\00\f5\bc\f6\b8\8e\edz\1e\ea?\00\00\00\00\00\e0\09='.J\ec\9b0\ea?\00\00\00\00\00\d8*=]\0aF\80\c9B\ea?\00\00\00\00\00\f0\1a\bd\9b%>\b2\03U\ea?\00\00\00\00\00`\0b=\13b\f4\8aJg\ea?\00\00\00\00\00\888=\a7\b30\13\9ey\ea?\00\00\00\00\00 \11=\8d.\c1S\fe\8b\ea?\00\00\00\00\00\c0\06=\d2\fcyUk\9e\ea?\00\00\00\00\00\b8)\bd\b8o5!\e5\b0\ea?\00\00\00\00\00p+=\81\f3\d3\bfk\c3\ea?\00\00\00\00\00\00\d9<\80'<:\ff\d5\ea?\00\00\00\00\00\00\e4<\a3\d2Z\99\9f\e8\ea?\00\00\00\00\00\90,\bdg\f3\22\e6L\fb\ea?\00\00\00\00\00P\16=\90\b7\8d)\07\0e\eb?\00\00\00\00\00\d4/=\a9\89\9al\ce \eb?\00\00\00\00\00p\12=K\1aO\b8\a23\eb?\00\00\00\00\00GM=\e7G\b7\15\84F\eb?\00\00\00\00\0088\bd:Y\e5\8drY\eb?\00\00\00\00\00\00\98<j\c5\f1)nl\eb?\00\00\00\00\00\d0\0a=P^\fb\f2v\7f\eb?\00\00\00\00\00\80\de<\b2I'\f2\8c\92\eb?\00\00\00\00\00\c0\04\bd\03\06\a10\b0\a5\eb?\00\00\00\00\00p\0d\bdfo\9a\b7\e0\b8\eb?\00\00\00\00\00\90\0d=\ff\c1K\90\1e\cc\eb?\00\00\00\00\00\a0\02=o\a1\f3\c3i\df\eb?\00\00\00\00\00x\1f\bd\b8\1d\d7[\c2\f2\eb?\00\00\00\00\00\a0\10\bd\e9\b2Aa(\06\ec?\00\00\00\00\00@\11\bd\e0R\85\dd\9b\19\ec?\00\00\00\00\00\e0\0b=\eed\fa\d9\1c-\ec?\00\00\00\00\00@\09\bd/\d0\ff_\ab@\ec?\00\00\00\00\00\d0\0e\bd\15\fd\faxGT\ec?\00\00\00\00\00f9=\cb\d0W.\f1g\ec?\00\00\00\00\00\10\1a\bd\b6\c1\88\89\a8{\ec?\00\00\00\00\80EX\bd3\e7\06\94m\8f\ec?\00\00\00\00\00H\1a\bd\df\c4QW@\a3\ec?\00\00\00\00\00\00\cb<\94\90\ef\dc \b7\ec?\00\00\00\00\00@\01=\89\16m.\0f\cb\ec?\00\00\00\00\00 \f0<\12\c4]U\0b\df\ec?\00\00\00\00\00`\f3<;\ab[[\15\f3\ec?\00\00\00\00\00\90\06\bd\bc\89\07J-\07\ed?\00\00\00\00\00\a0\09=\fa\c8\08+S\1b\ed?\00\00\00\00\00\e0\15\bd\85\8a\0d\08\87/\ed?\00\00\00\00\00(\1d=\03\a2\ca\ea\c8C\ed?\00\00\00\00\00\a0\01=\91\a4\fb\dc\18X\ed?\00\00\00\00\00\00\df<\a1\e6b\e8vl\ed?\00\00\00\00\00\a0\03\bdN\83\c9\16\e3\80\ed?\00\00\00\00\00\d8\0c\bd\90`\ffq]\95\ed?\00\00\00\00\00\c0\f4<\ae2\db\03\e6\a9\ed?\00\00\00\00\00\90\ff<%\83:\d6|\be\ed?\00\00\00\00\00\80\e9<E\b4\01\f3!\d3\ed?\00\00\00\00\00 \f5\bc\bf\05\1cd\d5\e7\ed?\00\00\00\00\00p\1d\bd\ec\9a{3\97\fc\ed?\00\00\00\00\00\14\16\bd^}\19kg\11\ee?\00\00\00\00\00H\0b=\e7\a3\f5\14F&\ee?\00\00\00\00\00\ce@=\5c\ee\16;3;\ee?\00\00\00\00\00h\0c=\b4?\8b\e7.P\ee?\00\00\00\00\000\09\bdhmg$9e\ee?\00\00\00\00\00\00\e5\bcDL\c7\fbQz\ee?\00\00\00\00\00\f8\07\bd&\b7\cdwy\8f\ee?\00\00\00\00\00p\f3\bc\e8\90\a4\a2\af\a4\ee?\00\00\00\00\00\d0\e5<\e4\ca|\86\f4\b9\ee?\00\00\00\00\00\1a\16=\0dh\8e-H\cf\ee?\00\00\00\00\00P\f5<\14\85\18\a2\aa\e4\ee?\00\00\00\00\00@\c6<\13Za\ee\1b\fa\ee?\00\00\00\00\00\80\ee\bc\06A\b6\1c\9c\0f\ef?\00\00\00\00\00\88\fa\bcc\b9k7+%\ef?\00\00\00\00\00\90,\bdur\ddH\c9:\ef?\00\00\00\00\00\00\aa<$En[vP\ef?\00\00\00\00\00\f0\f4\bc\fdD\88y2f\ef?\00\00\00\00\00\80\ca<8\be\9c\ad\fd{\ef?\00\00\00\00\00\bc\fa<\82<$\02\d8\91\ef?\00\00\00\00\00`\d4\bc\8e\90\9e\81\c1\a7\ef?\00\00\00\00\00\0c\0b\bd\11\d5\926\ba\bd\ef?\00\00\00\00\00\e0\c0\bc\94q\8f+\c2\d3\ef?\00\00\00\00\80\de\10\bd\ee#*k\d9\e9\ef?\00\00\00\00\00C\ee<\00\00\00\00\00\00\f0?\00\00\00\00\00\00\00\00\be\bcZ\fa\1a\0b\f0?\00\00\00\00\00@\b3\bc\033\fb\a9=\16\f0?\00\00\00\00\00\17\12\bd\82\02;\14h!\f0?\00\00\00\00\00@\ba<l\80w>\9a,\f0?\00\00\00\00\00\98\ef<\ca\bb\11.\d47\f0?\00\00\00\00\00@\c7\bc\89\7fn\e8\15C\f0?\00\00\00\00\000\d8<gT\f6r_N\f0?\00\00\00\00\00?\1a\bdZ\85\15\d3\b0Y\f0?\00\00\00\00\00\84\02\bd\95\1f<\0e\0ae\f0?\00\00\00\00\00`\f1<\1a\f7\dd)kp\f0?\00\00\00\00\00$\15=-\a8r+\d4{\f0?\00\00\00\00\00\a0\e9\bc\d0\9bu\18E\87\f0?\00\00\00\00\00@\e6<\c8\07f\f6\bd\92\f0?\00\00\00\00\00x\00\bd\83\f3\c6\ca>\9e\f0?\00\00\00\00\00\00\98\bc09\1f\9b\c7\a9\f0?\00\00\00\00\00\a0\ff<\fc\88\f9lX\b5\f0?\00\00\00\00\00\c8\fa\bc\8al\e4E\f1\c0\f0?\00\00\00\00\00\c0\d9<\16Hr+\92\cc\f0?\00\00\00\00\00 \05=\d8]9#;\d8\f0?\00\00\00\00\00\d0\fa\bc\f3\d1\d32\ec\e3\f0?\00\00\00\00\00\ac\1b=\a6\a9\df_\a5\ef\f0?\00\00\00\00\00\e8\04\bd\f0\d2\fe\aff\fb\f0?\00\00\00\00\000\0d\bdK#\d7(0\07\f1?\00\00\00\00\00P\f1<[[\12\d0\01\13\f1?\00\00\00\00\00\00\ec<\f9*^\ab\db\1e\f1?\00\00\00\00\00\bc\16=\d51l\c0\bd*\f1?\00\00\00\00\00@\e8<}\04\f2\14\a86\f1?\00\00\00\00\00\d0\0e\bd\e9-\a9\ae\9aB\f1?\00\00\00\00\00\e0\e8<81O\93\95N\f1?\00\00\00\00\00@\eb<q\8e\a5\c8\98Z\f1?\00\00\00\00\000\05=\df\c3qT\a4f\f1?\00\00\00\00\008\03=\11R}<\b8r\f1?\00\00\00\00\00\d4(=\9f\bb\95\86\d4~\f1?\00\00\00\00\00\d0\05\bd\93\8d\8c8\f9\8a\f1?\00\00\00\00\00\88\1c\bdf]7X&\97\f1?\00\00\00\00\00\f0\11=\a7\cbo\eb[\a3\f1?\00\00\00\00\00H\10=\e3\87\13\f8\99\af\f1?\00\00\00\00\009G\bdT]\04\84\e0\bb\f1?\00\00\00\00\00\e4$=C\1c(\95/\c8\f1?\00\00\00\00\00 \0a\bd\b2\b9h1\87\d4\f1?\00\00\00\00\00\80\e3<1@\b4^\e7\e0\f1?\00\00\00\00\00\c0\ea<8\d9\fc\22P\ed\f1?\00\00\00\00\00\90\01=\f7\cd8\84\c1\f9\f1?\00\00\00\00\00x\1b\bd\8f\8db\88;\06\f2?\00\00\00\00\00\94-=\1e\a8x5\be\12\f2?\00\00\00\00\00\00\d8<A\dd}\91I\1f\f2?\00\00\00\00\004+=#\13y\a2\dd+\f2?\00\00\00\00\00\f8\19=\e7aunz8\f2?\00\00\00\00\00\c8\19\bd'\14\82\fb\1fE\f2?\00\00\00\00\000\02=\02\a6\b2O\ceQ\f2?\00\00\00\00\00H\13\bd\b0\ce\1eq\85^\f2?\00\00\00\00\00p\12=\16}\e2eEk\f2?\00\00\00\00\00\d0\11=\0f\e0\1d4\0ex\f2?\00\00\00\00\00\ee1=>c\f5\e1\df\84\f2?\00\00\00\00\00\c0\14\bd0\bb\91u\ba\91\f2?\00\00\00\00\00\d8\13\bd\09\df\1f\f5\9d\9e\f2?\00\00\00\00\00\b0\08=\9b\0e\d1f\8a\ab\f2?\00\00\00\00\00|\22\bd:\da\da\d0\7f\b8\f2?\00\00\00\00\004*=\f9\1aw9~\c5\f2?\00\00\00\00\00\80\10\bd\d9\02\e4\a6\85\d2\f2?\00\00\00\00\00\d0\0e\bdy\15d\1f\96\df\f2?\00\00\00\00\00 \f4\bc\cf.>\a9\af\ec\f2?\00\00\00\00\00\98$\bd\22\88\bdJ\d2\f9\f2?\00\00\00\00\000\16\bd%\b61\0a\fe\06\f3?\00\00\00\00\0062\bd\0b\a5\ee\ed2\14\f3?\00\00\00\00\80\dfp\bd\b8\d7L\fcp!\f3?\00\00\00\00\00H\22\bd\a2\e9\a8;\b8.\f3?\00\00\00\00\00\98%\bdf\17d\b2\08<\f3?\00\00\00\00\00\d0\1e='\fa\e3fbI\f3?\00\00\00\00\00\00\dc\bc\0f\9f\92_\c5V\f3?\00\00\00\00\00\d80\bd\b9\88\de\a21d\f3?\00\00\00\00\00\c8\22=9\aa:7\a7q\f3?\00\00\00\00\00` =\fet\1e#&\7f\f3?\00\00\00\00\00`\16\bd8\d8\05m\ae\8c\f3?\00\00\00\00\00\e0\0a\bd\c3>q\1b@\9a\f3?\00\00\00\00\00rD\bd \a0\e54\db\a7\f3?\00\00\00\00\00 \08=\95n\ec\bf\7f\b5\f3?\00\00\00\00\00\80>=\f2\a8\13\c3-\c3\f3?\00\00\00\00\00\80\ef<\22\e1\edD\e5\d0\f3?\00\00\00\00\00\a0\17\bd\bb4\12L\a6\de\f3?\00\00\00\00\000&=\ccN\1c\dfp\ec\f3?\00\00\00\00\00\a6H\bd\8c~\ac\04E\fa\f3?\00\00\00\00\00\dc<\bd\bb\a0g\c3\22\08\f4?\00\00\00\00\00\b8%=\95.\f7!\0a\16\f4?\00\00\00\00\00\c0\1e=FF\09'\fb#\f4?\00\00\00\00\00`\13\bd \a9P\d9\f51\f4?\00\00\00\00\00\98#=\eb\b9\84?\fa?\f4?\00\00\00\00\00\00\fa<\19\89a`\08N\f4?\00\00\00\00\00\c0\f6\bc\01\d2\a7B \5c\f4?\00\00\00\00\00\c0\0b\bd\16\00\1d\edAj\f4?\00\00\00\00\00\80\12\bd&3\8bfmx\f4?\00\00\00\00\00\e00=\00<\c1\b5\a2\86\f4?\00\00\00\00\00@-\bd\04\af\92\e1\e1\94\f4?\00\00\00\00\00 \0c=r\d3\d7\f0*\a3\f4?\00\00\00\00\00P\1e\bd\01\b8m\ea}\b1\f4?\00\00\00\00\00\80\07=\e1)6\d5\da\bf\f4?\00\00\00\00\00\80\13\bd2\c1\17\b8A\ce\f4?\00\00\00\00\00\80\00=\db\dd\fd\99\b2\dc\f4?\00\00\00\00\00p,=\96\ab\d8\81-\eb\f4?\00\00\00\00\00\e0\1c\bd\02-\9dv\b2\f9\f4?\00\00\00\00\00 \19=\c11E\7fA\08\f5?\00\00\00\00\00\c0\08\bd*f\cf\a2\da\16\f5?\00\00\00\00\00\00\fa\bc\eaQ?\e8}%\f5?\00\00\00\00\00\08J=\daN\9dV+4\f5?\00\00\00\00\00\d8&\bd\1a\ac\f6\f4\e2B\f5?\00\00\00\00\00D2\bd\db\94]\ca\a4Q\f5?\00\00\00\00\00<H=k\11\e9\ddp`\f5?\00\00\00\00\00\b0$=\de)\b56Go\f5?\00\00\00\00\00ZA=\0e\c4\e2\db'~\f5?\00\00\00\00\00\e0)\bdo\c7\97\d4\12\8d\f5?\00\00\00\00\00\08#\bdL\0b\ff'\08\9c\f5?\00\00\00\00\00\ecM='TH\dd\07\ab\f5?\00\00\00\00\00\00\c4\bc\f4z\a8\fb\11\ba\f5?\00\00\00\00\00\080=\0bFY\8a&\c9\f5?\00\00\00\00\00\c8&\bd?\8e\99\90E\d8\f5?\00\00\00\00\00\9aF=\e1 \ad\15o\e7\f5?\00\00\00\00\00@\1b\bd\ca\eb\dc \a3\f6\f5?\00\00\00\00\00p\17=\b8\dcv\b9\e1\05\f6?\00\00\00\00\00\f8&=\15\f7\cd\e6*\15\f6?\00\00\00\00\00\00\01=1U:\b0~$\f6?\00\00\00\00\00\d0\15\bd\b5)\19\1d\dd3\f6?\00\00\00\00\00\d0\12\bd\13\c3\cc4FC\f6?\00\00\00\00\00\80\ea\bc\fa\8e\bc\fe\b9R\f6?\00\00\00\00\00`(\bd\973U\828b\f6?\00\00\00\00\00\feq=\8e2\08\c7\c1q\f6?\00\00\00\00\00 7\bd~\a9L\d4U\81\f6?\00\00\00\00\00\80\e6<q\94\9e\b1\f4\90\f6?\00\00\00\00\00x)\bd\00\00\00?\00\00\00\bf\cd;\7ff\9e\a0\e6?\87\01\ebs\14\a1\e7?\db\a0*B\e5\ac\e8?\90\f0\a3\82\91\c4\e9?\ad\d3Z\99\9f\e8\ea?\9cR\85\dd\9b\19\ec?\87\a4\fb\dc\18X\ed?\da\90\a4\a2\af\a4\ee?\00\00\00\00\00\00\f0?\0f\89\f9lX\b5\f0?{Q}<\b8r\f1?8bunz8\f2?\15\b71\0a\fe\06\f3?\224\12L\a6\de\f3?'*6\d5\da\bf\f4?)TH\dd\07\ab\f5?\00\00\00\00\00\00\f0?\8br\8d\f9\a2(\f4?=n=\a5\fee\f9?\03\00\00\00\04\00\00\00\04\00\00\00\06\00\00\00\83\f9\a2\00DNn\00\fc)\15\00\d1W'\00\dd4\f5\00b\db\c0\00<\99\95\00A\90C\00cQ\fe\00\bb\de\ab\00\b7a\c5\00:n$\00\d2MB\00I\06\e0\00\09\ea.\00\1c\92\d1\00\eb\1d\fe\00)\b1\1c\00\e8>\a7\00\f55\82\00D\bb.\00\9c\e9\84\00\b4&p\00A~_\00\d6\919\00S\839\00\9c\f49\00\8b_\84\00(\f9\bd\00\f8\1f;\00\de\ff\97\00\0f\98\05\00\11/\ef\00\0aZ\8b\00m\1fm\00\cf~6\00\09\cb'\00FO\b7\00\9ef?\00-\ea_\00\ba'u\00\e5\eb\c7\00={\f1\00\f79\07\00\92R\8a\00\fbk\ea\00\1f\b1_\00\08]\8d\000\03V\00{\fcF\00\f0\abk\00 \bc\cf\006\f4\9a\00\e3\a9\1d\00^a\91\00\08\1b\e6\00\85\99e\00\a0\14_\00\8d@h\00\80\d8\ff\00'sM\00\06\061\00\caV\15\00\c9\a8s\00{\e2`\00k\8c\c0\00\00\00\00@\fb!\f9?\00\00\00\00-Dt>\00\00\00\80\98F\f8<\00\00\00`Q\ccx;\00\00\00\80\83\1b\f09\00\00\00@ %z8\00\00\00\80\22\82\e36\00\00\00\00\1d\f3i5Q\b4\f0\b2\96\b1D\b0\f9\ae\b6\ady\acC\ab\14\aa\eb\a8\c8\a7\aa\a6\92\a5\80\a4s\a3k\a2h\a1j\a0p\9f{\9e\8a\9d\9d\9c\b5\9b\d1\9a\f0\99\13\99:\98e\97\93\96\c4\95\f8\940\94k\93\a9\92\ea\91.\91u\90\be\8f\0a\8fY\8e\aa\8d\fe\8cT\8c\ac\8b\07\8bd\8a\c4\89%\89\89\88\ee\87V\87\c0\86+\86\99\85\08\85y\84\ec\83a\83\d8\82P\82\c9\81E\81\c2\80@\80\02\ff\0e\fd%\fbG\f9s\f7\aa\f5\ea\f34\f2\87\f0\e3\eeG\ed\b3\eb'\ea\a3\e8'\e7\b2\e5C\e4\dc\e2z\e1 \e0\cb\de}\dd4\dc\f1\da\b3\d9{\d8H\d7\1a\d6\f1\d4\cd\d3\ad\d2\92\d1{\d0i\cf[\ceQ\cdJ\ccH\cbJ\caO\c9X\c8d\c7t\c6\87\c5\9d\c4\b7\c3\d4\c2\f4\c1\16\c1<\c0e\bf\90\be\be\bd\ef\bc#\bcY\bb\91\ba\cc\b9\0a\b9J\b8\8c\b7\d0\b6\17\b6`\b5\00\00\00\00\00\00\f0?\00\00\00\00\00\00\f8?\00\00\00\00\00\00\00\00\06\d0\cfC\eb\fdL>\00\00\00\00\00\00\00\00\00\00\00@\03\b8\e2?O\bba\05g\ac\dd?\18-DT\fb!\e9?\9b\f6\81\d2\0bs\ef?\18-DT\fb!\f9?\e2e/\22\7f+z<\07\5c\143&\a6\81<\bd\cb\f0z\88\07p<\07\5c\143&\a6\91<\00\00\00\00\00\00\e0?\00\00\00\00\00\00\e0\bf\18-DT\fb!\e9?\18-DT\fb!\e9\bf\d2!3\7f|\d9\02@\d2!3\7f|\d9\02\c0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\80\18-DT\fb!\09@\18-DT\fb!\09\c0\db\0fI?\db\0fI\bf\e4\cb\16@\e4\cb\16\c0\00\00\00\00\00\00\00\80\db\0fI@\db\0fI\c0")
   (@producers
     (language "Rust" "")
-    (processed-by "rustc" "1.94.0 (4a4ef493e 2026-03-02)")
+    (processed-by "rustc" "1.94.1 (e408947bf 2026-03-25)")
   )
   (@custom "target_features" (after data) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
 )


### PR DESCRIPTION
## Summary

Add a comprehensive collection of real-world ANTLR4 grammar files (`.g4`) to support end-to-end testing of Gale's grammar parser. These grammars cover multiple programming languages and serve as test fixtures for verifying that the g4 parser can correctly parse complex, production-grade grammar definitions.

## Key Changes

- **Added 10 grammar files** from the official ANTLR4 grammars-v4 repository:
  - Rust: `RustLexer.g4`, `RustParser.g4` (1201 lines)
  - TypeScript: `TypeScriptLexer.g4`, `TypeScriptParser.g4` (987 lines)
  - CSS3: `css3Lexer.g4`, `css3Parser.g4` (452 lines)
  - HTML: `HTMLLexer.g4`, `HTMLParser.g4` (93 lines)
  - ANTLR4 itself: `ANTLRv4Lexer.g4`, `ANTLRv4Parser.g4` (419 lines)

- **Added documentation** (`docs/antlr4-grammars.md`) explaining ANTLR4 grammar structure, rules, and conventions

- **Updated test architecture documentation** in `AGENTS.md` to clarify the two-layer e2e testing approach:
  - Layer 1: G4 parse tests verifying grammar parsing into IR
  - Layer 2: Golden fixture tests for code generation output

- **Updated README.md** with clearer explanation of Gale's approach to grammar-runtime coupling

## Implementation Details

All grammar files include:
- Original source attribution and license headers (MIT, BSD 3-Clause)
- ANTLR formatting directives for consistency
- Complete lexer and parser rule definitions from production grammars

These fixtures enable comprehensive testing of the g4 parser's ability to handle:
- Complex nested rules and alternatives
- Semantic predicates and actions
- Mode specifications (lexer-specific)
- Generic parameters and type annotations
- Real-world grammar complexity and edge cases

https://claude.ai/code/session_01DBmksjifiQjED7c6TwGB6t