### PR TITLE
Move ComponentPlan to wir_build module

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -86,7 +86,7 @@ Source (.wado) → Lexer → Parser → Bind → Load → Analyze → Resolve �
 | BlockFusion     | `optimize/labeled_block_fusion.rs`   | Labeled block fusion                                        |
 | StoreLoadFwd    | `optimize/store_load_forward.rs`     | Store-load forwarding for literal values                    |
 | TmplHoist       | `optimize/tmpl_hoist.rs`             | Template buffer hoisting out of loops                       |
-| WasmPlan        | `wasm_plan.rs`                       | `ComponentPlan` types and `build_component_plan`            |
+| ComponentPlan   | `wir_build/component_plan.rs`        | `ComponentPlan` types and `build_component_plan`            |
 | Stdlib          | `stdlib.rs`                          | Embedded core library sources                               |
 | CompilerHost    | `compiler_host.rs`                   | I/O abstraction for the compiler                            |
 | Logger          | `logger.rs`                          | Diagnostic logging with timestamps                          |

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -51,7 +51,7 @@ pub fn build_component(project: &Project, core_module: &[u8], wir_module: &WirMo
     let component_plan = project
         .component_plan
         .as_ref()
-        .expect("component_plan should be set by wasm_plan phase");
+        .expect("component_plan should be set by wir_build::plan_project");
     let bundled_functions = &component_plan.bundled_functions;
 
     // Core memory module
@@ -863,7 +863,7 @@ fn resolve_future_type(
 fn emit_world_exports(
     builder: &mut ComponentBuilder,
     ctx: &mut ComponentModelContext,
-    component_plan: &crate::wasm_plan::ComponentPlan,
+    component_plan: &crate::wir_build::component_plan::ComponentPlan,
     result_unit_type: u32,
 ) {
     for export in &component_plan.world_exports {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -30,7 +30,6 @@ pub mod tir;
 pub mod tir_visitor;
 pub mod token;
 pub mod unparse;
-pub mod wasm_plan;
 pub mod wir;
 pub mod wir_build;
 pub mod wir_optimize;

--- a/wado-compiler/src/project.rs
+++ b/wado-compiler/src/project.rs
@@ -14,7 +14,7 @@ use crate::hashmap::{IndexMap, IndexSet};
 use crate::name::{FunctionId, ModuleSource};
 use crate::symbol::SymbolTable;
 use crate::tir::{TirModule, TypeId};
-use crate::wasm_plan::ComponentPlan;
+use crate::wir_build::component_plan::ComponentPlan;
 use crate::world_registry::{self, WorldRegistry};
 
 /// A Wado project ready for code generation.
@@ -67,7 +67,7 @@ pub struct Project {
     /// Used by `optimize_dce` to override the builtin registry's single-`i32` signature.
     pub task_return_flat_params: Option<Vec<TypeId>>,
 
-    /// Component Model structure plan. Populated by the `wasm_plan` phase.
+    /// Component Model structure plan. Populated by `wir_build::plan_project`.
     pub component_plan: Option<ComponentPlan>,
 }
 

--- a/wado-compiler/src/wir_build.rs
+++ b/wado-compiler/src/wir_build.rs
@@ -7,6 +7,7 @@
 use crate::project::Project;
 use crate::wir::WirModule;
 
+pub mod component_plan;
 mod context;
 mod functions;
 mod translate;
@@ -14,7 +15,7 @@ mod types;
 
 pub use context::DEFINED_FUNC_BASE;
 
-/// Run the planning phase — previously the standalone `wasm_plan` pipeline step.
+/// Run the planning phase.
 ///
 /// Sets `project.has_http_handler_export` from world analysis and
 /// populates `project.component_plan` for use by `build_wir_module`.
@@ -23,7 +24,7 @@ pub fn plan_project(mut project: Project) -> Project {
     if let Some(world_info) = world_info {
         project.has_http_handler_export = world_info.has_http_handler_export();
     }
-    project.component_plan = Some(crate::wasm_plan::build_component_plan(&project));
+    project.component_plan = Some(component_plan::build_component_plan(&project));
     project
 }
 

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -1,10 +1,7 @@
-//! Wasm plan — Component Model planning types and builder.
+//! Component Model planning types and builder.
 //!
-//! Contains `ComponentPlan` and related structs used by `wir_build` and `codegen`.
-//! The planning logic (formerly the standalone `wasm_plan` pipeline phase) now runs
-//! inside `wir_build::plan_project`, called at the start of the WIR pipeline.
-//!
-//! Type-ordering utilities (topological sort) have moved to `wir_build::types`.
+//! Contains `ComponentPlan` and related structs that describe the Component Model
+//! structure. Built by `wir_build::plan_project`, consumed by `codegen`.
 
 use crate::ast::Type;
 use crate::project::Project;
@@ -12,7 +9,7 @@ use crate::world_registry::WorldExportInfo;
 
 /// Plan for the Component Model structure.
 ///
-/// Computed by `wasm_plan`, consumed by codegen. Contains all the structural
+/// Computed by `wir_build::component_plan`, consumed by codegen. Contains all the structural
 /// decisions about what the component needs, so codegen can focus on encoding.
 ///
 /// Canonical intrinsics (e.g., "stream-read", "task-return") are NOT stored here.


### PR DESCRIPTION
## Summary
Reorganize the codebase by moving the `ComponentPlan` type and `build_component_plan` function from the standalone `wasm_plan` module into `wir_build::component_plan`. This reflects the architectural reality that planning now runs as part of the WIR pipeline rather than as a separate phase.

## Key Changes
- **Moved** `wasm_plan.rs` → `wir_build/component_plan.rs`
  - Renamed module from `wasm_plan` to `component_plan` to better reflect its purpose
  - Updated module documentation to remove references to the standalone pipeline phase
  
- **Updated imports and references** across the codebase:
  - `wir_build.rs`: Added `pub mod component_plan` and updated `plan_project` to call `component_plan::build_component_plan`
  - `codegen/component.rs`: Updated type reference from `crate::wasm_plan::ComponentPlan` to `crate::wir_build::component_plan::ComponentPlan`
  - `project.rs`: Updated import and documentation to reference the new module location
  
- **Updated documentation**:
  - `docs/compiler.md`: Changed pipeline phase name from "WasmPlan" to "ComponentPlan" and updated file path
  - Removed `pub mod wasm_plan` from `lib.rs`

## Implementation Details
The planning logic that was previously a standalone pipeline phase (`wasm_plan`) is now properly integrated into the `wir_build` module where it's actually invoked. This change improves code organization by co-locating the planning logic with the WIR building pipeline that depends on it.

https://claude.ai/code/session_0119R9PRTKG7Dg6SrpVhefPc