### PR TITLE
Fix formatter kv-pair formatting and improve array literal rules

### DIFF
--- a/benchmark/sqlite_parse/sqlite_parse.wado
+++ b/benchmark/sqlite_parse/sqlite_parse.wado
@@ -51,8 +51,8 @@ export fn run() with Stdout, MonotonicClock, Preopens {
     let end = MonotonicClock::now();
     let elapsed_ns = (end - start) as u64;
     let elapsed_us = elapsed_ns / 1000;
-    let per_iter_us = elapsed_us / (iterations as u64);
+    let per_iter_us = elapsed_us / iterations as u64;
 
     println(`Elapsed: {elapsed_us / 1000}.{elapsed_us % 1000} ms ({iterations} iterations)`);
-    println(`Per iteration: {per_iter_us}.{(elapsed_us * 1000 / (iterations as u64)) % 1000} us`);
+    println(`Per iteration: {per_iter_us}.{elapsed_us * 1000 / iterations as u64 % 1000} us`);
 }

--- a/mise.toml
+++ b/mise.toml
@@ -117,7 +117,7 @@ run = """
 set -xe -o pipefail
 cargo run --bin wado -- format -w \
     $(grep -L '"compile_error"' wado-compiler/tests/fixtures/**/*.wado) \
-    $(find wado-compiler/lib example benchmark wasm-size -name '*.wado')
+    $(find wado-compiler/lib example benchmark wasm-size package-gale/src -name '*.wado')
 """
 
 [tasks.clippy]

--- a/package-gale/src/g4/integration_test.wado
+++ b/package-gale/src/g4/integration_test.wado
@@ -1,6 +1,15 @@
 use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement,
-    RepeatKind, LexerRule, LexerAlt, LexerElement, CharClass, CharRange,
+    Grammar,
+    ParserRule,
+    Alternative,
+    Element,
+    RepeatElement,
+    RepeatKind,
+    LexerRule,
+    LexerAlt,
+    LexerElement,
+    CharClass,
+    CharRange,
 } from "../ir.wado";
 use { parse } from "./parser.wado";
 

--- a/package-gale/src/g4/lexer.wado
+++ b/package-gale/src/g4/lexer.wado
@@ -101,7 +101,7 @@ impl G4Lexer {
                     }
                 },
                 _ => text.append_char(c),
-            };
+            }
         }
     }
 
@@ -127,7 +127,7 @@ impl G4Lexer {
                     }
                 },
                 _ => text.append_char(c),
-            };
+            }
         }
     }
 
@@ -211,9 +211,9 @@ pub fn tokenize(input: String) -> Array<Token> {
 }
 
 fn is_ident_start(c: char) -> bool {
-    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+    return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_';
 }
 
 fn is_ident_char(c: char) -> bool {
-    return is_ident_start(c) || (c >= '0' && c <= '9');
+    return is_ident_start(c) || c >= '0' && c <= '9';
 }

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -1,8 +1,19 @@
 use { Span, Token, ParseError } from "../runtime.wado";
 use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement,
-    RepeatKind, LexerRule, LexerAlt, LexerElement, LexerRepeatElement, LexerNotElement,
-    CharClass, CharRange,
+    Grammar,
+    ParserRule,
+    Alternative,
+    Element,
+    RepeatElement,
+    LabelElement,
+    RepeatKind,
+    LexerRule,
+    LexerAlt,
+    LexerElement,
+    LexerRepeatElement,
+    LexerNotElement,
+    CharClass,
+    CharRange,
 } from "../ir.wado";
 use { G4Token, make_token } from "./token.wado";
 use { tokenize } from "./lexer.wado";
@@ -182,9 +193,9 @@ impl G4Parser {
             self.advance();
             let ng = if self.is_kind(G4Token::Question) {
                 self.advance();
-                true
+                true;
             } else {
-                false
+                false;
             };
             return Result::<Element, ParseError>::Ok(
                 Element::Repeat(RepeatElement { kind: RepeatKind::Star, element: elem, non_greedy: ng }),
@@ -194,9 +205,9 @@ impl G4Parser {
             self.advance();
             let ng = if self.is_kind(G4Token::Question) {
                 self.advance();
-                true
+                true;
             } else {
-                false
+                false;
             };
             return Result::<Element, ParseError>::Ok(
                 Element::Repeat(RepeatElement { kind: RepeatKind::Plus, element: elem, non_greedy: ng }),
@@ -284,8 +295,7 @@ impl G4Parser {
         if self.is_kind(G4Token::StringLit) {
             let tok = self.advance();
             let text = tok.text;
-            let is_dot_dot = self.is_kind(G4Token::Dot)
-                && self.peek_kind_at(1) == G4Token::Dot as i32;
+            let is_dot_dot = self.is_kind(G4Token::Dot) && self.peek_kind_at(1) == G4Token::Dot as i32;
             if is_dot_dot && text.len() == 1 {
                 self.advance();
                 self.advance();
@@ -391,7 +401,7 @@ fn resolve_char(chars: &Array<char>, pos: &mut i32) -> char {
             for let mut i = 0; i < 4; i += 1 {
                 val = val * 16 + advance_char(chars, pos).hex_digit_value();
             }
-            char::from_i32(val).unwrap()
+            char::from_i32(val).unwrap();
         },
         _ => ec,
     };

--- a/package-gale/src/g4/parser_test.wado
+++ b/package-gale/src/g4/parser_test.wado
@@ -1,6 +1,16 @@
 use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement,
-    RepeatKind, LexerRule, LexerAlt, LexerElement, CharClass, CharRange,
+    Grammar,
+    ParserRule,
+    Alternative,
+    Element,
+    RepeatElement,
+    LabelElement,
+    RepeatKind,
+    LexerRule,
+    LexerAlt,
+    LexerElement,
+    CharClass,
+    CharRange,
 } from "../ir.wado";
 use { parse } from "./parser.wado";
 

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -37,11 +37,21 @@ pub fn to_lower(name: &String) -> String {
 }
 
 pub fn escape_char(c: char) -> String {
-    if c == '\'' { return "'\\''"; }
-    if c == '\\' { return "'\\\\'"; }
-    if c == '\n' { return "'\\n'"; }
-    if c == '\r' { return "'\\r'"; }
-    if c == '\t' { return "'\\t'"; }
+    if c == '\'' {
+        return "'\\''";
+    }
+    if c == '\\' {
+        return "'\\\\'";
+    }
+    if c == '\n' {
+        return "'\\n'";
+    }
+    if c == '\r' {
+        return "'\\r'";
+    }
+    if c == '\t' {
+        return "'\\t'";
+    }
     let code = c as i32;
     if code >= 32 && code < 127 {
         let mut s = String::with_capacity(3);
@@ -71,7 +81,7 @@ pub fn escape_string(s: &String) -> String {
                     result.append(`\\u\{{code:x}\}`);
                 }
             },
-        };
+        }
     }
     result.append_char('"');
     return result;
@@ -84,29 +94,75 @@ pub fn rule_type_name(name: &String) -> String {
 }
 
 pub fn literal_field_name(text: &String) -> String {
-    if *text == "+" { return "plus"; }
-    if *text == "-" { return "minus"; }
-    if *text == "*" { return "star"; }
-    if *text == "/" { return "slash"; }
-    if *text == "%" { return "percent"; }
-    if *text == "=" { return "eq"; }
-    if *text == "!" { return "bang"; }
-    if *text == "<" { return "lt"; }
-    if *text == ">" { return "gt"; }
-    if *text == "&" { return "amp"; }
-    if *text == "|" { return "pipe"; }
-    if *text == "^" { return "caret"; }
-    if *text == "~" { return "tilde"; }
-    if *text == "." { return "dot"; }
-    if *text == "," { return "comma"; }
-    if *text == ":" { return "colon"; }
-    if *text == ";" { return "semicolon"; }
-    if *text == "(" { return "lparen"; }
-    if *text == ")" { return "rparen"; }
-    if *text == "{" { return "lbrace"; }
-    if *text == "}" { return "rbrace"; }
-    if *text == "[" { return "lbracket"; }
-    if *text == "]" { return "rbracket"; }
+    if *text == "+" {
+        return "plus";
+    }
+    if *text == "-" {
+        return "minus";
+    }
+    if *text == "*" {
+        return "star";
+    }
+    if *text == "/" {
+        return "slash";
+    }
+    if *text == "%" {
+        return "percent";
+    }
+    if *text == "=" {
+        return "eq";
+    }
+    if *text == "!" {
+        return "bang";
+    }
+    if *text == "<" {
+        return "lt";
+    }
+    if *text == ">" {
+        return "gt";
+    }
+    if *text == "&" {
+        return "amp";
+    }
+    if *text == "|" {
+        return "pipe";
+    }
+    if *text == "^" {
+        return "caret";
+    }
+    if *text == "~" {
+        return "tilde";
+    }
+    if *text == "." {
+        return "dot";
+    }
+    if *text == "," {
+        return "comma";
+    }
+    if *text == ":" {
+        return "colon";
+    }
+    if *text == ";" {
+        return "semicolon";
+    }
+    if *text == "(" {
+        return "lparen";
+    }
+    if *text == ")" {
+        return "rparen";
+    }
+    if *text == "{" {
+        return "lbrace";
+    }
+    if *text == "}" {
+        return "rbrace";
+    }
+    if *text == "[" {
+        return "lbracket";
+    }
+    if *text == "]" {
+        return "rbracket";
+    }
     let mut result = String::with_capacity(text.len() + 4);
     result.append("lit_");
     for let c of text.chars() {
@@ -181,7 +237,7 @@ pub fn literal_const_name(text: &String) -> String {
                 '^' => result.append("CARET"),
                 '~' => result.append("TILDE"),
                 _ => result.append_char('_'),
-            };
+            }
         }
     }
     return result;

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -1,11 +1,5 @@
-use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement,
-    RepeatKind, LexerRule,
-} from "./ir.wado";
-use {
-    to_pascal_case, to_snake_case, to_lower,
-    rule_type_name, literal_field_name, strip_suffix,
-} from "./gen_util.wado";
+use { Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement, RepeatKind, LexerRule } from "./ir.wado";
+use { to_pascal_case, to_snake_case, to_lower, rule_type_name, literal_field_name, strip_suffix } from "./gen_util.wado";
 use { collect_literal_tokens, gen_token_constants, gen_lexer } from "./lexer_gen.wado";
 use { gen_parser } from "./parser_gen.wado";
 use { CodeWriter, StructSpec, VariantSpec, EnumSpec } from "./wadopoet.wado";
@@ -64,11 +58,7 @@ fn gen_parser_rule_type(w: &mut CodeWriter, rule: &ParserRule) {
         v.set_pub();
         for let mut i = 0; i < rule.alternatives.len(); i += 1 {
             let alt = &rule.alternatives[i];
-            let case_name = if all_labeled {
-                alt.label.unwrap()
-            } else {
-                `Alt{i}`
-            };
+            let case_name = if all_labeled { alt.label.unwrap() } else { `Alt{i}` };
             let struct_name = `{base}{case_name}`;
             v.add_case_with_payload(&case_name, &struct_name);
         }
@@ -77,11 +67,7 @@ fn gen_parser_rule_type(w: &mut CodeWriter, rule: &ParserRule) {
 
         for let mut i = 0; i < rule.alternatives.len(); i += 1 {
             let alt = &rule.alternatives[i];
-            let case_name = if all_labeled {
-                alt.label.unwrap()
-            } else {
-                `Alt{i}`
-            };
+            let case_name = if all_labeled { alt.label.unwrap() } else { `Alt{i}` };
             let struct_name = `{base}{case_name}`;
             gen_struct_for_alt(w, &struct_name, alt);
         }
@@ -112,11 +98,7 @@ fn collect_fields(elements: &Array<Element>) -> Array<Field> {
         if let Some(field) = element_to_field(&elements[i]) {
             let count = get_name_count(&name_counts, &field.name);
             increment_name_count(&mut name_counts, &field.name);
-            let final_name = if count > 0 {
-                `{field.name}_{count + 1}`
-            } else {
-                field.name
-            };
+            let final_name = if count > 0 { `{field.name}_{count + 1}` } else { field.name };
             fields.append(Field { name: final_name, type_str: field.type_str });
         }
     }

--- a/package-gale/src/generator_test.wado
+++ b/package-gale/src/generator_test.wado
@@ -1,6 +1,13 @@
 use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement,
-    RepeatKind, LexerRule, LexerAlt,
+    Grammar,
+    ParserRule,
+    Alternative,
+    Element,
+    RepeatElement,
+    LabelElement,
+    RepeatKind,
+    LexerRule,
+    LexerAlt,
 } from "./ir.wado";
 use { generate } from "./generator.wado";
 
@@ -22,11 +29,12 @@ test "generate token kind" {
     let grammar = Grammar {
         name: "Test",
         parser_rules: [],
-        lexer_rules: [
-            LexerRule { name: "NUMBER", is_fragment: false, skip: false, body: [] },
-            LexerRule { name: "DIGIT", is_fragment: true, skip: false, body: [] },
-            LexerRule { name: "WS", is_fragment: false, skip: true, body: [] },
-        ],
+        lexer_rules: [LexerRule { name: "NUMBER", is_fragment: false, skip: false, body: [] }, LexerRule {
+                name: "DIGIT",
+                is_fragment: true,
+                skip: false,
+                body: [],
+            }, LexerRule { name: "WS", is_fragment: false, skip: true, body: [] }],
     };
     let output = generate(&grammar);
     assert str_contains(&output, "pub enum TokenKind {");
@@ -46,10 +54,7 @@ test "generate single-alt struct" {
                 alternatives: [
                     Alternative {
                         label: null,
-                        elements: [
-                            Element::RuleRef("value"),
-                            Element::TokenRef("EOF"),
-                        ],
+                        elements: [Element::RuleRef("value"), Element::TokenRef("EOF")],
                     },
                 ],
             },
@@ -72,17 +77,11 @@ test "generate multi-alt variant with labels" {
                 alternatives: [
                     Alternative {
                         label: Option::<String>::Some("BinOp"),
-                        elements: [
-                            Element::RuleRef("expr"),
-                            Element::TokenRef("PLUS"),
-                            Element::RuleRef("term"),
-                        ],
+                        elements: [Element::RuleRef("expr"), Element::TokenRef("PLUS"), Element::RuleRef("term")],
                     },
                     Alternative {
                         label: Option::<String>::Some("Pass"),
-                        elements: [
-                            Element::RuleRef("term"),
-                        ],
+                        elements: [Element::RuleRef("term")],
                     },
                 ],
             },
@@ -169,11 +168,7 @@ test "generate duplicate field names" {
                 alternatives: [
                     Alternative {
                         label: null,
-                        elements: [
-                            Element::RuleRef("item"),
-                            Element::Literal(","),
-                            Element::RuleRef("item"),
-                        ],
+                        elements: [Element::RuleRef("item"), Element::Literal(","), Element::RuleRef("item")],
                     },
                 ],
             },

--- a/package-gale/src/ir_test.wado
+++ b/package-gale/src/ir_test.wado
@@ -1,6 +1,16 @@
 use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement,
-    RepeatKind, LexerRule, LexerAlt, LexerElement, CharClass, CharRange,
+    Grammar,
+    ParserRule,
+    Alternative,
+    Element,
+    RepeatElement,
+    LabelElement,
+    RepeatKind,
+    LexerRule,
+    LexerAlt,
+    LexerElement,
+    CharClass,
+    CharRange,
 } from "./ir.wado";
 
 test "Grammar construction" {

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -1,11 +1,20 @@
 use {
-    Grammar, LexerRule, LexerAlt, LexerElement, LexerRepeatElement,
-    LexerNotElement, CharClass, CharRange, RepeatKind,
-    ParserRule, Alternative, Element, RepeatElement, LabelElement,
+    Grammar,
+    LexerRule,
+    LexerAlt,
+    LexerElement,
+    LexerRepeatElement,
+    LexerNotElement,
+    CharClass,
+    CharRange,
+    RepeatKind,
+    ParserRule,
+    Alternative,
+    Element,
+    RepeatElement,
+    LabelElement,
 } from "./ir.wado";
-use {
-    to_lower, escape_char, array_contains_str, literal_const_name,
-} from "./gen_util.wado";
+use { to_lower, escape_char, array_contains_str, literal_const_name } from "./gen_util.wado";
 use { CodeWriter, StructSpec, ImplSpec, FnSpec, GlobalSpec } from "./wadopoet.wado";
 
 pub struct LitToken {
@@ -24,21 +33,13 @@ pub fn collect_literal_tokens(parser_rules: &Array<ParserRule>) -> Array<LitToke
     return result;
 }
 
-fn collect_lits_from_elements(
-    elements: &Array<Element>,
-    seen: &mut Array<String>,
-    result: &mut Array<LitToken>,
-) {
+fn collect_lits_from_elements(elements: &Array<Element>, seen: &mut Array<String>, result: &mut Array<LitToken>) {
     for let elem of elements {
         collect_lits_from_element(&elem, seen, result);
     }
 }
 
-fn collect_lits_from_element(
-    elem: &Element,
-    seen: &mut Array<String>,
-    result: &mut Array<LitToken>,
-) {
+fn collect_lits_from_element(elem: &Element, seen: &mut Array<String>, result: &mut Array<LitToken>) {
     if let Literal(text) = *elem {
         if !array_contains_str(seen, &text) {
             seen.append(text);
@@ -58,11 +59,7 @@ fn collect_lits_from_element(
     }
 }
 
-pub fn gen_token_constants(
-    w: &mut CodeWriter,
-    lexer_rules: &Array<LexerRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+pub fn gen_token_constants(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_tokens: &Array<LitToken>) {
     let mut idx = 0;
     for let rule of lexer_rules {
         if !rule.is_fragment {
@@ -131,7 +128,7 @@ fn gen_lexer_struct(w: &mut CodeWriter) {
     w.line("return s;");
     w.end();
 
-    w.end(); // impl
+    w.end();  // impl
     w.blank();
 }
 
@@ -143,11 +140,7 @@ fn gen_lexer_match_fns(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>) {
     }
 }
 
-fn gen_lexer_match_fn(
-    w: &mut CodeWriter,
-    rule: &LexerRule,
-    all_rules: &Array<LexerRule>,
-) {
+fn gen_lexer_match_fn(w: &mut CodeWriter, rule: &LexerRule, all_rules: &Array<LexerRule>) {
     let fn_name = `try_{to_lower(&rule.name)}`;
     let mut f = FnSpec::new(&fn_name);
     f.add_param("chars", "&Array<char>");
@@ -166,12 +159,7 @@ fn gen_lexer_match_fn(
     w.blank();
 }
 
-fn gen_lexer_alts(
-    w: &mut CodeWriter,
-    alts: &Array<LexerAlt>,
-    all_rules: &Array<LexerRule>,
-    fail_action: &String,
-) {
+fn gen_lexer_alts(w: &mut CodeWriter, alts: &Array<LexerAlt>, all_rules: &Array<LexerRule>, fail_action: &String) {
     let id = w.next_id();
     w.line(`let alts_saved_{id} = pos;`);
     w.line(`let mut alts_ok_{id} = false;`);
@@ -192,23 +180,13 @@ fn gen_lexer_alts(
     w.line(`if !alts_ok_{id} \{ {fail_action}; \}`);
 }
 
-fn gen_lexer_alt_seq(
-    w: &mut CodeWriter,
-    alt: &LexerAlt,
-    all_rules: &Array<LexerRule>,
-    fail_action: &String,
-) {
+fn gen_lexer_alt_seq(w: &mut CodeWriter, alt: &LexerAlt, all_rules: &Array<LexerRule>, fail_action: &String) {
     for let elem of alt.elements {
         gen_lexer_elem(w, &elem, all_rules, fail_action);
     }
 }
 
-fn gen_lexer_elem(
-    w: &mut CodeWriter,
-    elem: &LexerElement,
-    all_rules: &Array<LexerRule>,
-    fail_action: &String,
-) {
+fn gen_lexer_elem(w: &mut CodeWriter, elem: &LexerElement, all_rules: &Array<LexerRule>, fail_action: &String) {
     if let Literal(text) = *elem {
         let chars: Array<char> = text.chars().collect();
         for let mut i = 0; i < chars.len(); i += 1 {
@@ -218,7 +196,9 @@ fn gen_lexer_elem(
         return;
     }
     if let CharRange(pair) = *elem {
-        w.line(`if pos >= chars.len() || chars[pos] < {escape_char(pair.0)} || chars[pos] > {escape_char(pair.1)} \{ {fail_action}; \}`);
+        w.line(
+            `if pos >= chars.len() || chars[pos] < {escape_char(pair.0)} || chars[pos] > {escape_char(pair.1)} \{ {fail_action}; \}`,
+        );
         w.line("pos += 1;");
         return;
     }
@@ -268,11 +248,7 @@ fn gen_lexer_elem(
     }
 }
 
-fn gen_char_class(
-    w: &mut CodeWriter,
-    cc: &CharClass,
-    fail_action: &String,
-) {
+fn gen_char_class(w: &mut CodeWriter, cc: &CharClass, fail_action: &String) {
     w.line(`if pos >= chars.len() \{ {fail_action}; \}`);
     if cc.negated {
         w.write("if false");
@@ -283,7 +259,8 @@ fn gen_char_class(
                 w.write(` || chars[pos] >= {escape_char(range.start)} && chars[pos] <= {escape_char(range.end)}`);
             }
         }
-        w.write(` \{ {*fail_action}; \}\n`);
+        w.write(` \{ {*fail_action}; \}
+`);
     } else {
         w.write("if !(false");
         for let range of cc.ranges {
@@ -293,17 +270,13 @@ fn gen_char_class(
                 w.write(` || chars[pos] >= {escape_char(range.start)} && chars[pos] <= {escape_char(range.end)}`);
             }
         }
-        w.write(`) \{ {*fail_action}; \}\n`);
+        w.write(`) \{ {*fail_action}; \}
+`);
     }
     w.line("pos += 1;");
 }
 
-fn gen_lexer_repeat(
-    w: &mut CodeWriter,
-    rep: &LexerRepeatElement,
-    all_rules: &Array<LexerRule>,
-    fail_action: &String,
-) {
+fn gen_lexer_repeat(w: &mut CodeWriter, rep: &LexerRepeatElement, all_rules: &Array<LexerRule>, fail_action: &String) {
     let id = w.next_id();
     let label = `rep_{id}`;
     if let Star = rep.kind {
@@ -340,12 +313,7 @@ fn gen_lexer_repeat(
     }
 }
 
-fn gen_lexer_not(
-    w: &mut CodeWriter,
-    not_elem: &LexerNotElement,
-    all_rules: &Array<LexerRule>,
-    fail_action: &String,
-) {
+fn gen_lexer_not(w: &mut CodeWriter, not_elem: &LexerNotElement, all_rules: &Array<LexerRule>, fail_action: &String) {
     if let CharClass(cc) = not_elem.element {
         let flipped = CharClass {
             ranges: cc.ranges,
@@ -368,10 +336,7 @@ fn gen_lexer_not(
     w.line("pos += 1;");
 }
 
-fn find_fragment(
-    all_rules: &Array<LexerRule>,
-    name: &String,
-) -> Option<&LexerRule> {
+fn find_fragment(all_rules: &Array<LexerRule>, name: &String) -> Option<&LexerRule> {
     for let rule of all_rules {
         if rule.name == *name && rule.is_fragment {
             return Option::<&LexerRule>::Some(rule);
@@ -410,11 +375,7 @@ fn lit_try_fn_name(const_name: &String) -> String {
     return result;
 }
 
-fn gen_tokenize_fn(
-    w: &mut CodeWriter,
-    lexer_rules: &Array<LexerRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_tokens: &Array<LitToken>) {
     let mut f = FnSpec::new("tokenize");
     f.set_pub();
     f.add_param("input", "&String");
@@ -459,10 +420,10 @@ fn gen_tokenize_fn(
     w.line("tokens.append(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));");
     w.end();
     w.line("lexer.pos = best_end;");
-    w.end(); // else
-    w.end(); // while
+    w.end();  // else
+    w.end();  // while
     w.line("tokens.append(Token::new(TK_EOF, \"\", Span::new(lexer.pos, lexer.pos)));");
     w.line("return tokens;");
-    w.end(); // fn
+    w.end();  // fn
     w.blank();
 }

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1,11 +1,15 @@
-use {
-    Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement,
-    RepeatKind, LexerRule,
-} from "./ir.wado";
+use { Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement, RepeatKind, LexerRule } from "./ir.wado";
 use { LitToken } from "./lexer_gen.wado";
 use {
-    to_lower, to_snake_case, to_pascal_case, rule_type_name, literal_field_name,
-    strip_suffix, escape_string, literal_const_name, array_contains_str,
+    to_lower,
+    to_snake_case,
+    to_pascal_case,
+    rule_type_name,
+    literal_field_name,
+    strip_suffix,
+    escape_string,
+    literal_const_name,
+    array_contains_str,
 } from "./gen_util.wado";
 use { CodeWriter, StructSpec, ImplSpec, FnSpec } from "./wadopoet.wado";
 use { log_stderr } from "core:cli";
@@ -28,21 +32,15 @@ struct PredictionBranch {
     child: PredictionNode,
 }
 
-fn build_prediction(
-    alt_indices: &Array<i32>,
-    first_sets: &Array<Array<String>>,
-    alt_elements: &Array<Array<Element>>,
-    depth: i32,
-    max_depth: i32,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> PredictionNode {
+fn build_prediction(alt_indices: &Array<i32>, first_sets: &Array<Array<String>>, alt_elements: &Array<Array<Element>>, depth: i32, max_depth: i32, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> PredictionNode {
     if alt_indices.len() == 1 {
         return PredictionNode::Leaf(alt_indices[0]);
     }
     if depth >= max_depth {
         let mut bt_copy: Array<i32> = [];
-        for let ai of alt_indices { bt_copy.append(*ai); }
+        for let ai of alt_indices {
+            bt_copy.append(*ai);
+        }
         return PredictionNode::Backtrack(bt_copy);
     }
 
@@ -60,12 +58,16 @@ fn build_prediction(
     if depth > 0 {
         let mut has_empty = false;
         for let mut i = 0; i < alt_indices.len(); i += 1 {
-            if depth_firsts[i].len() == 0 { has_empty = true; }
+            if depth_firsts[i].len() == 0 {
+                has_empty = true;
+            }
         }
         if has_empty {
             let mut bt_copy: Array<i32> = [];
-        for let ai of alt_indices { bt_copy.append(*ai); }
-        return PredictionNode::Backtrack(bt_copy);
+            for let ai of alt_indices {
+                bt_copy.append(*ai);
+            }
+            return PredictionNode::Backtrack(bt_copy);
         }
     }
 
@@ -111,8 +113,15 @@ fn build_prediction(
                 });
             }
         } else {
-            let child = build_prediction(&matching_indices, &matching_firsts, &matching_elements,
-                depth + 1, max_depth, all_rules, lit_tokens);
+            let child = build_prediction(
+                &matching_indices,
+                &matching_firsts,
+                &matching_elements,
+                depth + 1,
+                max_depth,
+                all_rules,
+                lit_tokens,
+            );
             let mut merged = false;
             for let mut b = 0; b < branches.len(); b += 1 {
                 if prediction_node_eq(&branches[b].child, &child) {
@@ -131,7 +140,9 @@ fn build_prediction(
 
     if branches.len() == 0 {
         let mut bt_copy: Array<i32> = [];
-        for let ai of alt_indices { bt_copy.append(*ai); }
+        for let ai of alt_indices {
+            bt_copy.append(*ai);
+        }
         return PredictionNode::Backtrack(bt_copy);
     }
     return PredictionNode::Dispatch(PredictionDispatch { depth, branches });
@@ -139,13 +150,19 @@ fn build_prediction(
 
 fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
     if let Leaf(ai) = *a {
-        if let Leaf(bi) = *b { return ai == bi; }
+        if let Leaf(bi) = *b {
+            return ai == bi;
+        }
     }
     if let Backtrack(aa) = *a {
         if let Backtrack(ba) = *b {
-            if aa.len() != ba.len() { return false; }
+            if aa.len() != ba.len() {
+                return false;
+            }
             for let mut i = 0; i < aa.len(); i += 1 {
-                if aa[i] != ba[i] { return false; }
+                if aa[i] != ba[i] {
+                    return false;
+                }
             }
             return true;
         }
@@ -153,33 +170,41 @@ fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
     return false;
 }
 
-fn compute_deeper_first(
-    elements: &Array<Element>,
-    depth: i32,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> Array<String> {
+fn compute_deeper_first(elements: &Array<Element>, depth: i32, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> Array<String> {
     let mut pos = 0;
     let mut remaining = depth;
     while pos < elements.len() && remaining > 0 {
         let elem = &elements[pos];
-        if let TokenRef(_) | Literal(_) = *elem { remaining -= 1; pos += 1; continue; }
-        if is_nullable(elem) { pos += 1; continue; }
+        if let TokenRef(_) | Literal(_) = *elem {
+            remaining -= 1;
+            pos += 1;
+            continue;
+        }
+        if is_nullable(elem) {
+            pos += 1;
+            continue;
+        }
         return [];
     }
-    if pos >= elements.len() { return []; }
+    if pos >= elements.len() {
+        return [];
+    }
     return first_of_elements_from(elements, pos, all_rules, lit_tokens);
 }
 
 fn array_contains_i32(arr: &Array<i32>, val: i32) -> bool {
     for let mut i = 0; i < arr.len(); i += 1 {
-        if arr[i] == val { return true; }
+        if arr[i] == val {
+            return true;
+        }
     }
     return false;
 }
 
 fn count_backtrack_nodes(node: &PredictionNode) -> i32 {
-    if let Backtrack(_) = *node { return 1; }
+    if let Backtrack(_) = *node {
+        return 1;
+    }
     if let Dispatch(d) = *node {
         let mut count = 0;
         for let mut i = 0; i < d.branches.len(); i += 1 {
@@ -191,7 +216,9 @@ fn count_backtrack_nodes(node: &PredictionNode) -> i32 {
 }
 
 fn count_leaf_nodes(node: &PredictionNode) -> i32 {
-    if let Leaf(_) = *node { return 1; }
+    if let Leaf(_) = *node {
+        return 1;
+    }
     if let Dispatch(d) = *node {
         let mut count = 0;
         for let mut i = 0; i < d.branches.len(); i += 1 {
@@ -292,16 +319,11 @@ fn gen_parser_struct(w: &mut CodeWriter) {
     w.line("));");
     w.end();
 
-    w.end(); // impl
+    w.end();  // impl
     w.blank();
 }
 
-fn gen_parse_fn(
-    w: &mut CodeWriter,
-    rule: &ParserRule,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) {
     let type_name = rule_type_name(&rule.name);
     let fn_name = `parse_{to_snake_case(&rule.name)}`;
 
@@ -371,7 +393,15 @@ fn gen_parse_fn(
                     f.set_return_type(`Result<{type_name}, ParseError>`);
                     f.emit_begin(w);
                     w.line("let start = p.peek().span.start;");
-                    gen_alt_body(w, &type_name, Option::<String>::Some(case_name), Option::<String>::Some(sname), alt, all_rules, lit_tokens);
+                    gen_alt_body(
+                        w,
+                        &type_name,
+                        Option::<String>::Some(case_name),
+                        Option::<String>::Some(sname),
+                        alt,
+                        all_rules,
+                        lit_tokens,
+                    );
                     w.end();
                     w.blank();
                 }
@@ -442,15 +472,7 @@ fn gen_parse_fn(
     }
 }
 
-fn gen_alt_body(
-    w: &mut CodeWriter,
-    type_name: &String,
-    variant_case: Option<String>,
-    struct_name: Option<String>,
-    alt: &Alternative,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_alt_body(w: &mut CodeWriter, type_name: &String, variant_case: Option<String>, struct_name: Option<String>, alt: &Alternative, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) {
     gen_alt_elements(w, &alt.elements, all_rules, lit_tokens);
 
     if let Some(case) = variant_case {
@@ -471,13 +493,7 @@ fn gen_alt_body(
     }
 }
 
-fn gen_multi_alt_body(
-    w: &mut CodeWriter,
-    rule: &ParserRule,
-    type_name: &String,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_multi_alt_body(w: &mut CodeWriter, rule: &ParserRule, type_name: &String, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) {
     let all_labeled = all_alternatives_labeled(&rule.alternatives);
 
     let max_k = 5;
@@ -504,19 +520,22 @@ fn gen_multi_alt_body(
             w.begin("scope:");
         }
 
-        gen_alt_body(w, type_name, Option::<String>::Some(case_name), Option::<String>::Some(sname), alt, all_rules, lit_tokens);
+        gen_alt_body(
+            w,
+            type_name,
+            Option::<String>::Some(case_name),
+            Option::<String>::Some(sname),
+            alt,
+            all_rules,
+            lit_tokens,
+        );
         w.end();
     }
 
     gen_error_fallback(w, rule, type_name, all_rules, lit_tokens);
 }
 
-fn gen_alt_elements(
-    w: &mut CodeWriter,
-    elements: &Array<Element>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) {
     let mut name_counts: Array<[String, i32]> = [];
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
@@ -541,13 +560,7 @@ fn gen_alt_elements(
     }
 }
 
-fn gen_elements_with_non_greedy(
-    w: &mut CodeWriter,
-    elements: &Array<Element>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_elements_with_non_greedy(w: &mut CodeWriter, elements: &Array<Element>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, name_counts: &mut Array<[String, i32]>) {
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
         if let Repeat(rep) = *elem {
@@ -565,19 +578,16 @@ fn gen_elements_with_non_greedy(
 }
 
 fn is_ruleref_optional(elem: &Element) -> bool {
-    if let RuleRef(_) = *elem { return true; }
-    if let Label(lab) = *elem { return is_ruleref_optional(&lab.element); }
+    if let RuleRef(_) = *elem {
+        return true;
+    }
+    if let Label(lab) = *elem {
+        return is_ruleref_optional(&lab.element);
+    }
     return false;
 }
 
-fn gen_element(
-    w: &mut CodeWriter,
-    elem: &Element,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    store: bool,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_element(w: &mut CodeWriter, elem: &Element, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, store: bool, name_counts: &mut Array<[String, i32]>) {
     if let TokenRef(name) = *elem {
         let const_name = `TK_{name}`;
         if store {
@@ -626,13 +636,7 @@ fn gen_element(
     }
 }
 
-fn gen_repeat(
-    w: &mut CodeWriter,
-    rep: &RepeatElement,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, name_counts: &mut Array<[String, i32]>) {
     let inner = &rep.element;
     let mut visiting: Array<String> = [];
     let first = first_of_element(inner, all_rules, lit_tokens, &mut visiting);
@@ -690,16 +694,13 @@ fn gen_repeat(
     }
 }
 
-fn compute_follow_second(
-    elements: &Array<Element>,
-    follow_start: i32,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> Array<String> {
+fn compute_follow_second(elements: &Array<Element>, follow_start: i32, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> Array<String> {
     // Compute first set of the 2nd token of the follow element.
     // For patterns like (',' table_constraint)*, the follow's inner group is [',' table_constraint].
     // We want first(table_constraint), not first(',').
-    if follow_start >= elements.len() { return []; }
+    if follow_start >= elements.len() {
+        return [];
+    }
     let follow_elem = &elements[follow_start];
     if let Repeat(rep) = *follow_elem {
         if let Group(alts) = rep.element {
@@ -711,13 +712,7 @@ fn compute_follow_second(
     return [];
 }
 
-fn compute_non_greedy_condition(
-    inner: &Element,
-    follow_first: &Array<String>,
-    follow_second: &Array<String>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> String {
+fn compute_non_greedy_condition(inner: &Element, follow_first: &Array<String>, follow_second: &Array<String>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> String {
     let mut visiting: Array<String> = [];
     let raw_first = first_of_element(inner, all_rules, lit_tokens, &mut visiting);
     let continue_first = subtract_sets(&raw_first, follow_first);
@@ -755,17 +750,13 @@ fn compute_non_greedy_condition(
     return "false";
 }
 
-fn gen_repeat_non_greedy(
-    w: &mut CodeWriter,
-    rep: &RepeatElement,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    follow_first: &Array<String>,
-    follow_second: &Array<String>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_repeat_non_greedy(w: &mut CodeWriter, rep: &RepeatElement, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, follow_first: &Array<String>, follow_second: &Array<String>, name_counts: &mut Array<[String, i32]>) {
     let inner = &rep.element;
-    let is_plus = if let Plus = rep.kind { true } else { false };
+    let is_plus = if let Plus = rep.kind {
+        true;
+    } else {
+        false;
+    };
     let while_cond = compute_non_greedy_condition(inner, follow_first, follow_second, all_rules, lit_tokens);
 
     if has_field(inner) {
@@ -829,14 +820,7 @@ fn subtract_sets(a: &Array<String>, b: &Array<String>) -> Array<String> {
     return result;
 }
 
-fn gen_repeat_with_follow(
-    w: &mut CodeWriter,
-    rep: &RepeatElement,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    follow_first: &Array<String>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_repeat_with_follow(w: &mut CodeWriter, rep: &RepeatElement, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, follow_first: &Array<String>, name_counts: &mut Array<[String, i32]>) {
     let inner = &rep.element;
     let mut visiting: Array<String> = [];
     let raw_first = first_of_element(inner, all_rules, lit_tokens, &mut visiting);
@@ -871,7 +855,9 @@ fn gen_repeat_with_follow(
 
 fn is_optional_repeat(elem: &Element) -> bool {
     if let Repeat(rep) = *elem {
-        if let Optional = rep.kind { return true; }
+        if let Optional = rep.kind {
+            return true;
+        }
     }
     if let Label(lab) = *elem {
         return is_optional_repeat(&lab.element);
@@ -881,10 +867,14 @@ fn is_optional_repeat(elem: &Element) -> bool {
 
 fn has_nested_optionals(inner: &Element) -> bool {
     if let Group(alts) = *inner {
-        if alts.len() != 1 { return false; }
+        if alts.len() != 1 {
+            return false;
+        }
         for let mut i = 0; i < alts[0].elements.len(); i += 1 {
             let elem = &alts[0].elements[i];
-            if is_optional_repeat(elem) { return true; }
+            if is_optional_repeat(elem) {
+                return true;
+            }
         }
     }
     return false;
@@ -914,7 +904,7 @@ fn compute_shapes(elements: &Array<Element>) -> Array<Array<i32>> {
                 }
             }
             if is_opt {
-                if (mask >> opt_bit) & 1 == 1 {
+                if mask >> opt_bit & 1 == 1 {
                     shape.append(i);
                 }
             } else {
@@ -926,12 +916,7 @@ fn compute_shapes(elements: &Array<Element>) -> Array<Array<i32>> {
     return shapes;
 }
 
-fn shape_lookahead_signature(
-    shape: &Array<i32>,
-    elements: &Array<Element>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> Array<Array<String>> {
+fn shape_lookahead_signature(shape: &Array<i32>, elements: &Array<Element>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> Array<Array<String>> {
     let mut sig: Array<Array<String>> = [];
     for let mut si = 0; si < shape.len(); si += 1 {
         let idx = shape[si];
@@ -965,7 +950,9 @@ fn gen_lookahead_condition(sig: &Array<Array<String>>) -> String {
             let mut inner = String::with_capacity(64);
             inner.append("(");
             for let mut j = 0; j < tokens.len(); j += 1 {
-                if j > 0 { inner.append(" || "); }
+                if j > 0 {
+                    inner.append(" || ");
+                }
                 inner.append(`{check_expr} == {tokens[j]}`);
             }
             inner.append(")");
@@ -974,26 +961,24 @@ fn gen_lookahead_condition(sig: &Array<Array<String>>) -> String {
     }
     let mut result = String::with_capacity(128);
     for let mut i = 0; i < parts.len(); i += 1 {
-        if i > 0 { result.append(" && "); }
+        if i > 0 {
+            result.append(" && ");
+        }
         result.append(parts[i]);
     }
     return result;
 }
 
-fn gen_optional_with_lookahead(
-    w: &mut CodeWriter,
-    group_elements: &Array<Element>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_optional_with_lookahead(w: &mut CodeWriter, group_elements: &Array<Element>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, name_counts: &mut Array<[String, i32]>) {
     let shapes = compute_shapes(group_elements);
 
     let mut is_first = true;
     for let mut si = 0; si < shapes.len(); si += 1 {
         let shape = &shapes[si];
         let sig = shape_lookahead_signature(shape, group_elements, all_rules, lit_tokens);
-        if sig.len() == 0 { continue; }
+        if sig.len() == 0 {
+            continue;
+        }
         let cond = gen_lookahead_condition(&sig);
 
         if is_first {
@@ -1042,16 +1027,23 @@ fn optional_lookahead_depth(inner: &Element) -> i32 {
     // Returns the number of leading fixed tokens that can be checked via lookahead.
     // 0 if the first element is not a fixed token.
     if let Group(alts) = *inner {
-        if alts.len() != 1 { return 0; }
+        if alts.len() != 1 {
+            return 0;
+        }
         let mut depth = 0;
         for let mut i = 0; i < alts[0].elements.len(); i += 1 {
             let elem = &alts[0].elements[i];
-            if let TokenRef(_) | Literal(_) = *elem { depth += 1; }
-            else { break; }
+            if let TokenRef(_) | Literal(_) = *elem {
+                depth += 1;
+            } else {
+                break;
+            }
         }
         return depth;
     }
-    if let TokenRef(_) | Literal(_) = *inner { return 1; }
+    if let TokenRef(_) | Literal(_) = *inner {
+        return 1;
+    }
     return 0;
 }
 
@@ -1059,29 +1051,31 @@ fn optional_lookahead_tokens(inner: &Element, max_depth: i32) -> Array<String> {
     // Returns up to max_depth leading fixed token constants.
     let mut tokens: Array<String> = [];
     if let Group(alts) = *inner {
-        if alts.len() != 1 { return []; }
-        for let mut i = 0; i < alts[0].elements.len(); i += 1 {
-            if tokens.len() >= max_depth { break; }
-            let elem = &alts[0].elements[i];
-            if let TokenRef(name) = *elem { tokens.append(`TK_{name}`); }
-            else if let Literal(text) = *elem { tokens.append(literal_const_name(&text)); }
-            else { break; }
+        if alts.len() != 1 {
+            return [];
         }
-    } else {
-        if let TokenRef(name) = *inner { tokens.append(`TK_{name}`); }
-        else if let Literal(text) = *inner { tokens.append(literal_const_name(&text)); }
+        for let mut i = 0; i < alts[0].elements.len(); i += 1 {
+            if tokens.len() >= max_depth {
+                break;
+            }
+            let elem = &alts[0].elements[i];
+            if let TokenRef(name) = *elem {
+                tokens.append(`TK_{name}`);
+            } else if let Literal(text) = *elem {
+                tokens.append(literal_const_name(&text));
+            } else {
+                break;
+            }
+        }
+    } else if let TokenRef(name) = *inner {
+        tokens.append(`TK_{name}`);
+    } else if let Literal(text) = *inner {
+        tokens.append(literal_const_name(&text));
     }
     return tokens;
 }
 
-fn gen_optional_with_backtrack(
-    w: &mut CodeWriter,
-    inner: &Element,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    first: &Array<String>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, first: &Array<String>, name_counts: &mut Array<[String, i32]>) {
     if has_nested_optionals(inner) {
         if let Group(alts) = *inner {
             gen_optional_with_lookahead(w, &alts[0].elements, all_rules, lit_tokens, name_counts);
@@ -1100,7 +1094,9 @@ fn gen_optional_with_backtrack(
         }
         let mut cond = String::with_capacity(128);
         for let mut i = 0; i < cond_parts.len(); i += 1 {
-            if i > 0 { cond.append(" && "); }
+            if i > 0 {
+                cond.append(" && ");
+            }
             cond.append(cond_parts[i]);
         }
         w.begin(`if {cond}`);
@@ -1135,19 +1131,11 @@ fn gen_optional_with_backtrack(
         gen_element_failable(w, inner, all_rules, lit_tokens, &saved, &label, name_counts);
     }
 
-    w.end(); // label
-    w.end(); // if
+    w.end();  // label
+    w.end();  // if
 }
 
-fn gen_element_failable(
-    w: &mut CodeWriter,
-    elem: &Element,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    saved_var: &String,
-    label: &String,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_element_failable(w: &mut CodeWriter, elem: &Element, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, saved_var: &String, label: &String, name_counts: &mut Array<[String, i32]>) {
     if let TokenRef(name) = *elem {
         let const_name = `TK_{name}`;
         let r_var = dedup_name(&"opt_r", name_counts);
@@ -1191,8 +1179,12 @@ fn gen_element_failable(
 }
 
 fn has_field(elem: &Element) -> bool {
-    if let TokenRef(_) | Literal(_) | RuleRef(_) = *elem { return true; }
-    if let Label(lab) = *elem { return has_field(&lab.element); }
+    if let TokenRef(_) | Literal(_) | RuleRef(_) = *elem {
+        return true;
+    }
+    if let Label(lab) = *elem {
+        return has_field(&lab.element);
+    }
     return false;
 }
 
@@ -1219,11 +1211,7 @@ fn gen_field_assignments(w: &mut CodeWriter, elements: &Array<Element>) {
     }
 }
 
-fn gen_field_assignment(
-    w: &mut CodeWriter,
-    elem: &Element,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_field_assignment(w: &mut CodeWriter, elem: &Element, name_counts: &mut Array<[String, i32]>) {
     if let TokenRef(name) = *elem {
         let field_name = dedup_name(&to_lower(&name), name_counts);
         w.line(`{field_name},`);
@@ -1263,14 +1251,10 @@ fn gen_field_assignment(
     }
 }
 
-fn gen_consume_group(
-    w: &mut CodeWriter,
-    alts: &Array<Alternative>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    name_counts: &mut Array<[String, i32]>,
-) {
-    if alts.len() == 0 { return; }
+fn gen_consume_group(w: &mut CodeWriter, alts: &Array<Alternative>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, name_counts: &mut Array<[String, i32]>) {
+    if alts.len() == 0 {
+        return;
+    }
     if alts.len() == 1 {
         gen_elements_with_non_greedy(w, &alts[0].elements, all_rules, lit_tokens, name_counts);
         return;
@@ -1317,14 +1301,7 @@ fn gen_consume_group(
     w.end();
 }
 
-fn gen_backtracking_body(
-    w: &mut CodeWriter,
-    group: &Array<i32>,
-    alts: &Array<Alternative>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_backtracking_body(w: &mut CodeWriter, group: &Array<i32>, alts: &Array<Alternative>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, name_counts: &mut Array<[String, i32]>) {
     // Build prediction tree for the group alternatives.
     let mut pred_indices: Array<i32> = [];
     let mut pred_firsts: Array<Array<String>> = [];
@@ -1336,19 +1313,11 @@ fn gen_backtracking_body(
         pred_firsts.append(first_of_alt(&alts[alt_idx], all_rules, lit_tokens, &mut visiting));
         pred_elements.append(alts[alt_idx].elements);
     }
-    let tree = build_prediction(&pred_indices, &pred_firsts, &pred_elements,
-        0, 5, all_rules, lit_tokens);
+    let tree = build_prediction(&pred_indices, &pred_firsts, &pred_elements, 0, 5, all_rules, lit_tokens);
     gen_group_prediction_code(w, &tree, alts, all_rules, lit_tokens, name_counts);
 }
 
-fn gen_group_prediction_code(
-    w: &mut CodeWriter,
-    node: &PredictionNode,
-    alts: &Array<Alternative>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    name_counts: &mut Array<[String, i32]>,
-) {
+fn gen_group_prediction_code(w: &mut CodeWriter, node: &PredictionNode, alts: &Array<Alternative>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, name_counts: &mut Array<[String, i32]>) {
     if let Leaf(idx) = *node {
         gen_elements_with_non_greedy(w, &alts[idx].elements, all_rules, lit_tokens, name_counts);
         return;
@@ -1380,7 +1349,7 @@ fn gen_group_prediction_code(
                     gen_element_failable(w, &elem, all_rules, lit_tokens, &saved_var, &bt_label, &mut nc);
                 }
                 w.line(`{done_var} = true;`);
-                w.end(); // label
+                w.end();  // label
                 w.end();
             }
         }
@@ -1402,15 +1371,7 @@ fn gen_group_prediction_code(
     }
 }
 
-fn compute_lr_conflict_min_prec(
-    alt: &Alternative,
-    own_prec: i32,
-    lr_indices: &Array<i32>,
-    rule: &ParserRule,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    total_lr: i32,
-) -> i32 {
+fn compute_lr_conflict_min_prec(alt: &Alternative, own_prec: i32, lr_indices: &Array<i32>, rule: &ParserRule, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, total_lr: i32) -> i32 {
     // Scan suffix for fixed tokens that are also LR suffix first tokens.
     // If found, compute min_prec = max(own_prec + 1, conflicting_alt_prec + 1).
     let mut min_prec = own_prec + 1;
@@ -1418,23 +1379,34 @@ fn compute_lr_conflict_min_prec(
     let mut fixed_tokens: Array<String> = [];
     for let mut ei = 1; ei < alt.elements.len(); ei += 1 {
         let elem = &alt.elements[ei];
-        if let TokenRef(name) = *elem { fixed_tokens.append(`TK_{name}`); }
-        if let Literal(text) = *elem { fixed_tokens.append(literal_const_name(&text)); }
+        if let TokenRef(name) = *elem {
+            fixed_tokens.append(`TK_{name}`);
+        }
+        if let Literal(text) = *elem {
+            fixed_tokens.append(literal_const_name(&text));
+        }
     }
-    if fixed_tokens.len() == 0 { return min_prec; }
+    if fixed_tokens.len() == 0 {
+        return min_prec;
+    }
 
     // Check each LR alt's suffix first set for conflicts
     let mut lr_pos = 0;
     for let lr_idx_ref of lr_indices {
         let lr_idx = *lr_idx_ref;
         let other = &rule.alternatives[lr_idx];
-        if other.elements.len() <= 1 { lr_pos += 1; continue; }
+        if other.elements.len() <= 1 {
+            lr_pos += 1;
+            continue;
+        }
         let other_prec = total_lr - lr_pos;
         let suffix_first = first_of_elements_from(&other.elements, 1, all_rules, lit_tokens);
         for let ft of fixed_tokens {
             if array_contains_str(&suffix_first, &ft) {
                 let candidate = other_prec + 1;
-                if candidate > min_prec { min_prec = candidate; }
+                if candidate > min_prec {
+                    min_prec = candidate;
+                }
             }
         }
         lr_pos += 1;
@@ -1442,14 +1414,7 @@ fn compute_lr_conflict_min_prec(
     return min_prec;
 }
 
-fn gen_lr_suffix_helpers(
-    w: &mut CodeWriter,
-    rule: &ParserRule,
-    type_name: &String,
-    lr_indices: &Array<i32>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &String, lr_indices: &Array<i32>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) {
     let fn_name = `parse_{to_snake_case(&rule.name)}`;
     let prec_fn = `{fn_name}_prec`;
     let all_labeled = all_alternatives_labeled(&rule.alternatives);
@@ -1459,7 +1424,10 @@ fn gen_lr_suffix_helpers(
     for let lr_idx_ref of lr_indices {
         let lr_idx = *lr_idx_ref;
         let alt = &rule.alternatives[lr_idx];
-        if alt.elements.len() <= 1 { lr_pos += 1; continue; }
+        if alt.elements.len() <= 1 {
+            lr_pos += 1;
+            continue;
+        }
         let own_prec = total_lr - lr_pos;
 
         let case_name = if all_labeled { alt.label.unwrap() } else { `Alt{lr_idx}` };
@@ -1467,7 +1435,15 @@ fn gen_lr_suffix_helpers(
         let suffix_fn = `{fn_name}_lr_{lr_idx}`;
 
         // Compute min_prec for self-recursive calls in this helper
-        let inner_min_prec = compute_lr_conflict_min_prec(alt, own_prec, lr_indices, rule, all_rules, lit_tokens, total_lr);
+        let inner_min_prec = compute_lr_conflict_min_prec(
+            alt,
+            own_prec,
+            lr_indices,
+            rule,
+            all_rules,
+            lit_tokens,
+            total_lr,
+        );
 
         let mut f = FnSpec::new(&suffix_fn);
         f.add_param("p", "&mut Parser");
@@ -1517,18 +1493,13 @@ fn gen_lr_suffix_helpers(
         w.dedent();
         w.line("}));");
 
-        w.end(); // fn
+        w.end();  // fn
         w.blank();
         lr_pos += 1;
     }
 }
 
-fn compute_lr_second_token(
-    shared_token: &String,
-    elements: &Array<Element>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> Array<String> {
+fn compute_lr_second_token(shared_token: &String, elements: &Array<Element>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> Array<String> {
     // Find what token follows the shared_token in this alternative's suffix.
     // Walk suffix elements (starting at index 1) to find the shared token,
     // then return the first set of the next element.
@@ -1537,7 +1508,9 @@ fn compute_lr_second_token(
         // Check if this element contains the shared token
         let mut visiting: Array<String> = [];
         let elem_first = first_of_element(elem, all_rules, lit_tokens, &mut visiting);
-        if !array_contains_str(&elem_first, shared_token) { continue; }
+        if !array_contains_str(&elem_first, shared_token) {
+            continue;
+        }
 
         // This element matches the shared token. Check if it's an Optional that wraps it.
         if is_nullable(elem) {
@@ -1554,7 +1527,9 @@ fn compute_lr_second_token(
         if let Group(alts) = *elem {
             for let mut a = 0; a < alts.len(); a += 1 {
                 let alt = &alts[a];
-                if alt.elements.len() < 1 { continue; }
+                if alt.elements.len() < 1 {
+                    continue;
+                }
                 let mut v2: Array<String> = [];
                 let alt_first = first_of_element(&alt.elements[0], all_rules, lit_tokens, &mut v2);
                 if array_contains_str(&alt_first, shared_token) && alt.elements.len() >= 2 {
@@ -1571,12 +1546,7 @@ fn compute_lr_second_token(
     return [];
 }
 
-fn gen_lr_call_with_prec(
-    w: &mut CodeWriter,
-    suffix_fn: &String,
-    prec: i32,
-    use_prec: bool,
-) {
+fn gen_lr_call_with_prec(w: &mut CodeWriter, suffix_fn: &String, prec: i32, use_prec: bool) {
     if use_prec {
         w.begin(`if {prec} >= min_prec`);
         w.line(`result = {*suffix_fn}(p, result, start)?;`);
@@ -1588,18 +1558,7 @@ fn gen_lr_call_with_prec(
     }
 }
 
-fn gen_lr_overlap_dispatch(
-    w: &mut CodeWriter,
-    fn_name: &String,
-    rule: &ParserRule,
-    group: &Array<i32>,
-    valid_lr_indices: &Array<i32>,
-    lr_precs: &Array<i32>,
-    suffix_first_sets: &Array<Array<String>>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    use_prec: bool,
-) {
+fn gen_lr_overlap_dispatch(w: &mut CodeWriter, fn_name: &String, rule: &ParserRule, group: &Array<i32>, valid_lr_indices: &Array<i32>, lr_precs: &Array<i32>, suffix_first_sets: &Array<Array<String>>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, use_prec: bool) {
     // For each token in the group, find which alternatives match it.
     // Unique token → dispatch directly. Shared token → sub-dispatch via peek_at(1).
     let mut emitted: Array<String> = [];
@@ -1610,11 +1569,17 @@ fn gen_lr_overlap_dispatch(
         let this_first = &suffix_first_sets[group[k]];
         for let mut t = 0; t < this_first.len(); t += 1 {
             let tk = &this_first[t];
-            if array_contains_str(&emitted, tk) { continue; }
+            if array_contains_str(&emitted, tk) {
+                continue;
+            }
             let mut shared = false;
             for let mut j = 0; j < group.len(); j += 1 {
-                if j == k { continue; }
-                if array_contains_str(&suffix_first_sets[group[j]], tk) { shared = true; }
+                if j == k {
+                    continue;
+                }
+                if array_contains_str(&suffix_first_sets[group[j]], tk) {
+                    shared = true;
+                }
             }
             if !shared {
                 let lr_idx = valid_lr_indices[group[k]];
@@ -1636,7 +1601,9 @@ fn gen_lr_overlap_dispatch(
     let mut shared_tokens: Array<String> = [];
     for let mut k = 0; k < group.len(); k += 1 {
         for let tk of suffix_first_sets[group[k]] {
-            if array_contains_str(&emitted, &tk) { continue; }
+            if array_contains_str(&emitted, &tk) {
+                continue;
+            }
             if !array_contains_str(&shared_tokens, &tk) {
                 shared_tokens.append(tk);
             }
@@ -1658,7 +1625,9 @@ fn gen_lr_overlap_dispatch(
             }
         }
         for let mut k = 0; k < group.len(); k += 1 {
-            if !array_contains_str(&suffix_first_sets[group[k]], shared_tk) { continue; }
+            if !array_contains_str(&suffix_first_sets[group[k]], shared_tk) {
+                continue;
+            }
             let lr_idx = valid_lr_indices[group[k]];
             let prec = lr_precs[group[k]];
             let alt = &rule.alternatives[lr_idx];
@@ -1690,15 +1659,7 @@ fn gen_lr_overlap_dispatch(
     }
 }
 
-fn gen_lr_suffix_dispatch(
-    w: &mut CodeWriter,
-    rule: &ParserRule,
-    type_name: &String,
-    lr_indices: &Array<i32>,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    use_prec: bool,
-) {
+fn gen_lr_suffix_dispatch(w: &mut CodeWriter, rule: &ParserRule, type_name: &String, lr_indices: &Array<i32>, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, use_prec: bool) {
     let fn_name = `parse_{to_snake_case(&rule.name)}`;
     let total_lr = lr_indices.len();
 
@@ -1709,9 +1670,15 @@ fn gen_lr_suffix_dispatch(
     for let lr_idx_ref of lr_indices {
         let lr_idx = *lr_idx_ref;
         let alt = &rule.alternatives[lr_idx];
-        if alt.elements.len() <= 1 { lr_position += 1; continue; }
+        if alt.elements.len() <= 1 {
+            lr_position += 1;
+            continue;
+        }
         let suffix_first = first_of_elements_from(&alt.elements, 1, all_rules, lit_tokens);
-        if suffix_first.len() == 0 { lr_position += 1; continue; }
+        if suffix_first.len() == 0 {
+            lr_position += 1;
+            continue;
+        }
         valid_lr_indices.append(lr_idx);
         suffix_first_sets.append(suffix_first);
         // Precedence: first LR alt = highest (N), last = 1
@@ -1759,8 +1726,18 @@ fn gen_lr_suffix_dispatch(
                 w.line(`result = {suffix_fn}(p, result, start)?;`);
             }
         } else {
-            gen_lr_overlap_dispatch(w, &fn_name, rule, group, &valid_lr_indices, &lr_precs,
-                &suffix_first_sets, all_rules, lit_tokens, use_prec);
+            gen_lr_overlap_dispatch(
+                w,
+                &fn_name,
+                rule,
+                group,
+                &valid_lr_indices,
+                &lr_precs,
+                &suffix_first_sets,
+                all_rules,
+                lit_tokens,
+                use_prec,
+            );
         }
     }
 
@@ -1771,15 +1748,10 @@ fn gen_lr_suffix_dispatch(
     } else {
         w.line("break;");
     }
-    w.end(); // loop
+    w.end();  // loop
 }
 
-fn gen_prediction_code(
-    w: &mut CodeWriter,
-    node: &PredictionNode,
-    fn_name: &String,
-    alts: &Array<Alternative>,
-) {
+fn gen_prediction_code(w: &mut CodeWriter, node: &PredictionNode, fn_name: &String, alts: &Array<Alternative>) {
     if let Leaf(idx) = *node {
         w.line(`return {*fn_name}_bt_{idx}(p);`);
         return;
@@ -1821,16 +1793,7 @@ fn gen_prediction_code(
     }
 }
 
-fn gen_multi_alt_body_bt(
-    w: &mut CodeWriter,
-    rule: &ParserRule,
-    type_name: &String,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    groups: &Array<Array<i32>>,
-    first_sets: &Array<Array<String>>,
-    non_lr_indices: &Array<i32>,
-) {
+fn gen_multi_alt_body_bt(w: &mut CodeWriter, rule: &ParserRule, type_name: &String, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, groups: &Array<Array<i32>>, first_sets: &Array<Array<String>>, non_lr_indices: &Array<i32>) {
     let all_labeled = all_alternatives_labeled(&rule.alternatives);
     let fn_name = `parse_{to_snake_case(&rule.name)}`;
     w.line("let kind = p.peek_kind();");
@@ -1854,7 +1817,15 @@ fn gen_multi_alt_body_bt(
             let alt = &rule.alternatives[alt_idx];
             let case_name = if all_labeled { alt.label.unwrap() } else { `Alt{alt_idx}` };
             let sname = `{strip_suffix(type_name, "Node")}{case_name}`;
-            gen_alt_body(w, type_name, Option::<String>::Some(case_name), Option::<String>::Some(sname), alt, all_rules, lit_tokens);
+            gen_alt_body(
+                w,
+                type_name,
+                Option::<String>::Some(case_name),
+                Option::<String>::Some(sname),
+                alt,
+                all_rules,
+                lit_tokens,
+            );
         } else {
             // Sort group by specificity before building prediction tree.
             let mut sorted_group = group.sorted();
@@ -1869,8 +1840,7 @@ fn gen_multi_alt_body_bt(
                 pred_firsts.append(first_sets[idx]);
                 pred_elements.append(rule.alternatives[real_idx].elements);
             }
-            let tree = build_prediction(&pred_indices, &pred_firsts, &pred_elements,
-                0, 5, all_rules, lit_tokens);
+            let tree = build_prediction(&pred_indices, &pred_firsts, &pred_elements, 0, 5, all_rules, lit_tokens);
             let bt_count = count_backtrack_nodes(&tree);
 
             gen_prediction_code(w, &tree, &fn_name, &rule.alternatives);
@@ -1883,7 +1853,9 @@ fn gen_multi_alt_body_bt(
 }
 
 fn gen_parse_entry(w: &mut CodeWriter, parser_rules: &Array<ParserRule>) {
-    if parser_rules.len() == 0 { return; }
+    if parser_rules.len() == 0 {
+        return;
+    }
     let root = &parser_rules[0];
     let type_name = rule_type_name(&root.name);
     let fn_name = `parse_{to_snake_case(&root.name)}`;
@@ -1909,7 +1881,9 @@ fn kind_check_str(tokens: &Array<String>, expr: &String) -> String {
     }
     let mut result = String::with_capacity(64);
     for let mut i = 0; i < tokens.len(); i += 1 {
-        if i > 0 { result.append(" || "); }
+        if i > 0 {
+            result.append(" || ");
+        }
         result.append(`{expr} == {tokens[i]}`);
     }
     return result;
@@ -1918,7 +1892,9 @@ fn kind_check_str(tokens: &Array<String>, expr: &String) -> String {
 fn build_lookahead_condition(pos_sets: &Array<Array<String>>, depth: i32) -> String {
     let mut cond = String::with_capacity(128);
     for let mut d = 0; d < depth; d += 1 {
-        if d > 0 { cond.append(" && "); }
+        if d > 0 {
+            cond.append(" && ");
+        }
         let tokens = &pos_sets[d];
         let check_expr = if d == 0 { "kind" } else { `p.peek_at({d})` };
         if tokens.len() == 1 {
@@ -1926,7 +1902,9 @@ fn build_lookahead_condition(pos_sets: &Array<Array<String>>, depth: i32) -> Str
         } else {
             cond.append("(");
             for let mut j = 0; j < tokens.len(); j += 1 {
-                if j > 0 { cond.append(" || "); }
+                if j > 0 {
+                    cond.append(" || ");
+                }
                 cond.append(`{check_expr} == {tokens[j]}`);
             }
             cond.append(")");
@@ -1935,13 +1913,7 @@ fn build_lookahead_condition(pos_sets: &Array<Array<String>>, depth: i32) -> Str
     return cond;
 }
 
-fn gen_error_fallback(
-    w: &mut CodeWriter,
-    rule: &ParserRule,
-    type_name: &String,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) {
+fn gen_error_fallback(w: &mut CodeWriter, rule: &ParserRule, type_name: &String, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) {
     let mut expected: Array<String> = [];
     for let alt of rule.alternatives {
         let mut visiting: Array<String> = [];
@@ -1959,7 +1931,9 @@ fn gen_error_fallback(
     w.line("p.peek().span,");
     w.write("[");
     for let mut i = 0; i < expected.len(); i += 1 {
-        if i > 0 { w.write(", "); }
+        if i > 0 {
+            w.write(", ");
+        }
         let s = escape_string(&expected[i]);
         w.write(s);
     }
@@ -1968,12 +1942,7 @@ fn gen_error_fallback(
     w.line("));");
 }
 
-fn first_of_alt(
-    alt: &Alternative,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    visiting: &mut Array<String>,
-) -> Array<String> {
+fn first_of_alt(alt: &Alternative, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, visiting: &mut Array<String>) -> Array<String> {
     let mut result: Array<String> = [];
     for let elem of alt.elements {
         let elem_first = first_of_element(&elem, all_rules, lit_tokens, visiting);
@@ -1989,12 +1958,7 @@ fn first_of_alt(
     return result;
 }
 
-fn first_of_element(
-    elem: &Element,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    visiting: &mut Array<String>,
-) -> Array<String> {
+fn first_of_element(elem: &Element, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, visiting: &mut Array<String>) -> Array<String> {
     if let TokenRef(name) = *elem {
         return [`TK_{name}`];
     }
@@ -2025,12 +1989,7 @@ fn first_of_element(
     return [];
 }
 
-fn first_of_rule(
-    name: &String,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-    visiting: &mut Array<String>,
-) -> Array<String> {
+fn first_of_rule(name: &String, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>, visiting: &mut Array<String>) -> Array<String> {
     if array_contains_str(visiting, name) {
         return [];
     }
@@ -2064,9 +2023,13 @@ fn first_of_rule(
 
 fn is_simple_token_group(alts: &Array<Alternative>) -> bool {
     for let alt of alts {
-        if alt.elements.len() != 1 { return false; }
+        if alt.elements.len() != 1 {
+            return false;
+        }
         let elem = &alt.elements[0];
-        if let TokenRef(_) | Literal(_) = *elem { continue; }
+        if let TokenRef(_) | Literal(_) = *elem {
+            continue;
+        }
         return false;
     }
     return true;
@@ -2074,43 +2037,45 @@ fn is_simple_token_group(alts: &Array<Alternative>) -> bool {
 
 fn is_nullable(elem: &Element) -> bool {
     if let Repeat(rep) = *elem {
-        if let Star | Optional = rep.kind { return true; }
+        if let Star | Optional = rep.kind {
+            return true;
+        }
     }
     return false;
 }
 
-fn alt_position_first_sets(
-    alt: &Alternative,
-    max_depth: i32,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> Array<Array<String>> {
+fn alt_position_first_sets(alt: &Alternative, max_depth: i32, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> Array<Array<String>> {
     let mut result: Array<Array<String>> = [];
     let mut start = 0;
     while result.len() < max_depth && start < alt.elements.len() {
-        if result.len() > 0 && is_nullable(&alt.elements[start]) { break; }
+        if result.len() > 0 && is_nullable(&alt.elements[start]) {
+            break;
+        }
 
         let first = first_of_elements_from(&alt.elements, start, all_rules, lit_tokens);
-        if first.len() == 0 { break; }
+        if first.len() == 0 {
+            break;
+        }
         result.append(first);
         let mut skipped_nullable = false;
         while start < alt.elements.len() {
             let was_nullable = is_nullable(&alt.elements[start]);
-            if was_nullable { skipped_nullable = true; }
+            if was_nullable {
+                skipped_nullable = true;
+            }
             start += 1;
-            if !was_nullable { break; }
+            if !was_nullable {
+                break;
+            }
         }
-        if skipped_nullable { break; }
+        if skipped_nullable {
+            break;
+        }
     }
     return result;
 }
 
-fn first_of_elements_from(
-    elements: &Array<Element>,
-    start: i32,
-    all_rules: &Array<ParserRule>,
-    lit_tokens: &Array<LitToken>,
-) -> Array<String> {
+fn first_of_elements_from(elements: &Array<Element>, start: i32, all_rules: &Array<ParserRule>, lit_tokens: &Array<LitToken>) -> Array<String> {
     let mut result: Array<String> = [];
     for let mut i = start; i < elements.len(); i += 1 {
         let mut visiting: Array<String> = [];
@@ -2120,14 +2085,18 @@ fn first_of_elements_from(
                 result.append(tk);
             }
         }
-        if !is_nullable(&elements[i]) { break; }
+        if !is_nullable(&elements[i]) {
+            break;
+        }
     }
     return result;
 }
 
 fn sets_overlap(a: &Array<String>, b: &Array<String>) -> bool {
     for let x of a {
-        if array_contains_str(b, x) { return true; }
+        if array_contains_str(b, x) {
+            return true;
+        }
     }
     return false;
 }
@@ -2154,7 +2123,9 @@ fn find_needed_depth(all_position_sets: &Array<Array<Array<String>>>) -> i32 {
                 }
             }
         }
-        if all_ok { return depth; }
+        if all_ok {
+            return depth;
+        }
     }
     return max_k;
 }
@@ -2198,7 +2169,9 @@ fn all_alternatives_labeled(alts: &Array<Alternative>) -> bool {
 }
 
 fn is_left_recursive(alt: &Alternative, rule_name: &String) -> bool {
-    if alt.elements.len() == 0 { return false; }
+    if alt.elements.len() == 0 {
+        return false;
+    }
     let first = &alt.elements[0];
     if let RuleRef(name) = *first {
         return name == *rule_name;
@@ -2250,21 +2223,22 @@ fn compute_overlap_groups(first_sets: &Array<Array<String>>) -> Array<Array<i32>
 
 fn has_multi_alt_groups(groups: &Array<Array<i32>>) -> bool {
     for let group of groups {
-        if group.len() > 1 { return true; }
+        if group.len() > 1 {
+            return true;
+        }
     }
     return false;
 }
 
-fn sort_group_by_specificity(
-    group: &mut Array<i32>,
-    first_sets: &Array<Array<String>>,
-) {
+fn sort_group_by_specificity(group: &mut Array<i32>, first_sets: &Array<Array<String>>) {
     // Sort by first set size ascending: smaller first set = more specific = try first.
     // Ties broken by original order (stable-ish bubble sort).
     for let mut i = 0; i < group.len(); i += 1 {
         for let mut j = i + 1; j < group.len(); j += 1 {
             if first_sets[group[j]].len() < first_sets[group[i]].len() {
-                let tmp = group[i]; group[i] = group[j]; group[j] = tmp;
+                let tmp = group[i];
+                group[i] = group[j];
+                group[j] = tmp;
             }
         }
     }
@@ -2278,16 +2252,15 @@ fn alt_sort_priority(alt: &Alternative) -> i32 {
     // 1: Single Token/Literal — simple fallbacks (e.g. K_INSERT)
     if alt.elements.len() == 1 {
         let elem = &alt.elements[0];
-        if let RuleRef(_) = *elem { return 3; }
+        if let RuleRef(_) = *elem {
+            return 3;
+        }
         return 1;
     }
     return 2;
 }
 
-fn sort_group_by_element_count(
-    group: &mut Array<i32>,
-    alts: &Array<Alternative>,
-) {
+fn sort_group_by_element_count(group: &mut Array<i32>, alts: &Array<Alternative>) {
     for let mut i = 0; i < group.len(); i += 1 {
         for let mut j = i + 1; j < group.len(); j += 1 {
             let pi = alt_sort_priority(&alts[group[i]]);
@@ -2302,7 +2275,9 @@ fn sort_group_by_element_count(
                 }
             }
             if swap {
-                let tmp = group[i]; group[i] = group[j]; group[j] = tmp;
+                let tmp = group[i];
+                group[i] = group[j];
+                group[j] = tmp;
             }
         }
     }

--- a/package-gale/src/wadopoet.wado
+++ b/package-gale/src/wadopoet.wado
@@ -6,7 +6,6 @@
 ///
 /// Function bodies remain string-based via `CodeWriter` — the same
 /// pragmatic split as JavaPoet/KotlinPoet's `CodeBlock`.
-
 pub struct CodeWriter {
     buf: String,
     indent_level: i32,

--- a/package-gale/src/wadopoet_test.wado
+++ b/package-gale/src/wadopoet_test.wado
@@ -1,6 +1,15 @@
 use {
-    CodeWriter, FieldSpec, StructSpec, VariantSpec, EnumSpec, FlagsSpec,
-    ParamSpec, FnSpec, GlobalSpec, TraitSpec, ImplSpec,
+    CodeWriter,
+    FieldSpec,
+    StructSpec,
+    VariantSpec,
+    EnumSpec,
+    FlagsSpec,
+    ParamSpec,
+    FnSpec,
+    GlobalSpec,
+    TraitSpec,
+    ImplSpec,
 } from "./wadopoet.wado";
 
 // ---------------------------------------------------------------------------

--- a/wado-compiler/lib/core/collections.wado
+++ b/wado-compiler/lib/core/collections.wado
@@ -51,7 +51,7 @@ pub struct TreeMap<K, V> {
     deleted_count: i32,
 }
 
-impl TreeMap<K: Ord, V> {
+impl<K: Ord> TreeMap<K, V> {
     /// Creates a new empty TreeMap.
     pub fn new() -> TreeMap<K, V> {
         return TreeMap {
@@ -378,7 +378,7 @@ pub struct TreeSet<T> {
     inner: TreeMap<T, ()>,
 }
 
-impl TreeSet<T: Ord> {
+impl<T: Ord> TreeSet<T> {
     /// Creates a new empty TreeSet.
     pub fn new() -> TreeSet<T> {
         return TreeSet { inner: TreeMap::<T, ()>::new() };

--- a/wado-compiler/lib/core/json_value_test.wado
+++ b/wado-compiler/lib/core/json_value_test.wado
@@ -89,7 +89,10 @@ test "Value::Object serialize" {
 }
 
 test "Value::Object multiple keys serialize" {
-    let v = Value::Object(obj([["a", Value::Number(1.0)], ["b", Value::Bool(false)]]));
+    let v = Value::Object(obj([
+        ["a", Value::Number(1.0)],
+        ["b", Value::Bool(false)],
+    ]));
     let r = to_string::<Value>(&v);
     assert r matches { Ok(s) && s == "{\"a\":1,\"b\":false}" };
 }
@@ -233,7 +236,10 @@ test "inspect empty object" {
 }
 
 test "pretty-print object" {
-    let v = Value::Object(obj([["name", Value::String("Alice")], ["age", Value::Number(30.0)]]));
+    let v = Value::Object(obj([
+        ["name", Value::String("Alice")],
+        ["age", Value::Number(30.0)],
+    ]));
     assert `{v:#?}` == "{
   \"name\": \"Alice\",
   \"age\": 30.0,

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -389,7 +389,7 @@ impl Array<T> {
 }
 
 // sort/sorted require T: Ord (elements must be comparable via Ord::cmp)
-impl Array<T: Ord> {
+impl<T: Ord> Array<T> {
     pub fn sort(&mut self) {
         self.sort_by(|a: &T, b: &T| {
             return a.cmp(b);
@@ -454,13 +454,13 @@ impl ArrayIter<T> {
 
 use { Add } from "core:prelude/traits.wado";
 
-impl ArrayIter<T: Add> {
+impl<T: Add> ArrayIter<T> {
     pub fn sum(&mut self) -> Option<T> {
         return self.reduce(|a: T, b: T| a + b);
     }
 }
 
-impl ArrayIter<T: Ord> {
+impl<T: Ord> ArrayIter<T> {
     pub fn min(&mut self) -> Option<T> {
         if let Some(first) = self.next() {
             let mut result = first;

--- a/wado-compiler/lib/core/simd.wado
+++ b/wado-compiler/lib/core/simd.wado
@@ -1140,14 +1140,24 @@ impl u8x16 {
     /// The caller must ensure `offset + 16 <= s.len()`.
     pub fn from_string(s: &String, offset: i32) -> u8x16 {
         let arr = s.internal_raw_bytes();
-        let v: u8x16 = [builtin::array_get_u8(arr, offset) as i32, builtin::array_get_u8(arr, offset + 1) as i32,
-            builtin::array_get_u8(arr, offset + 2) as i32, builtin::array_get_u8(arr, offset + 3) as i32,
-            builtin::array_get_u8(arr, offset + 4) as i32, builtin::array_get_u8(arr, offset + 5) as i32,
-            builtin::array_get_u8(arr, offset + 6) as i32, builtin::array_get_u8(arr, offset + 7) as i32,
-            builtin::array_get_u8(arr, offset + 8) as i32, builtin::array_get_u8(arr, offset + 9) as i32,
-            builtin::array_get_u8(arr, offset + 10) as i32, builtin::array_get_u8(arr, offset + 11) as i32,
-            builtin::array_get_u8(arr, offset + 12) as i32, builtin::array_get_u8(arr, offset + 13) as i32,
-            builtin::array_get_u8(arr, offset + 14) as i32, builtin::array_get_u8(arr, offset + 15) as i32];
+        let v: u8x16 = [
+            builtin::array_get_u8(arr, offset) as i32,
+            builtin::array_get_u8(arr, offset + 1) as i32,
+            builtin::array_get_u8(arr, offset + 2) as i32,
+            builtin::array_get_u8(arr, offset + 3) as i32,
+            builtin::array_get_u8(arr, offset + 4) as i32,
+            builtin::array_get_u8(arr, offset + 5) as i32,
+            builtin::array_get_u8(arr, offset + 6) as i32,
+            builtin::array_get_u8(arr, offset + 7) as i32,
+            builtin::array_get_u8(arr, offset + 8) as i32,
+            builtin::array_get_u8(arr, offset + 9) as i32,
+            builtin::array_get_u8(arr, offset + 10) as i32,
+            builtin::array_get_u8(arr, offset + 11) as i32,
+            builtin::array_get_u8(arr, offset + 12) as i32,
+            builtin::array_get_u8(arr, offset + 13) as i32,
+            builtin::array_get_u8(arr, offset + 14) as i32,
+            builtin::array_get_u8(arr, offset + 15) as i32,
+        ];
         return v;
     }
 

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -1605,26 +1605,10 @@ impl<'a> Unparser<'a> {
             return;
         }
 
-        // Try single-line first
-        let snap = self.snapshot();
-        self.output.push('[');
-        for (i, elem) in tuple_lit.elements.iter().enumerate() {
-            if i > 0 {
-                self.output.push_str(", ");
-            }
-            self.unparse_expr(elem);
-        }
-        self.output.push(']');
-
-        if !self.output[snap..].contains('\n') && !self.exceeds_width_since(snap) {
-            return;
-        }
-
-        // Rollback for multi-line formatting
-        self.rollback(snap);
-
         // Key-value list heuristic: if all elements are 2-element tuple literals,
-        // format as one entry per line (Wasm CM associative array pattern).
+        // always format as one entry per line (Wasm CM associative array pattern).
+        // This check runs before the single-line attempt so kv-lists are never
+        // collapsed onto one line.
         let is_kv_list = tuple_lit.elements.len() >= 2
             && tuple_lit
                 .elements
@@ -1662,6 +1646,24 @@ impl<'a> Unparser<'a> {
             self.output.push(']');
             return;
         }
+
+        // Try single-line first
+        let snap = self.snapshot();
+        self.output.push('[');
+        for (i, elem) in tuple_lit.elements.iter().enumerate() {
+            if i > 0 {
+                self.output.push_str(", ");
+            }
+            self.unparse_expr(elem);
+        }
+        self.output.push(']');
+
+        if !self.output[snap..].contains('\n') && !self.exceeds_width_since(snap) {
+            return;
+        }
+
+        // Rollback for multi-line formatting
+        self.rollback(snap);
 
         // Fill-style: pack elements onto lines up to MAX_LINE_WIDTH
         self.output.push('[');

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -1640,7 +1640,20 @@ impl<'a> Unparser<'a> {
                 }
                 self.output.push('\n');
                 self.write_indent();
-                self.unparse_expr(elem);
+                // Force single-line formatting for each [k, v] pair so that
+                // key and value always stay together on one line.
+                if let Expr::TupleLiteral(inner) = elem {
+                    self.output.push('[');
+                    for (j, inner_elem) in inner.elements.iter().enumerate() {
+                        if j > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.unparse_expr(inner_elem);
+                    }
+                    self.output.push(']');
+                } else {
+                    self.unparse_expr(elem);
+                }
             }
             self.output.push(',');
             self.output.push('\n');

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -25,6 +25,22 @@ fn effective_start_line(attrs: &[Attribute], span_line: usize) -> usize {
         .map_or(span_line, |attr| attr.span.line.min(span_line))
 }
 
+fn contains_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call(_) | Expr::MethodCall(_) | Expr::StaticMethodCall(_) => true,
+        Expr::Binary(e) => contains_call(&e.left) || contains_call(&e.right),
+        Expr::Unary(e) => contains_call(&e.expr),
+        Expr::Cast(e) => contains_call(&e.expr),
+        Expr::TupleLiteral(e) => e.elements.iter().any(contains_call),
+        Expr::StructLiteral(e) => e.fields.iter().any(|f| contains_call(&f.value)),
+        Expr::Index(e) => contains_call(&e.expr) || contains_call(&e.index),
+        Expr::FieldAccess(e) => contains_call(&e.expr),
+        Expr::TryOp(e) => contains_call(&e.expr),
+        Expr::Spread(e, _) => contains_call(e),
+        _ => false,
+    }
+}
+
 pub struct Unparser<'a> {
     comments: &'a CommentMap,
     output: String,
@@ -1664,6 +1680,29 @@ impl<'a> Unparser<'a> {
 
         // Rollback for multi-line formatting
         self.rollback(snap);
+
+        // If any element contains a function/method call, use one-element-per-line
+        // instead of fill-style to keep complex expressions readable.
+        let has_call = tuple_lit.elements.iter().any(contains_call);
+
+        if has_call {
+            self.output.push('[');
+            self.indent_level += 1;
+            for (i, elem) in tuple_lit.elements.iter().enumerate() {
+                if i > 0 {
+                    self.output.push(',');
+                }
+                self.output.push('\n');
+                self.write_indent();
+                self.unparse_expr(elem);
+            }
+            self.output.push(',');
+            self.output.push('\n');
+            self.indent_level -= 1;
+            self.write_indent();
+            self.output.push(']');
+            return;
+        }
 
         // Fill-style: pack elements onto lines up to MAX_LINE_WIDTH
         self.output.push('[');

--- a/wado-compiler/tests/format.fixtures.golden/all.clean.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.clean.wado
@@ -359,7 +359,10 @@ fn tuple_array_literals() {
     let a: Array<i32> = [1, 2, 3];
     let b = [1, 2, 3] as Array<i32>;
     let empty: Array<i32> = [];
-    let nested: Array<Array<i32>> = [[1, 2], [3, 4]];
+    let nested: Array<Array<i32>> = [
+        [1, 2],
+        [3, 4],
+    ];
 }
 
 /// Destructuring: struct, tuple, in loops


### PR DESCRIPTION
## Summary

- **Fix kv-pair splitting**: Inner `[k, v]` pairs in kv-lists are now forced to stay on a single line, even when they exceed `MAX_LINE_WIDTH`
- **Always pretty-print kv-lists**: Sequences of 2-element tuples (`[[k, v], ...]`) are unconditionally expanded to one pair per line, never collapsed to a single line
- **One-element-per-line for calls**: When any element of a tuple/array literal contains a function/method call, use one-element-per-line formatting instead of fill-style packing
- **Add `package-gale/src` to `format-wado`**: Include package-gale source files in the formatter targets

## Test plan

- [x] All 81 formatter tests pass (idempotency, golden, round-trip AST)
- [x] `mise run format-wado` applies cleanly
- [x] `mise run on-task-done` passes (1283 tests, 0 failures)

https://claude.ai/code/session_01DVxGNdRHTJH7ZowNsGpCVY