### PR TITLE
Patch jco for WASM3/GC transpilation and fix P3 async stream runtime

### DIFF
--- a/.claude/skills/jco/SKILL.md
+++ b/.claude/skills/jco/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: jco
+description: Debug and patch jco (JS Component Tooling) for Wado wasm transpilation. Use when jco transpile or jco-transpiled code fails at runtime.
+---
+
+# jco Patching Workflow
+
+jco (`vendor/jco`) is bytecodealliance's tool for transpiling Wasm Components to JavaScript. Wado uses a patched fork because upstream jco has incomplete support for WASM3 (GC), CM async (P3 streams/futures), and JSPI integration.
+
+## Setup
+
+```sh
+git submodule update --init vendor/jco
+cd vendor/jco
+PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts
+```
+
+## Build Cycle
+
+After editing jco Rust source:
+
+```sh
+cd vendor/jco
+
+# 1. Rebuild wasm component (the transpiler itself runs as wasm)
+cargo clean -p js-component-bindgen --target wasm32-wasip1
+cargo build --workspace --target wasm32-wasip1
+
+# 2. Re-transpile the jco component to JS (bootstrap: uses existing jco to transpile itself)
+rm -f packages/jco/obj/js-component-bindgen-component.*
+cargo build -p xtask --target x86_64-unknown-linux-gnu
+./target/x86_64-unknown-linux-gnu/debug/xtask build debug
+
+# 3. Test with a Wado program
+cd /home/user/wado
+cargo run --bin wado -- compile -o /tmp/hello.wasm example/hello.wado
+rm -rf /tmp/hello-jco
+node vendor/jco/packages/jco/src/jco.js transpile /tmp/hello.wasm \
+  -o /tmp/hello-jco \
+  --map "wasi:cli/*=$(pwd)/example/jco-shim/cli.js#*"
+echo '{"type": "module"}' > /tmp/hello-jco/package.json
+node --experimental-wasm-jspi -e "
+  import('/tmp/hello-jco/hello.js')
+    .then(async m => { await m.run(); process.exit(0); })
+    .catch(e => { console.error(e); process.exit(1); });
+"
+```
+
+**IMPORTANT**: `cargo clean -p js-component-bindgen --target wasm32-wasip1` is required. Without it, cargo may not detect changes in `lib.rs` because the `WasmFeatures` bitflag values are const-evaluated and produce identical binaries. Always clean before rebuild.
+
+## Debugging Runtime Errors
+
+jco-transpiled code is a single large JS file (~165KB for hello). Key functions to know:
+
+| Wasm canonical built-in | jco JS function | Trampoline |
+|---|---|---|
+| `stream.new` | `streamNew()` | `trampoline8` |
+| `stream.write` | `streamWrite()` | `trampoline0` (JSPI Suspending) |
+| `stream.drop-writable` | `streamDropWritable()` | `trampoline7` |
+| `canon lower (async)` | `_lowerImport()` | `trampoline6` (JSPI Suspending) |
+| `task.return` | `taskReturn()` | `trampoline1` |
+| `waitable-set.new` | `waitableSetNew()` | `trampoline4` |
+| `waitable-set.wait` | `waitableSetWait()` | `trampoline5` (JSPI Suspending) |
+| `waitable.join` | `waitableJoin()` | `trampoline2` |
+| `subtask.drop` | `subtaskDrop()` | `trampoline9` |
+
+Trampoline indices may vary per component. Check the bottom of the transpiled JS for `const trampoline{N} = ...` assignments.
+
+### Debug technique: inject logging into transpiled JS
+
+```sh
+node -e "
+const fs = require('fs');
+let code = fs.readFileSync('/tmp/hello-jco/hello.js', 'utf-8');
+code = code.replace(
+  'function subtaskDrop(componentIdx, subtaskWaitableRep) {',
+  'function subtaskDrop(componentIdx, subtaskWaitableRep) { console.error(\"subtaskDrop:\", { componentIdx, subtaskWaitableRep });'
+);
+fs.writeFileSync('/tmp/hello-jco/hello.js', code);
+"
+```
+
+### Debug technique: catch unhandled rejections
+
+jco's async machinery swallows errors via unhandled Promise rejections. Always add:
+
+```js
+process.on('unhandledRejection', e => { console.error('UNHANDLED:', e); process.exit(1); });
+```
+
+### Common error patterns
+
+| Error | Likely cause |
+|---|---|
+| `rec group usage requires 'gc' proposal` | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3` |
+| `wide arithmetic support is not enabled` | Missing `WasmFeatures::WIDE_ARITHMETIC` |
+| `X is not defined` (runtime) | Missing intrinsic dependency in `intrinsics/mod.rs` |
+| `cannot drop subtask before resolve is delivered` | Subtask lifecycle issue — `deliverResolve()` not called |
+| `task.X is not a function` | Method not defined on `AsyncTask` class (jco implementation gap) |
+| `invalid variant discriminant for expected` | Async export returns `undefined` instead of result discriminant |
+| Hang / timeout | JSPI Suspending missing on a trampoline, or rendezvous deadlock |
+
+## Saving Patches
+
+After making changes in `vendor/jco`, save the patch relative to upstream:
+
+```sh
+cd vendor/jco
+# Find upstream base (the commit before our patches)
+git log --oneline | head -5
+# Save patch from upstream base
+git diff <upstream-commit> -- . > /home/user/wado/vendor/jco.patch
+```
+
+Then commit both the submodule ref update and the patch file:
+
+```sh
+cd /home/user/wado
+git add vendor/jco vendor/jco.patch
+git commit -m "Update jco patches: <description>"
+```
+
+## Key Source Locations in jco
+
+| File | Purpose |
+|---|---|
+| `crates/js-component-bindgen/src/lib.rs` | Top-level `WasmFeatures` validator config |
+| `crates/js-component-bindgen/src/core.rs` | Core module validation features |
+| `crates/js-component-bindgen/src/transpile_bindgen.rs` | Trampoline generation (JSPI wrapping) |
+| `crates/js-component-bindgen/src/function_bindgen.rs` | Function call/result codegen |
+| `crates/js-component-bindgen/src/intrinsics/mod.rs` | Intrinsic dependency resolution |
+| `crates/js-component-bindgen/src/intrinsics/lower.rs` | Value lowering (Result, Variant, etc.) |
+| `crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs` | Stream classes and operations |
+| `crates/js-component-bindgen/src/intrinsics/p3/waitable.rs` | WaitableSet wait/poll |
+| `crates/js-component-bindgen/src/intrinsics/p3/async_task.rs` | AsyncTask class |
+
+## WASI P3 Shims
+
+`example/jco-shim/` contains minimal shims for Node.js:
+
+- `cli.js` — stdout/stderr via `_jcoStreamWriteHook` (bypasses rendezvous)
+- `random.js` — `wasi:random` via Node.js crypto
+- `clocks.js` — `wasi:clocks` via `process.hrtime` / `Date.now`
+
+The `--map` flag maps WASI interfaces to shim files during transpilation.

--- a/.claude/skills/jco/SKILL.md
+++ b/.claude/skills/jco/SKILL.md
@@ -52,17 +52,17 @@ node --experimental-wasm-jspi -e "
 
 jco-transpiled code is a single large JS file (~165KB for hello). Key functions to know:
 
-| Wasm canonical built-in | jco JS function | Trampoline |
-|---|---|---|
-| `stream.new` | `streamNew()` | `trampoline8` |
-| `stream.write` | `streamWrite()` | `trampoline0` (JSPI Suspending) |
-| `stream.drop-writable` | `streamDropWritable()` | `trampoline7` |
-| `canon lower (async)` | `_lowerImport()` | `trampoline6` (JSPI Suspending) |
-| `task.return` | `taskReturn()` | `trampoline1` |
-| `waitable-set.new` | `waitableSetNew()` | `trampoline4` |
-| `waitable-set.wait` | `waitableSetWait()` | `trampoline5` (JSPI Suspending) |
-| `waitable.join` | `waitableJoin()` | `trampoline2` |
-| `subtask.drop` | `subtaskDrop()` | `trampoline9` |
+| Wasm canonical built-in | jco JS function        | Trampoline                      |
+| ----------------------- | ---------------------- | ------------------------------- |
+| `stream.new`            | `streamNew()`          | `trampoline8`                   |
+| `stream.write`          | `streamWrite()`        | `trampoline0` (JSPI Suspending) |
+| `stream.drop-writable`  | `streamDropWritable()` | `trampoline7`                   |
+| `canon lower (async)`   | `_lowerImport()`       | `trampoline6` (JSPI Suspending) |
+| `task.return`           | `taskReturn()`         | `trampoline1`                   |
+| `waitable-set.new`      | `waitableSetNew()`     | `trampoline4`                   |
+| `waitable-set.wait`     | `waitableSetWait()`    | `trampoline5` (JSPI Suspending) |
+| `waitable.join`         | `waitableJoin()`       | `trampoline2`                   |
+| `subtask.drop`          | `subtaskDrop()`        | `trampoline9`                   |
 
 Trampoline indices may vary per component. Check the bottom of the transpiled JS for `const trampoline{N} = ...` assignments.
 
@@ -90,15 +90,15 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED:', e); process.
 
 ### Common error patterns
 
-| Error | Likely cause |
-|---|---|
-| `rec group usage requires 'gc' proposal` | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3` |
-| `wide arithmetic support is not enabled` | Missing `WasmFeatures::WIDE_ARITHMETIC` |
-| `X is not defined` (runtime) | Missing intrinsic dependency in `intrinsics/mod.rs` |
-| `cannot drop subtask before resolve is delivered` | Subtask lifecycle issue — `deliverResolve()` not called |
-| `task.X is not a function` | Method not defined on `AsyncTask` class (jco implementation gap) |
-| `invalid variant discriminant for expected` | Async export returns `undefined` instead of result discriminant |
-| Hang / timeout | JSPI Suspending missing on a trampoline, or rendezvous deadlock |
+| Error                                             | Likely cause                                                     |
+| ------------------------------------------------- | ---------------------------------------------------------------- |
+| `rec group usage requires 'gc' proposal`          | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3`   |
+| `wide arithmetic support is not enabled`          | Missing `WasmFeatures::WIDE_ARITHMETIC`                          |
+| `X is not defined` (runtime)                      | Missing intrinsic dependency in `intrinsics/mod.rs`              |
+| `cannot drop subtask before resolve is delivered` | Subtask lifecycle issue — `deliverResolve()` not called          |
+| `task.X is not a function`                        | Method not defined on `AsyncTask` class (jco implementation gap) |
+| `invalid variant discriminant for expected`       | Async export returns `undefined` instead of result discriminant  |
+| Hang / timeout                                    | JSPI Suspending missing on a trampoline, or rendezvous deadlock  |
 
 ## Saving Patches
 
@@ -122,17 +122,17 @@ git commit -m "Update jco patches: <description>"
 
 ## Key Source Locations in jco
 
-| File | Purpose |
-|---|---|
-| `crates/js-component-bindgen/src/lib.rs` | Top-level `WasmFeatures` validator config |
-| `crates/js-component-bindgen/src/core.rs` | Core module validation features |
-| `crates/js-component-bindgen/src/transpile_bindgen.rs` | Trampoline generation (JSPI wrapping) |
-| `crates/js-component-bindgen/src/function_bindgen.rs` | Function call/result codegen |
-| `crates/js-component-bindgen/src/intrinsics/mod.rs` | Intrinsic dependency resolution |
-| `crates/js-component-bindgen/src/intrinsics/lower.rs` | Value lowering (Result, Variant, etc.) |
-| `crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs` | Stream classes and operations |
-| `crates/js-component-bindgen/src/intrinsics/p3/waitable.rs` | WaitableSet wait/poll |
-| `crates/js-component-bindgen/src/intrinsics/p3/async_task.rs` | AsyncTask class |
+| File                                                            | Purpose                                   |
+| --------------------------------------------------------------- | ----------------------------------------- |
+| `crates/js-component-bindgen/src/lib.rs`                        | Top-level `WasmFeatures` validator config |
+| `crates/js-component-bindgen/src/core.rs`                       | Core module validation features           |
+| `crates/js-component-bindgen/src/transpile_bindgen.rs`          | Trampoline generation (JSPI wrapping)     |
+| `crates/js-component-bindgen/src/function_bindgen.rs`           | Function call/result codegen              |
+| `crates/js-component-bindgen/src/intrinsics/mod.rs`             | Intrinsic dependency resolution           |
+| `crates/js-component-bindgen/src/intrinsics/lower.rs`           | Value lowering (Result, Variant, etc.)    |
+| `crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs` | Stream classes and operations             |
+| `crates/js-component-bindgen/src/intrinsics/p3/waitable.rs`     | WaitableSet wait/poll                     |
+| `crates/js-component-bindgen/src/intrinsics/p3/async_task.rs`   | AsyncTask class                           |
 
 ## WASI P3 Shims
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "vendor/component-model"]
 	path = vendor/component-model
 	url = https://github.com/WebAssembly/component-model.git
+[submodule "vendor/jco"]
+	path = vendor/jco
+	url = https://github.com/bytecodealliance/jco.git

--- a/example/jco-shim/cli.js
+++ b/example/jco-shim/cli.js
@@ -1,0 +1,42 @@
+// Minimal WASI P3 CLI shim for jco-transpiled Wado programs
+//
+// Works around the jco P3 async stream deadlock by starting concurrent
+// read loops that drain the stream while the wasm writes to it.
+
+export const types = {
+  OutputStream: class OutputStream {},
+};
+
+export const stdout = {
+  writeViaStream(stream) {
+    // Start reading from the stream concurrently
+    // We DON'T await this - let it run in the background
+    drainStream(stream, process.stdout);
+    // Return a future-like result
+    return { tag: "ok" };
+  },
+};
+stdout.writeViaStream._isHostProvided = true;
+
+export const stderr = {
+  writeViaStream(stream) {
+    drainStream(stream, process.stderr);
+    return { tag: "ok" };
+  },
+};
+stderr.writeViaStream._isHostProvided = true;
+
+function drainStream(stream, output) {
+  // Use setImmediate/queueMicrotask to start reading after current frame
+  queueMicrotask(async () => {
+    try {
+      while (true) {
+        const chunk = await stream.next();
+        if (chunk === undefined) break;
+        output.write(chunk);
+      }
+    } catch (_e) {
+      // Stream closed or errored
+    }
+  });
+}

--- a/example/jco-shim/cli.js
+++ b/example/jco-shim/cli.js
@@ -1,7 +1,23 @@
 // Minimal WASI P3 CLI shim for jco-transpiled Wado programs
 //
-// Works around the jco P3 async stream deadlock by starting concurrent
-// read loops that drain the stream while the wasm writes to it.
+// Uses a global stream write hook to intercept bulk data from stream.write,
+// bypassing the jco byte-at-a-time rendezvous mechanism.
+
+// Map: writable end waitable index -> output target
+const _streamTargets = new Map();
+
+// Global hook: called by patched jco's streamWrite when data is written
+globalThis._jcoStreamWriteHook = (writableEndIdx, data) => {
+  const target = _streamTargets.get(writableEndIdx);
+  if (target) {
+    target.write(data);
+    return true;
+  }
+  return false;
+};
+
+// Track which readable end idx maps to which output target
+const _pendingTargets = new Map();
 
 export const types = {
   OutputStream: class OutputStream {},
@@ -9,34 +25,35 @@ export const types = {
 
 export const stdout = {
   writeViaStream(stream) {
-    // Start reading from the stream concurrently
-    // We DON'T await this - let it run in the background
-    drainStream(stream, process.stdout);
-    // Return a future-like result
+    // The stream's globalRep identifies the readable end in the global stream map.
+    // We need the writable end's waitable idx. In jco's model, stream.new creates
+    // both ends as consecutive waitable handles. The readable end's idx is passed
+    // as arg0 to the lowered import. We register a "pending" target and resolve it
+    // when streamWrite is called with any writable idx we haven't seen.
+    //
+    // Simple approach: mark that the NEXT stream write should go to stdout.
+    _defaultTarget = process.stdout;
     return { tag: "ok" };
   },
 };
 stdout.writeViaStream._isHostProvided = true;
 
 export const stderr = {
-  writeViaStream(stream) {
-    drainStream(stream, process.stderr);
+  writeViaStream(_stream) {
+    _defaultTarget = process.stderr;
     return { tag: "ok" };
   },
 };
 stderr.writeViaStream._isHostProvided = true;
 
-function drainStream(stream, output) {
-  // Use setImmediate/queueMicrotask to start reading after current frame
-  queueMicrotask(async () => {
-    try {
-      while (true) {
-        const chunk = await stream.next();
-        if (chunk === undefined) break;
-        output.write(chunk);
-      }
-    } catch (_e) {
-      // Stream closed or errored
-    }
-  });
-}
+// Default target for unregistered writable ends
+let _defaultTarget = process.stdout;
+
+// Override the hook to auto-register unknown writable ends
+const _origHook = globalThis._jcoStreamWriteHook;
+globalThis._jcoStreamWriteHook = (writableEndIdx, data) => {
+  if (!_streamTargets.has(writableEndIdx) && _defaultTarget) {
+    _streamTargets.set(writableEndIdx, _defaultTarget);
+  }
+  return _origHook(writableEndIdx, data);
+};

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -1,0 +1,34 @@
+// Minimal WASI P3 clocks shim for jco-transpiled Wado programs
+
+export const monotonicClock = {
+  now() {
+    // Return nanoseconds as BigInt
+    const [sec, nsec] = process.hrtime();
+    return BigInt(sec) * 1000000000n + BigInt(nsec);
+  },
+  resolution() {
+    return 1n; // 1 nanosecond
+  },
+  subscribeInstant(_when) {
+    return { tag: "ok" };
+  },
+  subscribeDuration(_duration) {
+    return { tag: "ok" };
+  },
+};
+
+export const wallClock = {
+  now() {
+    const ms = Date.now();
+    return {
+      seconds: BigInt(Math.floor(ms / 1000)),
+      nanoseconds: (ms % 1000) * 1000000,
+    };
+  },
+  resolution() {
+    return {
+      seconds: 0n,
+      nanoseconds: 1000000, // 1ms
+    };
+  },
+};

--- a/example/jco-shim/random.js
+++ b/example/jco-shim/random.js
@@ -1,0 +1,32 @@
+// Minimal WASI P3 random shim for jco-transpiled Wado programs
+import { randomBytes } from "node:crypto";
+
+export const random = {
+  getRandomBytes(len) {
+    return new Uint8Array(randomBytes(len));
+  },
+  getRandomU64() {
+    const buf = randomBytes(8);
+    return new DataView(buf.buffer).getBigUint64(0, true);
+  },
+};
+
+export const insecure = {
+  getInsecureRandomBytes(len) {
+    return new Uint8Array(randomBytes(len));
+  },
+  getInsecureRandomU64() {
+    const buf = randomBytes(8);
+    return new DataView(buf.buffer).getBigUint64(0, true);
+  },
+};
+
+export const insecureSeed = {
+  insecureSeed() {
+    const buf = randomBytes(16);
+    return [
+      new DataView(buf.buffer).getBigUint64(0, true),
+      new DataView(buf.buffer).getBigUint64(8, true),
+    ];
+  },
+};

--- a/mise.toml
+++ b/mise.toml
@@ -329,3 +329,41 @@ run = "mise run -C benchmark sqlite-parse"
 [tasks.report-wasm-size]
 description = "Build all languages and report Wasm sizes"
 run = "mise run -C wasm-size report-wasm-size"
+
+[tasks.build-jco]
+description = "Build patched jco from vendor/jco"
+run = """
+#!/usr/bin/env bash
+set -xe -o pipefail
+cd vendor/jco
+PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts 2>&1 | tail -3
+cargo build --workspace --target wasm32-wasip1
+cargo build -p xtask --target x86_64-unknown-linux-gnu
+./target/x86_64-unknown-linux-gnu/debug/xtask build debug
+echo "jco built successfully at vendor/jco"
+"""
+
+[tasks.jco-transpile]
+description = "Transpile a Wado .wasm component to JS via patched jco"
+usage = "jco-transpile <wasm-file> [output-dir]"
+run = """
+#!/usr/bin/env bash
+set -e -o pipefail
+WASM_FILE="${1:?Usage: mise run jco-transpile <wasm-file> [output-dir]}"
+OUTPUT_DIR="${2:-${WASM_FILE%.wasm}-jco}"
+JCO="vendor/jco/packages/jco/src/jco.js"
+SHIM_DIR="$(pwd)/example/jco-shim"
+
+if [ ! -f "vendor/jco/packages/jco/obj/js-component-bindgen-component.js" ]; then
+  echo "jco not built yet. Run: mise run build-jco"
+  exit 1
+fi
+
+rm -rf "$OUTPUT_DIR"
+node "$JCO" transpile "$WASM_FILE" -o "$OUTPUT_DIR" \
+  --map "wasi:cli/*=${SHIM_DIR}/cli.js#*" \
+  --map "wasi:random/*=${SHIM_DIR}/random.js#*" \
+  --map "wasi:clocks/*=${SHIM_DIR}/clocks.js#*"
+echo '{"type": "module"}' > "$OUTPUT_DIR/package.json"
+echo "Transpiled to: $OUTPUT_DIR"
+"""

--- a/vendor/jco.patch
+++ b/vendor/jco.patch
@@ -11,6 +11,37 @@ index 582ba943..822b0e47 100644
          features.set(WasmFeatures::MULTI_MEMORY, false);
  
          match Validator::new_with_features(features).validate_all(translation.wasm) {
+diff --git a/crates/js-component-bindgen/src/function_bindgen.rs b/crates/js-component-bindgen/src/function_bindgen.rs
+index 9fd811c5..aa99de01 100644
+--- a/crates/js-component-bindgen/src/function_bindgen.rs
++++ b/crates/js-component-bindgen/src/function_bindgen.rs
+@@ -1491,11 +1491,24 @@ impl Bindgen for FunctionBindgen<'_> {
+                               taskID: task.id(),
+                               componentIdx: task.componentIdx(),
+                               fn: () => {callee}({args}),
+-                          }});
+-                          "#,
++                          }});"#,
+                     callee = self.callee,
+                     args = operands.join(", "),
+                 );
++                // For async exports using task.return, the JSPI Promising wrapper
++                // returns undefined (void core wasm function). The task's completion
++                // promise (resolved by task.return) provides the already-lifted result.
++                if self.is_async && sig_results_length > 0 {
++                    uwriteln!(
++                        self.src,
++                        r#"
++                          if (ret === undefined) {{
++                              const taskResult = await task.completionPromise();
++                              if (taskResult !== undefined) {{ return taskResult; }}
++                          }}
++                          "#,
++                    );
++                }
+ 
+                 if self.tracing_enabled {
+                     let prefix = self.tracing_prefix;
 diff --git a/crates/js-component-bindgen/src/intrinsics/lower.rs b/crates/js-component-bindgen/src/intrinsics/lower.rs
 index a8cc61b9..fe8e73f9 100644
 --- a/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -44,10 +75,20 @@ index a8cc61b9..fe8e73f9 100644
                              const rem = ctx.storagePtr % align32;
                              if (rem !== 0) {{
 diff --git a/crates/js-component-bindgen/src/intrinsics/mod.rs b/crates/js-component-bindgen/src/intrinsics/mod.rs
-index 0b50d4cf..2e33152f 100644
+index 0b50d4cf..2a501643 100644
 --- a/crates/js-component-bindgen/src/intrinsics/mod.rs
 +++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
-@@ -1279,6 +1279,22 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+@@ -1213,6 +1213,9 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+     if args
+         .intrinsics
+         .contains(&Intrinsic::Waitable(WaitableIntrinsic::WaitableSetPoll))
++        || args
++            .intrinsics
++            .contains(&Intrinsic::Waitable(WaitableIntrinsic::WaitableSetWait))
+     {
+         args.intrinsics
+             .extend([&Intrinsic::Host(HostIntrinsic::StoreEventInComponentMemory)]);
+@@ -1279,6 +1282,22 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
          ]);
      }
  
@@ -70,7 +111,7 @@ index 0b50d4cf..2e33152f 100644
      if args
          .intrinsics
          .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatStringUtf8))
-@@ -1364,10 +1380,14 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+@@ -1364,10 +1383,14 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
      if args
          .intrinsics
          .contains(&Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamWrite))
@@ -86,7 +127,7 @@ index 0b50d4cf..2e33152f 100644
      }
  
 diff --git a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
-index 5e027d19..967777a2 100644
+index 5e027d19..24d9951e 100644
 --- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
 +++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
 @@ -1140,7 +1140,7 @@ impl AsyncStreamIntrinsic {
@@ -170,6 +211,47 @@ index 5e027d19..967777a2 100644
                              streamTableIdx,
                              payloadLiftFn: payloadLiftFn,
                              payloadLowerFn: payloadLowerFn,
+@@ -1457,9 +1475,23 @@ impl AsyncStreamIntrinsic {
+                             throw new Error(`stream end table idx [${{streamEnd.streamTableIdx()}}] != operation table idx [${{streamTableIdx}}]`);
+                         }}
+ 
++                        const memory = getMemoryFn();
++
++                        // Host stream write hook: if a global hook is registered, deliver
++                        // stream data directly from linear memory, bypassing the rendezvous.
++                        // This enables WASI shims to receive bulk data from stream.write.
++                        if (typeof globalThis._jcoStreamWriteHook === 'function' && streamEnd.isWritable()) {{
++                            const actualCount = count >>> 0;
++                            const data = new Uint8Array(memory.buffer, ptr, actualCount);
++                            const handled = globalThis._jcoStreamWriteHook(streamEndWaitableIdx, new Uint8Array(data));
++                            if (handled) {{
++                                return (actualCount << 4) | 0;
++                            }}
++                        }}
++
+                         const result = await streamEnd.copy({{
+                             isAsync,
+-                            memory: getMemoryFn(),
++                            memory,
+                             ptr,
+                             count,
+                             eventCode: {event_code},
+diff --git a/crates/js-component-bindgen/src/intrinsics/p3/waitable.rs b/crates/js-component-bindgen/src/intrinsics/p3/waitable.rs
+index f7beb8a6..ba0ed043 100644
+--- a/crates/js-component-bindgen/src/intrinsics/p3/waitable.rs
++++ b/crates/js-component-bindgen/src/intrinsics/p3/waitable.rs
+@@ -392,8 +392,9 @@ impl WaitableIntrinsic {
+                             throw Error(`task component [${{task.componentIdx}}] !== executing component [${{componentIdx}}]`);
+                         }}
+ 
+-                        const event = await task.waitForEvent({{ waitableSetRep, isAsync }});
+-                        return {store_event_in_component_memory_fn}(memory, task, event, resultPtr);
++                        const memory = getMemoryFn();
++                        const event = await task.waitUntil({{ waitableSetRep, readyFn: () => true, cancellable: false }});
++                        return {store_event_in_component_memory_fn}({{ memory, ptr: resultPtr, event }});
+                     }}
+                 "#));
+             }
 diff --git a/crates/js-component-bindgen/src/lib.rs b/crates/js-component-bindgen/src/lib.rs
 index b3e08a2a..a33c54df 100644
 --- a/crates/js-component-bindgen/src/lib.rs
@@ -194,6 +276,25 @@ index b3e08a2a..a33c54df 100644
      );
  
      let mut types = ComponentTypesBuilder::new(&validator);
+diff --git a/crates/js-component-bindgen/src/transpile_bindgen.rs b/crates/js-component-bindgen/src/transpile_bindgen.rs
+index 8822efd0..8f0885b5 100644
+--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
++++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
+@@ -1202,12 +1202,12 @@ impl<'a> Instantiator<'a, '_> {
+                 uwriteln!(
+                     self.src.js,
+                     r#"
+-                    const trampoline{i} = {waitable_set_wait_fn}.bind(null, {{
++                    const trampoline{i} = new WebAssembly.Suspending({waitable_set_wait_fn}.bind(null, {{
+                         componentIdx: {instance_idx},
+                         isAsync: {async_},
+                         memoryIdx: {memory_idx},
+                         getMemoryFn: () => memory{memory_idx},
+-                    }});
++                    }}));
+                     "#,
+                 );
+             }
 diff --git a/package-lock.json b/package-lock.json
 index f34275d9..fd3ff020 100644
 --- a/package-lock.json

--- a/vendor/jco.patch
+++ b/vendor/jco.patch
@@ -1,0 +1,209 @@
+diff --git a/crates/js-component-bindgen/src/core.rs b/crates/js-component-bindgen/src/core.rs
+index 582ba943..822b0e47 100644
+--- a/crates/js-component-bindgen/src/core.rs
++++ b/crates/js-component-bindgen/src/core.rs
+@@ -98,7 +98,7 @@ impl<'a> Translation<'a> {
+         }
+ 
+         // Set up wasm features to use
+-        let mut features = WasmFeatures::default();
++        let mut features = WasmFeatures::WASM3 | WasmFeatures::WIDE_ARITHMETIC;
+         features.set(WasmFeatures::MULTI_MEMORY, false);
+ 
+         match Validator::new_with_features(features).validate_all(translation.wasm) {
+diff --git a/crates/js-component-bindgen/src/intrinsics/lower.rs b/crates/js-component-bindgen/src/intrinsics/lower.rs
+index a8cc61b9..fe8e73f9 100644
+--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
++++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
+@@ -542,15 +542,18 @@ impl LowerIntrinsic {
+ 
+                             ctx.resultPtr = originalPtr + payloadOffset32;
+ 
+-                            const payloadBytesWritten = lowerFn({{
+-                                memory,
+-                                realloc,
+-                                vals: [val],
+-                                storagePtr,
+-                                storageLen,
+-                                componentIdx,
+-                            }});
+-                            let bytesWritten = payloadOffset + payloadBytesWritten;
++                            let payloadBytesWritten = 0;
++                            if (lowerFn) {{
++                                payloadBytesWritten = lowerFn({{
++                                    memory,
++                                    realloc,
++                                    vals: [val],
++                                    storagePtr,
++                                    storageLen,
++                                    componentIdx,
++                                }});
++                            }}
++                            let bytesWritten = payloadOffset32 + payloadBytesWritten;
+ 
+                             const rem = ctx.storagePtr % align32;
+                             if (rem !== 0) {{
+diff --git a/crates/js-component-bindgen/src/intrinsics/mod.rs b/crates/js-component-bindgen/src/intrinsics/mod.rs
+index 0b50d4cf..2e33152f 100644
+--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
++++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
+@@ -1279,6 +1279,22 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+         ]);
+     }
+ 
++    if args
++        .intrinsics
++        .contains(&Intrinsic::Lower(LowerIntrinsic::LowerFlatResult))
++    {
++        args.intrinsics
++            .insert(Intrinsic::Lower(LowerIntrinsic::LowerFlatVariant));
++    }
++
++    if args
++        .intrinsics
++        .contains(&Intrinsic::Lower(LowerIntrinsic::LowerFlatOption))
++    {
++        args.intrinsics
++            .insert(Intrinsic::Lower(LowerIntrinsic::LowerFlatVariant));
++    }
++
+     if args
+         .intrinsics
+         .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatStringUtf8))
+@@ -1364,10 +1380,14 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+     if args
+         .intrinsics
+         .contains(&Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamWrite))
++        || args
++            .intrinsics
++            .contains(&Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamRead))
+     {
+         args.intrinsics.extend([
+             &Intrinsic::GlobalBufferManager,
+             &Intrinsic::AsyncTask(AsyncTaskIntrinsic::AsyncBlockedConstant),
++            &Intrinsic::AsyncEventCodeEnum,
+         ]);
+     }
+ 
+diff --git a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+index 5e027d19..967777a2 100644
+--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
++++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+@@ -1140,7 +1140,7 @@ impl AsyncStreamIntrinsic {
+                     r#"
+                     class {host_stream_class_name} {{
+                         #componentIdx;
+-                        #streamEndIdx;
++                        #streamEndWaitableIdx;
+                         #streamTableIdx;
+ 
+                         #payloadLiftFn;
+@@ -1162,14 +1162,18 @@ impl AsyncStreamIntrinsic {
+                             if (!args.payloadLowerFn) {{ throw new TypeError("missing payload lower fn"); }}
+                             this.#payloadLowerFn = args.payloadLowerFn;
+ 
+-                            if (args.streamEndIdx === undefined) {{ throw new Error("missing stream idx"); }}
++                            if (args.streamEndWaitableIdx === undefined) {{ throw new Error("missing stream idx"); }}
+                             if (args.streamTableIdx === undefined) {{ throw new Error("missing stream table idx"); }}
+-                            this.#streamEndIdx = args.streamEndIdx;
++                            this.#streamEndWaitableIdx = args.streamEndWaitableIdx;
+                             this.#streamTableIdx = args.streamTableIdx;
+ 
+                             this.#isUnitStream = args.isUnitStream;
+                         }}
+ 
++                        setRep(rep) {{
++                            this.#rep = rep;
++                        }}
++
+                         createUserStream(args) {{
+                            if (this.#userStream) {{ return this.#userStream; }}
+                            if (this.#rep === null) {{ throw new Error("unexpectedly missing rep for host stream"); }}
+@@ -1177,9 +1181,9 @@ impl AsyncStreamIntrinsic {
+                            const cstate = {get_or_create_async_state_fn}(this.#componentIdx);
+                            if (!cstate) {{ throw new Error(`missing async state for component [${{this.#componentIdx}}]`); }}
+ 
+-                           const streamEnd = cstate.getStreamEnd({{ tableIdx: this.#streamTableIdx, streamEndIdx: this.#streamEndIdx }});
++                           const streamEnd = cstate.getStreamEnd({{ tableIdx: this.#streamTableIdx, streamEndWaitableIdx: this.#streamEndWaitableIdx }});
+                            if (!streamEnd) {{
+-                               throw new Error(`missing stream [${{this.#streamEndIdx}}] (table [${{this.#streamTableIdx}}], component [${{this.#componentIdx}}]`);
++                               throw new Error(`missing stream [${{this.#streamEndWaitableIdx}}] (table [${{this.#streamTableIdx}}], component [${{this.#componentIdx}}]`);
+                            }}
+ 
+                             return new {external_stream_class}({{
+@@ -1266,6 +1270,20 @@ impl AsyncStreamIntrinsic {
+                             this.#writeFn(obj);
+                         }}
+ 
++                        intoReadableStream() {{
++                            const stream = this;
++                            return new ReadableStream({{
++                                async pull(controller) {{
++                                    const chunk = await stream.next();
++                                    if (chunk === undefined) {{
++                                        controller.close();
++                                    }} else {{
++                                        controller.enqueue(chunk);
++                                    }}
++                                }},
++                            }});
++                        }}
++
+                         [{symbol_dispose}]() {{
+                             this.#dropFn();
+                         }}
+@@ -1366,7 +1384,7 @@ impl AsyncStreamIntrinsic {
+                         {debug_log_fn}('[{stream_new_from_lift_fn}()] args', {{ ctx }});
+                         const {{
+                             componentIdx,
+-                            streamEndIdx,
++                            streamEndWaitableIdx,
+                             streamTableIdx,
+                             payloadLiftFn,
+                             payloadTypeSize32,
+@@ -1376,7 +1394,7 @@ impl AsyncStreamIntrinsic {
+ 
+                         const stream = new {host_stream_class}({{
+                             componentIdx,
+-                            streamEndIdx,
++                            streamEndWaitableIdx,
+                             streamTableIdx,
+                             payloadLiftFn: payloadLiftFn,
+                             payloadLowerFn: payloadLowerFn,
+diff --git a/crates/js-component-bindgen/src/lib.rs b/crates/js-component-bindgen/src/lib.rs
+index b3e08a2a..a33c54df 100644
+--- a/crates/js-component-bindgen/src/lib.rs
++++ b/crates/js-component-bindgen/src/lib.rs
+@@ -128,17 +128,14 @@ pub fn transpile(component: &[u8], opts: TranspileOpts) -> Result<Transpiled> {
+     // This does not require the correct execution of the related features post-transpilation,
+     // but without the right features specified, components won't load at all.
+     let mut validator = wasmtime_environ::wasmparser::Validator::new_with_features(
+-        WasmFeatures::WASM2
++        WasmFeatures::WASM3
+             | WasmFeatures::COMPONENT_MODEL
+             | WasmFeatures::CM_ASYNC
+             | WasmFeatures::CM_ASYNC_BUILTINS
+             | WasmFeatures::CM_ASYNC_STACKFUL
+             | WasmFeatures::CM_ERROR_CONTEXT
+             | WasmFeatures::CM_FIXED_SIZE_LIST
+-            | WasmFeatures::EXCEPTIONS
+-            | WasmFeatures::EXTENDED_CONST
+-            | WasmFeatures::MEMORY64
+-            | WasmFeatures::MULTI_MEMORY,
++            | WasmFeatures::WIDE_ARITHMETIC,
+     );
+ 
+     let mut types = ComponentTypesBuilder::new(&validator);
+diff --git a/package-lock.json b/package-lock.json
+index f34275d9..fd3ff020 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -9038,7 +9038,7 @@
+     },
+     "packages/jco": {
+       "name": "@bytecodealliance/jco",
+-      "version": "1.17.4",
++      "version": "1.17.5",
+       "license": "(Apache-2.0 WITH LLVM-exception)",
+       "dependencies": {
+         "@bytecodealliance/componentize-js": "^0.19.3",


### PR DESCRIPTION
## Summary

This PR patches [jco](https://github.com/bytecodealliance/jco) (v1.17.5) to transpile and **run** Wado-compiled Wasm components in Node.js via JSPI. All CLI examples (`hello`, `fizzbuzz`, `romu`, `mustache`, `simd-ascii`) produce correct output.

## Patch Details

Full patch: [`vendor/jco.patch`](vendor/jco.patch) (9 files changed, 99 insertions, 30 deletions)

### 1. Enable WASM3 and wide arithmetic features

**Files**: `lib.rs`, `core.rs`

The validator in `transpile()` and the core module validator in `Translation::new()` use `WasmFeatures::WASM2`, which excludes GC (rec groups, struct/array types), tail calls, relaxed SIMD, threads, etc. Wado targets Wasm 3.0 and uses GC and wide arithmetic (i128/u128).

**Fix**: Replace `WasmFeatures::WASM2` with `WasmFeatures::WASM3 | WasmFeatures::WIDE_ARITHMETIC` in both validators.

Without this, `jco transpile` fails with:
```
ComponentError: rec group usage requires `gc` proposal to be enabled
```

### 2. Fix `waitable-set.wait` trampoline missing JSPI Suspending

**File**: `transpile_bindgen.rs`

`waitable-set.wait` is an async canonical built-in that must suspend the Wasm caller while waiting for events. The generated trampoline was:
```js
const trampoline5 = waitableSetWait.bind(null, { ... });
```

Missing `WebAssembly.Suspending` wrapper means the Wasm caller does not suspend. It proceeds immediately to `subtask.drop`, which fails because the subtask hasn't been resolved yet.

**Fix**: Wrap in `new WebAssembly.Suspending(...)`.

Without this, runtime crashes with:
```
Error: cannot drop subtask before resolve is delivered
```

### 3. Fix `waitableSetWait` calling undefined `task.waitForEvent()`

**File**: `intrinsics/p3/waitable.rs`

The `waitableSetWait` implementation calls `task.waitForEvent()`, which does not exist on the `AsyncTask` class. The correct method is `task.waitUntil()`, which waits for an event in the WaitableSet.

**Fix**: Replace `task.waitForEvent({ waitableSetRep, isAsync })` with `task.waitUntil({ waitableSetRep, readyFn: () => true, cancellable: false })`.

Also fixes two additional issues in the same function:
- `memory` variable was used but never declared (should be `getMemoryFn()`)
- `_storeEventInComponentMemory` was called with positional args instead of the expected `{ memory, ptr, event }` object

Without this, runtime throws:
```
TypeError: task.waitForEvent is not a function
```

### 4. Add missing intrinsic dependencies

**File**: `intrinsics/mod.rs`

Several intrinsics use other intrinsics without declaring dependencies, causing "X is not defined" runtime errors:

| Intrinsic | Missing dependency |
|---|---|
| `LowerFlatResult` | `LowerFlatVariant` |
| `LowerFlatOption` | `LowerFlatVariant` |
| `StreamWrite` / `StreamRead` | `AsyncEventCodeEnum` |
| `WaitableSetWait` | `StoreEventInComponentMemory` |

### 5. Fix `_lowerFlatVariant` null payload and typo

**File**: `intrinsics/lower.rs`

Two bugs in the `_lowerFlatVariant` intrinsic function:

1. **Null lowerFn crash**: For unit-payload variants like `Result<(), E>`, the lower metadata is `['ok', null, ...]`. The code called `lowerFn({...})` unconditionally, crashing on `null(...)`.

   **Fix**: Guard with `if (lowerFn) { ... }`.

2. **Typo**: `payloadOffset` (undefined) instead of `payloadOffset32` (from destructuring).

### 6. Fix stream naming inconsistency

**Files**: `function_bindgen.rs`, `intrinsics/p3/async_stream.rs`

`streamNewFromLift` destructured `streamEndIdx` from its context, but the caller (`function_bindgen.rs`) passed `streamEndWaitableIdx`. The `HostStream` class and `getStreamEnd` also used inconsistent names.

**Fix**: Consistently use `streamEndWaitableIdx` everywhere.

Also adds missing `setRep()` method to `HostStream` (called by `streamNewFromLift` but never defined) and `intoReadableStream()` to the `Stream` class (expected by preview3-shim).

### 7. Handle async export void return via `task.completionPromise()`

**File**: `function_bindgen.rs`

CM async exports use `task.return` to deliver results — the core Wasm function itself returns void. When wrapped with `WebAssembly.promising()`, the JSPI wrapper returns `undefined`. The generated JS code passes this `undefined` to a `switch(ret)` that expects `0` (ok) or `1` (err), causing:

```
TypeError: invalid variant discriminant for expected
```

**Fix**: After `CallWasm` for async exports, if `ret === undefined`, fall back to `await task.completionPromise()` which contains the already-lifted result from `task.return`.

### 8. Add host stream write hook for direct memory delivery

**File**: `intrinsics/p3/async_stream.rs`

jco's `StreamReadableEnd.read()` uses `count = 1` (hardcoded), reading one byte at a time via the rendezvous mechanism. When the guest writes 14 bytes via `stream.write`, only the first byte is delivered before the rendezvous stalls.

**Fix**: Add a `globalThis._jcoStreamWriteHook(writableEndIdx, data)` callback in `streamWrite`. If the hook returns `true`, data is delivered directly from linear memory (as a `Uint8Array` copy), bypassing the rendezvous. This enables WASI shims to receive bulk stream data.

## Infrastructure

- `vendor/jco` — git submodule (bytecodealliance/jco v1.17.5 + patches)
- `vendor/jco.patch` — cumulative patch file
- `example/jco-shim/` — minimal WASI P3 shims (cli, random, clocks)
- `.claude/skills/jco/` — debug workflow documentation
- `mise.toml` tasks: `build-jco`, `jco-transpile`

## Test Plan

- [x] All 11 `example/*.wado` programs transpile successfully
- [x] `hello.wado` outputs "Hello, world!"
- [x] `fizzbuzz.wado` outputs correct FizzBuzz sequence
- [x] `romu.wado` outputs RNG state and numbers
- [x] `mustache.wado` outputs templated string
- [x] `simd-ascii.wado` outputs case-converted text

https://claude.ai/code/session_01JzP35mE7NiE9sKbFth2e44