### PR TITLE
Remove global rule index and use linear search in find_rule

### DIFF
--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -13,10 +13,6 @@ use {
 } from "./gen_util.wado";
 use { CodeWriter, StructSpec, ImplSpec, FnSpec } from "./wadopoet.wado";
 use { log_stderr } from "core:cli";
-use { TreeMap } from "core:collections";
-
-// Global rule index for O(log n) rule lookups.
-global mut RULE_INDEX: TreeMap<String, i32> = TreeMap::<String, i32>::new();
 
 // --- Prediction Engine ---
 
@@ -906,8 +902,10 @@ fn remove_from_visiting(visiting: &mut Array<String>, name: &String) {
 }
 
 fn find_rule(name: &String, all_rules: &Array<ParserRule>) -> Option<&ParserRule> {
-    if let Some(i) = RULE_INDEX.get(*name) {
-        return Option::<&ParserRule>::Some(&all_rules[i]);
+    for let mut i = 0; i < all_rules.len(); i += 1 {
+        if all_rules[i].name == *name {
+            return Option::<&ParserRule>::Some(&all_rules[i]);
+        }
     }
     return null;
 }
@@ -956,13 +954,6 @@ fn count_leaf_nodes(node: &PredictionNode) -> i32 {
 }
 
 pub fn gen_parser(w: &mut CodeWriter, grammar: &Grammar, lit_tokens: &Array<LitToken>) {
-    // Build rule name → index for O(log n) lookups.
-    let mut idx = TreeMap::<String, i32>::new();
-    for let mut i = 0; i < grammar.parser_rules.len(); i += 1 {
-        idx[grammar.parser_rules[i].name] = i;
-    }
-    RULE_INDEX = idx;
-
     gen_parser_struct(w);
     for let rule of grammar.parser_rules {
         gen_parse_fn(w, &rule, &grammar.parser_rules, lit_tokens);


### PR DESCRIPTION
## Summary
This change removes the global `RULE_INDEX` TreeMap optimization and replaces it with a simple linear search implementation in the `find_rule` function. The global index is no longer built during parser generation.

## Key Changes
- Removed the global mutable `RULE_INDEX: TreeMap<String, i32>` variable and its TreeMap import
- Removed the rule index building logic from `gen_parser()` that populated the TreeMap with rule name-to-index mappings
- Replaced the O(log n) TreeMap lookup in `find_rule()` with a linear O(n) search that iterates through the rules array

## Implementation Details
The `find_rule()` function now performs a simple linear scan through the `all_rules` array, comparing each rule's name with the target name, rather than using a pre-built index for faster lookups. This trades performance for simplicity and reduced memory overhead from maintaining the global index.

https://claude.ai/code/session_01MmrdM94cuSHiFoPB1KKhyp