### PR TITLE
Split String::eq into fast path + slow path for inlining

### DIFF
--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -880,6 +880,7 @@ impl Add for String {
 
 impl Eq for String {
     pub fn eq(&self, other: &Self) -> bool;
+    fn eq_bytes(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool;
 }
 
 impl Ord for String {

--- a/docs/stdlib-core.md
+++ b/docs/stdlib-core.md
@@ -1698,6 +1698,8 @@ String will contain invalid UTF-8, which may cause undefined behavior.
 
 ###### `pub fn eq(&self, other: &Self) -> bool`
 
+###### `fn eq_bytes(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool`
+
 ##### `impl Ord for String`
 
 ###### `pub fn cmp(&self, other: &Self) -> Ordering`

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -170,20 +170,18 @@ impl Add for String {
 impl Eq for String {
     pub fn eq(&self, other: &Self) -> bool {
         let len_a = self.len();
-        let len_b = other.len();
-
-        if len_a != len_b {
+        if len_a != other.len() {
             return false;
         }
+        return String::eq_bytes(self.internal_raw_bytes(), other.internal_raw_bytes(), len_a);
+    }
 
-        let a_repr = self.internal_raw_bytes();
-        let b_repr = other.internal_raw_bytes();
-        for let mut i = 0; i < len_a; i += 1 {
-            if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+    fn eq_bytes(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool {
+        for let mut i = 0; i < len; i += 1 {
+            if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                 return false;
             }
         }
-
         return true;
     }
 }

--- a/wado-compiler/tests/fixtures.golden/array_append_collapse.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/array_append_collapse.wir.wado
@@ -109,6 +109,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
@@ -1342,25 +1344,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l55: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/assert_inspect_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/assert_inspect_string.wir.wado
@@ -74,6 +74,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -365,25 +367,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l21: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/auto_deref_template.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/auto_deref_template.wir.wado
@@ -92,6 +92,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -651,25 +653,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l27: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/base64_encode.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/base64_encode.wir.wado
@@ -105,6 +105,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/StrUtf8ByteIter^Iterator::collect" = fn(ref StrUtf8ByteIter) -> ref Array<u8>;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -1099,25 +1101,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l61: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/closure_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_1.wir.wado
@@ -174,6 +174,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -1005,25 +1007,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l41: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/closure_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/closure_2.wir.wado
@@ -214,6 +214,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Fn<1,i32>>::append" = fn(ref Array<Fn<1,i32>>, ref struct);
@@ -2456,25 +2458,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l98: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/cross_module_treemap_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/cross_module_treemap_variant.wir.wado
@@ -135,6 +135,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/TreeMap<String,Value>::insert" = fn(ref "./sub/cross_module_treemap_variant_helper.wado/TreeMap<String,Value>", ref String, ref "./sub/cross_module_treemap_variant_helper.wado/Value");
@@ -568,25 +570,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l28: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/default_trait.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/default_trait.wir.wado
@@ -94,6 +94,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -476,25 +478,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l27: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/dict_mini.wir.wado
@@ -94,6 +94,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Tuple<String,String>>::append" = fn(ref Array<Tuple<String,String>>, ref "tuple/[String, String]");
@@ -503,25 +505,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l27: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/display_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_1.wir.wado
@@ -221,6 +221,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/DisplayPoint^Display::fmt" = fn(ref DisplayPoint, ref Formatter);
@@ -8380,25 +8382,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l454: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/display_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_2.wir.wado
@@ -157,6 +157,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -8836,25 +8838,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l430: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/from-literal-cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-cast.wir.wado
@@ -96,6 +96,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
@@ -666,25 +668,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l31: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/from-literal-custom.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-custom.wir.wado
@@ -103,6 +103,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
@@ -767,25 +769,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l35: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/from-literal-return.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from-literal-return.wir.wado
@@ -128,6 +128,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -538,25 +540,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l23: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/from_char_to_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/from_char_to_string.wir.wado
@@ -84,6 +84,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -546,25 +548,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l25: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/generic_function_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_function_merged.wir.wado
@@ -141,6 +141,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1866,25 +1868,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l177: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/generic_method_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_method_merged.wir.wado
@@ -132,6 +132,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -801,25 +803,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l44: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/generic_struct_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/generic_struct_1.wir.wado
@@ -227,6 +227,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -2617,25 +2619,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l207: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/http-request-path.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-request-path.wir.wado
@@ -287,6 +287,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1173,25 +1175,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l66: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/http-routing-created.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-routing-created.wir.wado
@@ -247,6 +247,8 @@ type "functype/core:internal/cm_lower_string" = fn(ref String) -> i64;
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/future-write" = fn(i32, i32) -> i32;
@@ -894,25 +896,23 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l52: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/http-routing.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-routing.wir.wado
@@ -247,6 +247,8 @@ type "functype/core:internal/cm_lower_string" = fn(ref String) -> i64;
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/wasi/future-new" = fn() -> i64;
 
 type "functype/wasi/future-write" = fn(i32, i32) -> i32;
@@ -896,25 +898,23 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l53: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/ident_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ident_merged.wir.wado
@@ -108,6 +108,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -772,25 +774,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l41: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/include_str_basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/include_str_basic.wir.wado
@@ -84,6 +84,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -454,25 +456,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l23: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/inspect_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_1.wir.wado
@@ -180,6 +180,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/InspColor^Inspect::inspect" = fn(enum:InspColor, ref Formatter);
@@ -3330,25 +3332,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l232: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/inspect_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_2.wir.wado
@@ -251,6 +251,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/InspPoint^Inspect::inspect" = fn(ref InspPoint, ref Formatter);
@@ -1869,25 +1871,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l53: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/inspect_3.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/inspect_3.wir.wado
@@ -161,6 +161,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/NDColor^Inspect::inspect" = fn(enum:NDColor, ref Formatter);
@@ -2264,25 +2266,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l178: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/iterator_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_merged.wir.wado
@@ -122,6 +122,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/ArrayIter<String>^Iterator::next" = fn(ref "core:allocator/ArrayIter<String>") -> ref null String;
@@ -929,25 +931,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l44: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/iterator_trait_map.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/iterator_trait_map.wir.wado
@@ -90,6 +90,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/String::from_iter<IterMap<StrCharIter,char>>" = fn(ref "core:allocator/IterMap<StrCharIter,char>") -> ref String;
@@ -625,25 +627,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l30: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-both-traits.wir.wado
@@ -97,6 +97,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
@@ -726,25 +728,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l32: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-conditional.wir.wado
@@ -119,6 +119,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -574,25 +576,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l24: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key-value-literal-immutable.wir.wado
@@ -102,6 +102,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
@@ -707,25 +709,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l30: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/local_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/local_merged.wir.wado
@@ -107,6 +107,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -634,25 +636,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l38: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/match_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_1.wir.wado
@@ -112,6 +112,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1177,25 +1179,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l61: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/match_ergonomics.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_ergonomics.wir.wado
@@ -104,6 +104,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -763,25 +765,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l41: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/match_or_pattern_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_or_pattern_1.wir.wado
@@ -76,6 +76,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -476,25 +478,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l32: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/match_or_pattern_3.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_or_pattern_3.wir.wado
@@ -74,6 +74,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -677,25 +679,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l69: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/match_or_pattern_6.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_or_pattern_6.wir.wado
@@ -76,6 +76,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -657,25 +659,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l54: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/match_return_from_arm.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/match_return_from_arm.wir.wado
@@ -76,6 +76,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -735,25 +737,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l43: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/mut_param.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param.wir.wado
@@ -104,6 +104,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -1347,25 +1349,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l51: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/mut_param_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/mut_param_merged.wir.wado
@@ -106,6 +106,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -1407,25 +1409,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l50: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/opt_copy_prop_multi_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_copy_prop_multi_field.wir.wado
@@ -123,6 +123,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -856,25 +858,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l45: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/opt_copy_prop_while_let.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_copy_prop_while_let.wir.wado
@@ -86,6 +86,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -648,25 +650,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l43: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/opt_crossmod_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_crossmod_array.wir.wado
@@ -124,6 +124,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -1206,25 +1208,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l54: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_box_parameter.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_box_parameter.wir.wado
@@ -184,6 +184,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/__Closure_5::__call" = fn(ref __Closure_5) -> ref String;
@@ -3728,25 +3730,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l250: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_single_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_single_field.wir.wado
@@ -123,6 +123,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Wrapper::set" = fn(ref Wrapper, i32);
@@ -2289,25 +2291,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l183: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_variant_per_case.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_variant_per_case.wir.wado
@@ -84,6 +84,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -678,25 +680,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l33: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/ordering-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ordering-basic.wir.wado
@@ -56,6 +56,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/Array<i32>^Eq::eq" = fn(ref Array<i32>, ref Array<i32>) -> bool;
@@ -305,25 +307,23 @@ fn i32^Ord::cmp(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l22: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
@@ -111,6 +111,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -888,25 +890,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l39: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/pub_struct_field_same_module.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pub_struct_field_same_module.wir.wado
@@ -89,6 +89,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Secret::describe" = fn(ref Secret) -> ref String;
@@ -467,25 +469,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l23: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/ref_equality_struct_with_ref.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/ref_equality_struct_with_ref.wir.wado
@@ -95,6 +95,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Container^Eq::eq" = fn(ref Container, ref Container) -> bool;
@@ -580,25 +582,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l24: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/return_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/return_merged.wir.wado
@@ -100,6 +100,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -631,25 +633,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l28: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
@@ -210,6 +210,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json/JsonStructSerializer", ref String, ref String) -> ref null "core:serde/SerializeError";
@@ -1225,25 +1227,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l127: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_array_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_array_string.wir.wado
@@ -162,6 +162,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -1102,25 +1104,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l107: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
@@ -244,6 +244,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Option<String>,DeserializeError>;
@@ -1530,25 +1532,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l146: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error.wir.wado
@@ -241,6 +241,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/__Closure_0::__call" = fn(ref __Closure_0, ref String, i32, i32) -> ref Option<i32>;
@@ -1554,25 +1556,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l131: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
@@ -367,6 +367,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -3555,25 +3557,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l288: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_int_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_int_types.wir.wado
@@ -168,6 +168,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
@@ -2104,25 +2106,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l204: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_large_int.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_large_int.wir.wado
@@ -203,6 +203,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
@@ -2323,25 +2325,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l233: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
@@ -240,6 +240,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Point,DeserializeError>;
@@ -2303,25 +2305,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l219: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
@@ -265,6 +265,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json/JsonDeserializer") -> ref Result<Array<i32>,DeserializeError>;
@@ -1570,25 +1572,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l140: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
@@ -218,6 +218,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
@@ -4042,25 +4044,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l300: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_rename.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_rename.wir.wado
@@ -202,6 +202,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json/JsonStructSerializer", ref String, ref String) -> ref null "core:serde/SerializeError";
@@ -1298,25 +1300,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l131: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_rename_all.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_rename_all.wir.wado
@@ -214,6 +214,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/__Closure_0::__call" = fn(ref __Closure_0, ref String, i32, i32) -> ref Option<i32>;
@@ -1766,25 +1768,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l212: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_result.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_result.wir.wado
@@ -162,6 +162,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/JsonVariantSerializer^SerializeVariant::payload<String>" = fn(ref "core:json/JsonVariantSerializer", ref String) -> ref null "core:serde/SerializeError";
@@ -1182,25 +1184,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l117: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
@@ -713,6 +713,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -6578,25 +6580,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l456: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_ser_error.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_ser_error.wir.wado
@@ -154,6 +154,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -2056,25 +2058,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l186: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_string_escape.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_string_escape.wir.wado
@@ -130,6 +130,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
@@ -1102,25 +1104,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l61: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.wir.wado
@@ -163,6 +163,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Color^Inspect::inspect" = fn(enum:Color, ref Formatter);
@@ -837,25 +839,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l52: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
@@ -235,6 +235,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json/JsonDeserializer");
@@ -2181,25 +2183,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l200: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
@@ -462,6 +462,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -2628,25 +2630,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l150: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
@@ -280,6 +280,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<String,DeserializeError>;
@@ -2094,25 +2096,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l183: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
@@ -297,6 +297,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json/JsonStructSerializer", ref String, ref String) -> ref null "core:serde/SerializeError";
@@ -2951,25 +2953,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l261: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/static_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_2.wir.wado
@@ -124,6 +124,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -900,25 +902,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l36: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
@@ -383,7 +383,7 @@ fn String::truncate_bytes(self, byte_len) {
             String::append_char(__local_10, 58);
             __local_11 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             __local_17 = __local_11;
-            i32::fmt_decimal(357, __local_17);
+            i32::fmt_decimal(355, __local_17);
             String::append_char(__local_10, 58);
             String::append_char(__local_10, 32);
             String::append(__local_10, String { repr: array.new_data<u8>("negative length"), used: 15 });
@@ -421,7 +421,7 @@ condition: byte_len >= 0
                 String::append_char(__local_12, 58);
                 __local_13 = Formatter { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
                 __local_28 = __local_13;
-                i32::fmt_decimal(362, __local_28);
+                i32::fmt_decimal(360, __local_28);
                 String::append_char(__local_12, 58);
                 String::append_char(__local_12, 32);
                 String::append(__local_12, String { repr: array.new_data<u8>("not on a UTF-8 character boundary"), used: 33 });

--- a/wado-compiler/tests/fixtures.golden/string_from_utf8_lossy_newtype.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_from_utf8_lossy_newtype.wir.wado
@@ -95,6 +95,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/String::from_utf8_lossy<Array<u8>>" = fn(ref Array<u8>) -> ref String;
@@ -400,25 +402,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l21: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/struct_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_2.wir.wado
@@ -137,6 +137,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/ArrayIter<SDPoint>^Iterator::next" = fn(ref "core:allocator/ArrayIter<SDPoint>") -> ref null SDPoint;
@@ -1060,25 +1062,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l44: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/struct_eq_auto_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_eq_auto_generic.wir.wado
@@ -86,6 +86,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Pair<String>^Inspect::inspect" = fn(ref Pair<String>, ref Formatter);
@@ -647,25 +649,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l30: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/struct_eq_auto_variant_field.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/struct_eq_auto_variant_field.wir.wado
@@ -79,6 +79,8 @@ type "functype/core:internal/cm_stream_write_raw_u8" = fn(i32, ref array<u8>, i3
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/Pixel^Eq::eq" = fn(ref Pixel, ref Pixel) -> bool;
 
 type "functype/Container^Eq::eq" = fn(ref Container, ref Container) -> bool;
@@ -292,25 +294,23 @@ fn "core:internal/cm_waitable_set_wait"(ws) {  // from core:internal
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l16: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/template-string-generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/template-string-generic.wir.wado
@@ -102,6 +102,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -723,25 +725,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l28: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/template_string_option_loop.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/template_string_option_loop.wir.wado
@@ -92,6 +92,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Case>::append" = fn(ref Array<Case>, ref Case);
@@ -525,25 +527,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l29: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/test_world_variant_group.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/test_world_variant_group.wir.wado
@@ -97,6 +97,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -410,25 +412,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l23: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_unsafe.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tmpl_hoist_escape_unsafe.wir.wado
@@ -119,6 +119,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -657,25 +659,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l34: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/trait_bound_7.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/trait_bound_7.wir.wado
@@ -108,6 +108,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -506,25 +508,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l27: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-basic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-basic.wir.wado
@@ -119,6 +119,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -679,25 +681,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l29: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-cast.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-cast.wir.wado
@@ -119,6 +119,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -610,25 +612,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l25: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-fn-arg.wir.wado
@@ -139,6 +139,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -578,25 +580,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l26: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-mutable.wir.wado
@@ -119,6 +119,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -606,25 +608,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l25: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap-literal-string-values.wir.wado
@@ -119,6 +119,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -632,25 +634,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l26: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap_btree.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree.wir.wado
@@ -156,6 +156,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -800,25 +802,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l39: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/treemap_btree2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/treemap_btree2.wir.wado
@@ -166,6 +166,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String^Ord::cmp" = fn(ref String, ref String) -> enum:Ordering;
 
 type "functype/String::append_char" = fn(ref String, char);
@@ -753,25 +755,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l31: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/try_merged.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/try_merged.wir.wado
@@ -240,6 +240,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<i32>::append" = fn(ref Array<i32>, i32);
@@ -1739,25 +1741,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l104: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/tuple_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_1.wir.wado
@@ -131,6 +131,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1267,25 +1269,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l41: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/tuple_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_2.wir.wado
@@ -157,6 +157,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/ArrayIter<Tuple<i32,String>>^Iterator::next" = fn(ref "core:allocator/ArrayIter<Tuple<i32,String>>") -> ref null "tuple/[i32, String]";
@@ -1115,25 +1117,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l56: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/tuple_for_of.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/tuple_for_of.wir.wado
@@ -159,6 +159,8 @@ type "functype/String::concat" = fn(ref String, ref String) -> ref String;
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/String^Describe::describe" = fn(ref String) -> ref String;
@@ -2730,25 +2732,23 @@ fn String::concat(a, b) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l210: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/variadic_1.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variadic_1.wir.wado
@@ -176,6 +176,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<String>::append" = fn(ref Array<String>, ref String);
@@ -1714,25 +1716,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l58: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/variadic_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variadic_2.wir.wado
@@ -130,6 +130,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1134,25 +1136,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l52: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/variadic_3.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variadic_3.wir.wado
@@ -247,6 +247,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -2733,25 +2735,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l221: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/variadic_deserialize.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variadic_deserialize.wir.wado
@@ -197,6 +197,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json/JsonSeqAccess") -> ref Result<String,DeserializeError>;
@@ -988,25 +990,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l97: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/variant_deref_cross_module.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_deref_cross_module.wir.wado
@@ -155,6 +155,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Array<Elem>::append" = fn(ref Array<Elem>, ref "./sub/variant_deref_helper.wado/Elem");
@@ -550,25 +552,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l33: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/variant_infer.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_infer.wir.wado
@@ -99,6 +99,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -538,25 +540,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l30: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/wir_issue8_cross_module_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wir_issue8_cross_module_variant.wir.wado
@@ -104,6 +104,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -577,25 +579,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l27: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/fixtures.golden/wir_optimize_unwrap_fresh_elision_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wir_optimize_unwrap_fresh_elision_edge.wir.wado
@@ -121,6 +121,8 @@ type "functype/String::append" = fn(ref String, ref String);
 
 type "functype/String^Eq::eq" = fn(ref String, ref String) -> bool;
 
+type "functype/String^Eq::eq_bytes" = fn(ref array<u8>, ref array<u8>, i32) -> bool;
+
 type "functype/String::append_char" = fn(ref String, char);
 
 type "functype/Formatter::write_char_n" = fn(ref Formatter, char, i32);
@@ -1299,25 +1301,23 @@ fn String::append(self, other) {
 
 fn String^Eq::eq(self, other) {
     let len_a: i32;
-    let len_b: i32;
-    let a_repr: ref array<u8>;
-    let b_repr: ref array<u8>;
-    let i: i32;
     len_a = self.used;
-    len_b = other.used;
-    if len_a != len_b {
+    if len_a != other.used {
         return 0;
     };
-    a_repr = self.repr;
-    b_repr = other.repr;
+    return String^Eq::eq_bytes(self.repr, other.repr, len_a);
+}
+
+fn String^Eq::eq_bytes(a, b, len) {
+    let i: i32;
     __for_1: block {
         i = 0;
         block {
             l52: loop {
-                if (i < len_a) == 0 {
+                if (i < len) == 0 {
                     break __for_1;
                 };
-                if builtin::array_get_u8(a_repr, i) != builtin::array_get_u8(b_repr, i) {
+                if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                     return 0;
                 };
                 i = i + 1;

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -10077,20 +10077,21 @@ pub fn "String^Add::add"(self: &String, other: &String) -> String {
 
 pub fn "String^Eq::eq"(self: &String, other: &String) -> bool {
     let len_a: i32 = self.String::len();
-    let len_b: i32 = other.String::len();
-    if (len_a != len_b) {
+    if (len_a != other.String::len()) {
         return false;
     }
-    let a_repr: builtin::array<u8> = self.String::internal_raw_bytes();
-    let b_repr: builtin::array<u8> = other.String::internal_raw_bytes();
+    return "core::prelude/string.wado::String^Eq::eq_bytes"(self.String::internal_raw_bytes(), other.String::internal_raw_bytes(), len_a);
+}
+
+fn "String^Eq::eq_bytes"(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool {
     __for_1: {
         let mut i: i32 = 0;
         loop {
-            if !(i < len_a) {
+            if !(i < len) {
                 break __for_1;
             }
             __for_1_body: {
-                if (core::builtin::array_get_u8(a_repr, i) != core::builtin::array_get_u8(b_repr, i)) {
+                if (core::builtin::array_get_u8(a, i) != core::builtin::array_get_u8(b, i)) {
                     return false;
                 }
             }
@@ -10544,7 +10545,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                 __r.String::append("core:prelude/string.wado");
                 __r.String::append(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 357 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 355 }."i32^Display::fmt"(&mut __f);
                 __r.String::append(": ");
                 __r.String::append("negative length");
                 __r.String::append("\ncondition: byte_len >= 0\n");
@@ -10573,7 +10574,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                     __r.String::append("core:prelude/string.wado");
                     __r.String::append(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 362 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 360 }."i32^Display::fmt"(&mut __f);
                     __r.String::append(": ");
                     __r.String::append("not on a UTF-8 character boundary");
                     __r.String::append("\ncondition: b < 0x80 || b >= 0xC0\n");

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -9289,20 +9289,21 @@ pub fn "String^Add::add"(self: &String, other: &String) -> String {
 
 pub fn "String^Eq::eq"(self: &String, other: &String) -> bool {
     let len_a: i32 = self.String::len();
-    let len_b: i32 = other.String::len();
-    if (len_a != len_b) {
+    if (len_a != other.String::len()) {
         return false;
     }
-    let a_repr: builtin::array<u8> = self.String::internal_raw_bytes();
-    let b_repr: builtin::array<u8> = other.String::internal_raw_bytes();
+    return "core::prelude/string.wado::String^Eq::eq_bytes"(self.String::internal_raw_bytes(), other.String::internal_raw_bytes(), len_a);
+}
+
+fn "String^Eq::eq_bytes"(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool {
     __for_1: {
         let mut i: i32 = 0;
         loop {
-            if !(i < len_a) {
+            if !(i < len) {
                 break __for_1;
             }
             __for_1_body: {
-                if (core::builtin::array_get_u8(a_repr, i) != core::builtin::array_get_u8(b_repr, i)) {
+                if (core::builtin::array_get_u8(a, i) != core::builtin::array_get_u8(b, i)) {
                     return false;
                 }
             }
@@ -9756,7 +9757,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                 __r.String::append("core:prelude/string.wado");
                 __r.String::append(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 357 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 355 }."i32^Display::fmt"(&mut __f);
                 __r.String::append(": ");
                 __r.String::append("negative length");
                 __r.String::append("\ncondition: byte_len >= 0\n");
@@ -9785,7 +9786,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                     __r.String::append("core:prelude/string.wado");
                     __r.String::append(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 362 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 360 }."i32^Display::fmt"(&mut __f);
                     __r.String::append(": ");
                     __r.String::append("not on a UTF-8 character boundary");
                     __r.String::append("\ncondition: b < 0x80 || b >= 0xC0\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -8583,20 +8583,21 @@ pub fn "String^Add::add"(self: &String, other: &String) -> String {
 
 pub fn "String^Eq::eq"(self: &String, other: &String) -> bool {
     let len_a: i32 = self.String::len();
-    let len_b: i32 = other.String::len();
-    if (len_a != len_b) {
+    if (len_a != other.String::len()) {
         return false;
     }
-    let a_repr: builtin::array<u8> = self.String::internal_raw_bytes();
-    let b_repr: builtin::array<u8> = other.String::internal_raw_bytes();
+    return "core::prelude/string.wado::String^Eq::eq_bytes"(self.String::internal_raw_bytes(), other.String::internal_raw_bytes(), len_a);
+}
+
+fn "String^Eq::eq_bytes"(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool {
     __for_1: {
         let mut i: i32 = 0;
         loop {
-            if !(i < len_a) {
+            if !(i < len) {
                 break __for_1;
             }
             __for_1_body: {
-                if (core::builtin::array_get_u8(a_repr, i) != core::builtin::array_get_u8(b_repr, i)) {
+                if (core::builtin::array_get_u8(a, i) != core::builtin::array_get_u8(b, i)) {
                     return false;
                 }
             }
@@ -9050,7 +9051,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                 __r.String::append("core:prelude/string.wado");
                 __r.String::append(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 357 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 355 }."i32^Display::fmt"(&mut __f);
                 __r.String::append(": ");
                 __r.String::append("negative length");
                 __r.String::append("\ncondition: byte_len >= 0\n");
@@ -9079,7 +9080,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                     __r.String::append("core:prelude/string.wado");
                     __r.String::append(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 362 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 360 }."i32^Display::fmt"(&mut __f);
                     __r.String::append(": ");
                     __r.String::append("not on a UTF-8 character boundary");
                     __r.String::append("\ncondition: b < 0x80 || b >= 0xC0\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -8583,20 +8583,21 @@ pub fn "String^Add::add"(self: &String, other: &String) -> String {
 
 pub fn "String^Eq::eq"(self: &String, other: &String) -> bool {
     let len_a: i32 = self.String::len();
-    let len_b: i32 = other.String::len();
-    if (len_a != len_b) {
+    if (len_a != other.String::len()) {
         return false;
     }
-    let a_repr: builtin::array<u8> = self.String::internal_raw_bytes();
-    let b_repr: builtin::array<u8> = other.String::internal_raw_bytes();
+    return "core::prelude/string.wado::String^Eq::eq_bytes"(self.String::internal_raw_bytes(), other.String::internal_raw_bytes(), len_a);
+}
+
+fn "String^Eq::eq_bytes"(a: builtin::array<u8>, b: builtin::array<u8>, len: i32) -> bool {
     __for_1: {
         let mut i: i32 = 0;
         loop {
-            if !(i < len_a) {
+            if !(i < len) {
                 break __for_1;
             }
             __for_1_body: {
-                if (core::builtin::array_get_u8(a_repr, i) != core::builtin::array_get_u8(b_repr, i)) {
+                if (core::builtin::array_get_u8(a, i) != core::builtin::array_get_u8(b, i)) {
                     return false;
                 }
             }
@@ -9050,7 +9051,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                 __r.String::append("core:prelude/string.wado");
                 __r.String::append(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 357 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 355 }."i32^Display::fmt"(&mut __f);
                 __r.String::append(": ");
                 __r.String::append("negative length");
                 __r.String::append("\ncondition: byte_len >= 0\n");
@@ -9079,7 +9080,7 @@ pub fn String::truncate_bytes(self: &mut String, byte_len: i32) {
                     __r.String::append("core:prelude/string.wado");
                     __r.String::append(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 362 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 360 }."i32^Display::fmt"(&mut __f);
                     __r.String::append(": ");
                     __r.String::append("not on a UTF-8 character boundary");
                     __r.String::append("\ncondition: b < 0x80 || b >= 0xC0\n");


### PR DESCRIPTION
## Summary

- Split `String^Eq::eq` into a small fast path (length comparison only) and a separate `eq_bytes` slow path (byte-by-byte loop)
- The fast path has few enough expressions to be inlined by the compiler, so callers skip the function call entirely when string lengths differ

## Benchmark

`gale gen SQLite.g4` (string-comparison-heavy workload):

| Before | After | Speedup |
|--------|-------|---------|
| 4m13s  | 1m04s | ~4x     |

Guest profiler showed `String^Eq::eq` at 28% inclusive time. Most calls in this workload compare strings of different lengths (e.g. `array_contains_str` scanning token arrays), so the length mismatch early-exit dominates.

## Test plan

- [x] `cargo test --release -p wado-compiler` — all tests pass
- [ ] CI green

https://claude.ai/code/session_01Mz8z6W978jr8Ad5x9nDoat