### PR TITLE
Redesign TODO test output: separate axis with pending/resolved

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -959,7 +959,8 @@ test "panics on invalid input" {
     panic("bad input");
 }
 
-// TODO test: like #[expect_trap], but should be solved in the future
+// TODO test: reported on a separate axis from pass/fail.
+// Pending (traps) = expected. Resolved (passes) = must remove #[TODO].
 #[TODO]
 test "not yet implemented" {
     panic("TODO: implement this");

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3301,8 +3301,8 @@ test {
     unreachable();
 }
 
-// TODO test: passes while the feature is unimplemented (body traps).
-// When it stops trapping, the runner warns to remove the attribute.
+// TODO test: marks a test for an unimplemented feature.
+// Reported on a separate axis from pass/fail (see Test Outcome Model).
 #[TODO]
 test "not yet implemented" {
     panic("TODO: implement this feature");
@@ -3359,7 +3359,7 @@ test "panics on null dereference" {
 
 **`#[TODO]` Attribute:**
 
-The `#[TODO]` attribute marks a test as a placeholder for a feature not yet implemented. It has the same trap-expectation semantics as `#[expect_trap]`, but the runner emits a distinct failure message when the body unexpectedly passes, reminding the developer to remove the attribute.
+The `#[TODO]` attribute marks a test as a placeholder for a feature not yet implemented. TODO tests are reported on a separate axis from regular pass/fail results (see Test Outcome Model below). When the body traps, the test is reported as **pending** (expected). When the body completes normally, the test is reported as **resolved**, which is a hard failure requiring the developer to remove the `#[TODO]` attribute.
 
 **`#[timeout_ms(N)]` Attribute:**
 
@@ -3372,6 +3372,79 @@ test "large data processing" {
     assert result.len() > 0;
 }
 ```
+
+### Test Outcome Model
+
+Test results are classified into two independent axes: the **pass/fail axis** for regular tests, and the **TODO axis** for tests marked with `#[TODO]`.
+
+#### Regular Tests
+
+| Condition                                               | Outcome  |
+| ------------------------------------------------------- | -------- |
+| Body completes normally                                 | **pass** |
+| Body traps (panic, assert failure, unreachable)         | **fail** |
+| Body traps and `#[expect_trap]` is present              | **pass** |
+| Body completes normally and `#[expect_trap]` is present | **fail** |
+
+#### TODO Tests
+
+Tests marked with `#[TODO]` are reported separately from regular tests. They do not contribute to the pass or fail count.
+
+| Condition               | Outcome             | Action Required                           |
+| ----------------------- | ------------------- | ----------------------------------------- |
+| Body traps              | **todo (pending)**  | None — the feature is still unimplemented |
+| Body completes normally | **todo (resolved)** | Remove `#[TODO]` — the feature now works  |
+
+A **resolved** TODO test is a hard failure (exit code 1). This enforces cleanup: once the underlying feature is implemented, the `#[TODO]` attribute must be removed so the test joins the regular pass/fail pool.
+
+A **pending** TODO test never causes a failure. This means fixing a compiler bug cannot increase the failure count — newly-passing TODO tests appear as "resolved" on the TODO axis rather than as unexpected failures on the pass/fail axis.
+
+#### `#![TODO]` Modules
+
+The `#![TODO]` inner attribute applies TODO semantics to an entire module:
+
+- If the module fails to compile, it is reported as a single **pending** TODO entry.
+- If the module compiles successfully, each test block is implicitly treated as `#[TODO]`.
+- If the module compiles and all tests pass (i.e., the feature is implemented), it is reported as **resolved** — a hard failure.
+
+#### Output Format
+
+The test runner displays results grouped by file. Regular tests use `✓` (green) and `✗` (red). TODO tests use `·` (yellow, pending) and `✓` (cyan, resolved):
+
+```
+Running tests in math_test.wado... (compiled in 50ms)
+  ✓ addition (2ms)
+  ✗ division_edge_case (3ms)
+    assertion failed at line 15
+  · future_feature # TODO (1ms)
+  ✓ now_works # TODO resolved (2ms)
+    remove the #[TODO] attribute
+```
+
+At the end of the run, a TODO summary section lists all TODO tests with their status:
+
+```
+TODO tests (3):
+  · pending   math_test.wado — future_feature
+  ✓ resolved  math_test.wado — now_works
+  · pending   unimpl_test.wado — #![TODO] module
+
+1 TODO test(s) resolved — remove the #[TODO] attribute
+```
+
+The final summary line reports both axes:
+
+```
+N passed, N failed; N todo (M resolved) (duration)
+```
+
+#### Exit Codes
+
+| Condition                                 | Exit Code |
+| ----------------------------------------- | --------- |
+| All regular tests pass, no resolved TODOs | 0         |
+| One or more regular tests fail            | 1         |
+| One or more TODO tests resolved           | 1         |
 
 **Effects:**
 
@@ -3407,25 +3480,9 @@ wado test --help
 
 When no files are specified, `wado test` searches for `**/*_test.wado` files recursively from the current directory.
 
-**Output:**
+**Output and Exit Codes:**
 
-```
-Running tests in math_test.wado...
-  ✓ addition works
-  ✓ subtraction works
-  ✗ division edge case
-    assertion failed at line 15
-
-Running tests in string_test.wado...
-  ✓ concatenation
-
-3 passed, 1 failed
-```
-
-**Exit Codes:**
-
-- `0`: All tests passed
-- `1`: One or more tests failed
+See Test Outcome Model above for the full output format, TODO summary, and exit code rules.
 
 ### Test File Conventions
 
@@ -4348,16 +4405,29 @@ struct Foo {
 }
 ```
 
-#### `#[expect_trap]` / `#[TODO]`
+#### `#[expect_trap]`
 
-Test block attributes. `#[expect_trap]` marks a test that is expected to trap. `#[TODO]` marks a test for an unimplemented feature (must fail; the test itself fails if the body passes, to remind you to remove the annotation).
+Test block attribute. Marks a test that is expected to trap. The test passes if the body traps, and fails if it completes normally.
 
 ```wado
 #[expect_trap]
 test "panics on invalid input" {
     panic("bad input");
 }
+```
 
+#### `#[TODO]`
+
+Test block attribute. Marks a test for an unimplemented feature. TODO tests are reported on a separate axis from regular pass/fail results:
+
+- If the body traps, the test is **pending** (expected — the feature is still unimplemented).
+- If the body completes normally, the test is **resolved** (hard failure — the `#[TODO]` attribute must be removed).
+
+Pending TODO tests never cause the test runner to fail. Resolved TODO tests always cause the test runner to fail with exit code 1.
+
+See Test Outcome Model in the Testing section for the full specification.
+
+```wado
 #[TODO]
 test "not yet implemented" {
     panic("TODO: implement this");
@@ -4395,7 +4465,13 @@ Module-level inner attribute. Prevents the automatic import of `core:prelude`. U
 
 #### `#![TODO]`
 
-Module-level inner attribute. Marks the entire module as TODO for `wado test`. The source must parse successfully (otherwise the attribute cannot be recognized), but compilation errors are tolerated. If compilation fails, the module is reported as a passing TODO test. If compilation succeeds, all test blocks are treated as `#[TODO]` tests: they must fail (trap or error). If any test passes, it becomes a test failure, signaling that the `#![TODO]` attribute should be removed.
+Module-level inner attribute. Marks the entire module as TODO for `wado test`. The source must parse successfully (otherwise the attribute cannot be recognized), but compilation errors are tolerated:
+
+- If compilation fails, the module is reported as a single **pending** TODO entry.
+- If compilation succeeds, all test blocks are implicitly treated as `#[TODO]` tests.
+- If the module compiles and all tests pass, it is reported as **resolved** (hard failure — the `#![TODO]` attribute must be removed).
+
+See Test Outcome Model in the Testing section for the full specification.
 
 ```wado
 #![TODO]

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -206,12 +206,26 @@ struct TestJob {
     timeout_ms: u64,
 }
 
+/// Outcome of a single test execution.
+///
+/// Regular tests are either Pass or Fail.
+/// TODO tests live on a separate axis:
+///   - TodoPending: trapped as expected (the feature is still unimplemented)
+///   - TodoResolved: passed unexpectedly (the feature may now work — remove #[TODO])
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TestOutcome {
+    Pass,
+    Fail,
+    TodoPending,
+    TodoResolved,
+}
+
 /// Result from a test execution
 struct TestResult {
     file_path: String,
     test_name: String,
     display_name: String,
-    passed: bool,
+    outcome: TestOutcome,
     error: Option<String>,
     duration: Duration,
 }
@@ -378,7 +392,7 @@ async fn run_single_test(module: &CompiledTestModule, job: &TestJob) -> TestResu
                 file_path: module.path.clone(),
                 test_name: job.test_name.clone(),
                 display_name: job.display_name.clone(),
-                passed: false,
+                outcome: TestOutcome::Fail,
                 error: Some(format!("failed to set up store: {e}")),
                 duration: start.elapsed(),
             };
@@ -395,7 +409,7 @@ async fn run_single_test(module: &CompiledTestModule, job: &TestJob) -> TestResu
                 file_path: module.path.clone(),
                 test_name: job.test_name.clone(),
                 display_name: job.display_name.clone(),
-                passed: false,
+                outcome: TestOutcome::Fail,
                 error: Some(format!("failed to set up linker: {e}")),
                 duration: start.elapsed(),
             };
@@ -413,7 +427,7 @@ async fn run_single_test(module: &CompiledTestModule, job: &TestJob) -> TestResu
                 file_path: module.path.clone(),
                 test_name: job.test_name.clone(),
                 display_name: job.display_name.clone(),
-                passed: false,
+                outcome: TestOutcome::Fail,
                 error: Some(format!("failed to instantiate: {e}")),
                 duration: start.elapsed(),
             };
@@ -423,53 +437,56 @@ async fn run_single_test(module: &CompiledTestModule, job: &TestJob) -> TestResu
     // Get and call the test function
     let test_func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, &job.test_name);
 
-    let (passed, error) = match test_func {
+    let (outcome, error) = match test_func {
         Ok(func) => match func.call_async(&mut store, ()).await {
             Ok((Ok(()),)) => {
                 if job.is_todo {
+                    // TODO test passed — the feature may now work. This is good news,
+                    // not a failure. Report as "resolved" so the developer can remove #[TODO].
                     (
-                        false,
-                        Some(
-                            "TODO test passed unexpectedly — \
-                             the feature may be implemented; remove the #[TODO] attribute"
-                                .to_string(),
-                        ),
+                        TestOutcome::TodoResolved,
+                        Some("remove the #[TODO] attribute".to_string()),
                     )
                 } else if job.expect_trap {
                     (
-                        false,
+                        TestOutcome::Fail,
                         Some("expected trap but test returned Ok(())".to_string()),
                     )
                 } else {
-                    (true, None)
+                    (TestOutcome::Pass, None)
                 }
             }
-            Ok((Err(()),)) => (false, Some("test returned error".to_string())),
+            Ok((Err(()),)) => (TestOutcome::Fail, Some("test returned error".to_string())),
             Err(e) => {
                 let is_timeout = is_epoch_deadline_error(&e);
                 if is_timeout {
                     (
-                        false,
+                        TestOutcome::Fail,
                         Some(format!(
                             "test timed out after {}ms (use #[timeout_ms(N)] to increase)",
                             job.timeout_ms
                         )),
                     )
-                } else if job.expect_trap || job.is_todo {
-                    (true, None) // expected trap: pass
+                } else if job.is_todo {
+                    (TestOutcome::TodoPending, None) // TODO test trapped as expected
+                } else if job.expect_trap {
+                    (TestOutcome::Pass, None) // expect_trap test trapped as expected
                 } else {
-                    (false, Some(format!("{e}")))
+                    (TestOutcome::Fail, Some(format!("{e}")))
                 }
             }
         },
-        Err(e) => (false, Some(format!("failed to get test function: {e}"))),
+        Err(e) => (
+            TestOutcome::Fail,
+            Some(format!("failed to get test function: {e}")),
+        ),
     };
 
     TestResult {
         file_path: module.path.clone(),
         test_name: job.test_name.clone(),
         display_name: job.display_name.clone(),
-        passed,
+        outcome,
         error,
         duration: start.elapsed(),
     }
@@ -609,8 +626,18 @@ pub async fn run(opts: TestOptions) {
         .collect();
 
     // Display results in file order (matching input order)
-    let mut total_passed = 0;
-    let mut total_failed = 0;
+    let mut total_passed = 0u32;
+    let mut total_failed = 0u32;
+    let mut total_todo = 0u32;
+    let mut total_todo_resolved = 0u32;
+
+    // Collect TODO entries for the summary section at the end
+    struct TodoEntry {
+        file_path: String,
+        display_name: String,
+        resolved: bool,
+    }
+    let mut todo_entries: Vec<TodoEntry> = Vec::new();
 
     // Build a lookup from path to compiled module for compile duration
     let module_by_path: indexmap::IndexMap<&str, &CompiledTestModule> = modules
@@ -623,8 +650,15 @@ pub async fn run(opts: TestOptions) {
         if let Some(todo_err) = todo_error_by_path.get(path.as_str()) {
             let compile = format_duration(todo_err.compile_duration);
             println!("Running tests in {path}... (compile error, {compile})");
-            println!("  \x1b[32m✓\x1b[0m #![TODO] module — compile error (expected) ({compile})");
-            total_passed += 1;
+            println!(
+                "  \x1b[33m·\x1b[0m #![TODO] module — compile error (expected) ({compile})"
+            );
+            total_todo += 1;
+            todo_entries.push(TodoEntry {
+                file_path: path.clone(),
+                display_name: "#![TODO] module".to_string(),
+                resolved: false,
+            });
             continue;
         }
 
@@ -649,25 +683,92 @@ pub async fn run(opts: TestOptions) {
 
             for result in sorted_results {
                 let dur = format_duration(result.duration);
-                if result.passed {
-                    println!("  \x1b[32m✓\x1b[0m {} ({dur})", result.display_name);
-                    total_passed += 1;
-                } else {
-                    println!("  \x1b[31m✗\x1b[0m {} ({dur})", result.display_name);
-                    if let Some(ref error) = result.error {
-                        println!("    {error}");
+                match result.outcome {
+                    TestOutcome::Pass => {
+                        println!("  \x1b[32m✓\x1b[0m {} ({dur})", result.display_name);
+                        total_passed += 1;
                     }
-                    total_failed += 1;
+                    TestOutcome::Fail => {
+                        println!("  \x1b[31m✗\x1b[0m {} ({dur})", result.display_name);
+                        if let Some(ref error) = result.error {
+                            println!("    {error}");
+                        }
+                        total_failed += 1;
+                    }
+                    TestOutcome::TodoPending => {
+                        println!(
+                            "  \x1b[33m·\x1b[0m {} \x1b[33m# TODO\x1b[0m ({dur})",
+                            result.display_name
+                        );
+                        total_todo += 1;
+                        todo_entries.push(TodoEntry {
+                            file_path: result.file_path.clone(),
+                            display_name: result.display_name.clone(),
+                            resolved: false,
+                        });
+                    }
+                    TestOutcome::TodoResolved => {
+                        println!(
+                            "  \x1b[36m✓\x1b[0m {} \x1b[36m# TODO resolved\x1b[0m ({dur})",
+                            result.display_name
+                        );
+                        if let Some(ref error) = result.error {
+                            println!("    {error}");
+                        }
+                        total_todo_resolved += 1;
+                        todo_entries.push(TodoEntry {
+                            file_path: result.file_path.clone(),
+                            display_name: result.display_name.clone(),
+                            resolved: true,
+                        });
+                    }
                 }
             }
         }
     }
 
+    // TODO summary section
+    if !todo_entries.is_empty() {
+        println!();
+        let todo_total = total_todo + total_todo_resolved;
+        println!("TODO tests ({todo_total}):");
+        for entry in &todo_entries {
+            if entry.resolved {
+                println!(
+                    "  \x1b[36m✓ resolved\x1b[0m  {} — {}",
+                    entry.file_path, entry.display_name
+                );
+            } else {
+                println!(
+                    "  \x1b[33m· pending\x1b[0m   {} — {}",
+                    entry.file_path, entry.display_name
+                );
+            }
+        }
+        if total_todo_resolved > 0 {
+            println!();
+            println!(
+                "\x1b[36m{total_todo_resolved} TODO test(s) resolved — \
+                 remove the #[TODO] attribute\x1b[0m"
+            );
+        }
+    }
+
+    // Summary line: "N passed, N failed; N todo (M resolved)"
     let total_dur = format_duration(overall_start.elapsed());
     println!();
-    println!("{total_passed} passed, {total_failed} failed ({total_dur})");
+    let mut summary = format!("{total_passed} passed, {total_failed} failed");
+    let todo_total = total_todo + total_todo_resolved;
+    if todo_total > 0 {
+        summary.push_str(&format!("; {todo_total} todo"));
+        if total_todo_resolved > 0 {
+            summary.push_str(&format!(" ({total_todo_resolved} resolved)"));
+        }
+    }
+    summary.push_str(&format!(" ({total_dur})"));
+    println!("{summary}");
 
-    if total_failed > 0 {
+    if total_failed > 0 || total_todo_resolved > 0 {
         process::exit(1);
     }
 }

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -210,8 +210,8 @@ struct TestJob {
 ///
 /// Regular tests are either Pass or Fail.
 /// TODO tests live on a separate axis:
-///   - TodoPending: trapped as expected (the feature is still unimplemented)
-///   - TodoResolved: passed unexpectedly (the feature may now work — remove #[TODO])
+///   - `TodoPending`: trapped as expected (the feature is still unimplemented)
+///   - `TodoResolved`: passed unexpectedly (the feature may now work — remove #[TODO])
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TestOutcome {
     Pass,

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -650,9 +650,7 @@ pub async fn run(opts: TestOptions) {
         if let Some(todo_err) = todo_error_by_path.get(path.as_str()) {
             let compile = format_duration(todo_err.compile_duration);
             println!("Running tests in {path}... (compile error, {compile})");
-            println!(
-                "  \x1b[33m·\x1b[0m #![TODO] module — compile error (expected) ({compile})"
-            );
+            println!("  \x1b[33m·\x1b[0m #![TODO] module — compile error (expected) ({compile})");
             total_todo += 1;
             todo_entries.push(TodoEntry {
                 file_path: path.clone(),

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -554,9 +554,11 @@ fn run_test_world(
             match func.call_async(&mut store, ()).await {
                 Ok((Ok(()),)) => {
                     if is_todo {
+                        // TODO test passed — the feature may now work.
+                        // This is a hard failure: #[TODO] must be removed.
                         anyhow::bail!(
-                            "[{test_id}] TODO test '{test_name}' passed unexpectedly — \
-                             the feature may be implemented; remove the #[TODO] attribute"
+                            "[{test_id}] TODO test '{test_name}' resolved — \
+                             remove the #[TODO] attribute"
                         );
                     } else if expect_trap {
                         anyhow::bail!(
@@ -579,7 +581,7 @@ fn run_test_world(
                             "[{test_id}] test '{test_name}' trapped: {e}. stderr: {stderr_text}"
                         );
                     }
-                    // expected trap (expect_trap or TODO): pass
+                    // expected trap (expect_trap or TODO): pending
                 }
             }
 
@@ -665,12 +667,14 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
         match test_result {
             Ok(()) if spec.test_world.is_some() => {
                 // Test world: individual tests are already marked #[TODO] by the resolver.
-                // Success here means all TODO tests trapped as expected — this is correct.
+                // Success here means all TODO tests resolved — report but don't fail.
             }
             Ok(()) => {
+                // #![TODO] module passed — the feature may now work.
+                // This is a hard failure: #![TODO] must be removed.
                 panic!(
-                    "[{test_id}] #![TODO] module PASSED! The feature may be implemented.\n\
-                     Remove the #![TODO] attribute from the source file."
+                    "[{test_id}] #![TODO] module resolved — \
+                     remove the #![TODO] attribute from the source file."
                 );
             }
             Err(err) => {
@@ -679,13 +683,13 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
                     .map(String::as_str)
                     .or_else(|| err.downcast_ref::<&str>().copied())
                     .unwrap_or("(unknown panic)");
-                eprintln!("[{test_id}] #![TODO] module failed as expected: {msg}");
+                eprintln!("[{test_id}] #![TODO] module pending: {msg}");
                 return;
             }
         }
     }
 
-    // Normal test - run without panic recovery
+    // Normal test (or resolved TODO module) - run without panic recovery
     run_normal_test(fixture_path, source, opt_level, &spec, &test_id);
 }
 


### PR DESCRIPTION
## Summary

- TODO tests (`#[TODO]`, `#![TODO]`) are now reported on a **separate axis** from pass/fail, inspired by TAP's TODO directive
- **Pending** (body traps): expected — the feature is still unimplemented. Does not affect exit code.
- **Resolved** (body passes): hard failure (exit code 1) — enforces removing `#[TODO]` when the feature works.
- New summary format: `N passed, N failed; N todo (M resolved)`
- TODO summary section at the end lists all TODO tests with file path and status
- Formal specification added to `docs/spec.md` (Test Outcome Model section)

### Motivation

Previously, TODO tests were "expected to fail" — if a compiler fix caused a TODO test to start passing, it showed up as a **test failure**, which was confusing and made compiler development harder. Now, newly-passing TODO tests appear as "resolved" on the TODO axis instead.

### Output example

```
Running tests in math_test.wado... (compiled in 50ms)
  ✓ addition (2ms)
  · future_feature # TODO (1ms)
  ✓ now_works # TODO resolved (2ms)
    remove the #[TODO] attribute

TODO tests (2):
  · pending   math_test.wado — future_feature
  ✓ resolved  math_test.wado — now_works

1 TODO test(s) resolved — remove the #[TODO] attribute

1 passed, 0 failed; 2 todo (1 resolved) (0.12s)
```

## Test plan

- [x] `cargo check --bin wado` passes
- [x] `cargo check --test e2e -p wado-compiler` passes
- [x] Unit tests for test name parsing pass
- [ ] `mise run on-task-done` (running)

https://claude.ai/code/session_01Dt11N9EJkrwhjhC7PhMLQG