### PR TITLE
Optimize cranelift-codegen in dev profile for faster E2E tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ libc = { version = "0.2" }
 [profile.dev.package.wado-compiler]
 opt-level = 1
 
+# Optimize Cranelift in dev/test builds for faster E2E tests.
+# Cranelift compiles Wasm→native for every test; without this it runs in debug mode.
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 disallowed_types = "warn"


### PR DESCRIPTION
## Summary

- Set `opt-level = 2` for `cranelift-codegen` in the dev profile to speed up E2E tests
- Cranelift compiles Wasm→native for every test; without optimization it runs in debug mode, accounting for ~70% of test time
- **O0 test suite: 319s → 246s (~23% faster)**

## Profiling details

Profiled the O0 E2E test suite (877 tests) and found:

| Phase | Time per test | Share |
|---|---|---|
| Wado compile (Wado→Wasm) | ~0.17s | ~30% |
| Wasmtime runtime (Cranelift + instantiate + run) | ~0.40s | ~70% |

- stdlib parsing is already cached via `OnceLock` — not a bottleneck
- Linker caching was tested but had no effect (`Linker::clone()` ≈ `add_to_linker` cost)
- Other wasmtime crates at O2 provided no additional improvement beyond `cranelift-codegen` alone
- Build time increases by ~16s (one-time cost, amortized across test runs)

## Test plan

- [x] Full O0 test suite passes (862 passed, 15 pre-existing failures)
- [x] Verified no behavior change — same pass/fail results as before
- [x] Build time impact measured (~16s increase)

https://claude.ai/code/session_01MvCfQRXKLDn386HwGHfSQM