### PR TITLE
Add undefined type validation in type definitions

### DIFF
--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -22,7 +22,7 @@ use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
 use super::Resolver;
 use super::types::{
     EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, GenericNewtypeInfo, ModuleTypeMaps,
-    ResourceInfo, StructFieldInfo, VariantCaseData, VariantInfo,
+    ResourceInfo, StructFieldInfo, TypeError, VariantCaseData, VariantInfo,
 };
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -514,11 +514,22 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     cache.insert(name.clone());
                 }
             }
+            for m in all_resource_types.values() {
+                for name in m.keys() {
+                    cache.insert(name.clone());
+                }
+            }
             for name in crate::tir::PrimitiveType::all_primitive_names() {
                 cache.insert(name.to_string());
             }
             cache
         };
+
+        // Validate type names in struct fields, variant payloads, and newtype definitions.
+        // At this point all type names from all modules are known, so any unrecognized
+        // Named type is truly undefined. This catches undefined types that would silently
+        // become UNKNOWN in static pre-resolution.
+        Self::validate_type_definitions(modules, &global_known_type_names, logger)?;
 
         // Second pass: resolve each module with per-module function_return_types and imports
         let _span = logger.span("resolve/modules");
@@ -1021,6 +1032,134 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
         // Convert indices back to sources
         sorted_indices.iter().map(|&i| sources[i].clone()).collect()
+    }
+
+    /// Validate that all named types in struct fields, variant payloads, and newtype
+    /// definitions refer to known types. Runs after the second sub-pass when all type
+    /// names from all modules have been collected.
+    fn validate_type_definitions(
+        modules: &IndexMap<ModuleSource, Module>,
+        known_type_names: &IndexSet<String>,
+        logger: &Logger<'_, H>,
+    ) -> Result<(), Bail> {
+        for (module_source, module) in modules {
+            logger.set_file(module_source.diagnostic_filename());
+            for item in &module.items {
+                match item {
+                    Item::Struct(struct_decl) => {
+                        let type_params: Vec<&str> = struct_decl
+                            .type_params
+                            .iter()
+                            .map(|p| p.name.as_str())
+                            .collect();
+                        for field in &struct_decl.fields {
+                            Self::validate_ast_type_names(
+                                &field.ty,
+                                known_type_names,
+                                &type_params,
+                                logger,
+                            )?;
+                        }
+                    }
+                    Item::Variant(variant_decl) => {
+                        let type_params: Vec<&str> = variant_decl
+                            .type_params
+                            .iter()
+                            .map(|p| p.name.as_str())
+                            .collect();
+                        for case in &variant_decl.cases {
+                            if let Some(payload_ty) = &case.payload {
+                                Self::validate_ast_type_names(
+                                    payload_ty,
+                                    known_type_names,
+                                    &type_params,
+                                    logger,
+                                )?;
+                            }
+                        }
+                    }
+                    Item::Newtype(newtype_decl) => {
+                        let type_params: Vec<&str> = newtype_decl
+                            .type_params
+                            .iter()
+                            .map(|p| p.name.as_str())
+                            .collect();
+                        Self::validate_ast_type_names(
+                            &newtype_decl.ty,
+                            known_type_names,
+                            &type_params,
+                            logger,
+                        )?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        logger.clear_file();
+        Ok(())
+    }
+
+    /// Walk an AST type expression and emit errors for unknown Named types.
+    /// Generic type names (Array, Result, etc.) are not checked here since they
+    /// may be builtins not present in the type name registry; only their type
+    /// arguments are validated recursively.
+    fn validate_ast_type_names(
+        ty: &Type,
+        known_type_names: &IndexSet<String>,
+        type_params: &[&str],
+        logger: &Logger<'_, H>,
+    ) -> Result<(), Bail> {
+        match ty {
+            Type::Named(named) => {
+                if named.name == "()" || named.name == "!" || named.name == "Self" {
+                    return Ok(());
+                }
+                if type_params.contains(&named.name.as_str()) {
+                    return Ok(());
+                }
+                if known_type_names.contains(&named.name) {
+                    return Ok(());
+                }
+                logger.error(TypeError::UnknownType {
+                    name: named.name.clone(),
+                    span: named.span,
+                })?;
+                Ok(())
+            }
+            Type::Generic(generic) => {
+                for arg in &generic.args {
+                    Self::validate_ast_type_names(arg, known_type_names, type_params, logger)?;
+                }
+                Ok(())
+            }
+            Type::NamespacedGeneric(ng) => {
+                for arg in &ng.args {
+                    Self::validate_ast_type_names(arg, known_type_names, type_params, logger)?;
+                }
+                Ok(())
+            }
+            Type::Reference(inner) | Type::MutReference(inner) => {
+                Self::validate_ast_type_names(inner, known_type_names, type_params, logger)
+            }
+            Type::Tuple(elems) => {
+                for elem in elems {
+                    Self::validate_ast_type_names(elem, known_type_names, type_params, logger)?;
+                }
+                Ok(())
+            }
+            Type::Function(ft) => {
+                for param in &ft.params {
+                    Self::validate_ast_type_names(param, known_type_names, type_params, logger)?;
+                }
+                Self::validate_ast_type_names(
+                    &ft.return_type,
+                    known_type_names,
+                    type_params,
+                    logger,
+                )
+            }
+            Type::TypePackSpread(_, _) => Ok(()),
+        }
     }
 
     /// Static version of `resolve_type` for use before the resolver is fully constructed

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -1165,15 +1165,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 }
                 Ok(())
             }
-            Type::Reference(inner) | Type::MutReference(inner) => {
-                Self::validate_ast_type_names(
-                    inner,
-                    known_type_names,
-                    resource_type_names,
-                    type_params,
-                    logger,
-                )
-            }
+            Type::Reference(inner) | Type::MutReference(inner) => Self::validate_ast_type_names(
+                inner,
+                known_type_names,
+                resource_type_names,
+                type_params,
+                logger,
+            ),
             Type::Tuple(elems) => {
                 for elem in elems {
                     Self::validate_ast_type_names(

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -514,11 +514,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     cache.insert(name.clone());
                 }
             }
-            for m in all_resource_types.values() {
-                for name in m.keys() {
-                    cache.insert(name.clone());
-                }
-            }
             for name in crate::tir::PrimitiveType::all_primitive_names() {
                 cache.insert(name.to_string());
             }
@@ -529,7 +524,19 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // At this point all type names from all modules are known, so any unrecognized
         // Named type is truly undefined. This catches undefined types that would silently
         // become UNKNOWN in static pre-resolution.
-        Self::validate_type_definitions(modules, &global_known_type_names, logger)?;
+        // Resource type names are kept separate from global_known_type_names because
+        // adding them would break is_known_type_name() used in impl block type parameter
+        // inference (e.g., `impl Request { ... }` would stop recognizing Request's methods).
+        let resource_type_names: IndexSet<String> = all_resource_types
+            .values()
+            .flat_map(|m| m.keys().cloned())
+            .collect();
+        Self::validate_type_definitions(
+            modules,
+            &global_known_type_names,
+            &resource_type_names,
+            logger,
+        )?;
 
         // Second pass: resolve each module with per-module function_return_types and imports
         let _span = logger.span("resolve/modules");
@@ -1040,6 +1047,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     fn validate_type_definitions(
         modules: &IndexMap<ModuleSource, Module>,
         known_type_names: &IndexSet<String>,
+        resource_type_names: &IndexSet<String>,
         logger: &Logger<'_, H>,
     ) -> Result<(), Bail> {
         for (module_source, module) in modules {
@@ -1056,6 +1064,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             Self::validate_ast_type_names(
                                 &field.ty,
                                 known_type_names,
+                                resource_type_names,
                                 &type_params,
                                 logger,
                             )?;
@@ -1072,6 +1081,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                 Self::validate_ast_type_names(
                                     payload_ty,
                                     known_type_names,
+                                    resource_type_names,
                                     &type_params,
                                     logger,
                                 )?;
@@ -1087,6 +1097,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         Self::validate_ast_type_names(
                             &newtype_decl.ty,
                             known_type_names,
+                            resource_type_names,
                             &type_params,
                             logger,
                         )?;
@@ -1106,6 +1117,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     fn validate_ast_type_names(
         ty: &Type,
         known_type_names: &IndexSet<String>,
+        resource_type_names: &IndexSet<String>,
         type_params: &[&str],
         logger: &Logger<'_, H>,
     ) -> Result<(), Bail> {
@@ -1120,6 +1132,9 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 if known_type_names.contains(&named.name) {
                     return Ok(());
                 }
+                if resource_type_names.contains(&named.name) {
+                    return Ok(());
+                }
                 logger.error(TypeError::UnknownType {
                     name: named.name.clone(),
                     span: named.span,
@@ -1128,32 +1143,63 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
             Type::Generic(generic) => {
                 for arg in &generic.args {
-                    Self::validate_ast_type_names(arg, known_type_names, type_params, logger)?;
+                    Self::validate_ast_type_names(
+                        arg,
+                        known_type_names,
+                        resource_type_names,
+                        type_params,
+                        logger,
+                    )?;
                 }
                 Ok(())
             }
             Type::NamespacedGeneric(ng) => {
                 for arg in &ng.args {
-                    Self::validate_ast_type_names(arg, known_type_names, type_params, logger)?;
+                    Self::validate_ast_type_names(
+                        arg,
+                        known_type_names,
+                        resource_type_names,
+                        type_params,
+                        logger,
+                    )?;
                 }
                 Ok(())
             }
             Type::Reference(inner) | Type::MutReference(inner) => {
-                Self::validate_ast_type_names(inner, known_type_names, type_params, logger)
+                Self::validate_ast_type_names(
+                    inner,
+                    known_type_names,
+                    resource_type_names,
+                    type_params,
+                    logger,
+                )
             }
             Type::Tuple(elems) => {
                 for elem in elems {
-                    Self::validate_ast_type_names(elem, known_type_names, type_params, logger)?;
+                    Self::validate_ast_type_names(
+                        elem,
+                        known_type_names,
+                        resource_type_names,
+                        type_params,
+                        logger,
+                    )?;
                 }
                 Ok(())
             }
             Type::Function(ft) => {
                 for param in &ft.params {
-                    Self::validate_ast_type_names(param, known_type_names, type_params, logger)?;
+                    Self::validate_ast_type_names(
+                        param,
+                        known_type_names,
+                        resource_type_names,
+                        type_params,
+                        logger,
+                    )?;
                 }
                 Self::validate_ast_type_names(
                     &ft.return_type,
                     known_type_names,
+                    resource_type_names,
                     type_params,
                     logger,
                 )

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1277,6 +1277,31 @@ impl TypeTable {
         }
     }
 
+    /// Check if a type contains UNKNOWN (undefined type that was not resolved).
+    pub fn contains_unknown(&self, id: TypeId) -> bool {
+        match self.get(id) {
+            ResolvedType::Unknown => true,
+            ResolvedType::BuiltinArray(inner)
+            | ResolvedType::Ref(inner)
+            | ResolvedType::MutRef(inner)
+            | ResolvedType::Reactive(inner) => self.contains_unknown(*inner),
+            ResolvedType::Tuple(elems) => elems.iter().any(|e| self.contains_unknown(*e)),
+            ResolvedType::Function {
+                params,
+                return_type,
+                ..
+            } => {
+                params.iter().any(|p| self.contains_unknown(*p))
+                    || self.contains_unknown(*return_type)
+            }
+            ResolvedType::GenericInstance { type_args, .. }
+            | ResolvedType::GenericResource { type_args, .. } => {
+                type_args.iter().any(|t| self.contains_unknown(*t))
+            }
+            _ => false,
+        }
+    }
+
     /// Check if a type is or contains type parameters or unresolved types (Unknown/Error)
     pub fn contains_type_param(&self, id: TypeId) -> bool {
         match self.get(id) {

--- a/wado-compiler/tests/fixtures/cross_module_undefined_struct_in_array.wado
+++ b/wado-compiler/tests/fixtures/cross_module_undefined_struct_in_array.wado
@@ -1,0 +1,10 @@
+use { println, Stdout } from "core:cli";
+use lib from "./sub/cross_module_undefined_struct_in_array.wado";
+
+export fn run() with Stdout {
+    let o = lib::make();
+    println(`{o.span}`);
+}
+
+__DATA__
+{"compile_error": "unknown type 'UndefinedStruct'"}

--- a/wado-compiler/tests/fixtures/sub/cross_module_undefined_struct_in_array.wado
+++ b/wado-compiler/tests/fixtures/sub/cross_module_undefined_struct_in_array.wado
@@ -1,0 +1,15 @@
+#![generated]
+
+pub struct Inner {
+    pub value: i32,
+}
+
+pub struct Outer {
+    pub span: i32,
+    pub items: Array<UndefinedStruct>,
+}
+
+pub fn make() -> Outer {
+    let items: Array<UndefinedStruct> = [];
+    return Outer { span: 0, items };
+}


### PR DESCRIPTION
## Summary

- Add `validate_type_definitions` pass that runs after all type names from all modules are known, catching undefined types used in struct fields, variant payloads, and newtype definitions
- Resource type names (Request, Response, Waitable, etc.) are passed separately from `global_known_type_names` to avoid breaking `is_known_type_name()` used in impl block type parameter inference
- Apply rustfmt formatting fix for CI Integrity

## Details

The compiler previously silently accepted undefined types in struct fields (e.g., `Array<UndefinedStruct>`), leading to confusing downstream errors or silent failures. This PR adds an early validation pass (`validate_ast_type_names`) that walks AST `Type` expressions and emits clear `TypeError::UnknownType` errors.

Key design decision: resource type names are kept in a **separate** `IndexSet` from `global_known_type_names` because adding them to the global set breaks `is_known_type_name()` — which is used in impl block type parameter inference (e.g., `impl Request { ... }` would stop recognizing Request's methods).

## Test plan

- [x] New E2E test `cross_module_undefined_struct_in_array.wado` verifies the error message
- [x] All existing tests pass (1268 wado tests, all E2E fixture tests)

https://claude.ai/code/session_01NrpYmXfjK2fwgu6ksYnMzw