### PR TITLE
Fix AGENTS.md: clarify bug priority, fix typo, remove fg instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ To initialize: `git submodule update --init --recommend-shallow`
 ## General Rules
 
 - All the documents and comments must be written in English.
-- If you find a compiler bug, fix it with the highest priority by TDD - a standalone minimum reproducible e2e fixture is required before fixing the bug.
+- If you find a compiler bug, always write a minimum reproducible e2e fixture first. If the bug blocks the current task, fix it immediately before continuing. Otherwise, commit the fixture and continue the current task.
 - Use sub-agents only for research tasks (searching, reading, exploring). Never use sub-agents for editing files.
 - `CLAUDE.md` is a symlink to `AGENTS.md`.
 
@@ -160,7 +160,7 @@ To initialize: `git submodule update --init --recommend-shallow`
 - Write correct code with correct design.
 - Manage dependencies in the workspace `Cargo.toml`.
 - Do not use `#![allow(deprecated)]`; use newer alternatives instead.
-- Use `panic!` for things that are not yet implemented or not supported.
+- Use `panic!` macro for things that are not yet implemented or not supported.
 - YAGNI. Do the simplest thing that could possibly work.
 - Use `IndexMap` and `IndexSet` from the `indexmap` crate in order to ensure deterministic behaviors.
 - Do not use any comment sections to separate or organize code.
@@ -231,5 +231,5 @@ When you have completed a task, make sure everything is up-to-date and tested:
 - Run `time mise run on-task-done`
   - It performs format, clippy-fix, update golden fixtures, generation of stdlib docs, and tests.
   - It will take 20+ minutes.
-  - Run it in foreground without `| tail` in order not to lost the results.
+  - Run it without `| tail` in order not to lose the results.
   - Commit the entire results of `on-task-done`.


### PR DESCRIPTION
## Summary
- Clarify compiler bug handling: always write a minimum reproducible fixture first; fix immediately only if it blocks the current task, otherwise commit the fixture and continue
- Fix typo: "lost" → "lose"
- Remove "in foreground" instruction (conflicts with Bash tool's 10-minute max timeout for a 20+ minute task)
- Clarify `panic!` → `panic!` macro in Rust rules

## Test plan
- [x] No code changes, documentation only
- [x] `mise run format` passes with no diff

https://claude.ai/code/session_0185mPgiBPVM7zfyyrrQGuYD