### PR TITLE
Add unified WIR visitor traits and migrate optimization passes

### DIFF
--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -145,6 +145,10 @@ Post-optimization rewrite that converts `if cond { a } else { b }` where both br
 
 Shared visitor infrastructure used by optimization passes to traverse and rewrite TIR trees.
 
+### WIR Visitor (`wir_visitor.rs`)
+
+Shared visitor infrastructure (`WirRefVisitor` / `WirMutVisitor`) for traversing and rewriting WIR instruction trees. Centralizes Block/Loop/If/Seq body traversal so individual optimization passes don't duplicate walk logic. Passes that only need body-level traversal (not expression children) override `visit_instr` to skip the `for_each_child` fallback.
+
 ## WIR Optimizations
 
 **Module:** `wir_optimize.rs`

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -33,8 +33,8 @@ pub mod unparse;
 pub mod wir;
 pub mod wir_build;
 pub mod wir_optimize;
-pub mod wir_visitor;
 pub mod wir_unparse;
+pub mod wir_visitor;
 pub mod world_registry;
 
 pub use analyze::Analyzer;

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -33,6 +33,7 @@ pub mod unparse;
 pub mod wir;
 pub mod wir_build;
 pub mod wir_optimize;
+pub mod wir_visitor;
 pub mod wir_unparse;
 pub mod world_registry;
 

--- a/wado-compiler/src/wir_optimize/array.rs
+++ b/wado-compiler/src/wir_optimize/array.rs
@@ -71,8 +71,7 @@ impl WirMutVisitor for PromoteConstantArrays<'_> {
             if let Some(Some(elem_type)) = self.array_elem_types.get(arr_type_idx)
                 && let Some(bytes) = try_pack_constant_elements(elem_type, elements)
             {
-                let data_index =
-                    u32::try_from(self.data.len()).expect("too many data segments");
+                let data_index = u32::try_from(self.data.len()).expect("too many data segments");
                 let len = i32::try_from(elements.len()).unwrap_or(0);
                 self.data.push(WirData {
                     bytes,

--- a/wado-compiler/src/wir_optimize/array.rs
+++ b/wado-compiler/src/wir_optimize/array.rs
@@ -8,6 +8,7 @@ use crate::hashmap::IndexSet;
 use crate::wir::{
     COMP_FEATURE_ARRAY_APPEND, WirData, WirInstr, WirModule, WirType, WirTypeDef, WirTypeId,
 };
+use crate::wir_visitor::WirMutVisitor;
 
 /// Minimum element count to trigger `array.new_data` promotion. Arrays with
 /// fewer constant elements keep using `array.new_fixed`.
@@ -34,76 +35,56 @@ pub(super) fn promote_constant_arrays_to_data(module: &mut WirModule) {
         })
         .collect();
 
+    let mut visitor = PromoteConstantArrays {
+        array_elem_types: &array_elem_types,
+        data: &mut module.data,
+    };
     for func in &mut module.functions {
         if let Some(body) = &mut func.body {
             for instr in body.iter_mut() {
-                promote_arrays_in_instr(instr, &array_elem_types, &mut module.data);
+                visitor.visit_instr(instr);
             }
         }
     }
 
     // Also check global initializers (e.g., `global ITEMS: Array<i32> = [1,2,3]`).
     for global in &mut module.globals {
-        promote_arrays_in_instr(&mut global.init, &array_elem_types, &mut module.data);
+        visitor.visit_instr(&mut global.init);
     }
 }
 
-/// Recursively walk an instruction tree and promote eligible `ArrayNewFixed` nodes.
-fn promote_arrays_in_instr(
-    instr: &mut WirInstr,
-    array_elem_types: &[Option<WirType>],
-    data: &mut Vec<WirData>,
-) {
-    // Recurse into children first (bottom-up).
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            for child in body.iter_mut() {
-                promote_arrays_in_instr(child, array_elem_types, data);
-            }
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            promote_arrays_in_instr(condition, array_elem_types, data);
-            for child in then_body.iter_mut() {
-                promote_arrays_in_instr(child, array_elem_types, data);
-            }
-            if let Some(eb) = else_body {
-                for child in eb.iter_mut() {
-                    promote_arrays_in_instr(child, array_elem_types, data);
-                }
-            }
-        }
-        _ => {
-            instr.for_each_boxed_child_mut(&mut |child| {
-                promote_arrays_in_instr(child, array_elem_types, data);
-            });
-        }
-    }
+struct PromoteConstantArrays<'a> {
+    array_elem_types: &'a [Option<WirType>],
+    data: &'a mut Vec<WirData>,
+}
 
-    // Check if THIS instruction is an eligible ArrayNewFixed.
-    if let WirInstr::ArrayNewFixed { type_id, elements } = instr
-        && elements.len() >= ARRAY_NEW_DATA_THRESHOLD
-    {
-        let arr_type_idx = type_id.index() as usize;
-        if let Some(Some(elem_type)) = array_elem_types.get(arr_type_idx)
-            && let Some(bytes) = try_pack_constant_elements(elem_type, elements)
+impl WirMutVisitor for PromoteConstantArrays<'_> {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        // Recurse into children first (bottom-up).
+        self.walk_instr(instr);
+
+        // Check if THIS instruction is an eligible ArrayNewFixed.
+        if let WirInstr::ArrayNewFixed { type_id, elements } = instr
+            && elements.len() >= ARRAY_NEW_DATA_THRESHOLD
         {
-            let data_index = u32::try_from(data.len()).expect("too many data segments");
-            let len = i32::try_from(elements.len()).unwrap_or(0);
-            data.push(WirData {
-                bytes,
-                offset: None, // passive segment
-            });
-            *instr = WirInstr::ArrayNewData {
-                type_id: type_id.clone(),
-                data_index,
-                offset: Box::new(WirInstr::I32Const(0)),
-                len: Box::new(WirInstr::I32Const(len)),
-            };
+            let arr_type_idx = type_id.index() as usize;
+            if let Some(Some(elem_type)) = self.array_elem_types.get(arr_type_idx)
+                && let Some(bytes) = try_pack_constant_elements(elem_type, elements)
+            {
+                let data_index =
+                    u32::try_from(self.data.len()).expect("too many data segments");
+                let len = i32::try_from(elements.len()).unwrap_or(0);
+                self.data.push(WirData {
+                    bytes,
+                    offset: None, // passive segment
+                });
+                *instr = WirInstr::ArrayNewData {
+                    type_id: type_id.clone(),
+                    data_index,
+                    offset: Box::new(WirInstr::I32Const(0)),
+                    len: Box::new(WirInstr::I32Const(len)),
+                };
+            }
         }
     }
 }
@@ -200,53 +181,31 @@ const ARRAY_NEW_FIXED_LIMIT: usize = 256;
 /// Walks all function bodies and rewrites any `ArrayNewFixed` with more than
 /// [`ARRAY_NEW_FIXED_LIMIT`] elements. Uses a module-level counter for unique local names.
 pub(super) fn split_large_array_literals(module: &mut WirModule) {
-    let mut counter: u32 = 0;
+    let mut visitor = SplitLargeArrays { counter: 0 };
     for func in &mut module.functions {
         if let Some(body) = &mut func.body {
             for instr in body.iter_mut() {
-                split_large_arrays_in_instr(instr, &mut counter);
+                visitor.visit_instr(instr);
             }
         }
     }
 }
 
-/// Recursively walk an instruction tree and replace large `ArrayNewFixed` nodes.
-fn split_large_arrays_in_instr(instr: &mut WirInstr, counter: &mut u32) {
-    // First, recurse into children so inner ArrayNewFixed nodes are handled first.
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            for child in body.iter_mut() {
-                split_large_arrays_in_instr(child, counter);
-            }
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            split_large_arrays_in_instr(condition, counter);
-            for child in then_body.iter_mut() {
-                split_large_arrays_in_instr(child, counter);
-            }
-            if let Some(eb) = else_body {
-                for child in eb.iter_mut() {
-                    split_large_arrays_in_instr(child, counter);
-                }
-            }
-        }
-        _ => {
-            instr.for_each_boxed_child_mut(&mut |child| {
-                split_large_arrays_in_instr(child, counter);
-            });
-        }
-    }
+struct SplitLargeArrays {
+    counter: u32,
+}
 
-    // Now check if THIS instruction is a large ArrayNewFixed that should be split.
-    if let WirInstr::ArrayNewFixed { elements, .. } = instr
-        && elements.len() > ARRAY_NEW_FIXED_LIMIT
-    {
-        rewrite_large_array_new_fixed(instr, counter);
+impl WirMutVisitor for SplitLargeArrays {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        // Recurse into children first (bottom-up).
+        self.walk_instr(instr);
+
+        // Check if THIS instruction is a large ArrayNewFixed that should be split.
+        if let WirInstr::ArrayNewFixed { elements, .. } = instr
+            && elements.len() > ARRAY_NEW_FIXED_LIMIT
+        {
+            rewrite_large_array_new_fixed(instr, &mut self.counter);
+        }
     }
 }
 
@@ -348,7 +307,11 @@ pub(super) fn collapse_array_append_sequences(module: &mut WirModule) {
 
     for func in &mut module.functions {
         if let Some(body) = &mut func.body {
-            collapse_appends_in_body(body, &append_func_indices, &array_struct_types);
+            let mut visitor = CollapseAppends {
+                append_func_indices: &append_func_indices,
+                array_struct_types: &array_struct_types,
+            };
+            visitor.visit_body(body);
         }
     }
 }
@@ -377,75 +340,43 @@ struct ArrayInitInfo {
     used_field_index: usize,
 }
 
-/// Scan an instruction tree for init + N×append patterns and collapse them.
-/// Recurses into all instruction bodies (blocks, loops, ifs, and also block bodies
-/// nested inside tree nodes like `ValueCopy { expr: Block { ... } }`).
-fn collapse_appends_in_instr(
-    instr: &mut WirInstr,
-    append_func_indices: &IndexSet<u32>,
-    array_struct_types: &IndexSet<u32>,
-) {
-    // If this instruction contains a Vec<WirInstr> body, process it.
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            collapse_appends_in_body(body, append_func_indices, array_struct_types);
-            return;
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            collapse_appends_in_instr(condition, append_func_indices, array_struct_types);
-            collapse_appends_in_body(then_body, append_func_indices, array_struct_types);
-            if let Some(eb) = else_body {
-                collapse_appends_in_body(eb, append_func_indices, array_struct_types);
-            }
-            return;
-        }
-        _ => {}
-    }
-
-    // For non-body instructions, recurse into all Box children.
-    instr.for_each_boxed_child_mut(&mut |child| {
-        collapse_appends_in_instr(child, append_func_indices, array_struct_types);
-    });
+struct CollapseAppends<'a> {
+    append_func_indices: &'a IndexSet<u32>,
+    array_struct_types: &'a IndexSet<u32>,
 }
 
-/// Scan a flat instruction list for init + N×append patterns and collapse them.
-fn collapse_appends_in_body(
-    body: &mut Vec<WirInstr>,
-    append_func_indices: &IndexSet<u32>,
-    array_struct_types: &IndexSet<u32>,
-) {
-    // First recurse into all children.
-    for instr in body.iter_mut() {
-        collapse_appends_in_instr(instr, append_func_indices, array_struct_types);
-    }
+impl WirMutVisitor for CollapseAppends<'_> {
+    fn visit_body(&mut self, body: &mut Vec<WirInstr>) {
+        // First recurse into all children.
+        self.walk_body(body);
 
-    // Now scan the flat body for init + append patterns.
-    let mut i = 0;
-    while i < body.len() {
-        if let Some(init_info) = try_match_array_init(&body[i], array_struct_types) {
-            let n = init_info.capacity;
-            // Check if the next instructions are matching append calls.
-            // Each append may be a single instruction (Block wrapping LocalSet+Call)
-            // or multiple flat instructions (LocalSet* + Call) from block flattening.
-            if n > 0
-                && let Some((values, consumed)) =
-                    try_match_append_sequence(&body[i + 1..], n, &init_info, append_func_indices)
-            {
-                // Rewrite: replace ArrayNewDefault with ArrayNewFixed in the init.
-                rewrite_init_to_fixed(&mut body[i], &init_info, values);
-                // Remove the consumed append instructions.
-                body.drain(i + 1..i + 1 + consumed);
-                // Continue from the next instruction after the rewritten init.
-                i += 1;
-                continue;
+        // Now scan the flat body for init + append patterns.
+        let mut i = 0;
+        while i < body.len() {
+            if let Some(init_info) = try_match_array_init(&body[i], self.array_struct_types) {
+                let n = init_info.capacity;
+                // Check if the next instructions are matching append calls.
+                // Each append may be a single instruction (Block wrapping LocalSet+Call)
+                // or multiple flat instructions (LocalSet* + Call) from block flattening.
+                if n > 0
+                    && let Some((values, consumed)) = try_match_append_sequence(
+                        &body[i + 1..],
+                        n,
+                        &init_info,
+                        self.append_func_indices,
+                    )
+                {
+                    // Rewrite: replace ArrayNewDefault with ArrayNewFixed in the init.
+                    rewrite_init_to_fixed(&mut body[i], &init_info, values);
+                    // Remove the consumed append instructions.
+                    body.drain(i + 1..i + 1 + consumed);
+                    // Continue from the next instruction after the rewritten init.
+                    i += 1;
+                    continue;
+                }
             }
+            i += 1;
         }
-        i += 1;
     }
 }
 

--- a/wado-compiler/src/wir_optimize/cleanup.rs
+++ b/wado-compiler/src/wir_optimize/cleanup.rs
@@ -6,13 +6,15 @@
 
 use crate::hashmap::IndexSet;
 use crate::wir::{WirInstr, WirModule};
+use crate::wir_visitor::{WirMutVisitor, WirRefVisitor};
 
 pub(super) fn cleanup(module: &mut WirModule) {
     for func in &mut module.functions {
         if let Some(body) = &mut func.body {
             // Remove DeclareLocal for locals that are never used (no LocalGet/LocalSet/LocalTee).
             eliminate_dead_locals(body);
-            cleanup_instrs(body);
+            let mut visitor = CleanupVisitor;
+            visitor.visit_body(body);
         }
     }
 }
@@ -21,134 +23,78 @@ pub(super) fn cleanup(module: &mut WirModule) {
 /// by any `LocalGet`, `LocalSet`, `LocalTee`, or `MultiValueLocalBind`.
 fn eliminate_dead_locals(body: &mut [WirInstr]) {
     let mut used: IndexSet<String> = IndexSet::default();
+    let mut collector = CollectLocalUses { used: &mut used };
     for instr in body.iter() {
-        collect_local_uses(instr, &mut used);
+        collector.visit_instr(instr);
     }
+    let mut noper = NopUnusedDeclareLocals { used: &used };
     for instr in body.iter_mut() {
-        nop_unused_declare_locals(instr, &used);
+        noper.visit_instr(instr);
     }
 }
 
-fn collect_local_uses(instr: &WirInstr, used: &mut IndexSet<String>) {
-    match instr {
-        WirInstr::LocalGet { name, .. } => {
-            used.insert(name.clone());
-        }
-        WirInstr::LocalSet { name, value } => {
-            used.insert(name.clone());
-            collect_local_uses(value, used);
-        }
-        WirInstr::LocalTee { name, value } => {
-            used.insert(name.clone());
-            collect_local_uses(value, used);
-        }
-        WirInstr::MultiValueLocalBind { instr, locals } => {
-            collect_local_uses(instr, used);
-            for local in locals.iter().flatten() {
-                used.insert(local.clone());
+struct CollectLocalUses<'a> {
+    used: &'a mut IndexSet<String>,
+}
+
+impl WirRefVisitor for CollectLocalUses<'_> {
+    fn visit_instr(&mut self, instr: &WirInstr) {
+        match instr {
+            WirInstr::LocalGet { name, .. }
+            | WirInstr::LocalSet { name, .. }
+            | WirInstr::LocalTee { name, .. } => {
+                self.used.insert(name.clone());
             }
-        }
-        WirInstr::DeclareLocal { .. } | WirInstr::Nop => {}
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            for i in body {
-                collect_local_uses(i, used);
-            }
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            collect_local_uses(condition, used);
-            for i in then_body {
-                collect_local_uses(i, used);
-            }
-            if let Some(eb) = else_body {
-                for i in eb {
-                    collect_local_uses(i, used);
+            WirInstr::MultiValueLocalBind { locals, .. } => {
+                for local in locals.iter().flatten() {
+                    self.used.insert(local.clone());
                 }
             }
+            _ => {}
         }
-        _ => {
-            instr.for_each_child(&mut |child| collect_local_uses(child, used));
-        }
+        self.walk_instr(instr);
     }
 }
 
-fn nop_unused_declare_locals(instr: &mut WirInstr, used: &IndexSet<String>) {
-    match instr {
-        WirInstr::DeclareLocal { name, .. } => {
-            if !used.contains(name.as_str()) {
+struct NopUnusedDeclareLocals<'a> {
+    used: &'a IndexSet<String>,
+}
+
+impl WirMutVisitor for NopUnusedDeclareLocals<'_> {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        if let WirInstr::DeclareLocal { name, .. } = instr {
+            if !self.used.contains(name.as_str()) {
                 *instr = WirInstr::Nop;
+                return;
             }
         }
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            for i in body {
-                nop_unused_declare_locals(i, used);
-            }
-        }
-        WirInstr::If {
-            then_body,
-            else_body,
-            ..
-        } => {
-            for i in then_body {
-                nop_unused_declare_locals(i, used);
-            }
-            if let Some(eb) = else_body {
-                for i in eb {
-                    nop_unused_declare_locals(i, used);
-                }
-            }
-        }
-        _ => {}
+        self.walk_instr(instr);
     }
 }
 
-fn cleanup_instrs(instrs: &mut Vec<WirInstr>) {
-    for instr in instrs.iter_mut() {
-        cleanup_instr(instr);
-    }
-    // Remove nops.
-    instrs.retain(|i| !matches!(i, WirInstr::Nop));
-    // Truncate after first unreachable (dead code elimination).
-    if let Some(pos) = instrs
-        .iter()
-        .position(|i| matches!(i, WirInstr::Unreachable))
-    {
-        instrs.truncate(pos + 1);
-    }
-}
+struct CleanupVisitor;
 
-fn cleanup_instr(instr: &mut WirInstr) {
-    // Recurse into nested bodies first (bottom-up).
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            cleanup_instrs(body);
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            cleanup_instr(condition);
-            cleanup_instrs(then_body);
-            if let Some(eb) = else_body {
-                cleanup_instrs(eb);
-            }
-        }
-        _ => {
-            instr.for_each_boxed_child_mut(&mut |child| cleanup_instr(child));
+impl WirMutVisitor for CleanupVisitor {
+    fn visit_body(&mut self, body: &mut Vec<WirInstr>) {
+        self.walk_body(body);
+        // Remove nops.
+        body.retain(|i| !matches!(i, WirInstr::Nop));
+        // Truncate after first unreachable (dead code elimination).
+        if let Some(pos) = body
+            .iter()
+            .position(|i| matches!(i, WirInstr::Unreachable))
+        {
+            body.truncate(pos + 1);
         }
     }
-    // Elide redundant RefAsNonNull when the inner expression is already non-null.
-    // `is_nonnull_result()` checks result_ty on LocalGet/GlobalGet/StructGet/ArrayGet,
-    // as well as StructNew/ArrayNew/etc.
-    if let WirInstr::RefAsNonNull(inner) = instr
-        && inner.is_nonnull_result()
-    {
-        *instr = std::mem::replace(inner.as_mut(), WirInstr::Nop);
+
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        self.walk_instr(instr);
+        // Post-visit: elide redundant RefAsNonNull when the inner expression is already non-null.
+        if let WirInstr::RefAsNonNull(inner) = instr
+            && inner.is_nonnull_result()
+        {
+            *instr = std::mem::replace(inner.as_mut(), WirInstr::Nop);
+        }
     }
 }

--- a/wado-compiler/src/wir_optimize/cleanup.rs
+++ b/wado-compiler/src/wir_optimize/cleanup.rs
@@ -62,11 +62,11 @@ struct NopUnusedDeclareLocals<'a> {
 
 impl WirMutVisitor for NopUnusedDeclareLocals<'_> {
     fn visit_instr(&mut self, instr: &mut WirInstr) {
-        if let WirInstr::DeclareLocal { name, .. } = instr {
-            if !self.used.contains(name.as_str()) {
-                *instr = WirInstr::Nop;
-                return;
-            }
+        if let WirInstr::DeclareLocal { name, .. } = instr
+            && !self.used.contains(name.as_str())
+        {
+            *instr = WirInstr::Nop;
+            return;
         }
         self.walk_instr(instr);
     }
@@ -80,10 +80,7 @@ impl WirMutVisitor for CleanupVisitor {
         // Remove nops.
         body.retain(|i| !matches!(i, WirInstr::Nop));
         // Truncate after first unreachable (dead code elimination).
-        if let Some(pos) = body
-            .iter()
-            .position(|i| matches!(i, WirInstr::Unreachable))
-        {
+        if let Some(pos) = body.iter().position(|i| matches!(i, WirInstr::Unreachable)) {
             body.truncate(pos + 1);
         }
     }

--- a/wado-compiler/src/wir_optimize/drve.rs
+++ b/wado-compiler/src/wir_optimize/drve.rs
@@ -6,6 +6,7 @@
 
 use crate::hashmap::IndexSet;
 use crate::wir::{WirFuncType, WirInstr, WirModule, WirType, WirTypeDef, WirTypeId};
+use crate::wir_visitor::{WirMutVisitor, WirRefVisitor};
 
 use super::util::{collect_pinned_func_ids, is_side_effect_free};
 
@@ -73,7 +74,9 @@ fn find_drve_candidates(module: &WirModule, pinned: &IndexSet<u32>) -> Vec<(u32,
 
         // All returns must be StructNew with all-pure field expressions.
         let body = func.body.as_ref().unwrap();
-        if !all_returns_are_pure_struct_new(body) {
+        let mut checker = AllReturnsPureStructNew { result: true };
+        checker.visit_body(body);
+        if !checker.result {
             continue;
         }
 
@@ -83,45 +86,32 @@ fn find_drve_candidates(module: &WirModule, pinned: &IndexSet<u32>) -> Vec<(u32,
     candidates
 }
 
-/// Returns true if every `Return { value: Some(...) }` in the tree is a `StructNew`
-/// with all side-effect-free field expressions.
-fn all_returns_are_pure_struct_new(instrs: &[WirInstr]) -> bool {
-    for instr in instrs {
+struct AllReturnsPureStructNew {
+    result: bool,
+}
+
+impl WirRefVisitor for AllReturnsPureStructNew {
+    fn visit_instr(&mut self, instr: &WirInstr) {
+        if !self.result {
+            return;
+        }
         match instr {
             WirInstr::Return { value: Some(v) } => {
                 let WirInstr::StructNew { fields, .. } = v.as_ref() else {
-                    return false;
+                    self.result = false;
+                    return;
                 };
                 if !fields.iter().all(is_side_effect_free) {
-                    return false;
+                    self.result = false;
                 }
             }
             WirInstr::Return { value: None } => {
-                return false;
-            }
-            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-                if !all_returns_are_pure_struct_new(body) {
-                    return false;
-                }
-            }
-            WirInstr::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                if !all_returns_are_pure_struct_new(then_body) {
-                    return false;
-                }
-                if let Some(eb) = else_body
-                    && !all_returns_are_pure_struct_new(eb)
-                {
-                    return false;
-                }
+                self.result = false;
             }
             _ => {}
         }
+        self.walk_instr(instr);
     }
-    true
 }
 
 fn validate_drve_call_sites(
@@ -134,7 +124,12 @@ fn validate_drve_call_sites(
 
     for func in &module.functions {
         if let Some(body) = &func.body {
-            check_drve_call_uses_in_body(body, &candidate_ids, &mut invalid, &mut has_drop_call);
+            let mut checker = CheckDrveCallUses {
+                candidate_ids: &candidate_ids,
+                invalid: &mut invalid,
+                has_drop_call: &mut has_drop_call,
+            };
+            checker.visit_body(body);
         }
     }
 
@@ -152,48 +147,32 @@ fn validate_drve_call_sites(
         .collect()
 }
 
-fn check_drve_call_uses_in_body(
-    instrs: &[WirInstr],
-    candidate_ids: &IndexSet<u32>,
-    invalid: &mut IndexSet<u32>,
-    has_drop_call: &mut IndexSet<u32>,
-) {
-    for instr in instrs {
+struct CheckDrveCallUses<'a> {
+    candidate_ids: &'a IndexSet<u32>,
+    invalid: &'a mut IndexSet<u32>,
+    has_drop_call: &'a mut IndexSet<u32>,
+}
+
+impl WirRefVisitor for CheckDrveCallUses<'_> {
+    fn visit_instr(&mut self, instr: &WirInstr) {
         match instr {
-            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } => {
-                check_drve_call_uses_in_body(body, candidate_ids, invalid, has_drop_call);
-            }
-            WirInstr::If {
-                condition,
-                then_body,
-                else_body,
-                ..
-            } => {
-                find_drve_candidate_calls(condition, candidate_ids, invalid);
-                check_drve_call_uses_in_body(then_body, candidate_ids, invalid, has_drop_call);
-                if let Some(eb) = else_body {
-                    check_drve_call_uses_in_body(eb, candidate_ids, invalid, has_drop_call);
-                }
-            }
-            WirInstr::Seq(body) => {
-                check_drve_call_uses_in_body(body, candidate_ids, invalid, has_drop_call);
-            }
             WirInstr::Drop(inner) => {
                 if let WirInstr::Call { func_id, args } = inner.as_ref()
-                    && candidate_ids.contains(&func_id.index())
+                    && self.candidate_ids.contains(&func_id.index())
                 {
-                    has_drop_call.insert(func_id.index());
+                    self.has_drop_call.insert(func_id.index());
                     for arg in args {
-                        find_drve_candidate_calls(arg, candidate_ids, invalid);
+                        find_drve_candidate_calls(arg, self.candidate_ids, self.invalid);
                     }
-                    continue;
+                    return;
                 }
-                find_drve_candidate_calls(inner, candidate_ids, invalid);
+                find_drve_candidate_calls(inner, self.candidate_ids, self.invalid);
             }
             _ => {
-                find_drve_candidate_calls(instr, candidate_ids, invalid);
+                find_drve_candidate_calls(instr, self.candidate_ids, self.invalid);
             }
         }
+        self.walk_instr(instr);
     }
 }
 
@@ -238,7 +217,8 @@ fn apply_drve(module: &mut WirModule, confirmed: &[(u32, DrveCandidate)]) {
         func.type_id = new_type_id;
 
         if let Some(body) = &mut func.body {
-            rewrite_drve_returns(body);
+            let mut rewriter = RewriteDrveReturns;
+            rewriter.visit_body(body);
         }
     }
 
@@ -246,61 +226,41 @@ fn apply_drve(module: &mut WirModule, confirmed: &[(u32, DrveCandidate)]) {
     for i in 0..module.functions.len() {
         if module.functions[i].body.is_some() {
             let body = module.functions[i].body.as_mut().unwrap();
-            rewrite_drve_call_sites(body, &candidate_set);
+            let mut rewriter = RewriteDrveCallSites {
+                candidate_set: &candidate_set,
+            };
+            rewriter.visit_body(body);
         }
     }
 }
 
-fn rewrite_drve_returns(instrs: &mut [WirInstr]) {
-    for instr in instrs.iter_mut() {
-        match instr {
-            WirInstr::Return { value: Some(v) }
-                if matches!(v.as_ref(), WirInstr::StructNew { .. }) =>
-            {
-                *instr = WirInstr::Return { value: None };
-            }
-            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-                rewrite_drve_returns(body);
-            }
-            WirInstr::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                rewrite_drve_returns(then_body);
-                if let Some(eb) = else_body {
-                    rewrite_drve_returns(eb);
-                }
-            }
-            _ => {}
+struct RewriteDrveReturns;
+
+impl WirMutVisitor for RewriteDrveReturns {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        if let WirInstr::Return { value: Some(v) } = instr
+            && matches!(v.as_ref(), WirInstr::StructNew { .. })
+        {
+            *instr = WirInstr::Return { value: None };
+            return;
         }
+        self.walk_instr(instr);
     }
 }
 
-fn rewrite_drve_call_sites(instrs: &mut [WirInstr], candidate_set: &IndexSet<u32>) {
-    for instr in instrs.iter_mut() {
-        match instr {
-            WirInstr::Drop(inner)
-                if matches!(inner.as_ref(), WirInstr::Call { func_id, .. }
-                    if candidate_set.contains(&func_id.index())) =>
-            {
-                let call = std::mem::replace(inner.as_mut(), WirInstr::Nop);
-                *instr = call;
-            }
-            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-                rewrite_drve_call_sites(body, candidate_set);
-            }
-            WirInstr::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                rewrite_drve_call_sites(then_body, candidate_set);
-                if let Some(eb) = else_body {
-                    rewrite_drve_call_sites(eb, candidate_set);
-                }
-            }
-            _ => {}
+struct RewriteDrveCallSites<'a> {
+    candidate_set: &'a IndexSet<u32>,
+}
+
+impl WirMutVisitor for RewriteDrveCallSites<'_> {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        if let WirInstr::Drop(inner) = instr
+            && matches!(inner.as_ref(), WirInstr::Call { func_id, .. }
+                if self.candidate_set.contains(&func_id.index()))
+        {
+            let call = std::mem::replace(inner.as_mut(), WirInstr::Nop);
+            *instr = call;
         }
+        self.walk_instr(instr);
     }
 }

--- a/wado-compiler/src/wir_optimize/elide_local.rs
+++ b/wado-compiler/src/wir_optimize/elide_local.rs
@@ -60,7 +60,7 @@ impl WirMutVisitor for ElideWriteOnly<'_> {
         // LocalSet only appears at body level, so expression children are skipped.
         match instr {
             WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-                self.visit_body(body)
+                self.visit_body(body);
             }
             WirInstr::If {
                 then_body,

--- a/wado-compiler/src/wir_optimize/elide_local.rs
+++ b/wado-compiler/src/wir_optimize/elide_local.rs
@@ -5,6 +5,7 @@
 
 use crate::hashmap::IndexSet;
 use crate::wir::{WirInstr, WirModule};
+use crate::wir_visitor::WirMutVisitor;
 
 use super::util::{collect_local_gets_deep, is_side_effect_free};
 
@@ -26,47 +27,52 @@ fn elide_write_only_locals_in_body(body: &mut [WirInstr]) -> bool {
         collect_local_gets_deep(instr, &mut read_locals);
     }
 
-    let mut changed = false;
+    let mut visitor = ElideWriteOnly {
+        read_locals: &read_locals,
+        changed: false,
+    };
     for instr in body.iter_mut() {
-        elide_write_only_in_instr(instr, &read_locals, &mut changed);
+        visitor.visit_instr(instr);
     }
-    changed
+    visitor.changed
 }
 
-fn elide_write_only_in_instr(
-    instr: &mut WirInstr,
-    read_locals: &IndexSet<String>,
-    changed: &mut bool,
-) {
-    match instr {
-        WirInstr::LocalSet { name, value } if !read_locals.contains(name.as_str()) => {
+struct ElideWriteOnly<'a> {
+    read_locals: &'a IndexSet<String>,
+    changed: bool,
+}
+
+impl WirMutVisitor for ElideWriteOnly<'_> {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        if let WirInstr::LocalSet { name, value } = instr
+            && !self.read_locals.contains(name.as_str())
+        {
             let value_expr = std::mem::replace(value.as_mut(), WirInstr::Nop);
             if is_side_effect_free(&value_expr) {
                 *instr = WirInstr::Nop;
             } else {
                 *instr = WirInstr::Drop(Box::new(value_expr));
             }
-            *changed = true;
+            self.changed = true;
+            return;
         }
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            for child in body.iter_mut() {
-                elide_write_only_in_instr(child, read_locals, changed);
-            }
-        }
-        WirInstr::If {
-            then_body,
-            else_body,
-            ..
-        } => {
-            for child in then_body.iter_mut() {
-                elide_write_only_in_instr(child, read_locals, changed);
-            }
-            if let Some(eb) = else_body {
-                for child in eb.iter_mut() {
-                    elide_write_only_in_instr(child, read_locals, changed);
+        // Only recurse into bodies (Block/Loop/If/Seq), not expression children.
+        // LocalSet only appears at body level, so expression children are skipped.
+        match instr {
+            WirInstr::Block { body, .. }
+            | WirInstr::Loop { body, .. }
+            | WirInstr::Seq(body) => self.visit_body(body),
+            WirInstr::If {
+                then_body,
+                else_body,
+                ..
+            } => {
+                self.visit_body(then_body);
+                if let Some(eb) = else_body {
+                    self.visit_body(eb);
                 }
             }
+            _ => {}
         }
-        _ => {}
     }
 }

--- a/wado-compiler/src/wir_optimize/elide_local.rs
+++ b/wado-compiler/src/wir_optimize/elide_local.rs
@@ -59,9 +59,9 @@ impl WirMutVisitor for ElideWriteOnly<'_> {
         // Only recurse into bodies (Block/Loop/If/Seq), not expression children.
         // LocalSet only appears at body level, so expression children are skipped.
         match instr {
-            WirInstr::Block { body, .. }
-            | WirInstr::Loop { body, .. }
-            | WirInstr::Seq(body) => self.visit_body(body),
+            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
+                self.visit_body(body)
+            }
             WirInstr::If {
                 then_body,
                 else_body,

--- a/wado-compiler/src/wir_optimize/elide_struct.rs
+++ b/wado-compiler/src/wir_optimize/elide_struct.rs
@@ -8,6 +8,7 @@
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::wir::{WirInstr, WirModule, WirTypeDef};
+use crate::wir_visitor::WirMutVisitor;
 
 pub(super) fn elide_single_field_struct_locals(module: &mut WirModule) {
     for func in &mut module.functions {
@@ -354,54 +355,36 @@ fn nop_local_set_of(instr: &mut WirInstr, name: &str) {
 /// This canonicalizes the pattern produced by the WIR builder for tuple destructuring,
 /// making it visible to downstream passes like multi-field struct local elision.
 pub(super) fn flatten_seq_assignments(module: &mut WirModule) {
+    let mut visitor = FlattenSeqAssignments;
     for func in &mut module.functions {
         if let Some(body) = &mut func.body {
-            flatten_seq_in_body(body);
+            visitor.visit_body(body);
         }
     }
 }
 
-fn flatten_seq_in_body(body: &mut Vec<WirInstr>) {
-    // First recurse into nested bodies.
-    for instr in body.iter_mut() {
-        flatten_seq_in_instr(instr);
-    }
-    // Then expand any LocalSet { value: Seq([..., final]) } at this level.
-    let old = std::mem::take(body);
-    for instr in old {
-        match instr {
-            WirInstr::LocalSet { name, value } if matches!(value.as_ref(), WirInstr::Seq(seq) if !seq.is_empty()) => {
-                if let WirInstr::Seq(mut seq) = *value {
-                    let final_val = seq.pop().unwrap();
-                    body.extend(seq);
-                    body.push(WirInstr::LocalSet {
-                        name,
-                        value: Box::new(final_val),
-                    });
+struct FlattenSeqAssignments;
+
+impl WirMutVisitor for FlattenSeqAssignments {
+    fn visit_body(&mut self, body: &mut Vec<WirInstr>) {
+        // First recurse into nested bodies.
+        self.walk_body(body);
+        // Then expand any LocalSet { value: Seq([..., final]) } at this level.
+        let old = std::mem::take(body);
+        for instr in old {
+            match instr {
+                WirInstr::LocalSet { name, value } if matches!(value.as_ref(), WirInstr::Seq(seq) if !seq.is_empty()) => {
+                    if let WirInstr::Seq(mut seq) = *value {
+                        let final_val = seq.pop().unwrap();
+                        body.extend(seq);
+                        body.push(WirInstr::LocalSet {
+                            name,
+                            value: Box::new(final_val),
+                        });
+                    }
                 }
-            }
-            other => body.push(other),
-        }
-    }
-}
-
-fn flatten_seq_in_instr(instr: &mut WirInstr) {
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            flatten_seq_in_body(body);
-        }
-        WirInstr::If {
-            then_body,
-            else_body,
-            condition,
-            ..
-        } => {
-            flatten_seq_in_instr(condition);
-            flatten_seq_in_body(then_body);
-            if let Some(eb) = else_body {
-                flatten_seq_in_body(eb);
+                other => body.push(other),
             }
         }
-        _ => {}
     }
 }

--- a/wado-compiler/src/wir_optimize/peephole.rs
+++ b/wado-compiler/src/wir_optimize/peephole.rs
@@ -310,7 +310,6 @@ fn fold_eqz_in_instr(instr: &mut WirInstr) {
 }
 
 fn try_fold_eqz(instr: &mut WirInstr) {
-
     // i32.eq(expr, 0) → i32.eqz(expr)
     // i32.eq(0, expr) → i32.eqz(expr)
     match instr {

--- a/wado-compiler/src/wir_optimize/peephole.rs
+++ b/wado-compiler/src/wir_optimize/peephole.rs
@@ -8,6 +8,7 @@
 //! - Multi-value struct elision (`MultiValueStructNew` + `StructGet` → `MultiValueLocalBind`)
 
 use crate::wir::{WirInstr, WirModule, WirTypeDef};
+use crate::wir_visitor::WirMutVisitor;
 use indexmap::IndexMap;
 
 /// Propagate trivial copies (`alias = source`) by replacing all uses of `alias`
@@ -24,26 +25,33 @@ pub(super) fn propagate_trivial_copies(module: &mut WirModule) {
 
 fn propagate_copies_in_body(instrs: &mut [WirInstr]) {
     // Recurse into nested blocks first (bottom-up)
-    for instr in instrs.iter_mut() {
-        match instr {
-            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } => {
-                propagate_copies_in_body(body);
-            }
-            WirInstr::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                propagate_copies_in_body(then_body);
-                if let Some(eb) = else_body {
-                    propagate_copies_in_body(eb);
-                }
-            }
-            WirInstr::Seq(body) => {
-                propagate_copies_in_body(body);
-            }
-            _ => {}
+    struct RecurseIntoBlocks;
+    impl WirMutVisitor for RecurseIntoBlocks {
+        fn visit_body(&mut self, body: &mut Vec<WirInstr>) {
+            propagate_copies_in_body(body);
         }
+        // Only recurse into bodies (Block/Loop/If/Seq), not expression children.
+        fn visit_instr(&mut self, instr: &mut WirInstr) {
+            match instr {
+                WirInstr::Block { body, .. }
+                | WirInstr::Loop { body, .. }
+                | WirInstr::Seq(body) => self.visit_body(body),
+                WirInstr::If {
+                    then_body,
+                    else_body,
+                    ..
+                } => {
+                    self.visit_body(then_body);
+                    if let Some(eb) = else_body {
+                        self.visit_body(eb);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    for instr in instrs.iter_mut() {
+        RecurseIntoBlocks.visit_instr(instr);
     }
 
     // Collect trivial copies: `LocalSet { alias, LocalGet { source } }`
@@ -212,31 +220,18 @@ fn fold_constant_comparisons(instrs: &mut [WirInstr]) {
 }
 
 fn fold_constant_comparisons_in_instr(instr: &mut WirInstr) {
-    // Recurse into children first (bottom-up folding)
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            fold_constant_comparisons(body);
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            fold_constant_comparisons_in_instr(condition);
-            fold_constant_comparisons(then_body);
-            if let Some(eb) = else_body {
-                fold_constant_comparisons(eb);
-            }
-        }
-        _ => {
-            instr.for_each_boxed_child_mut(&mut |child| {
-                fold_constant_comparisons_in_instr(child);
-            });
+    struct FoldConstComparisons;
+    impl WirMutVisitor for FoldConstComparisons {
+        fn visit_instr(&mut self, instr: &mut WirInstr) {
+            self.walk_instr(instr);
+            try_fold_comparison(instr);
         }
     }
+    FoldConstComparisons.visit_instr(instr);
+}
 
-    // Then try to fold this instruction
+fn try_fold_comparison(instr: &mut WirInstr) {
+    // Try to fold this instruction
     let result = match instr {
         WirInstr::I32GeS(l, r) => match (l.as_ref(), r.as_ref()) {
             (WirInstr::I32Const(lv), WirInstr::I32Const(rv)) => Some(i32::from(*lv >= *rv)),
@@ -304,29 +299,17 @@ fn fold_eqz_patterns(instrs: &mut [WirInstr]) {
 }
 
 fn fold_eqz_in_instr(instr: &mut WirInstr) {
-    // Recurse into children first (bottom-up)
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            fold_eqz_patterns(body);
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            fold_eqz_in_instr(condition);
-            fold_eqz_patterns(then_body);
-            if let Some(eb) = else_body {
-                fold_eqz_patterns(eb);
-            }
-        }
-        _ => {
-            instr.for_each_boxed_child_mut(&mut |child| {
-                fold_eqz_in_instr(child);
-            });
+    struct FoldEqz;
+    impl WirMutVisitor for FoldEqz {
+        fn visit_instr(&mut self, instr: &mut WirInstr) {
+            self.walk_instr(instr);
+            try_fold_eqz(instr);
         }
     }
+    FoldEqz.visit_instr(instr);
+}
+
+fn try_fold_eqz(instr: &mut WirInstr) {
 
     // i32.eq(expr, 0) → i32.eqz(expr)
     // i32.eq(0, expr) → i32.eqz(expr)

--- a/wado-compiler/src/wir_optimize/string.rs
+++ b/wado-compiler/src/wir_optimize/string.rs
@@ -6,6 +6,7 @@ use crate::wir::{
     COMP_FEATURE_STRING_APPEND, COMP_FEATURE_STRING_APPEND_CHAR, WirData, WirFuncId, WirInstr,
     WirModule,
 };
+use crate::wir_visitor::WirMutVisitor;
 
 /// Rewrite `String::append(buf, "short_constant")` calls into sequences of
 /// `String::append_char(buf, ch)` calls when the constant string is ≤8 bytes.
@@ -49,67 +50,39 @@ pub(super) fn simplify_short_string_appends(module: &mut WirModule) {
     let data = &module.data;
     for func in &mut module.functions {
         if let Some(body) = &mut func.body {
-            simplify_short_appends_in_body(body, &append_id, &append_char_id, data);
+            let mut visitor = SimplifyShortAppends {
+                append_id: &append_id,
+                append_char_id: &append_char_id,
+                data,
+            };
+            visitor.visit_body(body);
         }
     }
 }
 
-/// Recursively process instructions, looking for Call patterns to rewrite.
-fn simplify_short_appends_in_instr(
-    instr: &mut WirInstr,
-    append_id: &WirFuncId,
-    append_char_id: &WirFuncId,
-    data: &[WirData],
-) {
-    match instr {
-        WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
-            simplify_short_appends_in_body(body, append_id, append_char_id, data);
-            return;
-        }
-        WirInstr::If {
-            condition,
-            then_body,
-            else_body,
-            ..
-        } => {
-            simplify_short_appends_in_instr(condition, append_id, append_char_id, data);
-            simplify_short_appends_in_body(then_body, append_id, append_char_id, data);
-            if let Some(eb) = else_body {
-                simplify_short_appends_in_body(eb, append_id, append_char_id, data);
+struct SimplifyShortAppends<'a> {
+    append_id: &'a WirFuncId,
+    append_char_id: &'a WirFuncId,
+    data: &'a [WirData],
+}
+
+impl WirMutVisitor for SimplifyShortAppends<'_> {
+    fn visit_body(&mut self, body: &mut Vec<WirInstr>) {
+        // First recurse into children.
+        self.walk_body(body);
+
+        // Scan for String::append calls with short constant string args.
+        let mut i = 0;
+        while i < body.len() {
+            if let Some(replacements) =
+                try_rewrite_short_string_append(&body[i], self.append_id, self.append_char_id, self.data)
+            {
+                let n = replacements.len();
+                body.splice(i..=i, replacements);
+                i += n;
+            } else {
+                i += 1;
             }
-            return;
-        }
-        _ => {}
-    }
-
-    instr.for_each_boxed_child_mut(&mut |child| {
-        simplify_short_appends_in_instr(child, append_id, append_char_id, data);
-    });
-}
-
-/// Process a flat instruction body, replacing short-constant `String::append` calls.
-fn simplify_short_appends_in_body(
-    body: &mut Vec<WirInstr>,
-    append_id: &WirFuncId,
-    append_char_id: &WirFuncId,
-    data: &[WirData],
-) {
-    // First recurse into children.
-    for instr in body.iter_mut() {
-        simplify_short_appends_in_instr(instr, append_id, append_char_id, data);
-    }
-
-    // Scan for String::append calls with short constant string args.
-    let mut i = 0;
-    while i < body.len() {
-        if let Some(replacements) =
-            try_rewrite_short_string_append(&body[i], append_id, append_char_id, data)
-        {
-            let n = replacements.len();
-            body.splice(i..=i, replacements);
-            i += n;
-        } else {
-            i += 1;
         }
     }
 }

--- a/wado-compiler/src/wir_optimize/string.rs
+++ b/wado-compiler/src/wir_optimize/string.rs
@@ -74,9 +74,12 @@ impl WirMutVisitor for SimplifyShortAppends<'_> {
         // Scan for String::append calls with short constant string args.
         let mut i = 0;
         while i < body.len() {
-            if let Some(replacements) =
-                try_rewrite_short_string_append(&body[i], self.append_id, self.append_char_id, self.data)
-            {
+            if let Some(replacements) = try_rewrite_short_string_append(
+                &body[i],
+                self.append_id,
+                self.append_char_id,
+                self.data,
+            ) {
                 let n = replacements.len();
                 body.splice(i..=i, replacements);
                 i += n;

--- a/wado-compiler/src/wir_visitor.rs
+++ b/wado-compiler/src/wir_visitor.rs
@@ -1,0 +1,100 @@
+//! Generic visitor traits for mutable and immutable traversal of WIR instruction trees.
+//!
+//! These are used by WIR optimization passes that need to walk instruction trees.
+//! The visitors handle control-flow body traversal (Block, Loop, If, Seq) in one
+//! place so that individual passes don't need to duplicate that logic.
+
+use crate::wir::WirInstr;
+
+/// Trait for immutable traversal of WIR instruction trees.
+///
+/// Override `visit_instr` to add custom logic at each node.
+/// Call `self.walk_instr(instr)` within your override to recurse into children.
+/// Override `visit_body` to add custom logic when entering an instruction body.
+pub trait WirRefVisitor {
+    fn visit_instr(&mut self, instr: &WirInstr) {
+        self.walk_instr(instr);
+    }
+
+    fn visit_body(&mut self, body: &[WirInstr]) {
+        self.walk_body(body);
+    }
+
+    fn walk_body(&mut self, body: &[WirInstr]) {
+        for instr in body {
+            self.visit_instr(instr);
+        }
+    }
+
+    fn walk_instr(&mut self, instr: &WirInstr) {
+        match instr {
+            WirInstr::Block { body, .. }
+            | WirInstr::Loop { body, .. }
+            | WirInstr::Seq(body) => {
+                self.visit_body(body);
+            }
+            WirInstr::If {
+                condition,
+                then_body,
+                else_body,
+                ..
+            } => {
+                self.visit_instr(condition);
+                self.visit_body(then_body);
+                if let Some(eb) = else_body {
+                    self.visit_body(eb);
+                }
+            }
+            _ => {
+                instr.for_each_child(&mut |child| self.visit_instr(child));
+            }
+        }
+    }
+}
+
+/// Trait for mutable traversal of WIR instruction trees.
+///
+/// Override `visit_instr` to add custom logic at each node.
+/// Call `self.walk_instr(instr)` within your override to recurse into children.
+/// Override `visit_body` to add custom logic when entering an instruction body
+/// (e.g., removing nops, truncating dead code).
+pub trait WirMutVisitor {
+    fn visit_instr(&mut self, instr: &mut WirInstr) {
+        self.walk_instr(instr);
+    }
+
+    fn visit_body(&mut self, body: &mut Vec<WirInstr>) {
+        self.walk_body(body);
+    }
+
+    fn walk_body(&mut self, body: &mut Vec<WirInstr>) {
+        for instr in body.iter_mut() {
+            self.visit_instr(instr);
+        }
+    }
+
+    fn walk_instr(&mut self, instr: &mut WirInstr) {
+        match instr {
+            WirInstr::Block { body, .. }
+            | WirInstr::Loop { body, .. }
+            | WirInstr::Seq(body) => {
+                self.visit_body(body);
+            }
+            WirInstr::If {
+                condition,
+                then_body,
+                else_body,
+                ..
+            } => {
+                self.visit_instr(condition);
+                self.visit_body(then_body);
+                if let Some(eb) = else_body {
+                    self.visit_body(eb);
+                }
+            }
+            other => {
+                other.for_each_boxed_child_mut(&mut |child| self.visit_instr(child));
+            }
+        }
+    }
+}

--- a/wado-compiler/src/wir_visitor.rs
+++ b/wado-compiler/src/wir_visitor.rs
@@ -28,9 +28,7 @@ pub trait WirRefVisitor {
 
     fn walk_instr(&mut self, instr: &WirInstr) {
         match instr {
-            WirInstr::Block { body, .. }
-            | WirInstr::Loop { body, .. }
-            | WirInstr::Seq(body) => {
+            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
                 self.visit_body(body);
             }
             WirInstr::If {
@@ -75,9 +73,7 @@ pub trait WirMutVisitor {
 
     fn walk_instr(&mut self, instr: &mut WirInstr) {
         match instr {
-            WirInstr::Block { body, .. }
-            | WirInstr::Loop { body, .. }
-            | WirInstr::Seq(body) => {
+            WirInstr::Block { body, .. } | WirInstr::Loop { body, .. } | WirInstr::Seq(body) => {
                 self.visit_body(body);
             }
             WirInstr::If {


### PR DESCRIPTION
## Summary

- Add `WirRefVisitor` / `WirMutVisitor` traits in `wir_visitor.rs` that centralize Block/Loop/If/Seq body traversal, modeled after the existing `TirRefVisitor`/`TirMutVisitor` pattern
- Migrate 7 optimization pass files (array, cleanup, drve, elide_local, elide_struct, peephole, string), eliminating ~20 instances of duplicated walk patterns
- Passes that intentionally only walk body-level children (elide_local, peephole copy propagation) override `visit_instr` to preserve body-only semantics

## Test plan

- [x] All 4405+ E2E fixture tests pass (O0–O3, Os)
- [x] All unit tests pass
- [x] `mise run on-task-done` passes (format, clippy, golden fixtures, tests)
- [x] Verified no O2 regressions for pattern matching (`matches_merged_wado`, `serde_json_error_kind_wado`)

https://claude.ai/code/session_013crcQhrSbWCqjUBPYF43uu