### PR TITLE
Refactor package-gale: match ergonomics, match expressions, chained comparisons

### DIFF
--- a/package-gale/src/g4/lexer.wado
+++ b/package-gale/src/g4/lexer.wado
@@ -211,9 +211,9 @@ pub fn tokenize(input: String) -> Array<Token> {
 }
 
 fn is_ident_start(c: char) -> bool {
-    return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_';
+    return 'a' <= c <= 'z' || 'A' <= c <= 'Z' || c == '_';
 }
 
 fn is_ident_char(c: char) -> bool {
-    return is_ident_start(c) || c >= '0' && c <= '9';
+    return is_ident_start(c) || '0' <= c <= '9';
 }

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -30,7 +30,7 @@ fn first_char(s: &String) -> Option<char> {
 
 fn is_lexer_rule_name(name: &String) -> bool {
     if let Some(c) = first_char(name) {
-        return c >= 'A' && c <= 'Z';
+        return 'A' <= c <= 'Z';
     }
     return false;
 }

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -68,31 +68,22 @@ impl GenContext {
     }
 
     pub fn first_of_element(&mut self, elem: &Element, visiting: &mut Array<String>) -> Array<String> {
-        if let TokenRef(name) = *elem {
-            return [`TK_{name}`];
-        }
-        if let Literal(text) = *elem {
-            return [literal_const_name(&text)];
-        }
-        if let RuleRef(name) = *elem {
-            return self.first_of_rule(&name, visiting);
-        }
-        if let Group(alts) = *elem {
-            let mut result: Array<String> = [];
-    
-            for let alt of alts {
-                let af = self.first_of_alt(&alt, visiting);
-                extend_dedup(&mut result, &af);
-            }
-            return result;
-        }
-        if let Repeat(rep) = *elem {
-            return self.first_of_element(&rep.element, visiting);
-        }
-        if let Label(lab) = *elem {
-            return self.first_of_element(&lab.element, visiting);
-        }
-        return [];
+        return match *elem {
+            TokenRef(name) => [`TK_{name}`],
+            Literal(text) => [literal_const_name(&text)],
+            RuleRef(name) => self.first_of_rule(&name, visiting),
+            Group(alts) => {
+                let mut result: Array<String> = [];
+                for let alt of alts {
+                    let af = self.first_of_alt(&alt, visiting);
+                    extend_dedup(&mut result, &af);
+                }
+                result
+            },
+            Repeat(rep) => self.first_of_element(&rep.element, visiting),
+            Label(lab) => self.first_of_element(&lab.element, visiting),
+            _ => [],
+        };
     }
 
     pub fn first_of_alt(&mut self, alt: &Alternative, visiting: &mut Array<String>) -> Array<String> {

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -68,7 +68,7 @@ impl GenContext {
     }
 
     pub fn first_of_element(&mut self, elem: &Element, visiting: &mut Array<String>) -> Array<String> {
-        return match *elem {
+        return match elem {
             TokenRef(name) => [`TK_{name}`],
             Literal(text) => [literal_const_name(&text)],
             RuleRef(name) => self.first_of_rule(&name, visiting),

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -173,10 +173,10 @@ impl GenContext {
                     if non_nullable_count > 1 {
                         break;
                     }
-                    if let TokenRef(_) | Literal(_) = *elem {
+                    if let TokenRef(_) | Literal(_) = elem {
                         single_ok = true;
-                    } else if let RuleRef(r) = *elem {
-                        single_ok = self.rule_is_single_token(&r, visiting);
+                    } else if let RuleRef(r) = elem {
+                        single_ok = self.rule_is_single_token(r, visiting);
                     }
                 }
                 if non_nullable_count != 1 || !single_ok {
@@ -198,7 +198,7 @@ impl GenContext {
 }
 
 pub fn is_nullable(elem: &Element) -> bool {
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         if let Star | Optional = rep.kind {
             return true;
         }
@@ -222,7 +222,7 @@ pub fn is_simple_token_group(alts: &Array<Alternative>) -> bool {
             return false;
         }
         let elem = &alt.elements[0];
-        if let TokenRef(_) | Literal(_) = *elem {
+        if let TokenRef(_) | Literal(_) = elem {
             continue;
         }
         return false;

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -132,7 +132,7 @@ pub fn literal_field_name(text: &String) -> String {
     let mut result = String::with_capacity(text.len() + 4);
     result.append("lit_");
     for let c of chars {
-        if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+        if 'a' <= c <= 'z' || 'A' <= c <= 'Z' || '0' <= c <= '9' {
             result.append_char(c.to_ascii_lowercase());
         } else {
             result.append_char('_');
@@ -283,7 +283,7 @@ pub fn literal_const_name(text: &String) -> String {
     for let c of text.chars() {
         if c.is_ascii_lowercase() {
             result.append_char(c.to_ascii_uppercase());
-        } else if c.is_ascii_uppercase() || c >= '0' && c <= '9' {
+        } else if c.is_ascii_uppercase() || '0' <= c <= '9' {
             result.append_char(c);
         } else if let Some(names) = symbol_char_names(c) {
             result.append(&names.1);

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -234,22 +234,14 @@ pub fn is_storable_group(alts: &Array<Alternative>) -> bool {
 
 /// Get a field name for the elements in a single-alt group's element.
 fn element_base_name(elem: &Element) -> String {
-    if let RuleRef(name) = *elem {
-        return to_snake_case(&name);
-    }
-    if let TokenRef(name) = *elem {
-        return to_lower(&name);
-    }
-    if let Literal(text) = *elem {
-        return literal_field_name(&text);
-    }
-    if let Repeat(rep) = *elem {
-        return element_base_name(&rep.element);
-    }
-    if let Label(lab) = *elem {
-        return to_snake_case(&lab.name);
-    }
-    return "item";
+    return match *elem {
+        RuleRef(name) => to_snake_case(&name),
+        TokenRef(name) => to_lower(&name),
+        Literal(text) => literal_field_name(&text),
+        Repeat(rep) => element_base_name(&rep.element),
+        Label(lab) => to_snake_case(&lab.name),
+        _ => "item",
+    };
 }
 
 /// Generate a struct type name for a single-alt group from its elements.

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -234,7 +234,7 @@ pub fn is_storable_group(alts: &Array<Alternative>) -> bool {
 
 /// Get a field name for the elements in a single-alt group's element.
 fn element_base_name(elem: &Element) -> String {
-    return match *elem {
+    return match elem {
         RuleRef(name) => to_snake_case(&name),
         TokenRef(name) => to_lower(&name),
         Literal(text) => literal_field_name(&text),

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -94,16 +94,16 @@ fn gen_struct_for_alt(w: &mut CodeWriter, type_name: &String, alt: &Alternative,
 }
 
 fn repeat_inner_field(elem: &Element) -> Option<Field> {
-    if let Group(alts) = *elem {
-        if is_simple_cst_group(&alts) {
+    if let Group(alts) = elem {
+        if is_simple_cst_group(alts) {
             return Option::<Field>::Some(Field {
-                name: group_field_base_name(&alts),
-                type_str: group_variant_type_name(&alts),
+                name: group_field_base_name(alts),
+                type_str: group_variant_type_name(alts),
             });
         }
-        if is_token_only_group(&alts) {
+        if is_token_only_group(alts) {
             return Option::<Field>::Some(Field {
-                name: token_group_field_name(&alts),
+                name: token_group_field_name(alts),
                 type_str: "Token",
             });
         }
@@ -247,25 +247,25 @@ fn increment_name_count(counts: &mut Array<[String, i32]>, name: &String) {
 }
 
 fn element_to_field(elem: &Element) -> Option<Field> {
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         return Option::<Field>::Some(Field {
-            name: to_snake_case(&name),
-            type_str: rule_type_name(&name),
+            name: to_snake_case(name),
+            type_str: rule_type_name(name),
         });
     }
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         return Option::<Field>::Some(Field {
-            name: to_lower(&name),
+            name: to_lower(name),
             type_str: "Token",
         });
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         return Option::<Field>::Some(Field {
-            name: literal_field_name(&text),
+            name: literal_field_name(text),
             type_str: "Token",
         });
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         let inner_field = repeat_inner_field(&rep.element);
         if let Some(inner) = inner_field {
             let field = match rep.kind {
@@ -282,7 +282,7 @@ fn element_to_field(elem: &Element) -> Option<Field> {
         }
         return null;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         if let Some(inner) = element_to_field(&lab.element) {
             return Option::<Field>::Some(Field {
                 name: to_snake_case(&lab.name),
@@ -291,20 +291,20 @@ fn element_to_field(elem: &Element) -> Option<Field> {
         }
         return null;
     }
-    if let Group(alts) = *elem {
-        if is_simple_cst_group(&alts) {
+    if let Group(alts) = elem {
+        if is_simple_cst_group(alts) {
             return Option::<Field>::Some(Field {
-                name: group_field_base_name(&alts),
-                type_str: `Option<{group_variant_type_name(&alts)}>`,
+                name: group_field_base_name(alts),
+                type_str: `Option<{group_variant_type_name(alts)}>`,
             });
         }
-        if is_token_only_group(&alts) {
+        if is_token_only_group(alts) {
             return Option::<Field>::Some(Field {
-                name: token_group_field_name(&alts),
+                name: token_group_field_name(alts),
                 type_str: "Token",
             });
         }
-        if is_single_alt_group(&alts) {
+        if is_single_alt_group(alts) {
             return Option::<Field>::Some(Field {
                 name: single_alt_group_field_name(&alts[0]),
                 type_str: `Option<{single_alt_group_type_name(&alts[0])}>`,

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -197,64 +197,52 @@ fn gen_lexer_alt_seq(w: &mut CodeWriter, alt: &LexerAlt, all_rules: &Array<Lexer
 }
 
 fn gen_lexer_elem(w: &mut CodeWriter, elem: &LexerElement, all_rules: &Array<LexerRule>, fail_action: &String) {
-    if let Literal(text) = *elem {
-        let chars: Array<char> = text.chars().collect();
-        for let mut i = 0; i < chars.len(); i += 1 {
-            w.line(`if pos >= chars.len() || chars[pos] != {escape_char(chars[i])} \{ {fail_action}; \}`);
-            w.line("pos += 1;");
-        }
-        return;
-    }
-    if let CharRange(pair) = *elem {
-        w.line(
-            `if pos >= chars.len() || chars[pos] < {escape_char(pair.0)} || chars[pos] > {escape_char(pair.1)} \{ {fail_action}; \}`,
-        );
-        w.line("pos += 1;");
-        return;
-    }
-    if let CharClass(cc) = *elem {
-        gen_char_class(w, &cc, fail_action);
-        return;
-    }
-    if let AnyChar = *elem {
-        w.line(`if pos >= chars.len() \{ {fail_action}; \}`);
-        w.line("pos += 1;");
-        return;
-    }
-    if let RuleRef(name) = *elem {
-        if name == "EOF" {
-            w.line(`if pos < chars.len() \{ {fail_action}; \}`);
-            return;
-        }
-        let frag = find_fragment(all_rules, &name);
-        if let Some(f) = frag {
-            if f.body.len() == 1 {
-                gen_lexer_alt_seq(w, &f.body[0], all_rules, fail_action);
-            } else {
-                gen_lexer_alts(w, &f.body, all_rules, fail_action);
+    match *elem {
+        Literal(text) => {
+            let chars: Array<char> = text.chars().collect();
+            for let mut i = 0; i < chars.len(); i += 1 {
+                w.line(`if pos >= chars.len() || chars[pos] != {escape_char(chars[i])} \{ {fail_action}; \}`);
+                w.line("pos += 1;");
             }
-        } else {
-            let fn_name = `try_{to_lower(&name)}`;
-            w.line(`pos = {fn_name}(chars, pos);`);
-            w.line(`if pos < 0 \{ {fail_action}; \}`);
-        }
-        return;
-    }
-    if let Group(alts) = *elem {
-        if alts.len() == 1 {
-            gen_lexer_alt_seq(w, &alts[0], all_rules, fail_action);
-        } else {
-            gen_lexer_alts(w, &alts, all_rules, fail_action);
-        }
-        return;
-    }
-    if let Repeat(rep) = *elem {
-        gen_lexer_repeat(w, &rep, all_rules, fail_action);
-        return;
-    }
-    if let Not(not_elem) = *elem {
-        gen_lexer_not(w, &not_elem, all_rules, fail_action);
-        return;
+        },
+        CharRange(pair) => {
+            w.line(
+                `if pos >= chars.len() || chars[pos] < {escape_char(pair.0)} || chars[pos] > {escape_char(pair.1)} \{ {fail_action}; \}`,
+            );
+            w.line("pos += 1;");
+        },
+        CharClass(cc) => gen_char_class(w, &cc, fail_action),
+        AnyChar => {
+            w.line(`if pos >= chars.len() \{ {fail_action}; \}`);
+            w.line("pos += 1;");
+        },
+        RuleRef(name) => {
+            if name == "EOF" {
+                w.line(`if pos < chars.len() \{ {fail_action}; \}`);
+            } else {
+                let frag = find_fragment(all_rules, &name);
+                if let Some(f) = frag {
+                    if f.body.len() == 1 {
+                        gen_lexer_alt_seq(w, &f.body[0], all_rules, fail_action);
+                    } else {
+                        gen_lexer_alts(w, &f.body, all_rules, fail_action);
+                    }
+                } else {
+                    let fn_name = `try_{to_lower(&name)}`;
+                    w.line(`pos = {fn_name}(chars, pos);`);
+                    w.line(`if pos < 0 \{ {fail_action}; \}`);
+                }
+            }
+        },
+        Group(alts) => {
+            if alts.len() == 1 {
+                gen_lexer_alt_seq(w, &alts[0], all_rules, fail_action);
+            } else {
+                gen_lexer_alts(w, &alts, all_rules, fail_action);
+            }
+        },
+        Repeat(rep) => gen_lexer_repeat(w, &rep, all_rules, fail_action),
+        Not(not_elem) => gen_lexer_not(w, &not_elem, all_rules, fail_action),
     }
 }
 

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -49,21 +49,21 @@ fn collect_lits_from_elements(elements: &Array<Element>, seen: &mut Array<String
 }
 
 fn collect_lits_from_element(elem: &Element, seen: &mut Array<String>, result: &mut Array<LitToken>) {
-    if let Literal(text) = *elem {
-        if !seen_contains(seen, &text) {
-            seen.append(text);
-            result.append(LitToken { text, const_name: literal_const_name(&text) });
+    if let Literal(text) = elem {
+        if !seen_contains(seen, text) {
+            seen.append(*text);
+            result.append(LitToken { text: *text, const_name: literal_const_name(text) });
         }
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         collect_lits_from_element(&rep.element, seen, result);
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         for let alt of alts {
             collect_lits_from_elements(&alt.elements, seen, result);
         }
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         collect_lits_from_element(&lab.element, seen, result);
     }
 }

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -207,7 +207,7 @@ fn gen_lexer_elem(w: &mut CodeWriter, elem: &LexerElement, all_rules: &Array<Lex
         },
         CharRange(pair) => {
             w.line(
-                `if pos >= chars.len() || chars[pos] < {escape_char(pair.0)} || chars[pos] > {escape_char(pair.1)} \{ {fail_action}; \}`,
+                `if pos >= chars.len() || !({escape_char(pair.0)} <= chars[pos] <= {escape_char(pair.1)}) \{ {fail_action}; \}`,
             );
             w.line("pos += 1;");
         },
@@ -254,7 +254,7 @@ fn gen_char_class(w: &mut CodeWriter, cc: &CharClass, fail_action: &String) {
             if range.start == range.end {
                 w.write(` || chars[pos] == {escape_char(range.start)}`);
             } else {
-                w.write(` || chars[pos] >= {escape_char(range.start)} && chars[pos] <= {escape_char(range.end)}`);
+                w.write(` || {escape_char(range.start)} <= chars[pos] <= {escape_char(range.end)}`);
             }
         }
         w.write(` \{ {*fail_action}; \}
@@ -265,7 +265,7 @@ fn gen_char_class(w: &mut CodeWriter, cc: &CharClass, fail_action: &String) {
             if range.start == range.end {
                 w.write(` || chars[pos] == {escape_char(range.start)}`);
             } else {
-                w.write(` || chars[pos] >= {escape_char(range.start)} && chars[pos] <= {escape_char(range.end)}`);
+                w.write(` || {escape_char(range.start)} <= chars[pos] <= {escape_char(range.end)}`);
             }
         }
         w.write(`) \{ {*fail_action}; \}

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -212,7 +212,7 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
             // Check if the inner element is a multi-token RuleRef.
             // If so, enter it via return stack instead of skipping to pos+1.
             let mut entered = false;
-            if let Repeat(rep) = *elem {
+            if let Repeat(rep) = elem {
                 if let RuleRef(inner_name) = rep.element {
                     let mut stv: Array<String> = [];
                     if !ctx.rule_is_single_token(&inner_name, &mut stv) && c.return_stack.len() < 1 {
@@ -258,15 +258,15 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
         }
         if skip_pos < c.elements.len() {
             let skipped_elem = &c.elements[skip_pos];
-            if let TokenRef(name) = *skipped_elem {
+            if let TokenRef(name) = skipped_elem {
                 if `TK_{name}` == *token {
                     results.append(SllConfig { alt_index: c.alt_index, elements: c.elements, pos: skip_pos + 1, return_stack: c.return_stack });
                 }
-            } else if let Literal(text) = *skipped_elem {
+            } else if let Literal(text) = skipped_elem {
                 if literal_const_name(&text) == *token {
                     results.append(SllConfig { alt_index: c.alt_index, elements: c.elements, pos: skip_pos + 1, return_stack: c.return_stack });
                 }
-            } else if let RuleRef(name) = *skipped_elem {
+            } else if let RuleRef(name) = skipped_elem {
                 let mut v: Array<String> = [];
                 if first_contains(&ctx.first_of_rule(&name, &mut v), token) {
                     let mut stv: Array<String> = [];
@@ -287,13 +287,13 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
     }
 
     // Terminal: if token matches, advance past this element.
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         if `TK_{name}` == *token {
             return [SllConfig { alt_index: c.alt_index, elements: c.elements, pos: c.pos + 1, return_stack: c.return_stack }];
         }
         return [];
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         if literal_const_name(&text) == *token {
             return [SllConfig { alt_index: c.alt_index, elements: c.elements, pos: c.pos + 1, return_stack: c.return_stack }];
         }
@@ -303,7 +303,7 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
     // RuleRef: advance past only if the rule always consumes exactly one token.
     // Multi-token rules return opaque (pos=-1); expansion happens in build_sll_node
     // only when needed to resolve ambiguity.
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         let mut visiting: Array<String> = [];
         let rule_first = ctx.first_of_rule(&name, &mut visiting);
         if !first_contains(&rule_first, token) {
@@ -320,7 +320,7 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
     }
 
     // Group: treat as consuming one token if the token is in FIRST(group).
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         let mut group_first = TreeSet::<String>::new();
         for let alt of alts {
             let mut visiting: Array<String> = [];
@@ -334,7 +334,7 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
     }
 
     // Repeat: treat as consuming the inner element.
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         let mut inner_first: Array<String> = [];
         let mut visiting: Array<String> = [];
         inner_first = ctx.first_of_element(&rep.element, &mut visiting);
@@ -346,7 +346,7 @@ fn sll_advance_inner(c: &SllConfig, token: &String, ctx: &mut GenContext, inline
     }
 
     // Label: unwrap.
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         let unwrapped = SllConfig {
             alt_index: c.alt_index,
             elements: replace_element_at(&c.elements, c.pos, &lab.element),
@@ -701,11 +701,11 @@ fn sll_find_common_terminal(configs: &Array<SllConfig>) -> Option<Element> {
         }
     }
     let first_elem = &configs[0].elements[configs[0].pos];
-    if let TokenRef(name) = *first_elem {
+    if let TokenRef(name) = first_elem {
         for let mut i = 1; i < configs.len(); i += 1 {
             let elem = &configs[i].elements[configs[i].pos];
-            if let TokenRef(other) = *elem {
-                if other != name {
+            if let TokenRef(other) = elem {
+                if *other != *name {
                     return null;
                 }
             } else {
@@ -714,11 +714,11 @@ fn sll_find_common_terminal(configs: &Array<SllConfig>) -> Option<Element> {
         }
         return Option::<Element>::Some(*first_elem);
     }
-    if let Literal(text) = *first_elem {
+    if let Literal(text) = first_elem {
         for let mut i = 1; i < configs.len(); i += 1 {
             let elem = &configs[i].elements[configs[i].pos];
-            if let Literal(other) = *elem {
-                if other != text {
+            if let Literal(other) = elem {
+                if *other != *text {
                     return null;
                 }
             } else {
@@ -742,10 +742,10 @@ fn find_common_prefix_element(alt_elements: &Array<Array<Element>>) -> Option<El
         }
     }
     let first_elem = &alt_elements[0][0];
-    if let TokenRef(name) = *first_elem {
+    if let TokenRef(name) = first_elem {
         for let mut i = 1; i < alt_elements.len(); i += 1 {
             if let TokenRef(other) = alt_elements[i][0] {
-                if other != name {
+                if other != *name {
                     return null;
                 }
             } else {
@@ -754,10 +754,10 @@ fn find_common_prefix_element(alt_elements: &Array<Array<Element>>) -> Option<El
         }
         return Option::<Element>::Some(*first_elem);
     }
-    if let Literal(text) = *first_elem {
+    if let Literal(text) = first_elem {
         for let mut i = 1; i < alt_elements.len(); i += 1 {
             if let Literal(other) = alt_elements[i][0] {
-                if other != text {
+                if other != *text {
                     return null;
                 }
             } else {
@@ -766,10 +766,10 @@ fn find_common_prefix_element(alt_elements: &Array<Array<Element>>) -> Option<El
         }
         return Option::<Element>::Some(*first_elem);
     }
-    if let RuleRef(name) = *first_elem {
+    if let RuleRef(name) = first_elem {
         for let mut i = 1; i < alt_elements.len(); i += 1 {
             if let RuleRef(other) = alt_elements[i][0] {
-                if other != name {
+                if other != *name {
                     return null;
                 }
             } else {
@@ -842,7 +842,7 @@ fn compute_deeper_first(elements: &Array<Element>, depth: i32, ctx: &mut GenCont
     let mut remaining = depth;
     while pos < elements.len() && remaining > 0 {
         let elem = &elements[pos];
-        if let TokenRef(_) | Literal(_) = *elem {
+        if let TokenRef(_) | Literal(_) = elem {
             remaining -= 1;
             pos += 1;
             continue;
@@ -853,7 +853,7 @@ fn compute_deeper_first(elements: &Array<Element>, depth: i32, ctx: &mut GenCont
         }
         // SLL advancement: single-token RuleRef consumes exactly 1 token,
         // so we can safely advance past it and look at the next element.
-        if let RuleRef(name) = *elem {
+        if let RuleRef(name) = elem {
             let mut visiting: Array<String> = [];
             if ctx.rule_is_single_token(&name, &mut visiting) {
                 remaining -= 1;
@@ -876,34 +876,34 @@ fn array_contains_i32(arr: &Array<i32>, val: i32) -> bool {
 }
 
 fn count_backtrack_nodes(node: &PredictionNode) -> i32 {
-    if let Backtrack(_) = *node {
+    if let Backtrack(_) = node {
         return 1;
     }
-    if let Dispatch(d) = *node {
+    if let Dispatch(d) = node {
         let mut count = 0;
         for let mut i = 0; i < d.branches.len(); i += 1 {
             count += count_backtrack_nodes(&d.branches[i].child);
         }
         return count;
     }
-    if let Consume(c) = *node {
+    if let Consume(c) = node {
         return count_backtrack_nodes(&c.child);
     }
     return 0;
 }
 
 fn count_leaf_nodes(node: &PredictionNode) -> i32 {
-    if let Leaf(_) = *node {
+    if let Leaf(_) = node {
         return 1;
     }
-    if let Dispatch(d) = *node {
+    if let Dispatch(d) = node {
         let mut count = 0;
         for let mut i = 0; i < d.branches.len(); i += 1 {
             count += count_leaf_nodes(&d.branches[i].child);
         }
         return count;
     }
-    if let Consume(c) = *node {
+    if let Consume(c) = node {
         return count_leaf_nodes(&c.child);
     }
     return 0;
@@ -1181,7 +1181,7 @@ fn gen_alt_body_skip(w: &mut CodeWriter, type_name: &String, variant_case: Optio
     }
     for let mut i = skip; i < alt.elements.len(); i += 1 {
         let elem = &alt.elements[i];
-        if let Repeat(rep) = *elem {
+        if let Repeat(rep) = elem {
             if let Optional = rep.kind {
                 if is_ruleref_optional(&rep.element) {
                     let follow = ctx.first_of_elements_from(&alt.elements, i + 1);
@@ -1264,7 +1264,7 @@ fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut Gen
     let mut name_counts: Array<[String, i32]> = [];
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
-        if let Repeat(rep) = *elem {
+        if let Repeat(rep) = elem {
             if let Optional = rep.kind {
                 if is_ruleref_optional(&rep.element) {
                     let follow = ctx.first_of_elements_from(elements, i + 1);
@@ -1288,7 +1288,7 @@ fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut Gen
 fn gen_elements_with_non_greedy(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
-        if let Repeat(rep) = *elem {
+        if let Repeat(rep) = elem {
             if rep.non_greedy {
                 let follow = ctx.first_of_elements_from(elements, i + 1);
                 let follow_second = compute_follow_second(elements, i + 1, ctx);
@@ -1303,40 +1303,40 @@ fn gen_elements_with_non_greedy(w: &mut CodeWriter, elements: &Array<Element>, c
 }
 
 fn is_ruleref_optional(elem: &Element) -> bool {
-    if let RuleRef(_) = *elem {
+    if let RuleRef(_) = elem {
         return true;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         return is_ruleref_optional(&lab.element);
     }
     return false;
 }
 
 fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         let const_name = `TK_{name}`;
         let field_name = dedup_name(&to_lower(&name), name_counts);
         w.line(`let {field_name} = p.expect({const_name}, {escape_string(&name)})?;`);
         return;
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         let const_name = literal_const_name(&text);
         let display = `'{text}'`;
         let field_name = dedup_name(&literal_field_name(&text), name_counts);
         w.line(`let {field_name} = p.expect({const_name}, {escape_string(&display)})?;`);
         return;
     }
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         let fn_name = `parse_{to_snake_case(&name)}`;
         let field_name = dedup_name(&to_snake_case(&name), name_counts);
         w.line(`let {field_name} = {fn_name}(p)?;`);
         return;
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         gen_repeat(w, &rep, ctx, name_counts);
         return;
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         if is_simple_cst_group(&alts) {
             gen_consume_group_store_optional(w, &alts, ctx, name_counts);
         } else if is_token_only_group(&alts) {
@@ -1348,7 +1348,7 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
         }
         return;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         gen_element(w, &lab.element, ctx, name_counts);
         return;
     }
@@ -1434,7 +1434,7 @@ fn compute_follow_second(elements: &Array<Element>, follow_start: i32, ctx: &mut
         return [];
     }
     let follow_elem = &elements[follow_start];
-    if let Repeat(rep) = *follow_elem {
+    if let Repeat(rep) = follow_elem {
         if let Group(alts) = rep.element {
             if alts.len() == 1 && alts[0].elements.len() >= 2 {
                 return ctx.first_of_elements_from(&alts[0].elements, 1);
@@ -1466,7 +1466,7 @@ fn compute_non_greedy_condition(inner: &Element, follow_first: &Array<String>, f
     // Use 2-token lookahead with follow_second to disambiguate.
     // For (',' column_def)*? followed by (',' table_constraint)*:
     //   peek(0) == ',' for both, peek(1) distinguishes column_def from table_constraint.
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if alts.len() == 1 && alts[0].elements.len() >= 2 && follow_second.len() > 0 {
             let inner_second_first = ctx.first_of_elements_from(&alts[0].elements, 1);
             let second_continue = subtract_sets(&inner_second_first, follow_second);
@@ -1590,19 +1590,19 @@ fn gen_repeat_with_follow(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut Gen
 }
 
 fn is_optional_repeat(elem: &Element) -> bool {
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         if let Optional = rep.kind {
             return true;
         }
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         return is_optional_repeat(&lab.element);
     }
     return false;
 }
 
 fn has_nested_optionals(inner: &Element) -> bool {
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if alts.len() != 1 {
             return false;
         }
@@ -1659,7 +1659,7 @@ fn shape_lookahead_signature(shape: &Array<i32>, elements: &Array<Element>, ctx:
         let elem = &elements[idx];
         let actual = unwrap_optional(elem);
         // For a Group with single alt, compute token-by-token signature
-        if let Group(alts) = *actual {
+        if let Group(alts) = actual {
             if alts.len() == 1 {
                 for let mut j = 0; j < alts[0].elements.len(); j += 1 {
                     let mut visiting: Array<String> = [];
@@ -1730,7 +1730,7 @@ fn gen_optional_with_lookahead(w: &mut CodeWriter, group_elements: &Array<Elemen
             let idx = shape[k];
             let elem = &group_elements[idx];
             let actual = unwrap_optional(elem);
-            if let Group(alts) = *actual {
+            if let Group(alts) = actual {
                 if alts.len() == 1 {
                     for let mut j = 0; j < alts[0].elements.len(); j += 1 {
                         gen_element(w, &alts[0].elements[j], ctx, &mut nc);
@@ -1749,12 +1749,12 @@ fn gen_optional_with_lookahead(w: &mut CodeWriter, group_elements: &Array<Elemen
 }
 
 fn unwrap_optional(elem: &Element) -> &Element with stores[elem] {
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         if let Optional = rep.kind {
             return &rep.element;
         }
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         return unwrap_optional(&lab.element);
     }
     return elem;
@@ -1763,14 +1763,14 @@ fn unwrap_optional(elem: &Element) -> &Element with stores[elem] {
 fn optional_lookahead_depth(inner: &Element) -> i32 {
     // Returns the number of leading fixed tokens that can be checked via lookahead.
     // 0 if the first element is not a fixed token.
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if alts.len() != 1 {
             return 0;
         }
         let mut depth = 0;
         for let mut i = 0; i < alts[0].elements.len(); i += 1 {
             let elem = &alts[0].elements[i];
-            if let TokenRef(_) | Literal(_) = *elem {
+            if let TokenRef(_) | Literal(_) = elem {
                 depth += 1;
             } else {
                 break;
@@ -1778,7 +1778,7 @@ fn optional_lookahead_depth(inner: &Element) -> i32 {
         }
         return depth;
     }
-    if let TokenRef(_) | Literal(_) = *inner {
+    if let TokenRef(_) | Literal(_) = inner {
         return 1;
     }
     return 0;
@@ -1787,7 +1787,7 @@ fn optional_lookahead_depth(inner: &Element) -> i32 {
 fn optional_lookahead_tokens(inner: &Element, max_depth: i32) -> Array<String> {
     // Returns up to max_depth leading fixed token constants.
     let mut tokens: Array<String> = [];
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if alts.len() != 1 {
             return [];
         }
@@ -1796,17 +1796,17 @@ fn optional_lookahead_tokens(inner: &Element, max_depth: i32) -> Array<String> {
                 break;
             }
             let elem = &alts[0].elements[i];
-            if let TokenRef(name) = *elem {
+            if let TokenRef(name) = elem {
                 tokens.append(`TK_{name}`);
-            } else if let Literal(text) = *elem {
+            } else if let Literal(text) = elem {
                 tokens.append(literal_const_name(&text));
             } else {
                 break;
             }
         }
-    } else if let TokenRef(name) = *inner {
+    } else if let TokenRef(name) = inner {
         tokens.append(`TK_{name}`);
-    } else if let Literal(text) = *inner {
+    } else if let Literal(text) = inner {
         tokens.append(literal_const_name(&text));
     }
     return tokens;
@@ -1814,7 +1814,7 @@ fn optional_lookahead_tokens(inner: &Element, max_depth: i32) -> Array<String> {
 
 fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, first: &Array<String>, name_counts: &mut Array<[String, i32]>) {
     if has_nested_optionals(inner) {
-        if let Group(alts) = *inner {
+        if let Group(alts) = inner {
             gen_optional_with_lookahead(w, &alts[0].elements, ctx, name_counts);
             return;
         }
@@ -1838,7 +1838,7 @@ fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
         }
         w.begin(`if {cond}`);
         let mut nc: Array<[String, i32]> = [];
-        if let Group(alts) = *inner {
+        if let Group(alts) = inner {
             for let mut i = 0; i < alts[0].elements.len(); i += 1 {
                 gen_element(w, &alts[0].elements[i], ctx, &mut nc);
             }
@@ -1857,7 +1857,7 @@ fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
     w.begin(`{label}:`);
 
     let mut bt_nc: Array<[String, i32]> = [];
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if alts.len() == 1 {
             for let elem of alts[0].elements {
                 gen_element_failable(w, &elem, ctx, &saved, &label, &mut bt_nc);
@@ -1874,14 +1874,14 @@ fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
 }
 
 fn gen_element_failable(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, saved_var: &String, label: &String, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         let const_name = `TK_{name}`;
         let r_var = dedup_name(&"opt_r", name_counts);
         w.line(`let {r_var} = p.expect({const_name}, {escape_string(&name)});`);
         w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
         return;
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         let const_name = literal_const_name(&text);
         let display = `'{text}'`;
         let r_var = dedup_name(&"opt_r", name_counts);
@@ -1889,18 +1889,18 @@ fn gen_element_failable(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext
         w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
         return;
     }
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         let fn_name = `parse_{to_snake_case(&name)}`;
         let r_var = dedup_name(&"opt_r", name_counts);
         w.line(`let {r_var} = {fn_name}(p);`);
         w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
         return;
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         gen_repeat(w, &rep, ctx, name_counts);
         return;
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         if alts.len() == 1 {
             for let inner_elem of alts[0].elements {
                 gen_element_failable(w, &inner_elem, ctx, saved_var, label, name_counts);
@@ -1910,7 +1910,7 @@ fn gen_element_failable(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext
         }
         return;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         gen_element_failable(w, &lab.element, ctx, saved_var, label, name_counts);
         return;
     }
@@ -1980,7 +1980,7 @@ fn gen_storable_optional_with_lookahead(
     opt_name: &String,
     field_name: &String,
 ) {
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if alts.len() != 1 {
             return;
         }
@@ -2045,7 +2045,7 @@ fn gen_storable_optional_with_lookahead(
 
 /// Generate a null assignment for an absent optional element's struct field.
 fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &mut Array<[String, i32]>) {
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         if let Optional = rep.kind {
             if has_field(&rep.element) {
                 let info = element_field_info(&rep.element);
@@ -2055,7 +2055,7 @@ fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &m
         }
         return;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         gen_absent_optional_field(w, &lab.element, name_counts);
         return;
     }
@@ -2098,7 +2098,7 @@ fn gen_storable_optional_with_backtrack(
     w.line(`let mut {result_var}: Option<{type_str}> = null;`);
     w.begin(`{label}:`);
 
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if is_single_alt_group(&alts) {
             let alt = &alts[0];
             // Use fresh name counters so element names match field assignments
@@ -2140,7 +2140,7 @@ fn gen_storable_optional_with_backtrack(
 /// For TokenRef/Literal: generates `let r = p.expect(...); if Err, break; let name = r.unwrap();`
 /// For RuleRef: generates `let r = parse_foo(p); if Err, break; let foo = r.unwrap();`
 fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, saved_var: &String, label: &String, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         let const_name = `TK_{name}`;
         let field_name = dedup_name(&to_lower(&name), name_counts);
         let r_var = dedup_name(&"_bt_r", name_counts);
@@ -2149,7 +2149,7 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         w.line(`let {field_name} = {r_var}.unwrap();`);
         return;
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         let const_name = literal_const_name(&text);
         let display = `'{text}'`;
         let field_name = dedup_name(&literal_field_name(&text), name_counts);
@@ -2159,7 +2159,7 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         w.line(`let {field_name} = {r_var}.unwrap();`);
         return;
     }
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         let fn_name = `parse_{to_snake_case(&name)}`;
         let field_name = dedup_name(&to_snake_case(&name), name_counts);
         let r_var = dedup_name(&"_bt_r", name_counts);
@@ -2168,11 +2168,11 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         w.line(`let {field_name} = {r_var}.unwrap();`);
         return;
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         gen_repeat(w, &rep, ctx, name_counts);
         return;
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         if is_simple_cst_group(&alts) {
             gen_consume_group_store_optional(w, &alts, ctx, name_counts);
         } else if is_token_only_group(&alts) {
@@ -2184,46 +2184,46 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         }
         return;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         gen_element_failable_named(w, &lab.element, ctx, saved_var, label, name_counts);
         return;
     }
 }
 
 fn is_group_with_store(elem: &Element) -> bool {
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         return is_storable_group(&alts);
     }
     return false;
 }
 
 fn has_field(elem: &Element) -> bool {
-    if let TokenRef(_) | Literal(_) | RuleRef(_) = *elem {
+    if let TokenRef(_) | Literal(_) | RuleRef(_) = elem {
         return true;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         return has_field(&lab.element);
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         return is_storable_group(&alts);
     }
     return false;
 }
 
 fn element_field_info(elem: &Element) -> [String, String] {
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         return [to_lower(&name), "Token"];
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         return [literal_field_name(&text), "Token"];
     }
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         return [to_snake_case(&name), rule_type_name(&name)];
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         return element_field_info(&lab.element);
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         if is_simple_cst_group(&alts) {
             return [group_field_base_name(&alts), group_variant_type_name(&alts)];
         }
@@ -2245,22 +2245,22 @@ fn gen_field_assignments(w: &mut CodeWriter, elements: &Array<Element>) {
 }
 
 fn gen_field_assignment(w: &mut CodeWriter, elem: &Element, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         let field_name = dedup_name(&to_lower(&name), name_counts);
         w.line(`{field_name},`);
         return;
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         let field_name = dedup_name(&literal_field_name(&text), name_counts);
         w.line(`{field_name},`);
         return;
     }
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         let field_name = dedup_name(&to_snake_case(&name), name_counts);
         w.line(`{field_name},`);
         return;
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         if has_field(&rep.element) {
             let info = element_field_info(&rep.element);
             if let Star | Plus = rep.kind {
@@ -2274,7 +2274,7 @@ fn gen_field_assignment(w: &mut CodeWriter, elem: &Element, name_counts: &mut Ar
         }
         return;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         if has_field(&lab.element) {
             let field_name = to_snake_case(&lab.name);
             dedup_name(&field_name, name_counts);
@@ -2282,7 +2282,7 @@ fn gen_field_assignment(w: &mut CodeWriter, elem: &Element, name_counts: &mut Ar
         }
         return;
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         if is_simple_cst_group(&alts) {
             let field_name = dedup_name(&group_field_base_name(&alts), name_counts);
             w.line(`{field_name},`);
@@ -2300,19 +2300,19 @@ fn gen_field_assignment(w: &mut CodeWriter, elem: &Element, name_counts: &mut Ar
 /// Replay name counting for an element without emitting code.
 /// This advances the dedup counter so subsequent elements get correct suffixes.
 fn replay_element_names(elem: &Element, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         dedup_name(&to_lower(&name), name_counts);
         return;
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         dedup_name(&literal_field_name(&text), name_counts);
         return;
     }
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         dedup_name(&to_snake_case(&name), name_counts);
         return;
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         if has_field(&rep.element) {
             let info = element_field_info(&rep.element);
             if let Star | Plus = rep.kind {
@@ -2324,13 +2324,13 @@ fn replay_element_names(elem: &Element, name_counts: &mut Array<[String, i32]>) 
         }
         return;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         if has_field(&lab.element) {
             dedup_name(&to_snake_case(&lab.name), name_counts);
         }
         return;
     }
-    if let Group(alts) = *elem {
+    if let Group(alts) = elem {
         if is_simple_cst_group(&alts) {
             dedup_name(&group_field_base_name(&alts), name_counts);
         } else if is_token_only_group(&alts) {
@@ -2593,7 +2593,7 @@ fn gen_consume_group_store_optional(w: &mut CodeWriter, alts: &Array<Alternative
 }
 
 fn gen_group_store_any(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
-    if let Group(alts) = *inner {
+    if let Group(alts) = inner {
         if is_simple_cst_group(&alts) {
             gen_consume_group_store(w, &alts, ctx, name_counts);
         } else if is_token_only_group(&alts) {
@@ -2647,11 +2647,11 @@ fn gen_group_prediction_code(w: &mut CodeWriter, node: &PredictionNode, alts: &A
 }
 
 fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alts: &Array<Alternative>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, skip: i32) {
-    if let Leaf(idx) = *node {
-        let elems = &alts[idx].elements;
+    if let Leaf(idx) = node {
+        let elems = &alts[*idx].elements;
         for let mut i = skip; i < elems.len(); i += 1 {
             let elem = &elems[i];
-            if let Repeat(rep) = *elem {
+            if let Repeat(rep) = elem {
                 if rep.non_greedy {
                     let follow = ctx.first_of_elements_from(elems, i + 1);
                     let follow_second = compute_follow_second(elems, i + 1, ctx);
@@ -2663,12 +2663,12 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
         }
         return;
     }
-    if let Consume(c) = *node {
+    if let Consume(c) = node {
         gen_element(w, &c.element, ctx, name_counts);
         gen_group_prediction_code_skip(w, &c.child, alts, ctx, name_counts, skip + 1);
         return;
     }
-    if let Backtrack(indices) = *node {
+    if let Backtrack(indices) = node {
         let mut sorted = indices.sorted();
         sort_group_by_element_count(&mut sorted, alts);
         let saved_var = dedup_name(&"saved_pos", name_counts);
@@ -2701,7 +2701,7 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
         }
         return;
     }
-    if let Dispatch(d) = *node {
+    if let Dispatch(d) = node {
         let check_var = if d.depth == 0 { "p.peek_kind()" } else { `p.peek_at({d.depth})` };
         for let mut i = 0; i < d.branches.len(); i += 1 {
             let branch = &d.branches[i];
@@ -2725,10 +2725,10 @@ fn compute_lr_conflict_min_prec(alt: &Alternative, own_prec: i32, lr_indices: &A
     let mut fixed_tokens: Array<String> = [];
     for let mut ei = 1; ei < alt.elements.len(); ei += 1 {
         let elem = &alt.elements[ei];
-        if let TokenRef(name) = *elem {
+        if let TokenRef(name) = elem {
             fixed_tokens.append(`TK_{name}`);
         }
-        if let Literal(text) = *elem {
+        if let Literal(text) = elem {
             fixed_tokens.append(literal_const_name(&text));
         }
     }
@@ -2802,16 +2802,16 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
 
         for let mut ei = 1; ei < alt.elements.len(); ei += 1 {
             let elem = &alt.elements[ei];
-            if let RuleRef(name) = *elem {
-                if name == rule.name {
-                    let field_name = dedup_name(&to_snake_case(&name), &mut name_counts);
+            if let RuleRef(name) = elem {
+                if *name == rule.name {
+                    let field_name = dedup_name(&to_snake_case(name), &mut name_counts);
                     w.line(`let {field_name} = {prec_fn}(p, {inner_min_prec})?;`);
                 } else {
                     let elem_fn = `parse_{to_snake_case(&name)}`;
                     let field_name = dedup_name(&to_snake_case(&name), &mut name_counts);
                     w.line(`let {field_name} = {elem_fn}(p)?;`);
                 }
-            } else if let Group(alts) = *elem {
+            } else if let Group(alts) = elem {
                 if is_token_only_group(&alts) {
                     gen_consume_token_group(w, &alts, ctx, &mut name_counts);
                 } else if is_simple_token_group(&alts) {
@@ -2820,7 +2820,7 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
                 } else {
                     gen_element(w, elem, ctx, &mut name_counts);
                 }
-            } else if let Repeat(rep) = *elem {
+            } else if let Repeat(rep) = elem {
                 gen_repeat(w, &rep, ctx, &mut name_counts);
             } else {
                 gen_element(w, elem, ctx, &mut name_counts);
@@ -2871,7 +2871,7 @@ fn compute_lr_second_token(shared_token: &String, elements: &Array<Element>, ctx
         // The shared token is inside a Group (e.g. (K_ISNULL | K_NOTNULL | K_NOT K_NULL)).
         // Find the alternative within the group that starts with shared_token,
         // and return the first set of its second element.
-        if let Group(alts) = *elem {
+        if let Group(alts) = elem {
             for let mut a = 0; a < alts.len(); a += 1 {
                 let alt = &alts[a];
                 if alt.elements.len() < 1 {
@@ -3107,14 +3107,14 @@ fn gen_prediction_code(w: &mut CodeWriter, node: &PredictionNode, fn_name: &Stri
 }
 
 fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name: &String, alts: &Array<Alternative>, type_name: &String, ctx: &mut GenContext, skip: i32, name_counts: &mut Array<[String, i32]>) {
-    if let Leaf(idx) = *node {
+    if let Leaf(idx) = node {
         if skip == 0 {
             w.line(`return {*fn_name}_bt_{idx}(p);`);
         } else {
             // Consumed prefix tokens already — inline the remaining alt body.
             let all_labeled = all_alternatives_labeled(alts);
-            let alt = &alts[idx];
-            let case_name = if all_labeled { alt.label.unwrap() } else { `Alt{idx}` };
+            let alt = &alts[*idx];
+            let case_name = if all_labeled { alt.label.unwrap() } else { `Alt{*idx}` };
             let sname = `{strip_suffix(type_name, "Node")}{case_name}`;
             gen_alt_body_skip(
                 w,
@@ -3128,12 +3128,12 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
         }
         return;
     }
-    if let Consume(c) = *node {
+    if let Consume(c) = node {
         gen_element(w, &c.element, ctx, name_counts);
         gen_prediction_code_inner(w, &c.child, fn_name, alts, type_name, ctx, skip + 1, name_counts);
         return;
     }
-    if let Backtrack(indices) = *node {
+    if let Backtrack(indices) = node {
         // Sort by element count for proper ordering (single RuleRef first, etc.)
         let mut sorted_indices = indices.sorted();
         sort_group_by_element_count(&mut sorted_indices, alts);
@@ -3160,7 +3160,7 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
         }
         return;
     }
-    if let Dispatch(d) = *node {
+    if let Dispatch(d) = node {
         let check_var = if d.depth == 0 { "p.peek_kind()" } else { `p.peek_at({d.depth})` };
         for let mut i = 0; i < d.branches.len(); i += 1 {
             let branch = &d.branches[i];
@@ -3397,8 +3397,8 @@ fn is_left_recursive(alt: &Alternative, rule_name: &String) -> bool {
         return false;
     }
     let first = &alt.elements[0];
-    if let RuleRef(name) = *first {
-        return name == *rule_name;
+    if let RuleRef(name) = first {
+        return *name == *rule_name;
     }
     return false;
 }
@@ -3478,7 +3478,7 @@ fn alt_sort_priority(alt: &Alternative) -> i32 {
     // 1: Single Token/Literal — simple fallbacks (e.g. K_INSERT)
     if alt.elements.len() == 1 {
         let elem = &alt.elements[0];
-        if let RuleRef(_) = *elem {
+        if let RuleRef(_) = elem {
             return 3;
         }
         return 1;

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -807,13 +807,9 @@ fn first_of_elements(elements: &Array<Element>, ctx: &mut GenContext, visiting: 
 }
 
 fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
-    if let Leaf(ai) = *a {
-        if let Leaf(bi) = *b {
-            return ai == bi;
-        }
-    }
-    if let Backtrack(aa) = *a {
-        if let Backtrack(ba) = *b {
+    return match [*a, *b] {
+        [Leaf(ai), Leaf(bi)] => ai == bi,
+        [Backtrack(aa), Backtrack(ba)] => {
             if aa.len() != ba.len() {
                 return false;
             }
@@ -822,30 +818,20 @@ fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
                     return false;
                 }
             }
-            return true;
-        }
-    }
-    // Consume nodes: check same element kind and recurse on child.
-    if let Consume(ca) = *a {
-        if let Consume(cb) = *b {
-            return element_eq(&ca.element, &cb.element) && prediction_node_eq(&ca.child, &cb.child);
-        }
-    }
-    return false;
+            true
+        },
+        // Consume nodes: check same element kind and recurse on child.
+        [Consume(ca), Consume(cb)] => element_eq(&ca.element, &cb.element) && prediction_node_eq(&ca.child, &cb.child),
+        _ => false,
+    };
 }
 
 fn element_eq(a: &Element, b: &Element) -> bool {
-    if let TokenRef(na) = *a {
-        if let TokenRef(nb) = *b {
-            return na == nb;
-        }
-    }
-    if let Literal(ta) = *a {
-        if let Literal(tb) = *b {
-            return ta == tb;
-        }
-    }
-    return false;
+    return match [*a, *b] {
+        [TokenRef(na), TokenRef(nb)] => na == nb,
+        [Literal(ta), Literal(tb)] => ta == tb,
+        _ => false,
+    };
 }
 
 fn compute_deeper_first(elements: &Array<Element>, depth: i32, ctx: &mut GenContext) -> Array<String> {

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -85,25 +85,28 @@ fn build_prediction(alt_indices: &Array<i32>, first_sets: &Array<Array<String>>,
 /// Strip Consume nodes whose child is a Backtrack — fall back to
 /// Backtrack from the original position rather than consuming then failing.
 fn strip_dead_consume(node: PredictionNode) -> PredictionNode {
-    if let Consume(c) = node {
-        let child = strip_dead_consume(c.child);
-        if let Backtrack(_) = child {
-            // Consuming prefix didn't help — return Backtrack with original alts.
-            return child;
-        }
-        return PredictionNode::Consume(ConsumeNode { element: c.element, child });
-    }
-    if let Dispatch(d) = node {
-        let mut new_branches: Array<PredictionBranch> = [];
-        for let b of d.branches {
-            new_branches.append(PredictionBranch {
-                tokens: b.tokens,
-                child: strip_dead_consume(b.child),
-            });
-        }
-        return PredictionNode::Dispatch(PredictionDispatch { depth: d.depth, branches: new_branches });
-    }
-    return node;
+    return match node {
+        Consume(c) => {
+            let child = strip_dead_consume(c.child);
+            if let Backtrack(_) = child {
+                // Consuming prefix didn't help — return Backtrack with original alts.
+                child
+            } else {
+                PredictionNode::Consume(ConsumeNode { element: c.element, child })
+            }
+        },
+        Dispatch(d) => {
+            let mut new_branches: Array<PredictionBranch> = [];
+            for let b of d.branches {
+                new_branches.append(PredictionBranch {
+                    tokens: b.tokens,
+                    child: strip_dead_consume(b.child),
+                });
+            }
+            PredictionNode::Dispatch(PredictionDispatch { depth: d.depth, branches: new_branches })
+        },
+        _ => node,
+    };
 }
 
 

--- a/package-gale/src/visitor_gen.wado
+++ b/package-gale/src/visitor_gen.wado
@@ -85,10 +85,10 @@ fn gen_walk_action(w: &mut CodeWriter, action: &WalkAction, expr: &String) {
 }
 
 fn repeat_inner_walk_field(elem: &Element) -> Option<WalkField> {
-    if let Group(alts) = *elem {
-        if is_simple_cst_group(&alts) {
+    if let Group(alts) = elem {
+        if is_simple_cst_group(alts) {
             let mut cases: Array<GroupCaseInfo> = [];
-            for let alt of &alts {
+            for let alt of alts {
                 if let RuleRef(name) = &alt.elements[0] {
                     cases.append(GroupCaseInfo {
                         case_name: to_pascal_case(name),
@@ -97,19 +97,19 @@ fn repeat_inner_walk_field(elem: &Element) -> Option<WalkField> {
                 }
             }
             return Option::Some(WalkField {
-                name: group_field_base_name(&alts),
+                name: group_field_base_name(alts),
                 action: WalkAction::WalkGroup(cases),
                 wrapper: WalkWrapper::Direct,
             });
         }
-        if is_token_only_group(&alts) {
+        if is_token_only_group(alts) {
             return Option::Some(WalkField {
-                name: token_group_field_name(&alts),
+                name: token_group_field_name(alts),
                 action: WalkAction::VisitToken,
                 wrapper: WalkWrapper::Direct,
             });
         }
-        if is_single_alt_group(&alts) {
+        if is_single_alt_group(alts) {
             return Option::Some(WalkField {
                 name: single_alt_group_field_name(&alts[0]),
                 action: build_struct_walk_action(&alts[0]),
@@ -184,28 +184,28 @@ fn collect_walk_fields(elements: &Array<Element>) -> Array<WalkField> {
 }
 
 fn element_to_walk_field(elem: &Element) -> Option<WalkField> {
-    if let RuleRef(name) = *elem {
+    if let RuleRef(name) = elem {
         return Option::Some(WalkField {
-            name: to_snake_case(&name),
-            action: WalkAction::WalkRule(name),
+            name: to_snake_case(name),
+            action: WalkAction::WalkRule(*name),
             wrapper: WalkWrapper::Direct,
         });
     }
-    if let TokenRef(name) = *elem {
+    if let TokenRef(name) = elem {
         return Option::Some(WalkField {
-            name: to_lower(&name),
+            name: to_lower(name),
             action: WalkAction::VisitToken,
             wrapper: WalkWrapper::Direct,
         });
     }
-    if let Literal(text) = *elem {
+    if let Literal(text) = elem {
         return Option::Some(WalkField {
-            name: literal_field_name(&text),
+            name: literal_field_name(text),
             action: WalkAction::VisitToken,
             wrapper: WalkWrapper::Direct,
         });
     }
-    if let Repeat(rep) = *elem {
+    if let Repeat(rep) = elem {
         let inner_field = repeat_inner_walk_field(&rep.element);
         if let Some(inner) = inner_field {
             match rep.kind {
@@ -227,7 +227,7 @@ fn element_to_walk_field(elem: &Element) -> Option<WalkField> {
         }
         return null;
     }
-    if let Label(lab) = *elem {
+    if let Label(lab) = elem {
         if let Some(inner) = element_to_walk_field(&lab.element) {
             return Option::Some(WalkField {
                 name: to_snake_case(&lab.name),
@@ -237,10 +237,10 @@ fn element_to_walk_field(elem: &Element) -> Option<WalkField> {
         }
         return null;
     }
-    if let Group(alts) = *elem {
-        if is_simple_cst_group(&alts) {
+    if let Group(alts) = elem {
+        if is_simple_cst_group(alts) {
             let mut cases: Array<GroupCaseInfo> = [];
-            for let alt of &alts {
+            for let alt of alts {
                 if let RuleRef(name) = &alt.elements[0] {
                     cases.append(GroupCaseInfo {
                         case_name: to_pascal_case(name),
@@ -249,19 +249,19 @@ fn element_to_walk_field(elem: &Element) -> Option<WalkField> {
                 }
             }
             return Option::Some(WalkField {
-                name: group_field_base_name(&alts),
+                name: group_field_base_name(alts),
                 action: WalkAction::WalkGroup(cases),
                 wrapper: WalkWrapper::OptionalWrap,
             });
         }
-        if is_token_only_group(&alts) {
+        if is_token_only_group(alts) {
             return Option::Some(WalkField {
-                name: token_group_field_name(&alts),
+                name: token_group_field_name(alts),
                 action: WalkAction::VisitToken,
                 wrapper: WalkWrapper::Direct,
             });
         }
-        if is_single_alt_group(&alts) {
+        if is_single_alt_group(alts) {
             return Option::Some(WalkField {
                 name: single_alt_group_field_name(&alts[0]),
                 action: build_struct_walk_action(&alts[0]),

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -678,14 +678,14 @@ fn try_variable(chars: &Array<char>, start: i32) -> i32 {
     let mut alts_ok_0 = false;
     alts_0_0: {
         pos = alts_saved_0;
-        if pos >= chars.len() || chars[pos] < 'a' || chars[pos] > 'z' { break alts_0_0; }
+        if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_0_0; }
         pos += 1;
         alts_ok_0 = true;
     }
     if !alts_ok_0 {
         alts_0_1: {
             pos = alts_saved_0;
-            if pos >= chars.len() || chars[pos] < 'A' || chars[pos] > 'Z' { break alts_0_1; }
+            if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_0_1; }
             pos += 1;
             alts_ok_0 = true;
         }
@@ -710,14 +710,14 @@ fn try_variable(chars: &Array<char>, start: i32) -> i32 {
                 let mut alts_ok_3 = false;
                 alts_3_0: {
                     pos = alts_saved_3;
-                    if pos >= chars.len() || chars[pos] < 'a' || chars[pos] > 'z' { break alts_3_0; }
+                    if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_3_0; }
                     pos += 1;
                     alts_ok_3 = true;
                 }
                 if !alts_ok_3 {
                     alts_3_1: {
                         pos = alts_saved_3;
-                        if pos >= chars.len() || chars[pos] < 'A' || chars[pos] > 'Z' { break alts_3_1; }
+                        if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_3_1; }
                         pos += 1;
                         alts_ok_3 = true;
                     }
@@ -736,7 +736,7 @@ fn try_variable(chars: &Array<char>, start: i32) -> i32 {
             if !alts_ok_2 {
                 alts_2_1: {
                     pos = alts_saved_2;
-                    if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break alts_2_1; }
+                    if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break alts_2_1; }
                     pos += 1;
                     alts_ok_2 = true;
                 }
@@ -752,12 +752,12 @@ fn try_variable(chars: &Array<char>, start: i32) -> i32 {
 
 fn try_scientific_number(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
-    if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { return -1; }
+    if pos >= chars.len() || !('0' <= chars[pos] <= '9') { return -1; }
     pos += 1;
     loop {
         let rep_saved_4 = pos;
         rep_4: {
-            if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_4; }
+            if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_4; }
             pos += 1;
             continue;
         }
@@ -769,12 +769,12 @@ fn try_scientific_number(chars: &Array<char>, start: i32) -> i32 {
     rep_5: {
         if pos >= chars.len() || chars[pos] != '.' { break rep_5; }
         pos += 1;
-        if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_5; }
+        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_5; }
         pos += 1;
         loop {
             let rep_saved_6 = pos;
             rep_6: {
-                if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_6; }
+                if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_6; }
                 pos += 1;
                 continue;
             }
@@ -827,12 +827,12 @@ fn try_scientific_number(chars: &Array<char>, start: i32) -> i32 {
             opt_ok_9 = true;
         }
         if !opt_ok_9 { pos = opt_saved_9; }
-        if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_7; }
+        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_7; }
         pos += 1;
         loop {
             let rep_saved_11 = pos;
             rep_11: {
-                if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_11; }
+                if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_11; }
                 pos += 1;
                 continue;
             }
@@ -844,12 +844,12 @@ fn try_scientific_number(chars: &Array<char>, start: i32) -> i32 {
         rep_12: {
             if pos >= chars.len() || chars[pos] != '.' { break rep_12; }
             pos += 1;
-            if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_12; }
+            if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_12; }
             pos += 1;
             loop {
                 let rep_saved_13 = pos;
                 rep_13: {
-                    if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_13; }
+                    if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_13; }
                     pos += 1;
                     continue;
                 }

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -333,16 +333,16 @@ fn try_string(chars: &Array<char>, start: i32) -> i32 {
                         if pos >= chars.len() || chars[pos] != 'u' { break alts_2_1; }
                         pos += 1;
                         if pos >= chars.len() { break alts_2_1; }
-                        if !(false || chars[pos] >= '0' && chars[pos] <= '9' || chars[pos] >= 'a' && chars[pos] <= 'f' || chars[pos] >= 'A' && chars[pos] <= 'F') { break alts_2_1; }
+                        if !(false || '0' <= chars[pos] <= '9' || 'a' <= chars[pos] <= 'f' || 'A' <= chars[pos] <= 'F') { break alts_2_1; }
                         pos += 1;
                         if pos >= chars.len() { break alts_2_1; }
-                        if !(false || chars[pos] >= '0' && chars[pos] <= '9' || chars[pos] >= 'a' && chars[pos] <= 'f' || chars[pos] >= 'A' && chars[pos] <= 'F') { break alts_2_1; }
+                        if !(false || '0' <= chars[pos] <= '9' || 'a' <= chars[pos] <= 'f' || 'A' <= chars[pos] <= 'F') { break alts_2_1; }
                         pos += 1;
                         if pos >= chars.len() { break alts_2_1; }
-                        if !(false || chars[pos] >= '0' && chars[pos] <= '9' || chars[pos] >= 'a' && chars[pos] <= 'f' || chars[pos] >= 'A' && chars[pos] <= 'F') { break alts_2_1; }
+                        if !(false || '0' <= chars[pos] <= '9' || 'a' <= chars[pos] <= 'f' || 'A' <= chars[pos] <= 'F') { break alts_2_1; }
                         pos += 1;
                         if pos >= chars.len() { break alts_2_1; }
-                        if !(false || chars[pos] >= '0' && chars[pos] <= '9' || chars[pos] >= 'a' && chars[pos] <= 'f' || chars[pos] >= 'A' && chars[pos] <= 'F') { break alts_2_1; }
+                        if !(false || '0' <= chars[pos] <= '9' || 'a' <= chars[pos] <= 'f' || 'A' <= chars[pos] <= 'F') { break alts_2_1; }
                         pos += 1;
                         alts_ok_2 = true;
                     }
@@ -354,7 +354,7 @@ fn try_string(chars: &Array<char>, start: i32) -> i32 {
                 alts_1_1: {
                     pos = alts_saved_1;
                     if pos >= chars.len() { break alts_1_1; }
-                    if false || chars[pos] == '"' || chars[pos] == '\\' || chars[pos] >= '\u{0}' && chars[pos] <= '\u{1f}' { break alts_1_1; }
+                    if false || chars[pos] == '"' || chars[pos] == '\\' || '\u{0}' <= chars[pos] <= '\u{1f}' { break alts_1_1; }
                     pos += 1;
                     alts_ok_1 = true;
                 }
@@ -392,13 +392,13 @@ fn try_number(chars: &Array<char>, start: i32) -> i32 {
         alts_4_1: {
             pos = alts_saved_4;
             if pos >= chars.len() { break alts_4_1; }
-            if !(false || chars[pos] >= '1' && chars[pos] <= '9') { break alts_4_1; }
+            if !(false || '1' <= chars[pos] <= '9') { break alts_4_1; }
             pos += 1;
             loop {
                 let rep_saved_5 = pos;
                 rep_5: {
                     if pos >= chars.len() { break rep_5; }
-                    if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_5; }
+                    if !(false || '0' <= chars[pos] <= '9') { break rep_5; }
                     pos += 1;
                     continue;
                 }
@@ -415,13 +415,13 @@ fn try_number(chars: &Array<char>, start: i32) -> i32 {
         if pos >= chars.len() || chars[pos] != '.' { break rep_6; }
         pos += 1;
         if pos >= chars.len() { break rep_6; }
-        if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_6; }
+        if !(false || '0' <= chars[pos] <= '9') { break rep_6; }
         pos += 1;
         loop {
             let rep_saved_7 = pos;
             rep_7: {
                 if pos >= chars.len() { break rep_7; }
-                if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_7; }
+                if !(false || '0' <= chars[pos] <= '9') { break rep_7; }
                 pos += 1;
                 continue;
             }
@@ -447,13 +447,13 @@ fn try_number(chars: &Array<char>, start: i32) -> i32 {
         }
         if !opt_ok_9 { pos = opt_saved_9; }
         if pos >= chars.len() { break rep_8; }
-        if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_8; }
+        if !(false || '0' <= chars[pos] <= '9') { break rep_8; }
         pos += 1;
         loop {
             let rep_saved_10 = pos;
             rep_10: {
                 if pos >= chars.len() { break rep_10; }
-                if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_10; }
+                if !(false || '0' <= chars[pos] <= '9') { break rep_10; }
                 pos += 1;
                 continue;
             }

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -427,12 +427,12 @@ fn try_number(chars: &Array<char>, start: i32) -> i32 {
         opt_ok_7 = true;
     }
     if !opt_ok_7 { pos = opt_saved_7; }
-    if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { return -1; }
+    if pos >= chars.len() || !('0' <= chars[pos] <= '9') { return -1; }
     pos += 1;
     loop {
         let rep_saved_9 = pos;
         rep_9: {
-            if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_9; }
+            if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_9; }
             pos += 1;
             continue;
         }
@@ -444,12 +444,12 @@ fn try_number(chars: &Array<char>, start: i32) -> i32 {
     rep_10: {
         if pos >= chars.len() || chars[pos] != '.' { break rep_10; }
         pos += 1;
-        if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_10; }
+        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_10; }
         pos += 1;
         loop {
             let rep_saved_11 = pos;
             rep_11: {
-                if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break rep_11; }
+                if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_11; }
                 pos += 1;
                 continue;
             }
@@ -468,14 +468,14 @@ fn try_symbol(chars: &Array<char>, start: i32) -> i32 {
     let mut alts_ok_12 = false;
     alts_12_0: {
         pos = alts_saved_12;
-        if pos >= chars.len() || chars[pos] < 'a' || chars[pos] > 'z' { break alts_12_0; }
+        if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_12_0; }
         pos += 1;
         alts_ok_12 = true;
     }
     if !alts_ok_12 {
         alts_12_1: {
             pos = alts_saved_12;
-            if pos >= chars.len() || chars[pos] < 'A' || chars[pos] > 'Z' { break alts_12_1; }
+            if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_12_1; }
             pos += 1;
             alts_ok_12 = true;
         }
@@ -532,14 +532,14 @@ fn try_symbol(chars: &Array<char>, start: i32) -> i32 {
                 let mut alts_ok_15 = false;
                 alts_15_0: {
                     pos = alts_saved_15;
-                    if pos >= chars.len() || chars[pos] < 'a' || chars[pos] > 'z' { break alts_15_0; }
+                    if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_15_0; }
                     pos += 1;
                     alts_ok_15 = true;
                 }
                 if !alts_ok_15 {
                     alts_15_1: {
                         pos = alts_saved_15;
-                        if pos >= chars.len() || chars[pos] < 'A' || chars[pos] > 'Z' { break alts_15_1; }
+                        if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_15_1; }
                         pos += 1;
                         alts_ok_15 = true;
                     }
@@ -590,7 +590,7 @@ fn try_symbol(chars: &Array<char>, start: i32) -> i32 {
             if !alts_ok_14 {
                 alts_14_1: {
                     pos = alts_saved_14;
-                    if pos >= chars.len() || chars[pos] < '0' || chars[pos] > '9' { break alts_14_1; }
+                    if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break alts_14_1; }
                     pos += 1;
                     alts_ok_14 = true;
                 }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -5679,13 +5679,13 @@ fn try_identifier(chars: &Array<char>, start: i32) -> i32 {
                 alts_0_3: {
                     pos = alts_saved_0;
                     if pos >= chars.len() { break alts_0_3; }
-                    if !(false || chars[pos] >= 'a' && chars[pos] <= 'z' || chars[pos] >= 'A' && chars[pos] <= 'Z' || chars[pos] == '_') { break alts_0_3; }
+                    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { break alts_0_3; }
                     pos += 1;
                     loop {
                         let rep_saved_9 = pos;
                         rep_9: {
                             if pos >= chars.len() { break rep_9; }
-                            if !(false || chars[pos] >= 'a' && chars[pos] <= 'z' || chars[pos] >= 'A' && chars[pos] <= 'Z' || chars[pos] == '_' || chars[pos] >= '0' && chars[pos] <= '9') { break rep_9; }
+                            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_' || '0' <= chars[pos] <= '9') { break rep_9; }
                             pos += 1;
                             continue;
                         }
@@ -5708,13 +5708,13 @@ fn try_numeric_literal(chars: &Array<char>, start: i32) -> i32 {
     alts_10_0: {
         pos = alts_saved_10;
         if pos >= chars.len() { break alts_10_0; }
-        if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break alts_10_0; }
+        if !(false || '0' <= chars[pos] <= '9') { break alts_10_0; }
         pos += 1;
         loop {
             let rep_saved_11 = pos;
             rep_11: {
                 if pos >= chars.len() { break rep_11; }
-                if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_11; }
+                if !(false || '0' <= chars[pos] <= '9') { break rep_11; }
                 pos += 1;
                 continue;
             }
@@ -5730,7 +5730,7 @@ fn try_numeric_literal(chars: &Array<char>, start: i32) -> i32 {
                 let rep_saved_13 = pos;
                 rep_13: {
                     if pos >= chars.len() { break rep_13; }
-                    if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_13; }
+                    if !(false || '0' <= chars[pos] <= '9') { break rep_13; }
                     pos += 1;
                     continue;
                 }
@@ -5756,13 +5756,13 @@ fn try_numeric_literal(chars: &Array<char>, start: i32) -> i32 {
             }
             if !opt_ok_15 { pos = opt_saved_15; }
             if pos >= chars.len() { break rep_14; }
-            if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_14; }
+            if !(false || '0' <= chars[pos] <= '9') { break rep_14; }
             pos += 1;
             loop {
                 let rep_saved_16 = pos;
                 rep_16: {
                     if pos >= chars.len() { break rep_16; }
-                    if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_16; }
+                    if !(false || '0' <= chars[pos] <= '9') { break rep_16; }
                     pos += 1;
                     continue;
                 }
@@ -5780,13 +5780,13 @@ fn try_numeric_literal(chars: &Array<char>, start: i32) -> i32 {
             if pos >= chars.len() || chars[pos] != '.' { break alts_10_1; }
             pos += 1;
             if pos >= chars.len() { break alts_10_1; }
-            if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break alts_10_1; }
+            if !(false || '0' <= chars[pos] <= '9') { break alts_10_1; }
             pos += 1;
             loop {
                 let rep_saved_17 = pos;
                 rep_17: {
                     if pos >= chars.len() { break rep_17; }
-                    if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_17; }
+                    if !(false || '0' <= chars[pos] <= '9') { break rep_17; }
                     pos += 1;
                     continue;
                 }
@@ -5809,13 +5809,13 @@ fn try_numeric_literal(chars: &Array<char>, start: i32) -> i32 {
                 }
                 if !opt_ok_19 { pos = opt_saved_19; }
                 if pos >= chars.len() { break rep_18; }
-                if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_18; }
+                if !(false || '0' <= chars[pos] <= '9') { break rep_18; }
                 pos += 1;
                 loop {
                     let rep_saved_20 = pos;
                     rep_20: {
                         if pos >= chars.len() { break rep_20; }
-                        if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_20; }
+                        if !(false || '0' <= chars[pos] <= '9') { break rep_20; }
                         pos += 1;
                         continue;
                     }
@@ -5844,7 +5844,7 @@ fn try_bind_parameter(chars: &Array<char>, start: i32) -> i32 {
             let rep_saved_22 = pos;
             rep_22: {
                 if pos >= chars.len() { break rep_22; }
-                if !(false || chars[pos] >= '0' && chars[pos] <= '9') { break rep_22; }
+                if !(false || '0' <= chars[pos] <= '9') { break rep_22; }
                 pos += 1;
                 continue;
             }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -725,6 +725,7 @@ pub fn format(source: &str) -> Result<String, CompileError> {
         line: e.span.line,
         column: e.span.column,
         filename: None,
+        is_todo_module: parser.has_todo(),
     })?;
 
     // Unparse (no lowering - preserve high-level constructs)
@@ -756,6 +757,7 @@ pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
         line: e.span.line,
         column: e.span.column,
         filename: None,
+        is_todo_module: parser.has_todo(),
     })?;
     Ok(ParseResult {
         ast,
@@ -781,6 +783,8 @@ pub enum CompileError {
         line: usize,
         column: usize,
         filename: Option<String>,
+        /// True if the module had `#![TODO]` before the parse error occurred.
+        is_todo_module: bool,
     },
     /// Binding error (local name resolution)
     Bind {
@@ -794,6 +798,13 @@ pub enum CompileError {
         column: usize,
         filename: Option<String>,
     },
+}
+
+impl CompileError {
+    /// Returns true if the error occurred in a `#![TODO]` module.
+    pub fn is_todo_module(&self) -> bool {
+        matches!(self, CompileError::Parser { is_todo_module: true, .. })
+    }
 }
 
 impl std::fmt::Display for CompileError {
@@ -819,6 +830,7 @@ impl std::fmt::Display for CompileError {
                 line,
                 column,
                 filename,
+                ..
             } => {
                 if let Some(file) = filename {
                     write!(f, "{file}:{line}:{column}: parse error: {message}")

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -803,7 +803,13 @@ pub enum CompileError {
 impl CompileError {
     /// Returns true if the error occurred in a `#![TODO]` module.
     pub fn is_todo_module(&self) -> bool {
-        matches!(self, CompileError::Parser { is_todo_module: true, .. })
+        matches!(
+            self,
+            CompileError::Parser {
+                is_todo_module: true,
+                ..
+            }
+        )
     }
 }
 

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -35,6 +35,9 @@ pub struct Parser {
     data_section: Option<String>,
     /// Paths referenced by `#include_str` / `#include_bytes`, collected as they are parsed.
     include_paths: crate::hashmap::IndexSet<String>,
+    /// Inner attributes parsed before items. Retained even if parsing fails later,
+    /// so callers can check `has_todo()` after a parse error.
+    parsed_inner_attributes: Vec<InnerAttribute>,
 }
 
 #[derive(Debug)]
@@ -80,6 +83,7 @@ impl Parser {
             shebang: None,
             data_section: None,
             include_paths: crate::hashmap::IndexSet::default(),
+            parsed_inner_attributes: Vec::new(),
         }
     }
 
@@ -97,7 +101,14 @@ impl Parser {
             shebang,
             data_section,
             include_paths: crate::hashmap::IndexSet::default(),
+            parsed_inner_attributes: Vec::new(),
         }
+    }
+
+    /// Returns true if the parsed inner attributes include `#![TODO]`.
+    /// Valid even after a parse error, since inner attributes are parsed first.
+    pub fn has_todo(&self) -> bool {
+        self.parsed_inner_attributes.iter().any(|a| a.name == "TODO")
     }
 
     /// Parse an expression with struct literals restricted. Used in contexts
@@ -141,8 +152,10 @@ impl Parser {
     }
 
     pub fn parse(&mut self) -> ParseResult<Module> {
-        // Parse inner attributes at the start of the module
+        // Parse inner attributes at the start of the module.
+        // Store them so has_todo() works even if item parsing fails later.
         let inner_attributes = self.parse_inner_attributes()?;
+        self.parsed_inner_attributes = inner_attributes.clone();
 
         let mut items = Vec::new();
 

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -108,7 +108,9 @@ impl Parser {
     /// Returns true if the parsed inner attributes include `#![TODO]`.
     /// Valid even after a parse error, since inner attributes are parsed first.
     pub fn has_todo(&self) -> bool {
-        self.parsed_inner_attributes.iter().any(|a| a.name == "TODO")
+        self.parsed_inner_attributes
+            .iter()
+            .any(|a| a.name == "TODO")
     }
 
     /// Parse an expression with struct literals restricted. Used in contexts

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -147,6 +147,7 @@ pub fn bail_to_compile_error(diagnostics: &[Diagnostic], filename: Option<&str>)
                 line,
                 column,
                 filename: fname,
+                is_todo_module: false,
             }
         } else {
             // All other errors

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -115,6 +115,7 @@ fn main()
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("expected") || message.contains("{"),
@@ -146,6 +147,7 @@ fn main() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("expected") || message.contains("identifier"),
@@ -178,6 +180,7 @@ fn main() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("expected") || message.contains(";"),
@@ -207,6 +210,7 @@ use;
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("expected") || message.contains("identifier"),
@@ -300,6 +304,7 @@ fn run() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("!= operator cannot be chained"),
@@ -331,6 +336,7 @@ fn run() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("cannot mix ascending") || message.contains("descending"),
@@ -362,6 +368,7 @@ fn run() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("cannot mix ascending") || message.contains("descending"),
@@ -393,6 +400,7 @@ fn run() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("cannot mix ==") || message.contains("inequality"),
@@ -424,6 +432,7 @@ fn run() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("cannot mix ==") || message.contains("inequality"),
@@ -455,6 +464,7 @@ fn run() {
             line,
             column,
             filename,
+            ..
         } => {
             assert!(
                 message.contains("!= operator cannot be chained"),
@@ -475,6 +485,7 @@ fn test_error_display_with_filename() {
         line: 10,
         column: 5,
         filename: Some("test.wado".to_string()),
+        is_todo_module: false,
     };
 
     let display = format!("{err}");

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -631,9 +631,10 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
     // For test world: individual tests are already marked #[TODO] by the resolver,
     // so no special handling is needed here.
     // For CLI/HTTP worlds: runtime failures in #![TODO] modules need catch_unwind.
-    let is_todo_module = wado_compiler::parse(source)
-        .map(|r| r.ast.has_todo())
-        .unwrap_or(false);
+    let is_todo_module = match wado_compiler::parse(source) {
+        Ok(r) => r.ast.has_todo(),
+        Err(e) => e.is_todo_module(),
+    };
 
     if is_todo_module {
         eprintln!("[{test_id}] #![TODO] module — expecting failure");

--- a/wado-compiler/tests/fixtures/match_associated_constant_pattern.wado
+++ b/wado-compiler/tests/fixtures/match_associated_constant_pattern.wado
@@ -1,0 +1,37 @@
+// TODO: associated constants (Type::CONST) should be usable as match/matches patterns.
+// Currently the parser rejects `TokenKind::FOO =>` with "expected FatArrow, found ColonColon".
+
+#![TODO]
+
+struct TokenKind {}
+
+impl TokenKind {
+    pub const FOO: i32 = 10;
+    pub const BAR: i32 = 20;
+    pub const BAZ: i32 = 30;
+}
+
+fn describe(kind: i32) -> String {
+    return match kind {
+        TokenKind::FOO => "foo",
+        TokenKind::BAR => "bar",
+        TokenKind::BAZ => "baz",
+        _ => "unknown",
+    };
+}
+
+test "match with associated constants" {
+    assert describe(10) == "foo";
+    assert describe(20) == "bar";
+    assert describe(30) == "baz";
+    assert describe(99) == "unknown";
+}
+
+test "matches operator with associated constants" {
+    let x: i32 = 10;
+    assert x matches { TokenKind::FOO };
+    assert !(x matches { TokenKind::BAR });
+}
+
+__DATA__
+{"test": {}}

--- a/wado-compiler/tests/fixtures/match_global_constant_pattern.wado
+++ b/wado-compiler/tests/fixtures/match_global_constant_pattern.wado
@@ -1,0 +1,34 @@
+// TODO: immutable global variables should be usable as match/matches patterns.
+// Currently they are treated as fresh variable bindings instead of value comparisons,
+// causing all arms to match the first pattern unconditionally.
+
+#![TODO]
+
+global TK_FOO: i32 = 1;
+global TK_BAR: i32 = 2;
+global TK_BAZ: i32 = 3;
+
+fn describe(kind: i32) -> String {
+    return match kind {
+        TK_FOO => "foo",
+        TK_BAR => "bar",
+        TK_BAZ => "baz",
+        _ => "unknown",
+    };
+}
+
+test "match with global constants" {
+    assert describe(1) == "foo";
+    assert describe(2) == "bar";
+    assert describe(3) == "baz";
+    assert describe(99) == "unknown";
+}
+
+test "matches operator with global constants" {
+    let x: i32 = 1;
+    assert x matches { TK_FOO };
+    assert !(x matches { TK_BAR });
+}
+
+__DATA__
+{"test": {}}

--- a/wado-compiler/tests/fixtures/match_variant_array_struct_in_arm.wado
+++ b/wado-compiler/tests/fixtures/match_variant_array_struct_in_arm.wado
@@ -2,7 +2,10 @@
 // invalid Wasm: "type mismatch: expected (ref $type), found (ref (exact $type))"
 // Discovered while refactoring package-gale/src/parser_gen.wado if-let chains to match.
 
+#![TODO]
+
 use { println } from "core:cli";
+use { Stdout } from "core:cli";
 
 struct Pair {
     a: i32,
@@ -29,8 +32,6 @@ fn classify(s: Shape) -> Array<Pair> {
     };
 }
 
-use { Stdout } from "core:cli";
-
 export fn run() with Stdout {
     let result = classify(Shape::Circle(5));
     assert result.len() == 1;
@@ -46,3 +47,6 @@ export fn run() with Stdout {
 
     println("ok");
 }
+
+__DATA__
+{"stdout": "ok\n"}

--- a/wado-compiler/tests/fixtures/match_variant_array_struct_in_arm.wado
+++ b/wado-compiler/tests/fixtures/match_variant_array_struct_in_arm.wado
@@ -1,0 +1,48 @@
+// TODO: compiler bug — match arm returning Array<Struct> from if-else produces
+// invalid Wasm: "type mismatch: expected (ref $type), found (ref (exact $type))"
+// Discovered while refactoring package-gale/src/parser_gen.wado if-let chains to match.
+
+use { println } from "core:cli";
+
+struct Pair {
+    a: i32,
+    b: i32,
+}
+
+variant Shape {
+    Circle(i32),
+    Rect([i32, i32]),
+    Point,
+}
+
+fn classify(s: Shape) -> Array<Pair> {
+    return match s {
+        Circle(r) => {
+            if r > 0 {
+                [Pair { a: r, b: r }]
+            } else {
+                []
+            }
+        },
+        Rect(dims) => [Pair { a: dims.0, b: dims.1 }],
+        Point => [],
+    };
+}
+
+use { Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    let result = classify(Shape::Circle(5));
+    assert result.len() == 1;
+    assert result[0].a == 5;
+
+    let empty = classify(Shape::Circle(-1));
+    assert empty.len() == 0;
+
+    let rect = classify(Shape::Rect([3, 4]));
+    assert rect.len() == 1;
+    assert rect[0].a == 3;
+    assert rect[0].b == 4;
+
+    println("ok");
+}

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -1092,8 +1092,11 @@ fn test_format_idempotent_all_fixtures() {
         let source = fs::read_to_string(&path).expect("cannot read file");
         let filename = path.file_name().unwrap().to_str().unwrap();
 
-        // Skip files that expect compile errors or are TODO tests (check __DATA__ section)
-        if source.contains("compile_error") || source.contains("\"TODO\": true") {
+        // Skip files that expect compile errors or are TODO modules
+        if source.contains("compile_error")
+            || source.contains("\"TODO\": true")
+            || source.contains("#![TODO]")
+        {
             continue;
         }
 


### PR DESCRIPTION
## Summary

- Convert if-let chains to `match` expressions in `element_base_name()`, `first_of_element()`, `gen_lexer_elem()`, `strip_dead_consume()`, `prediction_node_eq()`, `element_eq()`
- Convert all `if let ... = *elem` patterns across package-gale to use match ergonomics (`= elem`), dereferencing at use sites — covers `gen_context.wado`, `gen_util.wado`, `generator.wado`, `lexer_gen.wado`, `parser_gen.wado`, `visitor_gen.wado`
- Use chained comparison syntax (`'a' <= c <= 'z'`) in `g4/lexer.wado`, `g4/parser.wado`, `gen_util.wado`, and generated lexer output
- Emit chained comparisons in generated lexer code (`lexer_gen.wado`)
- Add `#![TODO]` e2e test fixtures for: match with global constant patterns, match with associated constant patterns, match arm returning `Array<Struct>` from if-else (compiler codegen bug)
- Fix `#![TODO]` propagation through parse errors (parser-level approach)

## Notes

- Reference equality vs value equality: when converting `= *expr` to `= expr`, comparison sites need explicit `*` dereference because `&String != &String` compares by reference identity
- `matches` operator cannot be used with i32 global constants (token kinds), so those patterns were left as `||` chains
- `sll_advance_inner()` match conversion blocked by compiler bug (match arm `Array<Struct>` codegen); min repro committed as TODO fixture

## Test plan

- [x] `mise run test-wado` — 1278 passed, 0 failed
- [x] `mise run on-task-done` — all checks pass
- [x] Golden fixtures regenerated and verified

https://claude.ai/code/session_01M1w2B3ZER58ZVh15HSQqx8