### PR TITLE
Rename #[wasi("...")] attribute to #[cm("...")] for general CM support

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -281,7 +281,7 @@ The `WasiRegistry` module (`component_model.rs`) collects WASI import informatio
 
 **Purpose:**
 
-- Extract WASI version strings from `#[wasi(...)]` attributes (e.g., `0.3.0-rc-2025-09-16`)
+- Extract WASI version strings from `#[cm(...)]` attributes (e.g., `0.3.0-rc-2025-09-16`)
 - Map effect methods to function names using a unified naming scheme
 - Track which WASI interfaces are used for conditional import generation
 
@@ -336,7 +336,7 @@ Instead of a hardcoded whitelist, interfaces are included based on type support:
 To fully eliminate hardcoded CM structures, the registry would need to:
 
 1. Track WASI types (enums, resources) in addition to effect functions
-2. Parse enum variants from `#[wasi(...)]` annotated enums in wasi/\*.wado
+2. Parse enum variants from `#[cm(...)]` annotated enums in wasi/\*.wado
 3. Generate CM type definitions dynamically from parsed definitions
 
 ### Async Export Functions (`export async fn`)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2874,11 +2874,11 @@ assert rw as u32 == 3;
 // They produce a compile error; use bitwise operators (|, &, ^) instead
 ```
 
-Flags are implemented as newtypes over `u32`. Member names can carry `#[wasi("...")]` attributes for WIT/Component Model name mapping:
+Flags are implemented as newtypes over `u32`. Member names can carry `#[cm("...")]` attributes for Component Model name mapping:
 
 ```wado
 pub flags PathFlags {
-    #[wasi("symlink-follow")]
+    #[cm("symlink-follow")]
     SymlinkFollow,
 }
 ```
@@ -4346,23 +4346,23 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode> {
 - The `task return` expression is type-checked against the declared return type of the enclosing `export async fn`.
 - The `async` keyword on a function declaration has no effect on callers; Wado is fully colorless. `async` only appears in `export async fn` declarations to signal CM async calling convention at the component boundary.
 
-### Attribute Syntax for WASI Linking
+### Attribute Syntax for Component Model Linking
 
-Use `#[wasi(...)]` attributes to link Wado definitions to WASI interfaces:
+Use `#[cm(...)]` attributes to link Wado definitions to Component Model interfaces:
 
 ```wado
-// Link an effect interface to a WASI interface
-#[wasi("wasi:cli/stdout@0.3.0-rc-2025-09-16")]
+// Link an effect interface to a CM interface
+#[cm("wasi:cli/stdout@0.3.0-rc-2025-09-16")]
 pub effect Stdout {
-    #[wasi("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream")]
+    #[cm("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream")]
     fn write_via_stream(data: Stream<u8>) -> Result<(), ErrorCode>;
 }
 
-// Link a resource to a WASI resource
-#[wasi("wasi:cli/terminal-output@0.3.0-rc-2025-09-16")]
+// Link a resource to a CM resource
+#[cm("wasi:cli/terminal-output@0.3.0-rc-2025-09-16")]
 resource TerminalOutput;
 
-// Link an enum to a WASI enum
+// Link an enum to a CM enum
 pub enum ErrorCode {  // Maps to WIT: enum error-code
     Io,               // Maps to WIT: io
     IllegalByteSequence,  // Maps to WIT: illegal-byte-sequence
@@ -4542,9 +4542,9 @@ fn realloc(oldptr: i32, oldsize: i32, align: i32, newsize: i32) -> i32;
 
 Marks a function as providing a compiler feature. The compiler uses these flags to enable optimizations and synthesis passes (e.g., `array_append`, `string_append`, `option`, `result`, `default`). Used in `core:prelude` method implementations.
 
-#### `#[wasi("interface@version")]` / `#[wasi_params(...)]`
+#### `#[cm("namespace:pkg/interface@version")]` / `#[cm_params(...)]`
 
-Links Wado definitions (effects, resources, enums) to WASI interfaces. See [Attribute Syntax for WASI Linking](#attribute-syntax-for-wasi-linking).
+Links Wado definitions (effects, resources, enums) to Component Model interfaces. See [Attribute Syntax for Component Model Linking](#attribute-syntax-for-component-model-linking).
 
 ### The "mem" Core Module
 

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -87,7 +87,7 @@ Pipeline:
 
 ### Unified Attribute: `#[cm("...")]`
 
-The current `#[wasi("...")]` attribute is WASI-specific. Tide introduces a generalized `#[cm("...")]` attribute for all Component Model ABI mappings, with the namespace encoded in the value:
+The `#[cm("...")]` attribute provides Component Model ABI mappings for all namespaces, with the namespace encoded in the value:
 
 ```wado
 // Web API binding
@@ -97,7 +97,7 @@ pub resource Element extends Node { ... }
 #[cm("web:dom#Element.getAttribute")]
 fn get_attribute(&self, name: String) -> Option<String>;
 
-// WASI binding (replaces #[wasi("...")])
+// WASI binding
 #[cm("wasi:http/types@0.3.0#request")]
 pub resource Request { ... }
 ```
@@ -111,7 +111,7 @@ Sub-attributes for method kinds:
 #[cm("web:url#[static]URL.createObjectURL")]  // static method
 ```
 
-Parameter name mapping (replaces `#[wasi_params(...)]`):
+Parameter name mapping:
 
 ```wado
 #[cm_params("self", "qualified-name")]
@@ -931,7 +931,7 @@ Organized by W3C/WHATWG specification, mirroring how `wasi/` is organized by WAS
 ### Language Changes Required
 
 - `resource extends` syntax — new compiler feature for resource inheritance.
-- `#[cm("...")]` attribute — replaces `#[wasi("...")]` for all CM bindings.
+- `#[cm("...")]` attribute — Component Model bindings with namespace in the value string.
 - `downcast::<T>()` built-in on resources with `extends`.
 - Implicit upcast coercion for resource reference types.
 

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -508,17 +508,17 @@ async fn run_single(opts: &DumpOptions, input: &str) {
                         .map(|t| format!(" -> {t}"))
                         .unwrap_or_default();
                     let wasi = f
-                        .wasi_import
+                        .cm_import
                         .as_ref()
-                        .map(|w| format!(" [wasi: {}]", w.interface_path()))
+                        .map(|w| format!(" [cm: {}]", w.interface_path()))
                         .unwrap_or_default();
                     format!("fn({}){ret}{effects}{wasi}", f.params.join(", "))
                 }
                 wado_compiler::symbol::SymbolKind::Effect(e) => {
                     let wasi = e
-                        .wasi_import
+                        .cm_import
                         .as_ref()
-                        .map(|w| format!(" [wasi: {}]", w.interface_path()))
+                        .map(|w| format!(" [cm: {}]", w.interface_path()))
                         .unwrap_or_default();
                     format!("effect{{ {} }}{wasi}", e.methods.join(", "))
                 }
@@ -553,9 +553,9 @@ async fn run_single(opts: &DumpOptions, input: &str) {
                 }
                 wado_compiler::symbol::SymbolKind::Resource(r) => {
                     let wasi = r
-                        .wasi_import
+                        .cm_import
                         .as_ref()
-                        .map(|w| format!(" [wasi: {}]", w.interface_path()))
+                        .map(|w| format!(" [cm: {}]", w.interface_path()))
                         .unwrap_or_default();
                     format!("resource{{ {} }}{wasi}", r.methods.join(", "))
                 }

--- a/wado-compiler/lib/wasi/cli/environment.wado
+++ b/wado-compiler/lib/wasi/cli/environment.wado
@@ -3,7 +3,7 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit
 
-#[wasi("wasi:cli/environment@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/environment@0.3.0-rc-2026-03-15")]
 pub effect Environment {
     /// Get the POSIX-style environment variables.
     /// 
@@ -13,14 +13,14 @@ pub effect Environment {
     /// Morally, these are a value import, but until value imports are available
     /// in the component model, this import function should return the same
     /// values each time it is called.
-    #[wasi("wasi:cli/environment@0.3.0-rc-2026-03-15#get-environment")]
+    #[cm("wasi:cli/environment@0.3.0-rc-2026-03-15#get-environment")]
     fn get_environment() -> Array<[String, String]>;
     /// Get the POSIX-style arguments to the program.
-    #[wasi("wasi:cli/environment@0.3.0-rc-2026-03-15#get-arguments")]
+    #[cm("wasi:cli/environment@0.3.0-rc-2026-03-15#get-arguments")]
     fn get_arguments() -> Array<String>;
     /// Return a path that programs should use as their initial current working
     /// directory, interpreting `.` as shorthand for this.
-    #[wasi("wasi:cli/environment@0.3.0-rc-2026-03-15#get-initial-cwd")]
+    #[cm("wasi:cli/environment@0.3.0-rc-2026-03-15#get-initial-cwd")]
     fn get_initial_cwd() -> Option<String>;
 }
 

--- a/wado-compiler/lib/wasi/cli/exit.wado
+++ b/wado-compiler/lib/wasi/cli/exit.wado
@@ -3,11 +3,11 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit
 
-#[wasi("wasi:cli/exit@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/exit@0.3.0-rc-2026-03-15")]
 pub effect Exit {
     /// Exit the current instance and any linked instances.
-    #[wasi("wasi:cli/exit@0.3.0-rc-2026-03-15#exit")]
-    #[wasi_params("status")]
+    #[cm("wasi:cli/exit@0.3.0-rc-2026-03-15#exit")]
+    #[cm_params("status")]
     fn exit(status: Result<(), ()>);
     /// Exit the current instance and any linked instances, reporting the
     /// specified status code to the host.
@@ -17,8 +17,8 @@ pub effect Exit {
     /// 
     /// This function does not return; the effect is analogous to a trap, but
     /// without the connotation that something bad has happened.
-    #[wasi("wasi:cli/exit@0.3.0-rc-2026-03-15#exit-with-code")]
-    #[wasi_params("status-code")]
+    #[cm("wasi:cli/exit@0.3.0-rc-2026-03-15#exit-with-code")]
+    #[cm_params("status-code")]
     fn exit_with_code(status_code: u8);
 }
 

--- a/wado-compiler/lib/wasi/cli/run.wado
+++ b/wado-compiler/lib/wasi/cli/run.wado
@@ -3,10 +3,10 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit
 
-#[wasi("wasi:cli/run@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/run@0.3.0-rc-2026-03-15")]
 pub effect Run {
     /// Run the program.
-    #[wasi("wasi:cli/run@0.3.0-rc-2026-03-15#run")]
+    #[cm("wasi:cli/run@0.3.0-rc-2026-03-15#run")]
     async fn run() -> Result<(), ()>;
 }
 

--- a/wado-compiler/lib/wasi/cli/stderr.wado
+++ b/wado-compiler/lib/wasi/cli/stderr.wado
@@ -6,7 +6,7 @@
 use { ErrorCode } from "wasi:cli/types.wado";
 
 
-#[wasi("wasi:cli/stderr@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/stderr@0.3.0-rc-2026-03-15")]
 pub effect Stderr {
     /// Write the given stream to stderr.
     /// 
@@ -16,8 +16,8 @@ pub effect Stderr {
     /// 
     /// Otherwise if there is an error the readable end of the stream will be
     /// dropped and this function will return an error-code.
-    #[wasi("wasi:cli/stderr@0.3.0-rc-2026-03-15#write-via-stream")]
-    #[wasi_params("data")]
+    #[cm("wasi:cli/stderr@0.3.0-rc-2026-03-15#write-via-stream")]
+    #[cm_params("data")]
     fn write_via_stream(data: Stream<u8>) -> Future<Result<(), ErrorCode>>;
 }
 

--- a/wado-compiler/lib/wasi/cli/stdin.wado
+++ b/wado-compiler/lib/wasi/cli/stdin.wado
@@ -6,7 +6,7 @@
 use { ErrorCode } from "wasi:cli/types.wado";
 
 
-#[wasi("wasi:cli/stdin@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/stdin@0.3.0-rc-2026-03-15")]
 pub effect Stdin {
     /// Return a stream for reading from stdin.
     /// 
@@ -21,7 +21,7 @@ pub effect Stdin {
     /// 
     /// Multiple streams may be active at the same time. The behavior of concurrent
     /// reads is implementation-specific.
-    #[wasi("wasi:cli/stdin@0.3.0-rc-2026-03-15#read-via-stream")]
+    #[cm("wasi:cli/stdin@0.3.0-rc-2026-03-15#read-via-stream")]
     fn read_via_stream() -> [Stream<u8>, Future<Result<(), ErrorCode>>];
 }
 

--- a/wado-compiler/lib/wasi/cli/stdout.wado
+++ b/wado-compiler/lib/wasi/cli/stdout.wado
@@ -6,7 +6,7 @@
 use { ErrorCode } from "wasi:cli/types.wado";
 
 
-#[wasi("wasi:cli/stdout@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/stdout@0.3.0-rc-2026-03-15")]
 pub effect Stdout {
     /// Write the given stream to stdout.
     /// 
@@ -16,8 +16,8 @@ pub effect Stdout {
     /// 
     /// Otherwise if there is an error the readable end of the stream will be
     /// dropped and this function will return an error-code.
-    #[wasi("wasi:cli/stdout@0.3.0-rc-2026-03-15#write-via-stream")]
-    #[wasi_params("data")]
+    #[cm("wasi:cli/stdout@0.3.0-rc-2026-03-15#write-via-stream")]
+    #[cm_params("data")]
     fn write_via_stream(data: Stream<u8>) -> Future<Result<(), ErrorCode>>;
 }
 

--- a/wado-compiler/lib/wasi/cli/terminal-input.wado
+++ b/wado-compiler/lib/wasi/cli/terminal-input.wado
@@ -4,6 +4,6 @@
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit
 
 /// The input side of a terminal.
-#[wasi("wasi:cli/terminal-input@0.3.0-rc-2026-03-15#terminal-input")]
+#[cm("wasi:cli/terminal-input@0.3.0-rc-2026-03-15#terminal-input")]
 pub resource TerminalInput;
 

--- a/wado-compiler/lib/wasi/cli/terminal-output.wado
+++ b/wado-compiler/lib/wasi/cli/terminal-output.wado
@@ -4,6 +4,6 @@
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit
 
 /// The output side of a terminal.
-#[wasi("wasi:cli/terminal-output@0.3.0-rc-2026-03-15#terminal-output")]
+#[cm("wasi:cli/terminal-output@0.3.0-rc-2026-03-15#terminal-output")]
 pub resource TerminalOutput;
 

--- a/wado-compiler/lib/wasi/cli/terminal-stderr.wado
+++ b/wado-compiler/lib/wasi/cli/terminal-stderr.wado
@@ -8,11 +8,11 @@ use { TerminalOutput } from "wasi:cli/terminal-output.wado";
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
-#[wasi("wasi:cli/terminal-stderr@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/terminal-stderr@0.3.0-rc-2026-03-15")]
 pub effect TerminalStderr {
     /// If stderr is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
-    #[wasi("wasi:cli/terminal-stderr@0.3.0-rc-2026-03-15#get-terminal-stderr")]
+    #[cm("wasi:cli/terminal-stderr@0.3.0-rc-2026-03-15#get-terminal-stderr")]
     fn get_terminal_stderr() -> Option<TerminalOutput>;
 }
 

--- a/wado-compiler/lib/wasi/cli/terminal-stdin.wado
+++ b/wado-compiler/lib/wasi/cli/terminal-stdin.wado
@@ -8,11 +8,11 @@ use { TerminalInput } from "wasi:cli/terminal-input.wado";
 
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
-#[wasi("wasi:cli/terminal-stdin@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/terminal-stdin@0.3.0-rc-2026-03-15")]
 pub effect TerminalStdin {
     /// If stdin is connected to a terminal, return a `terminal-input` handle
     /// allowing further interaction with it.
-    #[wasi("wasi:cli/terminal-stdin@0.3.0-rc-2026-03-15#get-terminal-stdin")]
+    #[cm("wasi:cli/terminal-stdin@0.3.0-rc-2026-03-15#get-terminal-stdin")]
     fn get_terminal_stdin() -> Option<TerminalInput>;
 }
 

--- a/wado-compiler/lib/wasi/cli/terminal-stdout.wado
+++ b/wado-compiler/lib/wasi/cli/terminal-stdout.wado
@@ -8,11 +8,11 @@ use { TerminalOutput } from "wasi:cli/terminal-output.wado";
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
-#[wasi("wasi:cli/terminal-stdout@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/terminal-stdout@0.3.0-rc-2026-03-15")]
 pub effect TerminalStdout {
     /// If stdout is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
-    #[wasi("wasi:cli/terminal-stdout@0.3.0-rc-2026-03-15#get-terminal-stdout")]
+    #[cm("wasi:cli/terminal-stdout@0.3.0-rc-2026-03-15#get-terminal-stdout")]
     fn get_terminal_stdout() -> Option<TerminalOutput>;
 }
 

--- a/wado-compiler/lib/wasi/cli/types.wado
+++ b/wado-compiler/lib/wasi/cli/types.wado
@@ -3,16 +3,16 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:cli/types@0.3.0-rc-2026-03-15#error-code")]
+#[cm("wasi:cli/types@0.3.0-rc-2026-03-15#error-code")]
 pub enum ErrorCode {
     /// Input/output error
-    #[wasi("io")]
+    #[cm("io")]
     Io,
     /// Invalid or incomplete multibyte or wide character
-    #[wasi("illegal-byte-sequence")]
+    #[cm("illegal-byte-sequence")]
     IllegalByteSequence,
     /// Broken pipe
-    #[wasi("pipe")]
+    #[cm("pipe")]
     Pipe,
 }
 

--- a/wado-compiler/lib/wasi/cli/worlds.wado
+++ b/wado-compiler/lib/wasi/cli/worlds.wado
@@ -4,7 +4,7 @@
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:cli/imports@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {
     import Environment {
         get_environment,
@@ -154,7 +154,7 @@ pub world Imports {
     
 }
 
-#[wasi("wasi:cli/command@0.3.0-rc-2026-03-15")]
+#[cm("wasi:cli/command@0.3.0-rc-2026-03-15")]
 pub world Command {
     import Environment {
         get_environment,

--- a/wado-compiler/lib/wasi/clocks/monotonic-clock.wado
+++ b/wado-compiler/lib/wasi/clocks/monotonic-clock.wado
@@ -6,7 +6,7 @@
 use { Duration } from "wasi:clocks/types.wado";
 
 
-#[wasi("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#mark")]
+#[cm("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#mark")]
 pub type Mark = u64;
 
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
@@ -17,7 +17,7 @@ pub type Mark = u64;
 /// 
 /// A monotonic clock is a clock which has an unspecified initial value, and
 /// successive reads of the clock will produce non-decreasing values.
-#[wasi("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15")]
+#[cm("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15")]
 pub effect MonotonicClock {
     /// Read the current value of the clock.
     /// 
@@ -28,19 +28,19 @@ pub effect MonotonicClock {
     /// the value of the clock in a `mark`. Consequently, implementations
     /// should ensure that the starting time is low enough to avoid the
     /// possibility of overflow in practice.
-    #[wasi("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#now")]
+    #[cm("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#now")]
     fn now() -> Mark;
     /// Query the resolution of the clock. Returns the duration of time
     /// corresponding to a clock tick.
-    #[wasi("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#get-resolution")]
+    #[cm("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#get-resolution")]
     fn get_resolution() -> Duration;
     /// Wait until the specified mark has occurred.
-    #[wasi("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#wait-until")]
-    #[wasi_params("when")]
+    #[cm("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#wait-until")]
+    #[cm_params("when")]
     async fn wait_until(when: Mark);
     /// Wait for the specified duration to elapse.
-    #[wasi("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#wait-for")]
-    #[wasi_params("how-long")]
+    #[cm("wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#wait-for")]
+    #[cm_params("how-long")]
     async fn wait_for(how_long: Duration);
 }
 

--- a/wado-compiler/lib/wasi/clocks/system-clock.wado
+++ b/wado-compiler/lib/wasi/clocks/system-clock.wado
@@ -22,11 +22,11 @@ use { Duration } from "wasi:clocks/types.wado";
 /// 
 /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
 /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-#[wasi("wasi:clocks/system-clock@0.3.0-rc-2026-03-15#instant")]
+#[cm("wasi:clocks/system-clock@0.3.0-rc-2026-03-15#instant")]
 pub struct Instant {
-    #[wasi("seconds")]
+    #[cm("seconds")]
     pub seconds: i64,
-    #[wasi("nanoseconds")]
+    #[cm("nanoseconds")]
     pub nanoseconds: u32,
 }
 
@@ -40,7 +40,7 @@ pub struct Instant {
 /// monotonic, making it unsuitable for measuring elapsed time.
 /// 
 /// It is intended for reporting the current date and time for humans.
-#[wasi("wasi:clocks/system-clock@0.3.0-rc-2026-03-15")]
+#[cm("wasi:clocks/system-clock@0.3.0-rc-2026-03-15")]
 pub effect SystemClock {
     /// Read the current value of the clock.
     /// 
@@ -48,11 +48,11 @@ pub effect SystemClock {
     /// will not necessarily produce a sequence of non-decreasing values.
     /// 
     /// The nanoseconds field of the output is always less than 1000000000.
-    #[wasi("wasi:clocks/system-clock@0.3.0-rc-2026-03-15#now")]
+    #[cm("wasi:clocks/system-clock@0.3.0-rc-2026-03-15#now")]
     fn now() -> Instant;
     /// Query the resolution of the clock. Returns the smallest duration of time
     /// that the implementation permits distinguishing.
-    #[wasi("wasi:clocks/system-clock@0.3.0-rc-2026-03-15#get-resolution")]
+    #[cm("wasi:clocks/system-clock@0.3.0-rc-2026-03-15#get-resolution")]
     fn get_resolution() -> Duration;
 }
 

--- a/wado-compiler/lib/wasi/clocks/timezone.wado
+++ b/wado-compiler/lib/wasi/clocks/timezone.wado
@@ -6,7 +6,7 @@
 use { Instant } from "wasi:clocks/system-clock.wado";
 
 
-#[wasi("wasi:clocks/timezone@0.3.0-rc-2026-03-15")]
+#[cm("wasi:clocks/timezone@0.3.0-rc-2026-03-15")]
 pub effect Timezone {
     /// Return the IANA identifier of the currently configured timezone. This
     /// should be an identifier from the IANA Time Zone Database.
@@ -18,7 +18,7 @@ pub effect Timezone {
     /// to provide mappings from times to deltas between the configured timezone
     /// and UTC, or determining the current timezone fails, or the timezone does
     /// not have an IANA identifier, this returns nothing.
-    #[wasi("wasi:clocks/timezone@0.3.0-rc-2026-03-15#iana-id")]
+    #[cm("wasi:clocks/timezone@0.3.0-rc-2026-03-15#iana-id")]
     fn iana_id() -> Option<String>;
     /// The number of nanoseconds difference between UTC time and the local
     /// time of the currently configured timezone, at the exact time of
@@ -32,8 +32,8 @@ pub effect Timezone {
     /// to provide mappings from times to deltas between the configured timezone
     /// and UTC, or determining the current timezone fails, this returns
     /// nothing.
-    #[wasi("wasi:clocks/timezone@0.3.0-rc-2026-03-15#utc-offset")]
-    #[wasi_params("when")]
+    #[cm("wasi:clocks/timezone@0.3.0-rc-2026-03-15#utc-offset")]
+    #[cm_params("when")]
     fn utc_offset(when: Instant) -> Option<i64>;
     /// Returns a string that is suitable to assist humans in debugging whether
     /// any timezone is available, and if so, which. This may be the same string
@@ -43,7 +43,7 @@ pub effect Timezone {
     /// WARNING: The returned string should not be consumed mechanically! It may
     /// change across platforms, hosts, or other implementation details. Parsing
     /// this string is a major platform-compatibility hazard.
-    #[wasi("wasi:clocks/timezone@0.3.0-rc-2026-03-15#to-debug-string")]
+    #[cm("wasi:clocks/timezone@0.3.0-rc-2026-03-15#to-debug-string")]
     fn to_debug_string() -> String;
 }
 

--- a/wado-compiler/lib/wasi/clocks/types.wado
+++ b/wado-compiler/lib/wasi/clocks/types.wado
@@ -3,6 +3,6 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:clocks/types@0.3.0-rc-2026-03-15#duration")]
+#[cm("wasi:clocks/types@0.3.0-rc-2026-03-15#duration")]
 pub type Duration = u64;
 

--- a/wado-compiler/lib/wasi/clocks/worlds.wado
+++ b/wado-compiler/lib/wasi/clocks/worlds.wado
@@ -3,7 +3,7 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:clocks/imports@0.3.0-rc-2026-03-15")]
+#[cm("wasi:clocks/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {
     import MonotonicClock {
         now,

--- a/wado-compiler/lib/wasi/filesystem/preopens.wado
+++ b/wado-compiler/lib/wasi/filesystem/preopens.wado
@@ -6,10 +6,10 @@
 use { Descriptor } from "wasi:filesystem/types.wado";
 
 
-#[wasi("wasi:filesystem/preopens@0.3.0-rc-2026-03-15")]
+#[cm("wasi:filesystem/preopens@0.3.0-rc-2026-03-15")]
 pub effect Preopens {
     /// Return the set of preopened directories, and their paths.
-    #[wasi("wasi:filesystem/preopens@0.3.0-rc-2026-03-15#get-directories")]
+    #[cm("wasi:filesystem/preopens@0.3.0-rc-2026-03-15#get-directories")]
     fn get_directories() -> Array<[Descriptor, String]>;
 }
 

--- a/wado-compiler/lib/wasi/filesystem/types.wado
+++ b/wado-compiler/lib/wasi/filesystem/types.wado
@@ -6,51 +6,51 @@
 use { Instant } from "wasi:clocks/system-clock.wado";
 
 
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#filesize")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#filesize")]
 pub type Filesize = u64;
 
 /// The type of a filesystem object referenced by a descriptor.
 /// 
 /// Note: This was called `filetype` in earlier versions of WASI.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor-type")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor-type")]
 pub variant DescriptorType {
     /// The descriptor refers to a block device inode.
-    #[wasi("block-device")]
+    #[cm("block-device")]
     BlockDevice,
     /// The descriptor refers to a character device inode.
-    #[wasi("character-device")]
+    #[cm("character-device")]
     CharacterDevice,
     /// The descriptor refers to a directory inode.
-    #[wasi("directory")]
+    #[cm("directory")]
     Directory,
     /// The descriptor refers to a named pipe.
-    #[wasi("fifo")]
+    #[cm("fifo")]
     Fifo,
     /// The file refers to a symbolic link inode.
-    #[wasi("symbolic-link")]
+    #[cm("symbolic-link")]
     SymbolicLink,
     /// The descriptor refers to a regular file inode.
-    #[wasi("regular-file")]
+    #[cm("regular-file")]
     RegularFile,
     /// The descriptor refers to a socket.
-    #[wasi("socket")]
+    #[cm("socket")]
     Socket,
     /// The type of the descriptor or file is different from any of the
     /// other types specified.
-    #[wasi("other")]
+    #[cm("other")]
     Other(Option<String>),
 }
 
 /// Descriptor flags.
 /// 
 /// Note: This was called `fdflags` in earlier versions of WASI.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor-flags")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor-flags")]
 pub flags DescriptorFlags {
     /// Read mode: Data can be read.
-    #[wasi("read")]
+    #[cm("read")]
     Read,
     /// Write mode: Data can be written to.
-    #[wasi("write")]
+    #[cm("write")]
     Write,
     /// Request that writes be performed according to synchronized I/O file
     /// integrity completion. The data stored in the file and the file's
@@ -59,7 +59,7 @@ pub flags DescriptorFlags {
     /// The precise semantics of this operation have not yet been defined for
     /// WASI. At this time, it should be interpreted as a request, and not a
     /// requirement.
-    #[wasi("file-integrity-sync")]
+    #[cm("file-integrity-sync")]
     FileIntegritySync,
     /// Request that writes be performed according to synchronized I/O data
     /// integrity completion. Only the data stored in the file is
@@ -68,7 +68,7 @@ pub flags DescriptorFlags {
     /// The precise semantics of this operation have not yet been defined for
     /// WASI. At this time, it should be interpreted as a request, and not a
     /// requirement.
-    #[wasi("data-integrity-sync")]
+    #[cm("data-integrity-sync")]
     DataIntegritySync,
     /// Requests that reads be performed at the same level of integrity
     /// requested for writes. This is similar to `O_RSYNC` in POSIX.
@@ -76,7 +76,7 @@ pub flags DescriptorFlags {
     /// The precise semantics of this operation have not yet been defined for
     /// WASI. At this time, it should be interpreted as a request, and not a
     /// requirement.
-    #[wasi("requested-write-sync")]
+    #[cm("requested-write-sync")]
     RequestedWriteSync,
     /// Mutating directories mode: Directory contents may be mutated.
     /// 
@@ -87,97 +87,97 @@ pub flags DescriptorFlags {
     /// they would otherwise succeed.
     /// 
     /// This may only be set on directories.
-    #[wasi("mutate-directory")]
+    #[cm("mutate-directory")]
     MutateDirectory,
 }
 
 /// Flags determining the method of how paths are resolved.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#path-flags")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#path-flags")]
 pub flags PathFlags {
     /// As long as the resolved path corresponds to a symbolic link, it is
     /// expanded.
-    #[wasi("symlink-follow")]
+    #[cm("symlink-follow")]
     SymlinkFollow,
 }
 
 /// Open flags used by `open-at`.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#open-flags")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#open-flags")]
 pub flags OpenFlags {
     /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
-    #[wasi("create")]
+    #[cm("create")]
     Create,
     /// Fail if not a directory, similar to `O_DIRECTORY` in POSIX.
-    #[wasi("directory")]
+    #[cm("directory")]
     Directory,
     /// Fail if file already exists, similar to `O_EXCL` in POSIX.
-    #[wasi("exclusive")]
+    #[cm("exclusive")]
     Exclusive,
     /// Truncate file to size 0, similar to `O_TRUNC` in POSIX.
-    #[wasi("truncate")]
+    #[cm("truncate")]
     Truncate,
 }
 
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#link-count")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#link-count")]
 pub type LinkCount = u64;
 
 /// File attributes.
 /// 
 /// Note: This was called `filestat` in earlier versions of WASI.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor-stat")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor-stat")]
 pub struct DescriptorStat {
     /// File type.
-    #[wasi("type")]
+    #[cm("type")]
     pub type: DescriptorType,
     /// Number of hard links to the file.
-    #[wasi("link-count")]
+    #[cm("link-count")]
     pub link_count: LinkCount,
     /// For regular files, the file size in bytes. For symbolic links, the
     /// length in bytes of the pathname contained in the symbolic link.
-    #[wasi("size")]
+    #[cm("size")]
     pub size: Filesize,
     /// Last data access timestamp.
     /// 
     /// If the `option` is none, the platform doesn't maintain an access
     /// timestamp for this file.
-    #[wasi("data-access-timestamp")]
+    #[cm("data-access-timestamp")]
     pub data_access_timestamp: Option<Instant>,
     /// Last data modification timestamp.
     /// 
     /// If the `option` is none, the platform doesn't maintain a
     /// modification timestamp for this file.
-    #[wasi("data-modification-timestamp")]
+    #[cm("data-modification-timestamp")]
     pub data_modification_timestamp: Option<Instant>,
     /// Last file status-change timestamp.
     /// 
     /// If the `option` is none, the platform doesn't maintain a
     /// status-change timestamp for this file.
-    #[wasi("status-change-timestamp")]
+    #[cm("status-change-timestamp")]
     pub status_change_timestamp: Option<Instant>,
 }
 
 /// When setting a timestamp, this gives the value to set it to.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#new-timestamp")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#new-timestamp")]
 pub variant NewTimestamp {
     /// Leave the timestamp set to its previous value.
-    #[wasi("no-change")]
+    #[cm("no-change")]
     NoChange,
     /// Set the timestamp to the current time of the system clock associated
     /// with the filesystem.
-    #[wasi("now")]
+    #[cm("now")]
     Now,
     /// Set the timestamp to the given value.
-    #[wasi("timestamp")]
+    #[cm("timestamp")]
     Timestamp(Instant),
 }
 
 /// A directory entry.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#directory-entry")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#directory-entry")]
 pub struct DirectoryEntry {
     /// The type of the file referred to by this directory entry.
-    #[wasi("type")]
+    #[cm("type")]
     pub type: DescriptorType,
     /// The name of the object.
-    #[wasi("name")]
+    #[cm("name")]
     pub name: String,
 }
 
@@ -185,168 +185,168 @@ pub struct DirectoryEntry {
 /// Not all of these error codes are returned by the functions provided by this
 /// API; some are used in higher-level library layers, and others are provided
 /// merely for alignment with POSIX.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#error-code")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#error-code")]
 pub variant ErrorCode {
     /// Permission denied, similar to `EACCES` in POSIX.
-    #[wasi("access")]
+    #[cm("access")]
     Access,
     /// Connection already in progress, similar to `EALREADY` in POSIX.
-    #[wasi("already")]
+    #[cm("already")]
     Already,
     /// Bad descriptor, similar to `EBADF` in POSIX.
-    #[wasi("bad-descriptor")]
+    #[cm("bad-descriptor")]
     BadDescriptor,
     /// Device or resource busy, similar to `EBUSY` in POSIX.
-    #[wasi("busy")]
+    #[cm("busy")]
     Busy,
     /// Resource deadlock would occur, similar to `EDEADLK` in POSIX.
-    #[wasi("deadlock")]
+    #[cm("deadlock")]
     Deadlock,
     /// Storage quota exceeded, similar to `EDQUOT` in POSIX.
-    #[wasi("quota")]
+    #[cm("quota")]
     Quota,
     /// File exists, similar to `EEXIST` in POSIX.
-    #[wasi("exist")]
+    #[cm("exist")]
     Exist,
     /// File too large, similar to `EFBIG` in POSIX.
-    #[wasi("file-too-large")]
+    #[cm("file-too-large")]
     FileTooLarge,
     /// Illegal byte sequence, similar to `EILSEQ` in POSIX.
-    #[wasi("illegal-byte-sequence")]
+    #[cm("illegal-byte-sequence")]
     IllegalByteSequence,
     /// Operation in progress, similar to `EINPROGRESS` in POSIX.
-    #[wasi("in-progress")]
+    #[cm("in-progress")]
     InProgress,
     /// Interrupted function, similar to `EINTR` in POSIX.
-    #[wasi("interrupted")]
+    #[cm("interrupted")]
     Interrupted,
     /// Invalid argument, similar to `EINVAL` in POSIX.
-    #[wasi("invalid")]
+    #[cm("invalid")]
     Invalid,
     /// I/O error, similar to `EIO` in POSIX.
-    #[wasi("io")]
+    #[cm("io")]
     Io,
     /// Is a directory, similar to `EISDIR` in POSIX.
-    #[wasi("is-directory")]
+    #[cm("is-directory")]
     IsDirectory,
     /// Too many levels of symbolic links, similar to `ELOOP` in POSIX.
-    #[wasi("loop")]
+    #[cm("loop")]
     Loop,
     /// Too many links, similar to `EMLINK` in POSIX.
-    #[wasi("too-many-links")]
+    #[cm("too-many-links")]
     TooManyLinks,
     /// Message too large, similar to `EMSGSIZE` in POSIX.
-    #[wasi("message-size")]
+    #[cm("message-size")]
     MessageSize,
     /// Filename too long, similar to `ENAMETOOLONG` in POSIX.
-    #[wasi("name-too-long")]
+    #[cm("name-too-long")]
     NameTooLong,
     /// No such device, similar to `ENODEV` in POSIX.
-    #[wasi("no-device")]
+    #[cm("no-device")]
     NoDevice,
     /// No such file or directory, similar to `ENOENT` in POSIX.
-    #[wasi("no-entry")]
+    #[cm("no-entry")]
     NoEntry,
     /// No locks available, similar to `ENOLCK` in POSIX.
-    #[wasi("no-lock")]
+    #[cm("no-lock")]
     NoLock,
     /// Not enough space, similar to `ENOMEM` in POSIX.
-    #[wasi("insufficient-memory")]
+    #[cm("insufficient-memory")]
     InsufficientMemory,
     /// No space left on device, similar to `ENOSPC` in POSIX.
-    #[wasi("insufficient-space")]
+    #[cm("insufficient-space")]
     InsufficientSpace,
     /// Not a directory or a symbolic link to a directory, similar to `ENOTDIR` in POSIX.
-    #[wasi("not-directory")]
+    #[cm("not-directory")]
     NotDirectory,
     /// Directory not empty, similar to `ENOTEMPTY` in POSIX.
-    #[wasi("not-empty")]
+    #[cm("not-empty")]
     NotEmpty,
     /// State not recoverable, similar to `ENOTRECOVERABLE` in POSIX.
-    #[wasi("not-recoverable")]
+    #[cm("not-recoverable")]
     NotRecoverable,
     /// Not supported, similar to `ENOTSUP` and `ENOSYS` in POSIX.
-    #[wasi("unsupported")]
+    #[cm("unsupported")]
     Unsupported,
     /// Inappropriate I/O control operation, similar to `ENOTTY` in POSIX.
-    #[wasi("no-tty")]
+    #[cm("no-tty")]
     NoTty,
     /// No such device or address, similar to `ENXIO` in POSIX.
-    #[wasi("no-such-device")]
+    #[cm("no-such-device")]
     NoSuchDevice,
     /// Value too large to be stored in data type, similar to `EOVERFLOW` in POSIX.
-    #[wasi("overflow")]
+    #[cm("overflow")]
     Overflow,
     /// Operation not permitted, similar to `EPERM` in POSIX.
-    #[wasi("not-permitted")]
+    #[cm("not-permitted")]
     NotPermitted,
     /// Broken pipe, similar to `EPIPE` in POSIX.
-    #[wasi("pipe")]
+    #[cm("pipe")]
     Pipe,
     /// Read-only file system, similar to `EROFS` in POSIX.
-    #[wasi("read-only")]
+    #[cm("read-only")]
     ReadOnly,
     /// Invalid seek, similar to `ESPIPE` in POSIX.
-    #[wasi("invalid-seek")]
+    #[cm("invalid-seek")]
     InvalidSeek,
     /// Text file busy, similar to `ETXTBSY` in POSIX.
-    #[wasi("text-file-busy")]
+    #[cm("text-file-busy")]
     TextFileBusy,
     /// Cross-device link, similar to `EXDEV` in POSIX.
-    #[wasi("cross-device")]
+    #[cm("cross-device")]
     CrossDevice,
     /// A catch-all for errors not captured by the existing variants.
     /// Implementations can use this to extend the error type without
     /// breaking existing code.
-    #[wasi("other")]
+    #[cm("other")]
     Other(Option<String>),
 }
 
 /// File or memory access pattern advisory information.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#advice")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#advice")]
 pub enum Advice {
     /// The application has no advice to give on its behavior with respect
     /// to the specified data.
-    #[wasi("normal")]
+    #[cm("normal")]
     Normal,
     /// The application expects to access the specified data sequentially
     /// from lower offsets to higher offsets.
-    #[wasi("sequential")]
+    #[cm("sequential")]
     Sequential,
     /// The application expects to access the specified data in a random
     /// order.
-    #[wasi("random")]
+    #[cm("random")]
     Random,
     /// The application expects to access the specified data in the near
     /// future.
-    #[wasi("will-need")]
+    #[cm("will-need")]
     WillNeed,
     /// The application expects that it will not access the specified data
     /// in the near future.
-    #[wasi("dont-need")]
+    #[cm("dont-need")]
     DontNeed,
     /// The application expects to access the specified data once and then
     /// not reuse it thereafter.
-    #[wasi("no-reuse")]
+    #[cm("no-reuse")]
     NoReuse,
 }
 
 /// A 128-bit hash value, split into parts because wasm doesn't have a
 /// 128-bit integer type.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#metadata-hash-value")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#metadata-hash-value")]
 pub struct MetadataHashValue {
     /// 64 bits of a 128-bit hash value.
-    #[wasi("lower")]
+    #[cm("lower")]
     pub lower: u64,
     /// Another 64 bits of a 128-bit hash value.
-    #[wasi("upper")]
+    #[cm("upper")]
     pub upper: u64,
 }
 
 /// A descriptor is a reference to a filesystem object, which may be a file,
 /// directory, named pipe, special file, or other object on which filesystem
 /// calls may be made.
-#[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor")]
+#[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#descriptor")]
 pub resource Descriptor {
     /// Return a stream for reading from a file.
     /// 
@@ -364,8 +364,8 @@ pub resource Descriptor {
     /// resolves to `err` with an `error-code`.
     /// 
     /// Note: This is similar to `pread` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.read-via-stream")]
-    #[wasi_params("self", "offset")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.read-via-stream")]
+    #[cm_params("self", "offset")]
     fn read_via_stream(self: &Descriptor, offset: Filesize) -> [Stream<u8>, Future<Result<(), ErrorCode>>];
     /// Return a stream for writing to a file, if available.
     /// 
@@ -379,8 +379,8 @@ pub resource Descriptor {
     /// written or an error is encountered.
     /// 
     /// Note: This is similar to `pwrite` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.write-via-stream")]
-    #[wasi_params("self", "data", "offset")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.write-via-stream")]
+    #[cm_params("self", "data", "offset")]
     fn write_via_stream(self: &Descriptor, data: Stream<u8>, offset: Filesize) -> Future<Result<(), ErrorCode>>;
     /// Return a stream for appending to a file, if available.
     /// 
@@ -390,14 +390,14 @@ pub resource Descriptor {
     /// written or an error is encountered.
     /// 
     /// Note: This is similar to `write` with `O_APPEND` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.append-via-stream")]
-    #[wasi_params("self", "data")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.append-via-stream")]
+    #[cm_params("self", "data")]
     fn append_via_stream(self: &Descriptor, data: Stream<u8>) -> Future<Result<(), ErrorCode>>;
     /// Provide file advisory information on a descriptor.
     /// 
     /// This is similar to `posix_fadvise` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.advise")]
-    #[wasi_params("self", "offset", "length", "advice")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.advise")]
+    #[cm_params("self", "offset", "length", "advice")]
     async fn advise(self: &Descriptor, offset: Filesize, length: Filesize, advice: Advice) -> Result<(), ErrorCode>;
     /// Synchronize the data of a file to disk.
     /// 
@@ -405,8 +405,8 @@ pub resource Descriptor {
     /// opened for writing.
     /// 
     /// Note: This is similar to `fdatasync` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.sync-data")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.sync-data")]
+    #[cm_params("self")]
     async fn sync_data(self: &Descriptor) -> Result<(), ErrorCode>;
     /// Get flags associated with a descriptor.
     /// 
@@ -414,8 +414,8 @@ pub resource Descriptor {
     /// 
     /// Note: This returns the value that was the `fs_flags` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.get-flags")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.get-flags")]
+    #[cm_params("self")]
     async fn get_flags(self: &Descriptor) -> Result<DescriptorFlags, ErrorCode>;
     /// Get the dynamic type of a descriptor.
     /// 
@@ -427,23 +427,23 @@ pub resource Descriptor {
     /// 
     /// Note: This returns the value that was the `fs_filetype` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.get-type")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.get-type")]
+    #[cm_params("self")]
     async fn get_type(self: &Descriptor) -> Result<DescriptorType, ErrorCode>;
     /// Adjust the size of an open file. If this increases the file's size, the
     /// extra bytes are filled with zeros.
     /// 
     /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.set-size")]
-    #[wasi_params("self", "size")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.set-size")]
+    #[cm_params("self", "size")]
     async fn set_size(self: &Descriptor, size: Filesize) -> Result<(), ErrorCode>;
     /// Adjust the timestamps of an open file or directory.
     /// 
     /// Note: This is similar to `futimens` in POSIX.
     /// 
     /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.set-times")]
-    #[wasi_params("self", "data-access-timestamp", "data-modification-timestamp")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.set-times")]
+    #[cm_params("self", "data-access-timestamp", "data-modification-timestamp")]
     async fn set_times(self: &Descriptor, data_access_timestamp: NewTimestamp, data_modification_timestamp: NewTimestamp) -> Result<(), ErrorCode>;
     /// Read directory entries from a directory.
     /// 
@@ -457,8 +457,8 @@ pub resource Descriptor {
     /// 
     /// This function returns a future, which will resolve to an error code if
     /// reading full contents of the directory fails.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.read-directory")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.read-directory")]
+    #[cm_params("self")]
     fn read_directory(self: &Descriptor) -> [Stream<DirectoryEntry>, Future<Result<(), ErrorCode>>];
     /// Synchronize the data and metadata of a file to disk.
     /// 
@@ -466,14 +466,14 @@ pub resource Descriptor {
     /// opened for writing.
     /// 
     /// Note: This is similar to `fsync` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.sync")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.sync")]
+    #[cm_params("self")]
     async fn sync(self: &Descriptor) -> Result<(), ErrorCode>;
     /// Create a directory.
     /// 
     /// Note: This is similar to `mkdirat` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.create-directory-at")]
-    #[wasi_params("self", "path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.create-directory-at")]
+    #[cm_params("self", "path")]
     async fn create_directory_at(self: &Descriptor, path: String) -> Result<(), ErrorCode>;
     /// Return the attributes of an open file or directory.
     /// 
@@ -484,8 +484,8 @@ pub resource Descriptor {
     /// modified, use `metadata-hash`.
     /// 
     /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.stat")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.stat")]
+    #[cm_params("self")]
     async fn stat(self: &Descriptor) -> Result<DescriptorStat, ErrorCode>;
     /// Return the attributes of a file or directory.
     /// 
@@ -494,8 +494,8 @@ pub resource Descriptor {
     /// discussion of alternatives.
     /// 
     /// Note: This was called `path_filestat_get` in earlier versions of WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.stat-at")]
-    #[wasi_params("self", "path-flags", "path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.stat-at")]
+    #[cm_params("self", "path-flags", "path")]
     async fn stat_at(self: &Descriptor, path_flags: PathFlags, path: String) -> Result<DescriptorStat, ErrorCode>;
     /// Adjust the timestamps of a file or directory.
     /// 
@@ -503,8 +503,8 @@ pub resource Descriptor {
     /// 
     /// Note: This was called `path_filestat_set_times` in earlier versions of
     /// WASI.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.set-times-at")]
-    #[wasi_params("self", "path-flags", "path", "data-access-timestamp", "data-modification-timestamp")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.set-times-at")]
+    #[cm_params("self", "path-flags", "path", "data-access-timestamp", "data-modification-timestamp")]
     async fn set_times_at(self: &Descriptor, path_flags: PathFlags, path: String, data_access_timestamp: NewTimestamp, data_modification_timestamp: NewTimestamp) -> Result<(), ErrorCode>;
     /// Create a hard link.
     /// 
@@ -513,8 +513,8 @@ pub resource Descriptor {
     /// `error-code::not-permitted` if the old path is not a file.
     /// 
     /// Note: This is similar to `linkat` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.link-at")]
-    #[wasi_params("self", "old-path-flags", "old-path", "new-descriptor", "new-path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.link-at")]
+    #[cm_params("self", "old-path-flags", "old-path", "new-descriptor", "new-path")]
     async fn link_at(self: &Descriptor, old_path_flags: PathFlags, old_path: String, new_descriptor: &Descriptor, new_path: String) -> Result<(), ErrorCode>;
     /// Open a file or directory.
     /// 
@@ -528,8 +528,8 @@ pub resource Descriptor {
     /// `error-code::read-only`.
     /// 
     /// Note: This is similar to `openat` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.open-at")]
-    #[wasi_params("self", "path-flags", "path", "open-flags", "flags")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.open-at")]
+    #[cm_params("self", "path-flags", "path", "open-flags", "flags")]
     async fn open_at(self: &Descriptor, path_flags: PathFlags, path: String, open_flags: OpenFlags, flags: DescriptorFlags) -> Result<Descriptor, ErrorCode>;
     /// Read the contents of a symbolic link.
     /// 
@@ -537,22 +537,22 @@ pub resource Descriptor {
     /// filesystem, this function fails with `error-code::not-permitted`.
     /// 
     /// Note: This is similar to `readlinkat` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.readlink-at")]
-    #[wasi_params("self", "path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.readlink-at")]
+    #[cm_params("self", "path")]
     async fn readlink_at(self: &Descriptor, path: String) -> Result<String, ErrorCode>;
     /// Remove a directory.
     /// 
     /// Return `error-code::not-empty` if the directory is not empty.
     /// 
     /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.remove-directory-at")]
-    #[wasi_params("self", "path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.remove-directory-at")]
+    #[cm_params("self", "path")]
     async fn remove_directory_at(self: &Descriptor, path: String) -> Result<(), ErrorCode>;
     /// Rename a filesystem object.
     /// 
     /// Note: This is similar to `renameat` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.rename-at")]
-    #[wasi_params("self", "old-path", "new-descriptor", "new-path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.rename-at")]
+    #[cm_params("self", "old-path", "new-descriptor", "new-path")]
     async fn rename_at(self: &Descriptor, old_path: String, new_descriptor: &Descriptor, new_path: String) -> Result<(), ErrorCode>;
     /// Create a symbolic link (also known as a "symlink").
     /// 
@@ -560,8 +560,8 @@ pub resource Descriptor {
     /// `error-code::not-permitted`.
     /// 
     /// Note: This is similar to `symlinkat` in POSIX.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.symlink-at")]
-    #[wasi_params("self", "old-path", "new-path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.symlink-at")]
+    #[cm_params("self", "old-path", "new-path")]
     async fn symlink_at(self: &Descriptor, old_path: String, new_path: String) -> Result<(), ErrorCode>;
     /// Unlink a filesystem object that is not a directory.
     /// 
@@ -572,8 +572,8 @@ pub resource Descriptor {
     /// If the filesystem object is a directory, `error-code::access` or
     /// `error-code::is-directory` may be returned instead of the
     /// POSIX-specified `error-code::not-permitted`.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.unlink-file-at")]
-    #[wasi_params("self", "path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.unlink-file-at")]
+    #[cm_params("self", "path")]
     async fn unlink_file_at(self: &Descriptor, path: String) -> Result<(), ErrorCode>;
     /// Test whether two descriptors refer to the same filesystem object.
     /// 
@@ -581,8 +581,8 @@ pub resource Descriptor {
     /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
     /// wasi-filesystem does not expose device and inode numbers, so this function
     /// may be used instead.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.is-same-object")]
-    #[wasi_params("self", "other")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.is-same-object")]
+    #[cm_params("self", "other")]
     async fn is_same_object(self: &Descriptor, other: &Descriptor) -> bool;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a descriptor.
@@ -603,15 +603,15 @@ pub resource Descriptor {
     ///    computed hash.
     /// 
     /// However, none of these is required.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.metadata-hash")]
-    #[wasi_params("self")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.metadata-hash")]
+    #[cm_params("self")]
     async fn metadata_hash(self: &Descriptor) -> Result<MetadataHashValue, ErrorCode>;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a directory descriptor and a relative path.
     /// 
     /// This performs the same hash computation as `metadata-hash`.
-    #[wasi("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.metadata-hash-at")]
-    #[wasi_params("self", "path-flags", "path")]
+    #[cm("wasi:filesystem/types@0.3.0-rc-2026-03-15#[method]descriptor.metadata-hash-at")]
+    #[cm_params("self", "path-flags", "path")]
     async fn metadata_hash_at(self: &Descriptor, path_flags: PathFlags, path: String) -> Result<MetadataHashValue, ErrorCode>;
 }
 

--- a/wado-compiler/lib/wasi/filesystem/worlds.wado
+++ b/wado-compiler/lib/wasi/filesystem/worlds.wado
@@ -3,7 +3,7 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:filesystem/imports@0.3.0-rc-2026-03-15")]
+#[cm("wasi:filesystem/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {
     import SystemClock {
         now,

--- a/wado-compiler/lib/wasi/http/client.wado
+++ b/wado-compiler/lib/wasi/http/client.wado
@@ -18,12 +18,12 @@ use { ErrorCode, Request, Response } from "wasi:http/types.wado";
 /// (including WIT itself) is unable to represent a component importing two
 /// instances of the same interface. A `client.send` import may be linked
 /// directly to a `handler.handle` export to bypass the network.
-#[wasi("wasi:http/client@0.3.0-rc-2026-03-15")]
+#[cm("wasi:http/client@0.3.0-rc-2026-03-15")]
 pub effect Client {
     /// This function may be used to either send an outgoing request over the
     /// network or to forward it to another component.
-    #[wasi("wasi:http/client@0.3.0-rc-2026-03-15#send")]
-    #[wasi_params("request")]
+    #[cm("wasi:http/client@0.3.0-rc-2026-03-15#send")]
+    #[cm_params("request")]
     async fn send(request: Request) -> Result<Response, ErrorCode>;
 }
 

--- a/wado-compiler/lib/wasi/http/handler.wado
+++ b/wado-compiler/lib/wasi/http/handler.wado
@@ -15,12 +15,12 @@ use { ErrorCode, Request, Response } from "wasi:http/types.wado";
 /// 
 /// In `wasi:http/middleware` this interface is both exported and imported as
 /// the "downstream" and "upstream" directions of the middleware chain.
-#[wasi("wasi:http/handler@0.3.0-rc-2026-03-15")]
+#[cm("wasi:http/handler@0.3.0-rc-2026-03-15")]
 pub effect Handler {
     /// This function may be called with either an incoming request read from the
     /// network or a request synthesized or forwarded by another component.
-    #[wasi("wasi:http/handler@0.3.0-rc-2026-03-15#handle")]
-    #[wasi_params("request")]
+    #[cm("wasi:http/handler@0.3.0-rc-2026-03-15#handle")]
+    #[cm_params("request")]
     async fn handle(request: Request) -> Result<Response, ErrorCode>;
 }
 

--- a/wado-compiler/lib/wasi/http/types.wado
+++ b/wado-compiler/lib/wasi/http/types.wado
@@ -7,179 +7,179 @@ use { Duration } from "wasi:clocks/types.wado";
 
 
 /// This type corresponds to HTTP standard Methods.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#method")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#method")]
 pub variant Method {
-    #[wasi("get")]
+    #[cm("get")]
     Get,
-    #[wasi("head")]
+    #[cm("head")]
     Head,
-    #[wasi("post")]
+    #[cm("post")]
     Post,
-    #[wasi("put")]
+    #[cm("put")]
     Put,
-    #[wasi("delete")]
+    #[cm("delete")]
     Delete,
-    #[wasi("connect")]
+    #[cm("connect")]
     Connect,
-    #[wasi("options")]
+    #[cm("options")]
     Options,
-    #[wasi("trace")]
+    #[cm("trace")]
     Trace,
-    #[wasi("patch")]
+    #[cm("patch")]
     Patch,
-    #[wasi("other")]
+    #[cm("other")]
     Other(String),
 }
 
 /// This type corresponds to HTTP standard Related Schemes.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#scheme")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#scheme")]
 pub variant Scheme {
-    #[wasi("HTTP")]
+    #[cm("HTTP")]
     Http,
-    #[wasi("HTTPS")]
+    #[cm("HTTPS")]
     Https,
-    #[wasi("other")]
+    #[cm("other")]
     Other(String),
 }
 
 /// Defines the case payload type for `DNS-error` above:
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#DNS-error-payload")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#DNS-error-payload")]
 pub struct DnsErrorPayload {
-    #[wasi("rcode")]
+    #[cm("rcode")]
     pub rcode: Option<String>,
-    #[wasi("info-code")]
+    #[cm("info-code")]
     pub info_code: Option<u16>,
 }
 
 /// Defines the case payload type for `TLS-alert-received` above:
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#TLS-alert-received-payload")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#TLS-alert-received-payload")]
 pub struct TlsAlertReceivedPayload {
-    #[wasi("alert-id")]
+    #[cm("alert-id")]
     pub alert_id: Option<u8>,
-    #[wasi("alert-message")]
+    #[cm("alert-message")]
     pub alert_message: Option<String>,
 }
 
 /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#field-size-payload")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#field-size-payload")]
 pub struct FieldSizePayload {
-    #[wasi("field-name")]
+    #[cm("field-name")]
     pub field_name: Option<String>,
-    #[wasi("field-size")]
+    #[cm("field-size")]
     pub field_size: Option<u32>,
 }
 
 /// These cases are inspired by the IANA HTTP Proxy Error Types:
 ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#error-code")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#error-code")]
 pub variant ErrorCode {
-    #[wasi("DNS-timeout")]
+    #[cm("DNS-timeout")]
     DnsTimeout,
-    #[wasi("DNS-error")]
+    #[cm("DNS-error")]
     DnsError(DnsErrorPayload),
-    #[wasi("destination-not-found")]
+    #[cm("destination-not-found")]
     DestinationNotFound,
-    #[wasi("destination-unavailable")]
+    #[cm("destination-unavailable")]
     DestinationUnavailable,
-    #[wasi("destination-IP-prohibited")]
+    #[cm("destination-IP-prohibited")]
     DestinationIpProhibited,
-    #[wasi("destination-IP-unroutable")]
+    #[cm("destination-IP-unroutable")]
     DestinationIpUnroutable,
-    #[wasi("connection-refused")]
+    #[cm("connection-refused")]
     ConnectionRefused,
-    #[wasi("connection-terminated")]
+    #[cm("connection-terminated")]
     ConnectionTerminated,
-    #[wasi("connection-timeout")]
+    #[cm("connection-timeout")]
     ConnectionTimeout,
-    #[wasi("connection-read-timeout")]
+    #[cm("connection-read-timeout")]
     ConnectionReadTimeout,
-    #[wasi("connection-write-timeout")]
+    #[cm("connection-write-timeout")]
     ConnectionWriteTimeout,
-    #[wasi("connection-limit-reached")]
+    #[cm("connection-limit-reached")]
     ConnectionLimitReached,
-    #[wasi("TLS-protocol-error")]
+    #[cm("TLS-protocol-error")]
     TlsProtocolError,
-    #[wasi("TLS-certificate-error")]
+    #[cm("TLS-certificate-error")]
     TlsCertificateError,
-    #[wasi("TLS-alert-received")]
+    #[cm("TLS-alert-received")]
     TlsAlertReceived(TlsAlertReceivedPayload),
-    #[wasi("HTTP-request-denied")]
+    #[cm("HTTP-request-denied")]
     HttpRequestDenied,
-    #[wasi("HTTP-request-length-required")]
+    #[cm("HTTP-request-length-required")]
     HttpRequestLengthRequired,
-    #[wasi("HTTP-request-body-size")]
+    #[cm("HTTP-request-body-size")]
     HttpRequestBodySize(Option<u64>),
-    #[wasi("HTTP-request-method-invalid")]
+    #[cm("HTTP-request-method-invalid")]
     HttpRequestMethodInvalid,
-    #[wasi("HTTP-request-URI-invalid")]
+    #[cm("HTTP-request-URI-invalid")]
     HttpRequestUriInvalid,
-    #[wasi("HTTP-request-URI-too-long")]
+    #[cm("HTTP-request-URI-too-long")]
     HttpRequestUriTooLong,
-    #[wasi("HTTP-request-header-section-size")]
+    #[cm("HTTP-request-header-section-size")]
     HttpRequestHeaderSectionSize(Option<u32>),
-    #[wasi("HTTP-request-header-size")]
+    #[cm("HTTP-request-header-size")]
     HttpRequestHeaderSize(Option<FieldSizePayload>),
-    #[wasi("HTTP-request-trailer-section-size")]
+    #[cm("HTTP-request-trailer-section-size")]
     HttpRequestTrailerSectionSize(Option<u32>),
-    #[wasi("HTTP-request-trailer-size")]
+    #[cm("HTTP-request-trailer-size")]
     HttpRequestTrailerSize(FieldSizePayload),
-    #[wasi("HTTP-response-incomplete")]
+    #[cm("HTTP-response-incomplete")]
     HttpResponseIncomplete,
-    #[wasi("HTTP-response-header-section-size")]
+    #[cm("HTTP-response-header-section-size")]
     HttpResponseHeaderSectionSize(Option<u32>),
-    #[wasi("HTTP-response-header-size")]
+    #[cm("HTTP-response-header-size")]
     HttpResponseHeaderSize(FieldSizePayload),
-    #[wasi("HTTP-response-body-size")]
+    #[cm("HTTP-response-body-size")]
     HttpResponseBodySize(Option<u64>),
-    #[wasi("HTTP-response-trailer-section-size")]
+    #[cm("HTTP-response-trailer-section-size")]
     HttpResponseTrailerSectionSize(Option<u32>),
-    #[wasi("HTTP-response-trailer-size")]
+    #[cm("HTTP-response-trailer-size")]
     HttpResponseTrailerSize(FieldSizePayload),
-    #[wasi("HTTP-response-transfer-coding")]
+    #[cm("HTTP-response-transfer-coding")]
     HttpResponseTransferCoding(Option<String>),
-    #[wasi("HTTP-response-content-coding")]
+    #[cm("HTTP-response-content-coding")]
     HttpResponseContentCoding(Option<String>),
-    #[wasi("HTTP-response-timeout")]
+    #[cm("HTTP-response-timeout")]
     HttpResponseTimeout,
-    #[wasi("HTTP-upgrade-failed")]
+    #[cm("HTTP-upgrade-failed")]
     HttpUpgradeFailed,
-    #[wasi("HTTP-protocol-error")]
+    #[cm("HTTP-protocol-error")]
     HttpProtocolError,
-    #[wasi("loop-detected")]
+    #[cm("loop-detected")]
     LoopDetected,
-    #[wasi("configuration-error")]
+    #[cm("configuration-error")]
     ConfigurationError,
     /// This is a catch-all error for anything that doesn't fit cleanly into a
     /// more specific case. It also includes an optional string for an
     /// unstructured description of the error. Users should not depend on the
     /// string for diagnosing errors, as it's not required to be consistent
     /// between implementations.
-    #[wasi("internal-error")]
+    #[cm("internal-error")]
     InternalError(Option<String>),
 }
 
 /// This type enumerates the different kinds of errors that may occur when
 /// setting or appending to a `fields` resource.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#header-error")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#header-error")]
 pub variant HeaderError {
     /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
     /// `fields`.
-    #[wasi("invalid-syntax")]
+    #[cm("invalid-syntax")]
     InvalidSyntax,
     /// This error indicates that a forbidden `field-name` was used when trying
     /// to set a header in a `fields`.
-    #[wasi("forbidden")]
+    #[cm("forbidden")]
     Forbidden,
     /// This error indicates that the operation on the `fields` was not
     /// permitted because the fields are immutable.
-    #[wasi("immutable")]
+    #[cm("immutable")]
     Immutable,
     /// This error indicates that the operation would exceed an
     /// implementation-defined limit on field sizes. This may apply to
     /// an individual `field-value`, a single `field-name` plus all its
     /// values, or the total aggregate size of all fields.
-    #[wasi("size-exceeded")]
+    #[cm("size-exceeded")]
     SizeExceeded,
     /// This is a catch-all error for anything that doesn't fit cleanly into a
     /// more specific case. Implementations can use this to extend the error
@@ -187,20 +187,20 @@ pub variant HeaderError {
     /// string for an unstructured description of the error. Users should not
     /// depend on the string for diagnosing errors, as it's not required to be
     /// consistent between implementations.
-    #[wasi("other")]
+    #[cm("other")]
     Other(Option<String>),
 }
 
 /// This type enumerates the different kinds of errors that may occur when
 /// setting fields of a `request-options` resource.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#request-options-error")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#request-options-error")]
 pub variant RequestOptionsError {
     /// Indicates the specified field is not supported by this implementation.
-    #[wasi("not-supported")]
+    #[cm("not-supported")]
     NotSupported,
     /// Indicates that the operation on the `request-options` was not permitted
     /// because it is immutable.
-    #[wasi("immutable")]
+    #[cm("immutable")]
     Immutable,
     /// This is a catch-all error for anything that doesn't fit cleanly into a
     /// more specific case. Implementations can use this to extend the error
@@ -208,23 +208,23 @@ pub variant RequestOptionsError {
     /// string for an unstructured description of the error. Users should not
     /// depend on the string for diagnosing errors, as it's not required to be
     /// consistent between implementations.
-    #[wasi("other")]
+    #[cm("other")]
     Other(Option<String>),
 }
 
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#field-name")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#field-name")]
 pub type FieldName = String;
 
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#field-value")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#field-value")]
 pub type FieldValue = Array<u8>;
 
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#headers")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#headers")]
 pub type Headers = Fields;
 
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#trailers")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#trailers")]
 pub type Trailers = Fields;
 
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#status-code")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#status-code")]
 pub type StatusCode = u16;
 
 /// This following block defines the `fields` resource which corresponds to
@@ -246,12 +246,12 @@ pub type StatusCode = u16;
 /// Implementations may impose limits on individual field values and on total
 /// aggregate field section size. Operations that would exceed these limits
 /// fail with `header-error.size-exceeded`
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#fields")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#fields")]
 pub resource Fields {
     /// Construct an empty HTTP Fields.
     /// 
     /// The resulting `fields` is mutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[constructor]fields")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[constructor]fields")]
     fn new() -> Fields;
     /// Construct an HTTP Fields.
     /// 
@@ -269,20 +269,20 @@ pub resource Fields {
     /// An error result will be returned if any header or value was
     /// syntactically invalid, if a header was forbidden, or if the
     /// entries would exceed an implementation size limit.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[static]fields.from-list")]
-    #[wasi_params("entries")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[static]fields.from-list")]
+    #[cm_params("entries")]
     fn from_list(entries: Array<[FieldName, FieldValue]>) -> Result<Fields, HeaderError>;
     /// Get all of the values corresponding to a name. If the name is not present
     /// in this `fields`, an empty list is returned. However, if the name is
     /// present but empty, this is represented by a list with one or more
     /// empty field-values present.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.get")]
-    #[wasi_params("self", "name")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.get")]
+    #[cm_params("self", "name")]
     fn get(self: &Fields, name: FieldName) -> Array<FieldValue>;
     /// Returns `true` when the name is present in this `fields`. If the name is
     /// syntactically invalid, `false` is returned.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.has")]
-    #[wasi_params("self", "name")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.has")]
+    #[cm_params("self", "name")]
     fn has(self: &Fields, name: FieldName) -> bool;
     /// Set all of the values for a name. Clears any existing values for that
     /// name, if they have been set.
@@ -291,15 +291,15 @@ pub resource Fields {
     /// 
     /// Fails with `header-error.size-exceeded` if the name or values would
     /// exceed an implementation-defined size limit.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.set")]
-    #[wasi_params("self", "name", "value")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.set")]
+    #[cm_params("self", "name", "value")]
     fn set(self: &Fields, name: FieldName, value: Array<FieldValue>) -> Result<(), HeaderError>;
     /// Delete all values for a name. Does nothing if no values for the name
     /// exist.
     /// 
     /// Fails with `header-error.immutable` if the `fields` are immutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.delete")]
-    #[wasi_params("self", "name")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.delete")]
+    #[cm_params("self", "name")]
     fn delete(self: &Fields, name: FieldName) -> Result<(), HeaderError>;
     /// Delete all values for a name. Does nothing if no values for the name
     /// exist.
@@ -307,8 +307,8 @@ pub resource Fields {
     /// Returns all values previously corresponding to the name, if any.
     /// 
     /// Fails with `header-error.immutable` if the `fields` are immutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.get-and-delete")]
-    #[wasi_params("self", "name")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.get-and-delete")]
+    #[cm_params("self", "name")]
     fn get_and_delete(self: &Fields, name: FieldName) -> Result<Array<FieldValue>, HeaderError>;
     /// Append a value for a name. Does not change or delete any existing
     /// values for that name.
@@ -317,8 +317,8 @@ pub resource Fields {
     /// 
     /// Fails with `header-error.size-exceeded` if the value would exceed
     /// an implementation-defined size limit.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.append")]
-    #[wasi_params("self", "name", "value")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.append")]
+    #[cm_params("self", "name", "value")]
     fn append(self: &Fields, name: FieldName, value: FieldValue) -> Result<(), HeaderError>;
     /// Retrieve the full set of names and values in the Fields. Like the
     /// constructor, the list represents each name-value pair.
@@ -329,19 +329,19 @@ pub resource Fields {
     /// 
     /// The names and values are always returned in the original casing and in
     /// the order in which they will be serialized for transport.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.copy-all")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.copy-all")]
+    #[cm_params("self")]
     fn copy_all(self: &Fields) -> Array<[FieldName, FieldValue]>;
     /// Make a deep copy of the Fields. Equivalent in behavior to calling the
     /// `fields` constructor on the return value of `copy-all`. The resulting
     /// `fields` is mutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.clone")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]fields.clone")]
+    #[cm_params("self")]
     fn clone(self: &Fields) -> Fields;
 }
 
 /// Represents an HTTP Request.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#request")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#request")]
 pub resource Request {
     /// Construct a new `request` with a default `method` of `GET`, and
     /// `none` values for `path-with-query`, `scheme`, and `authority`.
@@ -364,52 +364,52 @@ pub resource Request {
     /// to reject invalid constructions of `request`.
     /// 
     /// The returned future resolves to result of transmission of this request.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[static]request.new")]
-    #[wasi_params("headers", "contents", "trailers", "options")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[static]request.new")]
+    #[cm_params("headers", "contents", "trailers", "options")]
     fn new(headers: Headers, contents: Option<Stream<u8>>, trailers: Future<Result<Option<Trailers>, ErrorCode>>, options: Option<RequestOptions>) -> [Request, Future<Result<(), ErrorCode>>];
     /// Get the Method for the Request.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-method")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-method")]
+    #[cm_params("self")]
     fn get_method(self: &Request) -> Method;
     /// Set the Method for the Request. Fails if the string present in a
     /// `method.other` argument is not a syntactically valid method.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-method")]
-    #[wasi_params("self", "method")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-method")]
+    #[cm_params("self", "method")]
     fn set_method(self: &Request, method: Method) -> Result<(), ()>;
     /// Get the combination of the HTTP Path and Query for the Request.  When
     /// `none`, this represents an empty Path and empty Query.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-path-with-query")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-path-with-query")]
+    #[cm_params("self")]
     fn get_path_with_query(self: &Request) -> Option<String>;
     /// Set the combination of the HTTP Path and Query for the Request.  When
     /// `none`, this represents an empty Path and empty Query. Fails is the
     /// string given is not a syntactically valid path and query uri component.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-path-with-query")]
-    #[wasi_params("self", "path-with-query")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-path-with-query")]
+    #[cm_params("self", "path-with-query")]
     fn set_path_with_query(self: &Request, path_with_query: Option<String>) -> Result<(), ()>;
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-scheme")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-scheme")]
+    #[cm_params("self")]
     fn get_scheme(self: &Request) -> Option<Scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme. Fails if the
     /// string given is not a syntactically valid uri scheme.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-scheme")]
-    #[wasi_params("self", "scheme")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-scheme")]
+    #[cm_params("self", "scheme")]
     fn set_scheme(self: &Request, scheme: Option<Scheme>) -> Result<(), ()>;
     /// Get the authority of the Request's target URI. A value of `none` may be used
     /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-authority")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-authority")]
+    #[cm_params("self")]
     fn get_authority(self: &Request) -> Option<String>;
     /// Set the authority of the Request's target URI. A value of `none` may be used
     /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority. Fails if the string given is
     /// not a syntactically valid URI authority.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-authority")]
-    #[wasi_params("self", "authority")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.set-authority")]
+    #[cm_params("self", "authority")]
     fn set_authority(self: &Request, authority: Option<String>) -> Result<(), ()>;
     /// Get the `request-options` to be associated with this request
     /// 
@@ -419,15 +419,15 @@ pub resource Request {
     /// This `request-options` resource is a child: it must be dropped before
     /// the parent `request` is dropped, or its ownership is transferred to
     /// another component by e.g. `handler.handle`.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-options")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-options")]
+    #[cm_params("self")]
     fn get_options(self: &Request) -> Option<RequestOptions>;
     /// Get the headers associated with the Request.
     /// 
     /// The returned `headers` resource is immutable: `set`, `append`, and
     /// `delete` operations will fail with `header-error.immutable`.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-headers")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request.get-headers")]
+    #[cm_params("self")]
     fn get_headers(self: &Request) -> Headers;
     /// Get body of the Request.
     /// 
@@ -441,8 +441,8 @@ pub resource Request {
     /// 
     /// Note that function will move the `request`, but references to headers or
     /// request options acquired from it previously will remain valid.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[static]request.consume-body")]
-    #[wasi_params("this", "res")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[static]request.consume-body")]
+    #[cm_params("this", "res")]
     fn consume_body(this: Request, res: Future<Result<(), ErrorCode>>) -> [Stream<u8>, Future<Result<Option<Trailers>, ErrorCode>>];
 }
 
@@ -452,51 +452,51 @@ pub resource Request {
 /// 
 /// These timeouts are separate from any the user may use to bound an
 /// asynchronous call.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#request-options")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#request-options")]
 pub resource RequestOptions {
     /// Construct a default `request-options` value.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[constructor]request-options")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[constructor]request-options")]
     fn new() -> RequestOptions;
     /// The timeout for the initial connect to the HTTP Server.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.get-connect-timeout")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.get-connect-timeout")]
+    #[cm_params("self")]
     fn get_connect_timeout(self: &RequestOptions) -> Option<Duration>;
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported or that this
     /// handle is immutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.set-connect-timeout")]
-    #[wasi_params("self", "duration")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.set-connect-timeout")]
+    #[cm_params("self", "duration")]
     fn set_connect_timeout(self: &RequestOptions, duration: Option<Duration>) -> Result<(), RequestOptionsError>;
     /// The timeout for receiving the first byte of the Response body.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.get-first-byte-timeout")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.get-first-byte-timeout")]
+    #[cm_params("self")]
     fn get_first_byte_timeout(self: &RequestOptions) -> Option<Duration>;
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported or that
     /// this handle is immutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.set-first-byte-timeout")]
-    #[wasi_params("self", "duration")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.set-first-byte-timeout")]
+    #[cm_params("self", "duration")]
     fn set_first_byte_timeout(self: &RequestOptions, duration: Option<Duration>) -> Result<(), RequestOptionsError>;
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.get-between-bytes-timeout")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.get-between-bytes-timeout")]
+    #[cm_params("self")]
     fn get_between_bytes_timeout(self: &RequestOptions) -> Option<Duration>;
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported or that this handle is immutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.set-between-bytes-timeout")]
-    #[wasi_params("self", "duration")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.set-between-bytes-timeout")]
+    #[cm_params("self", "duration")]
     fn set_between_bytes_timeout(self: &RequestOptions, duration: Option<Duration>) -> Result<(), RequestOptionsError>;
     /// Make a deep copy of the `request-options`.
     /// The resulting `request-options` is mutable.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.clone")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]request-options.clone")]
+    #[cm_params("self")]
     fn clone(self: &RequestOptions) -> RequestOptions;
 }
 
 /// Represents an HTTP Response.
-#[wasi("wasi:http/types@0.3.0-rc-2026-03-15#response")]
+#[cm("wasi:http/types@0.3.0-rc-2026-03-15#response")]
 pub resource Response {
     /// Construct a new `response`, with a default `status-code` of `200`.
     /// If a different `status-code` is needed, it must be set via the
@@ -511,24 +511,24 @@ pub resource Response {
     /// will be closed immediately.
     /// 
     /// The returned future resolves to result of transmission of this response.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[static]response.new")]
-    #[wasi_params("headers", "contents", "trailers")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[static]response.new")]
+    #[cm_params("headers", "contents", "trailers")]
     fn new(headers: Headers, contents: Option<Stream<u8>>, trailers: Future<Result<Option<Trailers>, ErrorCode>>) -> [Response, Future<Result<(), ErrorCode>>];
     /// Get the HTTP Status Code for the Response.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]response.get-status-code")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]response.get-status-code")]
+    #[cm_params("self")]
     fn get_status_code(self: &Response) -> StatusCode;
     /// Set the HTTP Status Code for the Response. Fails if the status-code
     /// given is not a valid http status code.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]response.set-status-code")]
-    #[wasi_params("self", "status-code")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]response.set-status-code")]
+    #[cm_params("self", "status-code")]
     fn set_status_code(self: &Response, status_code: StatusCode) -> Result<(), ()>;
     /// Get the headers associated with the Response.
     /// 
     /// The returned `headers` resource is immutable: `set`, `append`, and
     /// `delete` operations will fail with `header-error.immutable`.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[method]response.get-headers")]
-    #[wasi_params("self")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[method]response.get-headers")]
+    #[cm_params("self")]
     fn get_headers(self: &Response) -> Headers;
     /// Get body of the Response.
     /// 
@@ -542,8 +542,8 @@ pub resource Response {
     /// 
     /// Note that function will move the `response`, but references to headers
     /// acquired from it previously will remain valid.
-    #[wasi("wasi:http/types@0.3.0-rc-2026-03-15#[static]response.consume-body")]
-    #[wasi_params("this", "res")]
+    #[cm("wasi:http/types@0.3.0-rc-2026-03-15#[static]response.consume-body")]
+    #[cm_params("this", "res")]
     fn consume_body(this: Response, res: Future<Result<(), ErrorCode>>) -> [Stream<u8>, Future<Result<Option<Trailers>, ErrorCode>>];
 }
 

--- a/wado-compiler/lib/wasi/http/worlds.wado
+++ b/wado-compiler/lib/wasi/http/worlds.wado
@@ -6,7 +6,7 @@
 /// The `wasi:http/service` world captures a broad category of HTTP services
 /// including web applications, API servers, and proxies. It may be `include`d
 /// in more specific worlds such as `wasi:http/middleware`.
-#[wasi("wasi:http/service@0.3.0-rc-2026-03-15")]
+#[cm("wasi:http/service@0.3.0-rc-2026-03-15")]
 pub world Service {
     import Stdout {
         write_via_stream,
@@ -103,7 +103,7 @@ pub world Service {
 /// Components may implement this world to allow them to participate in handler
 /// "chains" where a `request` flows through handlers on its way to some terminal
 /// `service` and corresponding `response` flows in the opposite direction.
-#[wasi("wasi:http/middleware@0.3.0-rc-2026-03-15")]
+#[cm("wasi:http/middleware@0.3.0-rc-2026-03-15")]
 pub world Middleware {
     import Types {
         Fields::new,

--- a/wado-compiler/lib/wasi/random/insecure-seed.wado
+++ b/wado-compiler/lib/wasi/random/insecure-seed.wado
@@ -7,7 +7,7 @@
 /// 
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-#[wasi("wasi:random/insecure-seed@0.3.0-rc-2026-03-15")]
+#[cm("wasi:random/insecure-seed@0.3.0-rc-2026-03-15")]
 pub effect InsecureSeed {
     /// Return a 128-bit value that may contain a pseudo-random value.
     /// 
@@ -26,7 +26,7 @@ pub effect InsecureSeed {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
-    #[wasi("wasi:random/insecure-seed@0.3.0-rc-2026-03-15#get-insecure-seed")]
+    #[cm("wasi:random/insecure-seed@0.3.0-rc-2026-03-15#get-insecure-seed")]
     fn get_insecure_seed() -> [u64, u64];
 }
 

--- a/wado-compiler/lib/wasi/random/insecure.wado
+++ b/wado-compiler/lib/wasi/random/insecure.wado
@@ -7,7 +7,7 @@
 /// 
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-#[wasi("wasi:random/insecure@0.3.0-rc-2026-03-15")]
+#[cm("wasi:random/insecure@0.3.0-rc-2026-03-15")]
 pub effect Insecure {
     /// Return up to `max-len` insecure pseudo-random bytes.
     /// 
@@ -24,14 +24,14 @@ pub effect Insecure {
     /// Implementations MUST return at least 1 byte when `max-len` is greater
     /// than zero. When `max-len` is zero, implementations MUST return an empty
     /// list without trapping.
-    #[wasi("wasi:random/insecure@0.3.0-rc-2026-03-15#get-insecure-random-bytes")]
-    #[wasi_params("max-len")]
+    #[cm("wasi:random/insecure@0.3.0-rc-2026-03-15#get-insecure-random-bytes")]
+    #[cm_params("max-len")]
     fn get_insecure_random_bytes(max_len: u64) -> Array<u8>;
     /// Return an insecure pseudo-random `u64` value.
     /// 
     /// This function returns the same type of pseudo-random data as
     /// `get-insecure-random-bytes`, represented as a `u64`.
-    #[wasi("wasi:random/insecure@0.3.0-rc-2026-03-15#get-insecure-random-u64")]
+    #[cm("wasi:random/insecure@0.3.0-rc-2026-03-15#get-insecure-random-u64")]
     fn get_insecure_random_u64() -> u64;
 }
 

--- a/wado-compiler/lib/wasi/random/random.wado
+++ b/wado-compiler/lib/wasi/random/random.wado
@@ -7,7 +7,7 @@
 /// 
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-#[wasi("wasi:random/random@0.3.0-rc-2026-03-15")]
+#[cm("wasi:random/random@0.3.0-rc-2026-03-15")]
 pub effect Random {
     /// Return up to `max-len` cryptographically-secure random or pseudo-random
     /// bytes.
@@ -29,14 +29,14 @@ pub effect Random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
-    #[wasi("wasi:random/random@0.3.0-rc-2026-03-15#get-random-bytes")]
-    #[wasi_params("max-len")]
+    #[cm("wasi:random/random@0.3.0-rc-2026-03-15#get-random-bytes")]
+    #[cm_params("max-len")]
     fn get_random_bytes(max_len: u64) -> Array<u8>;
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     /// 
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
-    #[wasi("wasi:random/random@0.3.0-rc-2026-03-15#get-random-u64")]
+    #[cm("wasi:random/random@0.3.0-rc-2026-03-15#get-random-u64")]
     fn get_random_u64() -> u64;
 }
 

--- a/wado-compiler/lib/wasi/random/worlds.wado
+++ b/wado-compiler/lib/wasi/random/worlds.wado
@@ -3,7 +3,7 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:random/imports@0.3.0-rc-2026-03-15")]
+#[cm("wasi:random/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {
     import Random {
         get_random_bytes,

--- a/wado-compiler/lib/wasi/sockets/ip-name-lookup.wado
+++ b/wado-compiler/lib/wasi/sockets/ip-name-lookup.wado
@@ -7,41 +7,41 @@ use { IpAddress } from "wasi:sockets/types.wado";
 
 
 /// Lookup error codes.
-#[wasi("wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15#error-code")]
+#[cm("wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15#error-code")]
 pub variant ErrorCode {
     /// Access denied.
     /// 
     /// POSIX equivalent: EACCES, EPERM
-    #[wasi("access-denied")]
+    #[cm("access-denied")]
     AccessDenied,
     /// `name` is a syntactically invalid domain name or IP address.
     /// 
     /// POSIX equivalent: EINVAL
-    #[wasi("invalid-argument")]
+    #[cm("invalid-argument")]
     InvalidArgument,
     /// Name does not exist or has no suitable associated IP addresses.
     /// 
     /// POSIX equivalent: EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY
-    #[wasi("name-unresolvable")]
+    #[cm("name-unresolvable")]
     NameUnresolvable,
     /// A temporary failure in name resolution occurred.
     /// 
     /// POSIX equivalent: EAI_AGAIN
-    #[wasi("temporary-resolver-failure")]
+    #[cm("temporary-resolver-failure")]
     TemporaryResolverFailure,
     /// A permanent failure in name resolution occurred.
     /// 
     /// POSIX equivalent: EAI_FAIL
-    #[wasi("permanent-resolver-failure")]
+    #[cm("permanent-resolver-failure")]
     PermanentResolverFailure,
     /// A catch-all for errors not captured by the existing variants.
     /// Implementations can use this to extend the error type without
     /// breaking existing code.
-    #[wasi("other")]
+    #[cm("other")]
     Other(Option<String>),
 }
 
-#[wasi("wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15")]
+#[cm("wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15")]
 pub effect IpNameLookup {
     /// Resolve an internet host name to a list of IP addresses.
     /// 
@@ -62,8 +62,8 @@ pub effect IpNameLookup {
     /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-    #[wasi("wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15#resolve-addresses")]
-    #[wasi_params("name")]
+    #[cm("wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15#resolve-addresses")]
+    #[cm_params("name")]
     async fn resolve_addresses(name: String) -> Result<Array<IpAddress>, ErrorCode>;
 }
 

--- a/wado-compiler/lib/wasi/sockets/types.wado
+++ b/wado-compiler/lib/wasi/sockets/types.wado
@@ -17,140 +17,140 @@ use { Duration } from "wasi:clocks/types.wado";
 /// - `out-of-memory`
 /// 
 /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#error-code")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#error-code")]
 pub variant ErrorCode {
     /// Access denied.
     /// 
     /// POSIX equivalent: EACCES, EPERM
-    #[wasi("access-denied")]
+    #[cm("access-denied")]
     AccessDenied,
     /// The operation is not supported.
     /// 
     /// POSIX equivalent: EOPNOTSUPP, ENOPROTOOPT, EPFNOSUPPORT, EPROTONOSUPPORT, ESOCKTNOSUPPORT
-    #[wasi("not-supported")]
+    #[cm("not-supported")]
     NotSupported,
     /// One of the arguments is invalid.
     /// 
     /// POSIX equivalent: EINVAL, EDESTADDRREQ, EAFNOSUPPORT
-    #[wasi("invalid-argument")]
+    #[cm("invalid-argument")]
     InvalidArgument,
     /// Not enough memory to complete the operation.
     /// 
     /// POSIX equivalent: ENOMEM, ENOBUFS
-    #[wasi("out-of-memory")]
+    #[cm("out-of-memory")]
     OutOfMemory,
     /// The operation timed out before it could finish completely.
     /// 
     /// POSIX equivalent: ETIMEDOUT
-    #[wasi("timeout")]
+    #[cm("timeout")]
     Timeout,
     /// The operation is not valid in the socket's current state.
-    #[wasi("invalid-state")]
+    #[cm("invalid-state")]
     InvalidState,
     /// The local address is not available.
     /// 
     /// POSIX equivalent: EADDRNOTAVAIL
-    #[wasi("address-not-bindable")]
+    #[cm("address-not-bindable")]
     AddressNotBindable,
     /// A bind operation failed because the provided address is already in
     /// use or because there are no ephemeral ports available.
     /// 
     /// POSIX equivalent: EADDRINUSE
-    #[wasi("address-in-use")]
+    #[cm("address-in-use")]
     AddressInUse,
     /// The remote address is not reachable.
     /// 
     /// POSIX equivalent: EHOSTUNREACH, EHOSTDOWN, ENETDOWN, ENETUNREACH, ENONET
-    #[wasi("remote-unreachable")]
+    #[cm("remote-unreachable")]
     RemoteUnreachable,
     /// The connection was forcefully rejected.
     /// 
     /// POSIX equivalent: ECONNREFUSED
-    #[wasi("connection-refused")]
+    #[cm("connection-refused")]
     ConnectionRefused,
     /// A write failed because the connection was broken.
     /// 
     /// POSIX equivalent: EPIPE
-    #[wasi("connection-broken")]
+    #[cm("connection-broken")]
     ConnectionBroken,
     /// The connection was reset.
     /// 
     /// POSIX equivalent: ECONNRESET
-    #[wasi("connection-reset")]
+    #[cm("connection-reset")]
     ConnectionReset,
     /// The connection was aborted.
     /// 
     /// POSIX equivalent: ECONNABORTED
-    #[wasi("connection-aborted")]
+    #[cm("connection-aborted")]
     ConnectionAborted,
     /// The size of a datagram sent to a UDP socket exceeded the maximum
     /// supported size.
     /// 
     /// POSIX equivalent: EMSGSIZE
-    #[wasi("datagram-too-large")]
+    #[cm("datagram-too-large")]
     DatagramTooLarge,
     /// A catch-all for errors not captured by the existing variants.
     /// Implementations can use this to extend the error type without
     /// breaking existing code.
-    #[wasi("other")]
+    #[cm("other")]
     Other(Option<String>),
 }
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ip-address-family")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ip-address-family")]
 pub enum IpAddressFamily {
     /// Similar to `AF_INET` in POSIX.
-    #[wasi("ipv4")]
+    #[cm("ipv4")]
     Ipv4,
     /// Similar to `AF_INET6` in POSIX.
-    #[wasi("ipv6")]
+    #[cm("ipv6")]
     Ipv6,
 }
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv4-address")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv4-address")]
 pub type Ipv4Address = [u8, u8, u8, u8];
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv6-address")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv6-address")]
 pub type Ipv6Address = [u16, u16, u16, u16, u16, u16, u16, u16];
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ip-address")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ip-address")]
 pub variant IpAddress {
-    #[wasi("ipv4")]
+    #[cm("ipv4")]
     Ipv4(Ipv4Address),
-    #[wasi("ipv6")]
+    #[cm("ipv6")]
     Ipv6(Ipv6Address),
 }
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv4-socket-address")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv4-socket-address")]
 pub struct Ipv4SocketAddress {
     /// sin_port
-    #[wasi("port")]
+    #[cm("port")]
     pub port: u16,
     /// sin_addr
-    #[wasi("address")]
+    #[cm("address")]
     pub address: Ipv4Address,
 }
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv6-socket-address")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ipv6-socket-address")]
 pub struct Ipv6SocketAddress {
     /// sin6_port
-    #[wasi("port")]
+    #[cm("port")]
     pub port: u16,
     /// sin6_flowinfo
-    #[wasi("flow-info")]
+    #[cm("flow-info")]
     pub flow_info: u32,
     /// sin6_addr
-    #[wasi("address")]
+    #[cm("address")]
     pub address: Ipv6Address,
     /// sin6_scope_id
-    #[wasi("scope-id")]
+    #[cm("scope-id")]
     pub scope_id: u32,
 }
 
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#ip-socket-address")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#ip-socket-address")]
 pub variant IpSocketAddress {
-    #[wasi("ipv4")]
+    #[cm("ipv4")]
     Ipv4(Ipv4SocketAddress),
-    #[wasi("ipv6")]
+    #[cm("ipv6")]
     Ipv6(Ipv6SocketAddress),
 }
 
@@ -186,7 +186,7 @@ pub variant IpSocketAddress {
 /// In addition to the general error codes documented on the
 /// `types::error-code` type, TCP socket methods may always return
 /// `error(invalid-state)` when in the `closed` state.
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#tcp-socket")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#tcp-socket")]
 pub resource TcpSocket {
     /// Create a new TCP socket.
     /// 
@@ -206,8 +206,8 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[static]tcp-socket.create")]
-    #[wasi_params("address-family")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[static]tcp-socket.create")]
+    #[cm_params("address-family")]
     fn create(address_family: IpAddressFamily) -> Result<TcpSocket, ErrorCode>;
     /// Bind the socket to the provided IP address and port.
     /// 
@@ -242,8 +242,8 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.bind")]
-    #[wasi_params("self", "local-address")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.bind")]
+    #[cm_params("self", "local-address")]
     fn bind(self: &TcpSocket, local_address: IpSocketAddress) -> Result<(), ErrorCode>;
     /// Connect to a remote endpoint.
     /// 
@@ -279,8 +279,8 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.connect")]
-    #[wasi_params("self", "remote-address")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.connect")]
+    #[cm_params("self", "remote-address")]
     async fn connect(self: &TcpSocket, remote_address: IpSocketAddress) -> Result<(), ErrorCode>;
     /// Start listening and return a stream of new inbound connections.
     /// 
@@ -352,8 +352,8 @@ pub resource TcpSocket {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.listen")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.listen")]
+    #[cm_params("self")]
     fn listen(self: &TcpSocket) -> Result<Stream<TcpSocket>, ErrorCode>;
     /// Transmit data to peer.
     /// 
@@ -377,8 +377,8 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/send.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.send")]
-    #[wasi_params("self", "data")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.send")]
+    #[cm_params("self", "data")]
     fn send(self: &TcpSocket, data: Stream<u8>) -> Future<Result<(), ErrorCode>>;
     /// Read data from peer.
     /// 
@@ -407,8 +407,8 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.receive")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.receive")]
+    #[cm_params("self")]
     fn receive(self: &TcpSocket) -> [Stream<u8>, Future<Result<(), ErrorCode>>];
     /// Get the bound local address.
     /// 
@@ -427,8 +427,8 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-local-address")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-local-address")]
+    #[cm_params("self")]
     fn get_local_address(self: &TcpSocket) -> Result<IpSocketAddress, ErrorCode>;
     /// Get the remote address.
     /// 
@@ -440,22 +440,22 @@ pub resource TcpSocket {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-remote-address")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-remote-address")]
+    #[cm_params("self")]
     fn get_remote_address(self: &TcpSocket) -> Result<IpSocketAddress, ErrorCode>;
     /// Whether the socket is in the `listening` state.
     /// 
     /// Equivalent to the SO_ACCEPTCONN socket option.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-is-listening")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-is-listening")]
+    #[cm_params("self")]
     fn get_is_listening(self: &TcpSocket) -> bool;
     /// Whether this is a IPv4 or IPv6 socket.
     /// 
     /// This is the value passed to the constructor.
     /// 
     /// Equivalent to the SO_DOMAIN socket option.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-address-family")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-address-family")]
+    #[cm_params("self")]
     fn get_address_family(self: &TcpSocket) -> IpAddressFamily;
     /// Hints the desired listen queue size. Implementations are free to
     /// ignore this.
@@ -468,8 +468,8 @@ pub resource TcpSocket {
     /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
     /// - `invalid-argument`:     (set) The provided value was 0.
     /// - `invalid-state`:        (set) The socket is in the `connecting` or `connected` state.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-listen-backlog-size")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-listen-backlog-size")]
+    #[cm_params("self", "value")]
     fn set_listen_backlog_size(self: &TcpSocket, value: u64) -> Result<(), ErrorCode>;
     /// Enables or disables keepalive.
     /// 
@@ -481,11 +481,11 @@ pub resource TcpSocket {
     /// false, but only come into effect when `keep-alive-enabled` is true.
     /// 
     /// Equivalent to the SO_KEEPALIVE socket option.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-enabled")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-enabled")]
+    #[cm_params("self")]
     fn get_keep_alive_enabled(self: &TcpSocket) -> Result<bool, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-enabled")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-enabled")]
+    #[cm_params("self", "value")]
     fn set_keep_alive_enabled(self: &TcpSocket, value: bool) -> Result<(), ErrorCode>;
     /// Amount of time the connection has to be idle before TCP starts
     /// sending keepalive packets.
@@ -499,11 +499,11 @@ pub resource TcpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-idle-time")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-idle-time")]
+    #[cm_params("self")]
     fn get_keep_alive_idle_time(self: &TcpSocket) -> Result<Duration, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-idle-time")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-idle-time")]
+    #[cm_params("self", "value")]
     fn set_keep_alive_idle_time(self: &TcpSocket, value: Duration) -> Result<(), ErrorCode>;
     /// The time between keepalive packets.
     /// 
@@ -516,11 +516,11 @@ pub resource TcpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-interval")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-interval")]
+    #[cm_params("self")]
     fn get_keep_alive_interval(self: &TcpSocket) -> Result<Duration, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-interval")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-interval")]
+    #[cm_params("self", "value")]
     fn set_keep_alive_interval(self: &TcpSocket, value: Duration) -> Result<(), ErrorCode>;
     /// The maximum amount of keepalive packets TCP should send before
     /// aborting the connection.
@@ -534,11 +534,11 @@ pub resource TcpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-count")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-keep-alive-count")]
+    #[cm_params("self")]
     fn get_keep_alive_count(self: &TcpSocket) -> Result<u32, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-count")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-keep-alive-count")]
+    #[cm_params("self", "value")]
     fn set_keep_alive_count(self: &TcpSocket, value: u32) -> Result<(), ErrorCode>;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     /// 
@@ -546,11 +546,11 @@ pub resource TcpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-hop-limit")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-hop-limit")]
+    #[cm_params("self")]
     fn get_hop_limit(self: &TcpSocket) -> Result<u8, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-hop-limit")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-hop-limit")]
+    #[cm_params("self", "value")]
     fn set_hop_limit(self: &TcpSocket, value: u8) -> Result<(), ErrorCode>;
     /// Kernel buffer space reserved for sending/receiving on this socket.
     /// Implementations usually treat this as a cap the buffer can grow to,
@@ -573,22 +573,22 @@ pub resource TcpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-receive-buffer-size")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-receive-buffer-size")]
+    #[cm_params("self")]
     fn get_receive_buffer_size(self: &TcpSocket) -> Result<u64, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-receive-buffer-size")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-receive-buffer-size")]
+    #[cm_params("self", "value")]
     fn set_receive_buffer_size(self: &TcpSocket, value: u64) -> Result<(), ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-send-buffer-size")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.get-send-buffer-size")]
+    #[cm_params("self")]
     fn get_send_buffer_size(self: &TcpSocket) -> Result<u64, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-send-buffer-size")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]tcp-socket.set-send-buffer-size")]
+    #[cm_params("self", "value")]
     fn set_send_buffer_size(self: &TcpSocket, value: u64) -> Result<(), ErrorCode>;
 }
 
 /// A UDP socket handle.
-#[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#udp-socket")]
+#[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#udp-socket")]
 pub resource UdpSocket {
     /// Create a new UDP socket.
     /// 
@@ -605,8 +605,8 @@ pub resource UdpSocket {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[static]udp-socket.create")]
-    #[wasi_params("address-family")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[static]udp-socket.create")]
+    #[cm_params("address-family")]
     fn create(address_family: IpAddressFamily) -> Result<UdpSocket, ErrorCode>;
     /// Bind the socket to the provided IP address and port.
     /// 
@@ -627,8 +627,8 @@ pub resource UdpSocket {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.bind")]
-    #[wasi_params("self", "local-address")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.bind")]
+    #[cm_params("self", "local-address")]
     fn bind(self: &UdpSocket, local_address: IpSocketAddress) -> Result<(), ErrorCode>;
     /// Associate this socket with a specific peer address.
     /// 
@@ -666,8 +666,8 @@ pub resource UdpSocket {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.connect")]
-    #[wasi_params("self", "remote-address")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.connect")]
+    #[cm_params("self", "remote-address")]
     fn connect(self: &UdpSocket, remote_address: IpSocketAddress) -> Result<(), ErrorCode>;
     /// Dissociate this socket from its peer address.
     /// 
@@ -684,8 +684,8 @@ pub resource UdpSocket {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.disconnect")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.disconnect")]
+    #[cm_params("self")]
     fn disconnect(self: &UdpSocket) -> Result<(), ErrorCode>;
     /// Send a message on the socket to a particular peer.
     /// 
@@ -729,8 +729,8 @@ pub resource UdpSocket {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.send")]
-    #[wasi_params("self", "data", "remote-address")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.send")]
+    #[cm_params("self", "data", "remote-address")]
     async fn send(self: &UdpSocket, data: Array<u8>, remote_address: Option<IpSocketAddress>) -> Result<(), ErrorCode>;
     /// Receive a message on the socket.
     /// 
@@ -755,8 +755,8 @@ pub resource UdpSocket {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_wsarecvmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.receive")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.receive")]
+    #[cm_params("self")]
     async fn receive(self: &UdpSocket) -> Result<[Array<u8>, IpSocketAddress], ErrorCode>;
     /// Get the current bound address.
     /// 
@@ -775,8 +775,8 @@ pub resource UdpSocket {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-local-address")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-local-address")]
+    #[cm_params("self")]
     fn get_local_address(self: &UdpSocket) -> Result<IpSocketAddress, ErrorCode>;
     /// Get the address the socket is currently "connected" to.
     /// 
@@ -788,16 +788,16 @@ pub resource UdpSocket {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-remote-address")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-remote-address")]
+    #[cm_params("self")]
     fn get_remote_address(self: &UdpSocket) -> Result<IpSocketAddress, ErrorCode>;
     /// Whether this is a IPv4 or IPv6 socket.
     /// 
     /// This is the value passed to the constructor.
     /// 
     /// Equivalent to the SO_DOMAIN socket option.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-address-family")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-address-family")]
+    #[cm_params("self")]
     fn get_address_family(self: &UdpSocket) -> IpAddressFamily;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     /// 
@@ -805,11 +805,11 @@ pub resource UdpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-unicast-hop-limit")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-unicast-hop-limit")]
+    #[cm_params("self")]
     fn get_unicast_hop_limit(self: &UdpSocket) -> Result<u8, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.set-unicast-hop-limit")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.set-unicast-hop-limit")]
+    #[cm_params("self", "value")]
     fn set_unicast_hop_limit(self: &UdpSocket, value: u8) -> Result<(), ErrorCode>;
     /// Kernel buffer space reserved for sending/receiving on this socket.
     /// Implementations usually treat this as a cap the buffer can grow to,
@@ -824,17 +824,17 @@ pub resource UdpSocket {
     /// 
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-receive-buffer-size")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-receive-buffer-size")]
+    #[cm_params("self")]
     fn get_receive_buffer_size(self: &UdpSocket) -> Result<u64, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.set-receive-buffer-size")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.set-receive-buffer-size")]
+    #[cm_params("self", "value")]
     fn set_receive_buffer_size(self: &UdpSocket, value: u64) -> Result<(), ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-send-buffer-size")]
-    #[wasi_params("self")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.get-send-buffer-size")]
+    #[cm_params("self")]
     fn get_send_buffer_size(self: &UdpSocket) -> Result<u64, ErrorCode>;
-    #[wasi("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.set-send-buffer-size")]
-    #[wasi_params("self", "value")]
+    #[cm("wasi:sockets/types@0.3.0-rc-2026-03-15#[method]udp-socket.set-send-buffer-size")]
+    #[cm_params("self", "value")]
     fn set_send_buffer_size(self: &UdpSocket, value: u64) -> Result<(), ErrorCode>;
 }
 

--- a/wado-compiler/lib/wasi/sockets/worlds.wado
+++ b/wado-compiler/lib/wasi/sockets/worlds.wado
@@ -3,7 +3,7 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit
 
-#[wasi("wasi:sockets/imports@0.3.0-rc-2026-03-15")]
+#[cm("wasi:sockets/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {
     import Types {
         TcpSocket::create,

--- a/wado-compiler/lib/wasi/wasi-http/worlds.wado
+++ b/wado-compiler/lib/wasi/wasi-http/worlds.wado
@@ -3,7 +3,7 @@
 // Source files:
 //   - vendor/wasmtime/crates/wasi-http/src/p3/wit/world.wit
 
-#[wasi("wasmtime:wasi-http/bindings")]
+#[cm("wasmtime:wasi-http/bindings")]
 pub world Bindings {
     import Stdout {
         write_via_stream,

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -196,8 +196,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
 
                 Item::Effect(effect) => {
                     // Extract effect-level CM import from attributes
-                    let effect_cm_import =
-                        effect.attrs.first().and_then(|a| a.cm_import.clone());
+                    let effect_cm_import = effect.attrs.first().and_then(|a| a.cm_import.clone());
 
                     let kind = SymbolKind::Effect(EffectSymbol {
                         methods: effect.methods.iter().map(|m| m.name.clone()).collect(),

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -187,7 +187,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                         return_type: func.return_type.as_ref().map(|_| "unknown".to_string()),
                         effects: func.effects.clone(),
                         is_builtin,
-                        wasi_import: func.attrs.first().and_then(|a| a.wasi_import.clone()),
+                        cm_import: func.attrs.first().and_then(|a| a.cm_import.clone()),
                     });
 
                     self.symbols
@@ -195,13 +195,13 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 }
 
                 Item::Effect(effect) => {
-                    // Extract effect-level WASI import from attributes
-                    let effect_wasi_import =
-                        effect.attrs.first().and_then(|a| a.wasi_import.clone());
+                    // Extract effect-level CM import from attributes
+                    let effect_cm_import =
+                        effect.attrs.first().and_then(|a| a.cm_import.clone());
 
                     let kind = SymbolKind::Effect(EffectSymbol {
                         methods: effect.methods.iter().map(|m| m.name.clone()).collect(),
-                        wasi_import: effect_wasi_import,
+                        cm_import: effect_cm_import,
                     });
 
                     self.symbols
@@ -211,14 +211,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     // with the fully qualified name "{Effect}.{method}"
                     // This allows importing them via use statements
                     for method in &effect.methods {
-                        let wasi_import = method.attrs.first().and_then(|a| a.wasi_import.clone());
+                        let cm_import = method.attrs.first().and_then(|a| a.cm_import.clone());
 
                         let func_kind = SymbolKind::Function(FunctionSymbol {
                             params: method.params.iter().map(|p| p.name.clone()).collect(),
                             return_type: method.return_type.as_ref().map(|_| "unknown".to_string()),
                             effects: vec![effect.name.clone()], // Effect methods implicitly require their effect
                             is_builtin: matches!(module_source, ModuleSource::Core { .. }),
-                            wasi_import,
+                            cm_import,
                         });
 
                         // Register as "{Effect}::{method}"
@@ -297,7 +297,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 Item::Resource(resource) => {
                     let kind = SymbolKind::Resource(ResourceSymbol {
                         methods: resource.methods.iter().map(|m| m.name.clone()).collect(),
-                        wasi_import: resource.attrs.first().and_then(|a| a.wasi_import.clone()),
+                        cm_import: resource.attrs.first().and_then(|a| a.cm_import.clone()),
                     });
 
                     self.symbols
@@ -306,14 +306,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     // Register each resource method as a function symbol
                     // with the fully qualified name "{Resource}::{method}"
                     for method in &resource.methods {
-                        let wasi_import = method.attrs.first().and_then(|a| a.wasi_import.clone());
+                        let cm_import = method.attrs.first().and_then(|a| a.cm_import.clone());
 
                         let func_kind = SymbolKind::Function(FunctionSymbol {
                             params: method.params.iter().map(|p| p.name.clone()).collect(),
                             return_type: method.return_type.as_ref().map(|_| "unknown".to_string()),
                             effects: vec![], // Resource methods don't have effect requirements
                             is_builtin: matches!(module_source, ModuleSource::Core { .. }),
-                            wasi_import,
+                            cm_import,
                         });
 
                         // Register as "{Resource}::{method}"

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -149,7 +149,7 @@ pub struct GlobalDecl {
 /// `unparse` can reconstruct the original syntax faithfully.
 ///
 /// Examples:
-/// - `#[wasi("wasi:cli/stdout")]`          → `[Str("wasi:cli/stdout")]`
+/// - `#[cm("wasi:cli/stdout")]`          → `[Str("wasi:cli/stdout")]`
 /// - `#[inline(always)]`                   → `[Ident("always")]`
 /// - `#[serde(rename = "type")]`           → `[KeyValue("rename", "type")]`
 /// - `#[canonical("wasi", "stream-new")]`  → `[Str("wasi"), Str("stream-new")]`
@@ -173,7 +173,7 @@ impl AttrArg {
     }
 }
 
-/// Attribute like #[wasi("...")]
+/// Attribute like #[cm("...")]
 #[derive(Debug, Clone)]
 pub struct Attribute {
     pub name: String,
@@ -183,7 +183,7 @@ pub struct Attribute {
     /// - `#[serde(rename = "type")]`           → `[KeyValue("rename", "type")]`
     /// - `#[serde(default)]`                   → `[Ident("default")]`
     pub args: Vec<AttrArg>,
-    pub wasi_import: Option<WasiImport>,
+    pub cm_import: Option<CmImport>,
     pub span: Span,
 }
 
@@ -212,10 +212,10 @@ impl Attribute {
     }
 }
 
-/// Parsed WASI import path
+/// Parsed Component Model import path
 /// e.g., "wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream"
 #[derive(Debug, Clone)]
-pub struct WasiImport {
+pub struct CmImport {
     /// Namespace (e.g., "wasi")
     pub namespace: String,
     /// Package (e.g., "cli")
@@ -228,13 +228,13 @@ pub struct WasiImport {
     pub function: Option<String>,
 }
 
-impl WasiImport {
-    /// Parse a WASI path string
+impl CmImport {
+    /// Parse a CM import path string
     /// Format: "namespace:package/interface@version#function"
     /// Examples:
     ///   "wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream"
     ///   "wasi:cli/terminal-input@0.3.0-rc-2025-09-16"
-    pub fn parse(s: &str) -> Option<WasiImport> {
+    pub fn parse(s: &str) -> Option<CmImport> {
         // Split by '#' first to extract function name
         let (path, function) = if let Some(pos) = s.rfind('#') {
             (&s[..pos], Some(s[pos + 1..].to_string()))
@@ -255,7 +255,7 @@ impl WasiImport {
         // Split by '/' to extract package and interface
         let (package, interface) = rest.split_once('/')?;
 
-        Some(WasiImport {
+        Some(CmImport {
             namespace: namespace.to_string(),
             package: package.to_string(),
             interface: interface.to_string(),
@@ -1235,7 +1235,7 @@ pub struct StructDecl {
     /// Generic type parameters: `struct Pair<T, U> { ... }`
     pub type_params: Vec<GenericParam>,
     pub fields: Vec<StructField>,
-    /// Attributes like `#[wasi("...")]`
+    /// Attributes like `#[cm("...")]`
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }
@@ -1245,7 +1245,7 @@ pub struct StructField {
     pub name: String,
     pub is_pub: bool,
     pub ty: Type,
-    /// Attributes like `#[wasi("...")]` for CM name override
+    /// Attributes like `#[cm("...")]` for CM name override
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }
@@ -1257,7 +1257,7 @@ pub struct EnumDecl {
     /// Generic type parameters: `enum Option<T> { Some(T), None }`
     pub type_params: Vec<GenericParam>,
     pub cases: Vec<EnumCase>,
-    /// Attributes like #[wasi("...")]
+    /// Attributes like #[cm("...")]
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }
@@ -1267,7 +1267,7 @@ pub struct EnumDecl {
 #[derive(Debug, Clone)]
 pub struct EnumCase {
     pub name: String,
-    /// Attributes like `#[wasi("wit-kebab-name")]` for CM name override
+    /// Attributes like `#[cm("wit-kebab-name")]` for CM name override
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }
@@ -1292,7 +1292,7 @@ pub struct FlagsDecl {
 #[derive(Debug, Clone)]
 pub struct FlagsVariant {
     pub name: String,
-    /// Attributes like `#[wasi("wit-kebab-name")]` for CM name override
+    /// Attributes like `#[cm("wit-kebab-name")]` for CM name override
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }
@@ -1311,7 +1311,7 @@ pub struct VariantDecl {
     /// Generic type parameters: `variant Option<T> { Some(T), None }`
     pub type_params: Vec<GenericParam>,
     pub cases: Vec<VariantCase>,
-    /// Attributes like `#[wasi("...")]`
+    /// Attributes like `#[cm("...")]`
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }
@@ -1329,7 +1329,7 @@ pub struct VariantCase {
     /// Payload type for this case. None for unit variants like `None`.
     /// At TIR level, unit variants are normalized to have `()` payload.
     pub payload: Option<Type>,
-    /// Attributes like `#[wasi("wit-kebab-name")]` for CM name override
+    /// Attributes like `#[cm("wit-kebab-name")]` for CM name override
     pub attrs: Vec<Attribute>,
     pub span: Span,
 }

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2563,8 +2563,7 @@ fn import_resource_using_interfaces(
                 };
                 // Use package-qualified names to avoid collision with same-named interfaces
                 // from different packages (e.g., wasi:cli/types vs wasi:filesystem/types).
-                let src_instance_name =
-                    format!("{}-{}", cm_import.package, cm_import.interface);
+                let src_instance_name = format!("{}-{}", cm_import.package, cm_import.interface);
                 let src_instance_type_name = format!("{src_instance_name}-instance-type");
                 if !ctx.has_type(&src_instance_type_name) {
                     // Import the resource-defining interface minimally (just the resource export)

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -30,7 +30,7 @@ pub fn build_component(project: &Project, core_module: &[u8], wir_module: &WirMo
     let mut ctx = ComponentModelContext::new();
 
     // Generate WASI imports dynamically from registry
-    generate_wasi_imports(&mut builder, &mut ctx, project);
+    generate_cm_imports(&mut builder, &mut ctx, project);
 
     // Type: result unit for run function (needed for task.return)
     let result_unit_type = ctx.register_type("result-unit");
@@ -100,7 +100,7 @@ pub fn build_component(project: &Project, core_module: &[u8], wir_module: &WirMo
                 ),
                 CmStreamPayload::Record(name) => {
                     // Alias the record type from the WASI interface that defines it.
-                    // WASI imports are already generated (generate_wasi_imports runs first),
+                    // WASI imports are already generated (generate_cm_imports runs first),
                     // so we can alias the exported type from the interface instance.
                     let val = if let Some(interface_name) = project
                         .wasi_registry
@@ -641,7 +641,7 @@ fn build_cm_tuple_types(
 
 /// Collect resource type names referenced anywhere in a type tree.
 ///
-/// Used to build the `needed_resources` list for `generate_wasi_imports`.
+/// Used to build the `needed_resources` list for `generate_cm_imports`.
 fn collect_resources_in_type(
     ty: &Type,
     wasi_registry: &crate::component_model::WasiRegistry,
@@ -1254,7 +1254,7 @@ fn emit_world_exports(
 }
 
 /// Generate WASI imports dynamically from the registry.
-fn generate_wasi_imports(
+fn generate_cm_imports(
     builder: &mut ComponentBuilder,
     ctx: &mut ComponentModelContext,
     project: &Project,
@@ -2349,7 +2349,7 @@ fn import_interfaces_with_resources(
             continue;
         };
 
-        let Some(wasi_import) = crate::ast::WasiImport::parse(source_path) else {
+        let Some(cm_import) = crate::ast::CmImport::parse(source_path) else {
             continue;
         };
 
@@ -2362,7 +2362,7 @@ fn import_interfaces_with_resources(
                 .wasi_registry
                 .has_enum_in_interface(source_path, "ErrorCode");
 
-        let instance_type_name = format!("{}-instance-type", wasi_import.interface);
+        let instance_type_name = format!("{}-instance-type", cm_import.interface);
         let instance_type_idx = ctx.register_type(&instance_type_name);
         #[allow(unused_assignments)]
         let mut local_type_idx = 0u32;
@@ -2412,7 +2412,7 @@ fn import_interfaces_with_resources(
             enc.instance(&instance_type);
         }
 
-        ctx.register_instance(&wasi_import.interface);
+        ctx.register_instance(&cm_import.interface);
         builder.import(
             source_path,
             wasm_encoder::ComponentTypeRef::Instance(instance_type_idx),
@@ -2421,19 +2421,19 @@ fn import_interfaces_with_resources(
         let resource_type_name = format!("resource:{resource_cm_name}");
         ctx.register_type(&resource_type_name);
         builder.alias_export(
-            ctx.instance_idx(&wasi_import.interface),
+            ctx.instance_idx(&cm_import.interface),
             resource_cm_name,
             ComponentExportKind::Type,
         );
 
         // Alias error-code at outer scope
         if source_has_error_code {
-            let package = &wasi_import.package;
+            let package = &cm_import.package;
             let error_code_key = format!("{package}-error-code");
             if !ctx.has_type(&error_code_key) {
                 ctx.register_type(&error_code_key);
                 builder.alias_export(
-                    ctx.instance_idx(&wasi_import.interface),
+                    ctx.instance_idx(&cm_import.interface),
                     "error-code",
                     ComponentExportKind::Type,
                 );
@@ -2525,12 +2525,12 @@ fn import_resource_using_interfaces(
         }
 
         // Only handle interfaces that reference resources from other interfaces.
-        // Interfaces with no resources are already handled in generate_wasi_imports.
+        // Interfaces with no resources are already handled in generate_cm_imports.
         if needed_resources.is_empty() {
             continue;
         }
 
-        // Skip if already imported (e.g., previously handled by generate_wasi_imports on a prior build)
+        // Skip if already imported (e.g., previously handled by generate_cm_imports on a prior build)
         let first_func_local_name = supported_functions
             .first()
             .map(|f| f.local_alias_name())
@@ -2558,13 +2558,13 @@ fn import_resource_using_interfaces(
                 else {
                     continue;
                 };
-                let Some(wasi_import) = crate::ast::WasiImport::parse(source_path) else {
+                let Some(cm_import) = crate::ast::CmImport::parse(source_path) else {
                     continue;
                 };
                 // Use package-qualified names to avoid collision with same-named interfaces
                 // from different packages (e.g., wasi:cli/types vs wasi:filesystem/types).
                 let src_instance_name =
-                    format!("{}-{}", wasi_import.package, wasi_import.interface);
+                    format!("{}-{}", cm_import.package, cm_import.interface);
                 let src_instance_type_name = format!("{src_instance_name}-instance-type");
                 if !ctx.has_type(&src_instance_type_name) {
                     // Import the resource-defining interface minimally (just the resource export)

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -10,7 +10,7 @@ use crate::hashmap::{IndexMap, IndexSet};
 
 use wasm_encoder::ValType;
 
-use crate::ast::{GenericType, Type, WasiImport};
+use crate::ast::{CmImport, GenericType, Type};
 use crate::tir::{TypeId, TypeTable};
 
 /// A variant case with both CM and Wado names.
@@ -24,18 +24,18 @@ pub struct CmVariantCase {
     pub payload: Option<Type>,
 }
 
-/// Extract the CM name from a `#[wasi("...")]` attribute.
+/// Extract the CM name from a `#[cm("...")]` attribute.
 ///
 /// Handles two formats:
-/// - Type-level: `#[wasi("wasi:pkg/iface@ver#cm-name")]` → takes the fragment after `#`
-/// - Case-level: `#[wasi("cm-name")]` → uses the whole arg directly
+/// - Type-level: `#[cm("wasi:pkg/iface@ver#cm-name")]` → takes the fragment after `#`
+/// - Case-level: `#[cm("cm-name")]` → uses the whole arg directly
 ///
 /// Preserves acronym casing from the WIT source (e.g., `DNS-timeout`, `TLS-protocol-error`).
-/// Panics if no `#[wasi]` attribute is present — all WASI names must be metadata-driven.
-fn wasi_attr_cm_name(attrs: &[crate::ast::Attribute], wado_name: &str) -> String {
+/// Panics if no `#[cm]` attribute is present — all CM names must be metadata-driven.
+fn cm_attr_cm_name(attrs: &[crate::ast::Attribute], wado_name: &str) -> String {
     attrs
         .iter()
-        .find(|a| a.name == "wasi")
+        .find(|a| a.name == "cm")
         .and_then(|a| a.args.first())
         .map(|arg| {
             let s = arg.as_str();
@@ -46,14 +46,14 @@ fn wasi_attr_cm_name(attrs: &[crate::ast::Attribute], wado_name: &str) -> String
                 s.to_owned()
             }
         })
-        .unwrap_or_else(|| panic!("missing #[wasi] attribute for WASI name: {wado_name}"))
+        .unwrap_or_else(|| panic!("missing #[cm] attribute for CM name: {wado_name}"))
 }
 
-/// Extract CM parameter names from a `#[wasi_params("param-a", "param-b")]` attribute.
-fn extract_wasi_params_attr(attrs: &[crate::ast::Attribute]) -> Vec<String> {
+/// Extract CM parameter names from a `#[cm_params("param-a", "param-b")]` attribute.
+fn extract_cm_params_attr(attrs: &[crate::ast::Attribute]) -> Vec<String> {
     attrs
         .iter()
-        .find(|a| a.name == "wasi_params")
+        .find(|a| a.name == "cm_params")
         .map(|a| a.args.iter().map(|arg| arg.as_str().to_string()).collect())
         .unwrap_or_default()
 }
@@ -359,14 +359,14 @@ impl WasiRegistry {
         // Collect resource types from this module
         for item in &module.items {
             if let Item::Resource(resource) = item {
-                // Use the #[wasi] fragment as the CM name (preserves acronym casing like DNS, TLS)
-                let cm_name = wasi_attr_cm_name(&resource.attrs, &resource.name);
-                // Extract source interface path from #[wasi] attribute
-                // Format: #[wasi("wasi:cli/terminal-input@0.3.0-rc-2026-01-06#terminal-input")]
+                // Use the #[cm] fragment as the CM name (preserves acronym casing like DNS, TLS)
+                let cm_name = cm_attr_cm_name(&resource.attrs, &resource.name);
+                // Extract source interface path from #[cm] attribute
+                // Format: #[cm("wasi:cli/terminal-input@0.3.0-rc-2026-01-06#terminal-input")]
                 let source_interface = resource
                     .attrs
                     .iter()
-                    .find(|a| a.name == "wasi")
+                    .find(|a| a.name == "cm")
                     .and_then(|a| a.args.first())
                     .and_then(|arg| arg.as_str().split('#').next())
                     .unwrap_or("")
@@ -379,13 +379,13 @@ impl WasiRegistry {
         // Collect struct types from this module (e.g., DnsErrorPayload -> DNS-error-payload)
         for item in &module.items {
             if let Item::Struct(struct_def) = item {
-                // Use the #[wasi] fragment as the CM name (preserves acronym casing)
-                let cm_name = wasi_attr_cm_name(&struct_def.attrs, &struct_def.name);
-                // Extract source interface path (part before #) from #[wasi] attribute
+                // Use the #[cm] fragment as the CM name (preserves acronym casing)
+                let cm_name = cm_attr_cm_name(&struct_def.attrs, &struct_def.name);
+                // Extract source interface path (part before #) from #[cm] attribute
                 let source_interface = struct_def
                     .attrs
                     .iter()
-                    .find(|a| a.name == "wasi")
+                    .find(|a| a.name == "cm")
                     .and_then(|a| a.args.first())
                     .and_then(|arg| arg.as_str().split('#').next())
                     .unwrap_or("")
@@ -393,7 +393,7 @@ impl WasiRegistry {
                 let fields: Vec<(String, Type)> = struct_def
                     .fields
                     .iter()
-                    .map(|f| (wasi_attr_cm_name(&f.attrs, &f.name), f.ty.clone()))
+                    .map(|f| (cm_attr_cm_name(&f.attrs, &f.name), f.ty.clone()))
                     .collect();
                 let wado_fields: Vec<(String, String, Type)> = struct_def
                     .fields
@@ -401,7 +401,7 @@ impl WasiRegistry {
                     .map(|f| {
                         (
                             f.name.clone(),
-                            wasi_attr_cm_name(&f.attrs, &f.name),
+                            cm_attr_cm_name(&f.attrs, &f.name),
                             f.ty.clone(),
                         )
                     })
@@ -416,16 +416,16 @@ impl WasiRegistry {
         // Collect flags types from this module
         for item in &module.items {
             if let Item::Flags(flags_def) = item {
-                // Use the #[wasi] fragment as the CM name (preserves acronym casing)
-                let cm_name = wasi_attr_cm_name(
+                // Use the #[cm] fragment as the CM name (preserves acronym casing)
+                let cm_name = cm_attr_cm_name(
                     flags_def.attributes.as_deref().unwrap_or(&[]),
                     &flags_def.name,
                 );
-                // Use per-member #[wasi] attr for CM name
+                // Use per-member #[cm] attr for CM name
                 let member_names: Vec<String> = flags_def
                     .flags
                     .iter()
-                    .map(|m| wasi_attr_cm_name(&m.attrs, &m.name))
+                    .map(|m| cm_attr_cm_name(&m.attrs, &m.name))
                     .collect();
                 self.flags
                     .insert(flags_def.name.clone(), (cm_name, member_names));
@@ -433,24 +433,24 @@ impl WasiRegistry {
         }
 
         // Collect enum types from this module
-        // Use interface path from #[wasi] attribute as key to distinguish same-named enums
+        // Use interface path from #[cm] attribute as key to distinguish same-named enums
         for item in &module.items {
             if let Item::Enum(enum_def) = item {
-                // Use the #[wasi] fragment as the CM name (preserves acronym casing)
-                let cm_name = wasi_attr_cm_name(&enum_def.attrs, &enum_def.name);
-                // Use per-case #[wasi] attr for CM name
+                // Use the #[cm] fragment as the CM name (preserves acronym casing)
+                let cm_name = cm_attr_cm_name(&enum_def.attrs, &enum_def.name);
+                // Use per-case #[cm] attr for CM name
                 let variant_names: Vec<String> = enum_def
                     .cases
                     .iter()
-                    .map(|c| wasi_attr_cm_name(&c.attrs, &c.name))
+                    .map(|c| cm_attr_cm_name(&c.attrs, &c.name))
                     .collect();
 
-                // Extract interface path from #[wasi] attribute if present
-                // Format: #[wasi("wasi:sockets/types@0.3.0-rc-2025-09-16#error-code")]
+                // Extract interface path from #[cm] attribute if present
+                // Format: #[cm("wasi:sockets/types@0.3.0-rc-2025-09-16#error-code")]
                 let interface_path = enum_def
                     .attrs
                     .iter()
-                    .find(|a| a.name == "wasi")
+                    .find(|a| a.name == "cm")
                     .and_then(|a| a.args.first())
                     .and_then(|arg| arg.as_str().split('#').next())
                     .map(str::to_string);
@@ -473,14 +473,14 @@ impl WasiRegistry {
         // Collect variant types from this module (e.g., HeaderError)
         for item in &module.items {
             if let Item::Variant(variant_def) = item {
-                // Use the #[wasi] fragment as the CM name (preserves acronym casing)
-                let cm_name = wasi_attr_cm_name(&variant_def.attrs, &variant_def.name);
+                // Use the #[cm] fragment as the CM name (preserves acronym casing)
+                let cm_name = cm_attr_cm_name(&variant_def.attrs, &variant_def.name);
                 // Store both CM and Wado names for each case
                 let cases: Vec<CmVariantCase> = variant_def
                     .cases
                     .iter()
                     .map(|c| CmVariantCase {
-                        cm_name: wasi_attr_cm_name(&c.attrs, &c.name),
+                        cm_name: cm_attr_cm_name(&c.attrs, &c.name),
                         wado_name: c.name.clone(),
                         payload: c.payload.clone(),
                     })
@@ -493,7 +493,7 @@ impl WasiRegistry {
                 let interface_path = variant_def
                     .attrs
                     .iter()
-                    .find(|a| a.name == "wasi")
+                    .find(|a| a.name == "cm")
                     .and_then(|a| a.args.first())
                     .and_then(|arg| arg.as_str().split('#').next())
                     .map(str::to_string);
@@ -523,9 +523,9 @@ impl WasiRegistry {
         for item in &module.items {
             if let Item::Effect(effect) = item {
                 for method in &effect.methods {
-                    if let Some(wasi) = method.attrs.first().and_then(|a| a.wasi_import.as_ref()) {
-                        // Extract CM param names from #[wasi_params] attribute
-                        let cm_param_names = extract_wasi_params_attr(&method.attrs);
+                    if let Some(wasi) = method.attrs.first().and_then(|a| a.cm_import.as_ref()) {
+                        // Extract CM param names from #[cm_params] attribute
+                        let cm_param_names = extract_cm_params_attr(&method.attrs);
                         let params: Vec<(String, String, Type)> = method
                             .params
                             .iter()
@@ -535,7 +535,7 @@ impl WasiRegistry {
                                     .get(i)
                                     .unwrap_or_else(|| {
                                         panic!(
-                                            "missing #[wasi_params] for param '{}' in {}.{}",
+                                            "missing #[cm_params] for param '{}' in {}.{}",
                                             p.name, effect.name, method.name
                                         )
                                     })
@@ -565,9 +565,9 @@ impl WasiRegistry {
         for item in &module.items {
             if let Item::Resource(resource) = item {
                 for method in &resource.methods {
-                    if let Some(wasi) = method.attrs.first().and_then(|a| a.wasi_import.as_ref()) {
-                        // Extract CM param names from #[wasi_params] attribute
-                        let cm_param_names = extract_wasi_params_attr(&method.attrs);
+                    if let Some(wasi) = method.attrs.first().and_then(|a| a.cm_import.as_ref()) {
+                        // Extract CM param names from #[cm_params] attribute
+                        let cm_param_names = extract_cm_params_attr(&method.attrs);
                         let params: Vec<(String, String, Type)> = method
                             .params
                             .iter()
@@ -577,7 +577,7 @@ impl WasiRegistry {
                                     .get(i)
                                     .unwrap_or_else(|| {
                                         panic!(
-                                            "missing #[wasi_params] for param '{}' in {}.{}",
+                                            "missing #[cm_params] for param '{}' in {}.{}",
                                             p.name, resource.name, method.name
                                         )
                                     })
@@ -794,7 +794,7 @@ impl WasiRegistry {
     pub fn find_interface_for_struct_cm_name(&self, cm_name: &str) -> Option<String> {
         for (wado_name, (struct_cm_name, source_path, _, _)) in &self.structs {
             if struct_cm_name == cm_name || wado_name == cm_name {
-                let wasi = WasiImport::parse(source_path)?;
+                let wasi = CmImport::parse(source_path)?;
                 return Some(wasi.interface);
             }
         }
@@ -934,7 +934,7 @@ impl WasiRegistry {
         &mut self,
         effect_name: &str,
         method_name: &str,
-        wasi: &WasiImport,
+        wasi: &CmImport,
         is_async: bool,
         params: Vec<(String, String, Type)>,
         return_type: Option<Type>,
@@ -1025,7 +1025,7 @@ impl WasiRegistry {
     pub fn interfaces(&self) -> impl Iterator<Item = WasiInterfaceInfo> + '_ {
         self.interfaces.iter().map(|(path, functions)| {
             // Parse the interface path to extract components
-            let wasi = WasiImport::parse(path);
+            let wasi = CmImport::parse(path);
 
             // Check if any function returns a resource type (Option<ResourceName>)
             let resource_type = functions
@@ -1058,7 +1058,7 @@ impl WasiRegistry {
     /// Check if a specific interface is in the registry (by interface name, e.g., "monotonic-clock")
     pub fn has_interface(&self, interface_name: &str) -> bool {
         self.interfaces.keys().any(|path| {
-            if let Some(wasi) = crate::ast::WasiImport::parse(path) {
+            if let Some(wasi) = crate::ast::CmImport::parse(path) {
                 wasi.interface == interface_name
             } else {
                 false
@@ -1080,7 +1080,7 @@ impl WasiRegistry {
     /// Returns None if no wasi:cli interfaces are registered.
     pub fn get_cli_version(&self) -> Option<&str> {
         for path in self.interfaces.keys() {
-            if let Some(wasi) = WasiImport::parse(path)
+            if let Some(wasi) = CmImport::parse(path)
                 && wasi.namespace == "wasi"
                 && wasi.package == "cli"
                 && wasi.version.is_some()
@@ -1100,7 +1100,7 @@ impl WasiRegistry {
     /// Returns the version string from the first interface of that package.
     pub fn get_package_version(&self, package: &str) -> Option<&str> {
         for path in self.interfaces.keys() {
-            if let Some(wasi) = WasiImport::parse(path)
+            if let Some(wasi) = CmImport::parse(path)
                 && wasi.namespace == "wasi"
                 && wasi.package == package
                 && let Some(at_pos) = path.find('@')
@@ -2518,7 +2518,7 @@ mod tests {
         let mut registry = WasiRegistry::new();
 
         let wasi =
-            WasiImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
+            CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
 
         registry.register(
             "Stdout",
@@ -2547,7 +2547,7 @@ mod tests {
 
         // Register stdout
         let stdout_wasi =
-            WasiImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
+            CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
         registry.register(
             "Stdout",
             "write_via_stream",
@@ -2563,7 +2563,7 @@ mod tests {
 
         // Register stderr - different interface, same function name
         let stderr_wasi =
-            WasiImport::parse("wasi:cli/stderr@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
+            CmImport::parse("wasi:cli/stderr@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
         registry.register(
             "Stderr",
             "write_via_stream",
@@ -2596,7 +2596,7 @@ mod tests {
         let mut registry = WasiRegistry::new();
 
         let wasi =
-            WasiImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
+            CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
 
         registry.register(
             "Stdout",

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -2517,8 +2517,7 @@ mod tests {
     fn test_register_and_resolve() {
         let mut registry = WasiRegistry::new();
 
-        let wasi =
-            CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
+        let wasi = CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
 
         registry.register(
             "Stdout",
@@ -2595,8 +2594,7 @@ mod tests {
     fn test_interfaces_iteration() {
         let mut registry = WasiRegistry::new();
 
-        let wasi =
-            CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
+        let wasi = CmImport::parse("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").unwrap();
 
         registry.register(
             "Stdout",

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -14,7 +14,7 @@ use crate::ast::{
     StoresEntry, StructDecl, StructField, StructLiteralExpr, StructLiteralField,
     StructPatternField, TaskReturnStmt, TestDecl, TraitDecl, TryOpExpr, TupleLiteralExpr,
     TupleTypeDecl, Type, UnaryExpr, UnaryOp, UseDecl, UseItem, UseItemSimple, VariantCase,
-    VariantDecl, WasiImport, WhileStmt, WorldDecl, WorldExport, WorldImport,
+    VariantDecl, CmImport, WhileStmt, WorldDecl, WorldExport, WorldImport,
 };
 use crate::token::{Span, Token, TokenKind};
 
@@ -622,9 +622,9 @@ impl Parser {
 
         self.expect(&TokenKind::RBracket)?;
 
-        // Parse WASI import path if this is a wasi attribute
-        let wasi_import = if name == "wasi" {
-            args.first().and_then(|s| WasiImport::parse(s.as_str()))
+        // Parse CM import path if this is a cm attribute
+        let cm_import = if name == "cm" {
+            args.first().and_then(|s| CmImport::parse(s.as_str()))
         } else {
             None
         };
@@ -632,7 +632,7 @@ impl Parser {
         Ok(Attribute {
             name,
             args,
-            wasi_import,
+            cm_import,
             span: start_span,
         })
     }
@@ -3261,7 +3261,7 @@ impl Parser {
     }
 
     fn parse_effect_method(&mut self) -> ParseResult<EffectMethod> {
-        // Parse any attributes on the method (e.g., #[wasi("...")])
+        // Parse any attributes on the method (e.g., #[cm("...")])
         let attrs = self.parse_attributes()?;
 
         let start_span = self.peek().span;
@@ -4574,10 +4574,10 @@ mod tests {
     }
 
     #[test]
-    fn test_effect_with_wasi_attribute() {
+    fn test_effect_with_cm_attribute() {
         let source = r#"
             pub effect Stdout {
-                #[wasi("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream")]
+                #[cm("wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream")]
                 async fn write_via_stream(data: Stream<u8>) -> Result<(), ErrorCode>;
             }
         "#;
@@ -4595,14 +4595,14 @@ mod tests {
             assert_eq!(method.attrs.len(), 1);
 
             let attr = &method.attrs[0];
-            assert_eq!(attr.name, "wasi");
-            assert!(attr.wasi_import.is_some());
+            assert_eq!(attr.name, "cm");
+            assert!(attr.cm_import.is_some());
 
-            let wasi = attr.wasi_import.as_ref().unwrap();
-            assert_eq!(wasi.namespace, "wasi");
-            assert_eq!(wasi.package, "cli");
-            assert_eq!(wasi.interface, "stdout");
-            assert_eq!(wasi.function.as_deref(), Some("write-via-stream"));
+            let cm = attr.cm_import.as_ref().unwrap();
+            assert_eq!(cm.namespace, "wasi");
+            assert_eq!(cm.package, "cli");
+            assert_eq!(cm.interface, "stdout");
+            assert_eq!(cm.function.as_deref(), Some("write-via-stream"));
         } else {
             panic!("expected effect declaration");
         }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -4,7 +4,7 @@
 use crate::ast::{
     AssertStmt, AssignExpr, AssociatedConst, AssociatedTypeBinding, AssociatedTypeDecl, AttrArg,
     Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, CallExpr, CastExpr, ChainedComparison,
-    ClosureExpr, ClosureParam, ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp,
+    ClosureExpr, ClosureParam, CmImport, ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp,
     Condition, ConditionElement, ContinueStmt, EffectDecl, EffectMethod, EnumCase, EnumDecl, Expr,
     ExprStmt, FieldAccessExpr, FlagsDecl, FlagsVariant, ForOfStmt, ForStmt, FormatSpec, Function,
     FunctionType, GenericType, GlobalDecl, IdentExpr, IfExpr, IfStmt, ImplBlock, ImportAttributes,
@@ -14,7 +14,7 @@ use crate::ast::{
     StoresEntry, StructDecl, StructField, StructLiteralExpr, StructLiteralField,
     StructPatternField, TaskReturnStmt, TestDecl, TraitDecl, TryOpExpr, TupleLiteralExpr,
     TupleTypeDecl, Type, UnaryExpr, UnaryOp, UseDecl, UseItem, UseItemSimple, VariantCase,
-    VariantDecl, CmImport, WhileStmt, WorldDecl, WorldExport, WorldImport,
+    VariantDecl, WhileStmt, WorldDecl, WorldExport, WorldImport,
 };
 use crate::token::{Span, Token, TokenKind};
 

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -6,7 +6,7 @@
 use crate::hashmap::IndexMap;
 use std::ops::Index;
 
-use crate::ast::WasiImport;
+use crate::ast::CmImport;
 use crate::name::ModuleSource;
 use crate::token::Span;
 
@@ -85,8 +85,8 @@ pub struct FunctionSymbol {
     pub effects: Vec<String>,
     /// Whether this is a builtin function (e.g., println from `core::cli`)
     pub is_builtin: bool,
-    /// WASI import metadata if this function maps to a WASI function
-    pub wasi_import: Option<WasiImport>,
+    /// CM import metadata if this function maps to a CM function
+    pub cm_import: Option<CmImport>,
 }
 
 /// Effect symbol data
@@ -94,8 +94,8 @@ pub struct FunctionSymbol {
 pub struct EffectSymbol {
     /// Method names defined in this effect
     pub methods: Vec<String>,
-    /// WASI import metadata if this effect maps to a WASI interface
-    pub wasi_import: Option<WasiImport>,
+    /// CM import metadata if this effect maps to a CM interface
+    pub cm_import: Option<CmImport>,
 }
 
 /// Struct symbol data
@@ -163,8 +163,8 @@ pub struct GlobalSymbol {
 pub struct ResourceSymbol {
     /// Method names defined on this resource
     pub methods: Vec<String>,
-    /// WASI import metadata if this resource maps to a WASI resource
-    pub wasi_import: Option<WasiImport>,
+    /// CM import metadata if this resource maps to a CM resource
+    pub cm_import: Option<CmImport>,
 }
 
 /// World symbol data
@@ -219,12 +219,12 @@ impl Symbol {
         matches!(&self.kind, SymbolKind::Function(f) if f.is_builtin)
     }
 
-    /// Get the WASI import metadata if this symbol has one
-    pub fn wasi_import(&self) -> Option<&WasiImport> {
+    /// Get the CM import metadata if this symbol has one
+    pub fn cm_import(&self) -> Option<&CmImport> {
         match &self.kind {
-            SymbolKind::Function(f) => f.wasi_import.as_ref(),
-            SymbolKind::Effect(e) => e.wasi_import.as_ref(),
-            SymbolKind::Resource(r) => r.wasi_import.as_ref(),
+            SymbolKind::Function(f) => f.cm_import.as_ref(),
+            SymbolKind::Effect(e) => e.cm_import.as_ref(),
+            SymbolKind::Resource(r) => r.cm_import.as_ref(),
             _ => None,
         }
     }
@@ -518,7 +518,7 @@ mod tests {
                 return_type: None,
                 effects: vec!["Stdout".to_string()],
                 is_builtin: true,
-                wasi_import: None,
+                cm_import: None,
             }),
             &core_cli,
             None,
@@ -542,7 +542,7 @@ mod tests {
                 return_type: None,
                 effects: vec![],
                 is_builtin: true,
-                wasi_import: None,
+                cm_import: None,
             }),
             &core_cli,
             None,

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -3090,8 +3090,8 @@ pub struct WirNames {
 /// Component Model wrapper information.
 #[derive(Debug, Default)]
 pub struct WirComponent {
-    /// WASI interfaces to import.
-    pub wasi_imports: Vec<WirWasiImport>,
+    /// Component Model interfaces to import.
+    pub cm_imports: Vec<WirCmImport>,
     /// Bundled modules (fts, libm).
     pub bundled_modules: Vec<WirBundledModule>,
     /// World exports.
@@ -3100,18 +3100,18 @@ pub struct WirComponent {
     pub memory: WirMemoryConfig,
 }
 
-/// A WASI interface import.
+/// A Component Model interface import.
 #[derive(Debug)]
-pub struct WirWasiImport {
+pub struct WirCmImport {
     /// Interface name (e.g., "wasi:cli/stdout@0.2.0").
     pub interface: String,
     /// Functions imported from this interface.
-    pub functions: Vec<WirWasiFunc>,
+    pub functions: Vec<WirCmFunc>,
 }
 
-/// A function from a WASI interface.
+/// A function from a CM interface.
 #[derive(Debug)]
-pub struct WirWasiFunc {
+pub struct WirCmFunc {
     /// WIT-level function name (e.g., "write-via-stream").
     pub wit_name: String,
     /// Internal function name in the core module.

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -4,7 +4,7 @@
 //! and provides export signature information for code generation.
 //!
 //! Worlds are keyed by their fully-qualified name (e.g., "wasi:cli/command",
-//! "wasi:http/service") derived from the `#[wasi("...")]` attribute.
+//! "wasi:http/service") derived from the `#[cm("...")]` attribute.
 
 use crate::hashmap::IndexMap;
 
@@ -105,13 +105,13 @@ pub struct WorldRegistry {
     worlds: IndexMap<String, WorldInfo>,
 }
 
-/// Extract the fully-qualified world name (without version) from `#[wasi("...")]` attribute.
+/// Extract the fully-qualified world name (without version) from `#[cm("...")]` attribute.
 ///
-/// For example, `#[wasi("wasi:cli/command@0.3.0-rc-2026-01-06")]` returns `"wasi:cli/command"`.
+/// For example, `#[cm("wasi:cli/command@0.3.0-rc-2026-01-06")]` returns `"wasi:cli/command"`.
 fn fq_name_from_attrs(attrs: &[crate::ast::Attribute]) -> Option<String> {
     attrs
         .iter()
-        .find(|a| a.name == "wasi")
+        .find(|a| a.name == "cm")
         .and_then(|a| a.args.first())
         .map(|arg| {
             let s = arg.as_str();
@@ -132,7 +132,7 @@ impl WorldRegistry {
 
     /// Register a world from a parsed world declaration.
     ///
-    /// The world is keyed by its fully-qualified name from the `#[wasi("...")]` attribute.
+    /// The world is keyed by its fully-qualified name from the `#[cm("...")]` attribute.
     /// If no attribute is present, the `PascalCase` name is used as fallback.
     pub fn register(&mut self, world: &WorldDecl) {
         let fq_name = fq_name_from_attrs(&world.attrs).unwrap_or_else(|| world.name.clone());
@@ -197,9 +197,9 @@ mod tests {
             name: "Command".to_string(),
             is_pub: false,
             attrs: vec![Attribute {
-                name: "wasi".to_string(),
+                name: "cm".to_string(),
                 args: vec![ast::AttrArg::Str("wasi:cli/command@0.3.0".to_string())],
-                wasi_import: None,
+                cm_import: None,
                 span: make_span(),
             }],
             imports: vec![],

--- a/wado-compiler/tests/format.fixtures.golden/no_prelude.clean.wado
+++ b/wado-compiler/tests/format.fixtures.golden/no_prelude.clean.wado
@@ -4,7 +4,7 @@
 use { println } from "core:cli";
 
 /// Doc comment on enum
-#[wasi("my-enum")]
+#[cm("my-enum")]
 enum Color {
     /// Red case
     Red,
@@ -15,7 +15,7 @@ enum Color {
 }
 
 /// Doc comment on variant
-#[wasi("my-variant")]
+#[cm("my-variant")]
 variant Shape {
     /// Circle with radius
     Circle(f64),
@@ -66,39 +66,39 @@ pub resource Stream {
 }
 
 /// Type alias with attribute preserved
-#[wasi("wasi:http/types#field-name")]
+#[cm("wasi:http/types#field-name")]
 pub type FieldName = String;
 
 /// Type alias with attribute and no visibility
-#[wasi("wasi:http/types#status-code")]
+#[cm("wasi:http/types#status-code")]
 type StatusCode = u16;
 
 /// Enum with attributed cases (no extra blank lines)
-#[wasi("wasi:sockets/types#ip-address-family")]
+#[cm("wasi:sockets/types#ip-address-family")]
 enum IpFamily {
-    #[wasi("ipv4")]
+    #[cm("ipv4")]
     Ipv4,
-    #[wasi("ipv6")]
+    #[cm("ipv6")]
     Ipv6,
 }
 
 /// Variant with attributed cases (no extra blank lines)
-#[wasi("wasi:http/types#scheme")]
+#[cm("wasi:http/types#scheme")]
 variant Scheme {
-    #[wasi("HTTP")]
+    #[cm("HTTP")]
     Http,
-    #[wasi("HTTPS")]
+    #[cm("HTTPS")]
     Https,
-    #[wasi("other")]
+    #[cm("other")]
     Other(String),
 }
 
 /// Struct with attributed fields (no extra blank lines)
-#[wasi("wasi:http/types#dns-error-payload")]
+#[cm("wasi:http/types#dns-error-payload")]
 struct DnsError {
-    #[wasi("rcode")]
+    #[cm("rcode")]
     pub rcode: Option<String>,
-    #[wasi("info-code")]
+    #[cm("info-code")]
     pub info_code: Option<u16>,
 }
 

--- a/wado-compiler/tests/format.fixtures/no_prelude.dirty.wado
+++ b/wado-compiler/tests/format.fixtures/no_prelude.dirty.wado
@@ -4,7 +4,7 @@
 use { println } from "core:cli";
 
 /// Doc comment on enum
-#[wasi("my-enum")]
+#[cm("my-enum")]
 enum Color {
     /// Red case
     Red,
@@ -15,7 +15,7 @@ enum Color {
 }
 
 /// Doc comment on variant
-#[wasi("my-variant")]
+#[cm("my-variant")]
 variant Shape {
     /// Circle with radius
     Circle(f64),
@@ -66,39 +66,39 @@ pub resource Stream {
 }
 
 /// Type alias with attribute preserved
-#[wasi("wasi:http/types#field-name")]
+#[cm("wasi:http/types#field-name")]
 pub type FieldName = String;
 
 /// Type alias with attribute and no visibility
-#[wasi("wasi:http/types#status-code")]
+#[cm("wasi:http/types#status-code")]
 type StatusCode = u16;
 
 /// Enum with attributed cases (no extra blank lines)
-#[wasi("wasi:sockets/types#ip-address-family")]
+#[cm("wasi:sockets/types#ip-address-family")]
 enum IpFamily {
-    #[wasi("ipv4")]
+    #[cm("ipv4")]
     Ipv4,
-    #[wasi("ipv6")]
+    #[cm("ipv6")]
     Ipv6,
 }
 
 /// Variant with attributed cases (no extra blank lines)
-#[wasi("wasi:http/types#scheme")]
+#[cm("wasi:http/types#scheme")]
 variant Scheme {
-    #[wasi("HTTP")]
+    #[cm("HTTP")]
     Http,
-    #[wasi("HTTPS")]
+    #[cm("HTTPS")]
     Https,
-    #[wasi("other")]
+    #[cm("other")]
     Other(String),
 }
 
 /// Struct with attributed fields (no extra blank lines)
-#[wasi("wasi:http/types#dns-error-payload")]
+#[cm("wasi:http/types#dns-error-payload")]
 struct DnsError {
-    #[wasi("rcode")]
+    #[cm("rcode")]
     pub rcode: Option<String>,
-    #[wasi("info-code")]
+    #[cm("info-code")]
     pub info_code: Option<u16>,
 }
 

--- a/wado-from-wit/src/codegen.rs
+++ b/wado-from-wit/src/codegen.rs
@@ -92,8 +92,8 @@ impl WadoCodeGenerator {
                 {
                     return;
                 }
-                if let Some(ref attr) = a.wasi_attr {
-                    self.writeln(&format!("#[wasi(\"{attr}\")]"));
+                if let Some(ref attr) = a.cm_attr {
+                    self.writeln(&format!("#[cm(\"{attr}\")]"));
                 }
                 self.writeln(&format!(
                     "pub type {} = {};",
@@ -106,16 +106,16 @@ impl WadoCodeGenerator {
 
     fn write_enum(&mut self, e: &WadoEnum) {
         self.write_doc_comment(e.doc_comment.as_ref());
-        if let Some(ref attr) = e.wasi_attr {
-            self.writeln(&format!("#[wasi(\"{attr}\")]"));
+        if let Some(ref attr) = e.cm_attr {
+            self.writeln(&format!("#[cm(\"{attr}\")]"));
         }
         self.writeln(&format!("pub enum {} {{", e.name));
         self.indent += 1;
 
         for variant in &e.variants {
             self.write_doc_comment(variant.doc_comment.as_ref());
-            if let Some(ref attr) = variant.wasi_attr {
-                self.writeln(&format!("#[wasi(\"{attr}\")]"));
+            if let Some(ref attr) = variant.cm_attr {
+                self.writeln(&format!("#[cm(\"{attr}\")]"));
             }
             self.writeln(&format!("{},", variant.name));
         }
@@ -126,15 +126,15 @@ impl WadoCodeGenerator {
 
     fn write_flags(&mut self, f: &WadoFlags) {
         self.write_doc_comment(f.doc_comment.as_ref());
-        if let Some(ref attr) = f.wasi_attr {
-            self.writeln(&format!("#[wasi(\"{attr}\")]"));
+        if let Some(ref attr) = f.cm_attr {
+            self.writeln(&format!("#[cm(\"{attr}\")]"));
         }
         self.writeln(&format!("pub flags {} {{", f.name));
         self.indent += 1;
 
         for flag in &f.flags {
             self.write_doc_comment(flag.doc_comment.as_ref());
-            self.writeln(&format!("#[wasi(\"{}\")]", flag.wasi_attr));
+            self.writeln(&format!("#[cm(\"{}\")]", flag.cm_attr));
             self.writeln(&format!("{},", flag.name));
         }
 
@@ -144,15 +144,15 @@ impl WadoCodeGenerator {
 
     fn write_struct(&mut self, s: &WadoStruct) {
         self.write_doc_comment(s.doc_comment.as_ref());
-        if let Some(ref attr) = s.wasi_attr {
-            self.writeln(&format!("#[wasi(\"{attr}\")]"));
+        if let Some(ref attr) = s.cm_attr {
+            self.writeln(&format!("#[cm(\"{attr}\")]"));
         }
         self.writeln(&format!("pub struct {} {{", s.name));
         self.indent += 1;
 
         for field in &s.fields {
             self.write_doc_comment(field.doc_comment.as_ref());
-            self.writeln(&format!("#[wasi(\"{}\")]", field.wasi_attr));
+            self.writeln(&format!("#[cm(\"{}\")]", field.cm_attr));
             self.writeln(&format!(
                 "pub {}: {},",
                 field.name,
@@ -166,16 +166,16 @@ impl WadoCodeGenerator {
 
     fn write_variant(&mut self, v: &WadoVariant) {
         self.write_doc_comment(v.doc_comment.as_ref());
-        if let Some(ref attr) = v.wasi_attr {
-            self.writeln(&format!("#[wasi(\"{attr}\")]"));
+        if let Some(ref attr) = v.cm_attr {
+            self.writeln(&format!("#[cm(\"{attr}\")]"));
         }
         self.writeln(&format!("pub variant {} {{", v.name));
         self.indent += 1;
 
         for case in &v.cases {
             self.write_doc_comment(case.doc_comment.as_ref());
-            if let Some(ref attr) = case.wasi_attr {
-                self.writeln(&format!("#[wasi(\"{attr}\")]"));
+            if let Some(ref attr) = case.cm_attr {
+                self.writeln(&format!("#[cm(\"{attr}\")]"));
             }
             match &case.payload {
                 Some(ty) => self.writeln(&format!("{}({}),", case.name, Self::format_type(ty))),
@@ -189,7 +189,7 @@ impl WadoCodeGenerator {
 
     fn write_resource(&mut self, resource: &WadoResource) {
         self.write_doc_comment(resource.doc_comment.as_ref());
-        self.writeln(&format!("#[wasi(\"{}\")]", resource.wasi_attr));
+        self.writeln(&format!("#[cm(\"{}\")]", resource.cm_attr));
 
         if resource.methods.is_empty() {
             self.writeln(&format!("pub resource {};", resource.name));
@@ -208,7 +208,7 @@ impl WadoCodeGenerator {
 
     fn write_effect(&mut self, effect: &WadoEffect) {
         self.write_doc_comment(effect.doc_comment.as_ref());
-        self.writeln(&format!("#[wasi(\"{}\")]", effect.wasi_interface));
+        self.writeln(&format!("#[cm(\"{}\")]", effect.cm_interface));
         self.writeln(&format!("pub effect {} {{", effect.name));
         self.indent += 1;
 
@@ -222,16 +222,16 @@ impl WadoCodeGenerator {
 
     fn write_function(&mut self, func: &WadoFunction) {
         self.write_doc_comment(func.doc_comment.as_ref());
-        self.writeln(&format!("#[wasi(\"{}\")]", func.wasi_attr));
+        self.writeln(&format!("#[cm(\"{}\")]", func.cm_attr));
 
-        // Emit #[wasi_params] with original WIT kebab-case parameter names
+        // Emit #[cm_params] with original WIT kebab-case parameter names
         if !func.params.is_empty() {
             let wit_names: Vec<String> = func
                 .params
                 .iter()
                 .map(|p| format!("\"{}\"", p.wit_name))
                 .collect();
-            self.writeln(&format!("#[wasi_params({})]", wit_names.join(", ")));
+            self.writeln(&format!("#[cm_params({})]", wit_names.join(", ")));
         }
 
         let params = Self::format_params(&func.params);
@@ -253,7 +253,7 @@ impl WadoCodeGenerator {
     fn write_world(&mut self, world: &WadoWorld) {
         self.write_doc_comment(world.doc_comment.as_ref());
         // Write the canonical WIT world name as an attribute
-        self.writeln(&format!("#[wasi(\"{}\")]", world.canonical_name));
+        self.writeln(&format!("#[cm(\"{}\")]", world.canonical_name));
         self.writeln(&format!("pub world {} {{", world.name));
         self.indent += 1;
 

--- a/wado-from-wit/src/ir.rs
+++ b/wado-from-wit/src/ir.rs
@@ -88,7 +88,7 @@ pub enum WadoTypeDef {
 pub struct WadoEnum {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_attr: Option<String>,
+    pub cm_attr: Option<String>,
     pub variants: Vec<WadoEnumVariant>,
 }
 
@@ -96,15 +96,15 @@ pub struct WadoEnum {
 pub struct WadoEnumVariant {
     pub name: String,
     pub doc_comment: Option<String>,
-    /// Original WIT kebab-case name for the `#[wasi("...")]` attribute
-    pub wasi_attr: Option<String>,
+    /// Original WIT kebab-case name for the `#[cm("...")]` attribute
+    pub cm_attr: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct WadoFlags {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_attr: Option<String>,
+    pub cm_attr: Option<String>,
     pub flags: Vec<WadoFlagMember>,
 }
 
@@ -112,15 +112,15 @@ pub struct WadoFlags {
 pub struct WadoFlagMember {
     pub name: String,
     pub doc_comment: Option<String>,
-    /// Original WIT kebab-case name for the `#[wasi("...")]` attribute
-    pub wasi_attr: String,
+    /// Original WIT kebab-case name for the `#[cm("...")]` attribute
+    pub cm_attr: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct WadoStruct {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_attr: Option<String>,
+    pub cm_attr: Option<String>,
     pub fields: Vec<WadoField>,
 }
 
@@ -129,15 +129,15 @@ pub struct WadoField {
     pub name: String,
     pub ty: WadoType,
     pub doc_comment: Option<String>,
-    /// Original WIT kebab-case name for the `#[wasi("...")]` attribute
-    pub wasi_attr: String,
+    /// Original WIT kebab-case name for the `#[cm("...")]` attribute
+    pub cm_attr: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct WadoVariant {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_attr: Option<String>,
+    pub cm_attr: Option<String>,
     pub cases: Vec<WadoVariantCase>,
 }
 
@@ -146,14 +146,14 @@ pub struct WadoVariantCase {
     pub name: String,
     pub payload: Option<WadoType>,
     pub doc_comment: Option<String>,
-    /// Original WIT kebab-case name for the `#[wasi("...")]` attribute
-    pub wasi_attr: Option<String>,
+    /// Original WIT kebab-case name for the `#[cm("...")]` attribute
+    pub cm_attr: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct WadoNewtype {
     pub name: String,
-    pub wasi_attr: Option<String>,
+    pub cm_attr: Option<String>,
     pub target: WadoType,
 }
 
@@ -161,7 +161,7 @@ pub struct WadoNewtype {
 pub struct WadoResource {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_attr: String,
+    pub cm_attr: String,
     pub methods: Vec<WadoFunction>,
 }
 
@@ -169,7 +169,7 @@ pub struct WadoResource {
 pub struct WadoEffect {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_interface: String,
+    pub cm_interface: String,
     pub functions: Vec<WadoFunction>,
 }
 
@@ -177,7 +177,7 @@ pub struct WadoEffect {
 pub struct WadoFunction {
     pub name: String,
     pub doc_comment: Option<String>,
-    pub wasi_attr: String,
+    pub cm_attr: String,
     pub params: Vec<WadoParam>,
     pub return_type: Option<WadoType>,
     pub is_async: bool,
@@ -188,7 +188,7 @@ pub struct WadoFunction {
 pub struct WadoParam {
     pub name: String,
     pub ty: WadoType,
-    /// Original WIT kebab-case name for the `#[wasi_params]` attribute
+    /// Original WIT kebab-case name for the `#[cm_params]` attribute
     pub wit_name: String,
 }
 

--- a/wado-from-wit/src/transform.rs
+++ b/wado-from-wit/src/transform.rs
@@ -41,9 +41,9 @@ impl<'a> Transformer<'a> {
     /// Returns an error if type transformation fails.
     pub fn transform_interface(&self, iface_id: InterfaceId) -> Result<WadoModule> {
         let iface = &self.resolve.interfaces[iface_id];
-        let (pkg_name, iface_name, version) = self.get_interface_path(iface_id);
+        let (namespace, pkg_name, iface_name, version) = self.get_interface_path(iface_id);
 
-        let wasi_interface = format!("wasi:{pkg_name}/{iface_name}@{version}");
+        let cm_interface = format!("{namespace}:{pkg_name}/{iface_name}@{version}");
 
         // Track current interface for cross-interface import detection
         *self.current_interface.borrow_mut() = Some(iface_id);
@@ -53,14 +53,14 @@ impl<'a> Transformer<'a> {
 
         // Transform types
         for (_, type_id) in &iface.types {
-            if let Some(type_def) = self.transform_type_def(*type_id, &wasi_interface)? {
+            if let Some(type_def) = self.transform_type_def(*type_id, &cm_interface)? {
                 module.types.push(type_def);
             }
         }
 
         // Transform resources
         for (_, type_id) in &iface.types {
-            if let Some(resource) = self.transform_resource(*type_id, &wasi_interface)? {
+            if let Some(resource) = self.transform_resource(*type_id, &cm_interface)? {
                 module.resources.push(resource);
             }
         }
@@ -75,14 +75,14 @@ impl<'a> Transformer<'a> {
                     FunctionKind::Freestanding | FunctionKind::AsyncFreestanding
                 )
             })
-            .map(|(name, func)| self.transform_function(name, func, &wasi_interface))
+            .map(|(name, func)| self.transform_function(name, func, &cm_interface))
             .collect::<Result<Vec<_>>>()?;
 
         if !functions.is_empty() {
             module.effects.push(WadoEffect {
                 name: to_upper_camel_case(&iface_name),
                 doc_comment: iface.docs.contents.clone(),
-                wasi_interface,
+                cm_interface,
                 functions,
             });
         }
@@ -238,21 +238,22 @@ impl<'a> Transformer<'a> {
         }
     }
 
-    fn get_interface_path(&self, iface_id: InterfaceId) -> (String, String, String) {
+    fn get_interface_path(&self, iface_id: InterfaceId) -> (String, String, String, String) {
         let iface = &self.resolve.interfaces[iface_id];
         let iface_name = iface.name.clone().unwrap_or_else(|| "unknown".to_string());
 
         if let Some(pkg_id) = iface.package {
             let pkg = &self.resolve.packages[pkg_id];
+            let namespace = pkg.name.namespace.clone();
             let pkg_name = pkg.name.name.clone();
             let version = pkg
                 .name
                 .version
                 .as_ref()
                 .map_or_else(|| "0.0.0".to_string(), ToString::to_string);
-            (pkg_name, iface_name, version)
+            (namespace, pkg_name, iface_name, version)
         } else {
-            ("unknown".to_string(), iface_name, "0.0.0".to_string())
+            ("unknown".to_string(), "unknown".to_string(), iface_name, "0.0.0".to_string())
         }
     }
 
@@ -265,9 +266,9 @@ impl<'a> Transformer<'a> {
         &self,
         name: &str,
         func: &Function,
-        wasi_interface: &str,
+        cm_interface: &str,
     ) -> Result<WadoFunction> {
-        let wasi_attr = format!("{wasi_interface}#{name}");
+        let cm_attr = format!("{cm_interface}#{name}");
 
         let params = self.transform_params(&func.params)?;
         let return_type = self.transform_result(func.result.as_ref())?;
@@ -278,7 +279,7 @@ impl<'a> Transformer<'a> {
         Ok(WadoFunction {
             name: to_snake_case(name),
             doc_comment: func.docs.contents.clone(),
-            wasi_attr,
+            cm_attr,
             params,
             return_type,
             is_async,
@@ -415,7 +416,7 @@ impl<'a> Transformer<'a> {
     fn transform_type_def(
         &self,
         type_id: TypeId,
-        wasi_interface: &str,
+        cm_interface: &str,
     ) -> Result<Option<WadoTypeDef>> {
         let ty = &self.resolve.types[type_id];
 
@@ -425,30 +426,30 @@ impl<'a> Transformer<'a> {
             None => return Ok(None),
         };
 
-        let wasi_attr = format!("{}#{}", wasi_interface, ty.name.as_ref().unwrap());
+        let cm_attr = format!("{}#{}", cm_interface, ty.name.as_ref().unwrap());
         let doc_comment = ty.docs.contents.clone();
 
         let def = match &ty.kind {
             TypeDefKind::Enum(e) => {
-                WadoTypeDef::Enum(Self::transform_enum(e, name, doc_comment, wasi_attr))
+                WadoTypeDef::Enum(Self::transform_enum(e, name, doc_comment, cm_attr))
             }
             TypeDefKind::Flags(f) => {
-                WadoTypeDef::Flags(Self::transform_flags(f, name, doc_comment, wasi_attr))
+                WadoTypeDef::Flags(Self::transform_flags(f, name, doc_comment, cm_attr))
             }
             TypeDefKind::Record(r) => {
-                WadoTypeDef::Struct(self.transform_record(r, name, doc_comment, wasi_attr)?)
+                WadoTypeDef::Struct(self.transform_record(r, name, doc_comment, cm_attr)?)
             }
             TypeDefKind::Variant(v) => {
-                WadoTypeDef::Variant(self.transform_variant(v, name, doc_comment, wasi_attr)?)
+                WadoTypeDef::Variant(self.transform_variant(v, name, doc_comment, cm_attr)?)
             }
             TypeDefKind::Type(inner) => WadoTypeDef::Newtype(WadoNewtype {
                 name,
-                wasi_attr: Some(wasi_attr),
+                cm_attr: Some(cm_attr),
                 target: self.transform_type(*inner)?,
             }),
             TypeDefKind::Tuple(t) => WadoTypeDef::Newtype(WadoNewtype {
                 name,
-                wasi_attr: Some(wasi_attr),
+                cm_attr: Some(cm_attr),
                 target: WadoType::Tuple(
                     t.types
                         .iter()
@@ -458,7 +459,7 @@ impl<'a> Transformer<'a> {
             }),
             TypeDefKind::List(inner) => WadoTypeDef::Newtype(WadoNewtype {
                 name,
-                wasi_attr: Some(wasi_attr),
+                cm_attr: Some(cm_attr),
                 target: WadoType::Array(Box::new(self.transform_type(*inner)?)),
             }),
             _ => return Ok(None),
@@ -470,7 +471,7 @@ impl<'a> Transformer<'a> {
         e: &wit_parser::Enum,
         name: String,
         doc_comment: Option<String>,
-        wasi_attr: String,
+        cm_attr: String,
     ) -> WadoEnum {
         let variants = e
             .cases
@@ -478,13 +479,13 @@ impl<'a> Transformer<'a> {
             .map(|case| WadoEnumVariant {
                 name: to_upper_camel_case(&case.name),
                 doc_comment: case.docs.contents.clone(),
-                wasi_attr: Some(case.name.clone()),
+                cm_attr: Some(case.name.clone()),
             })
             .collect();
         WadoEnum {
             name,
             doc_comment,
-            wasi_attr: Some(wasi_attr),
+            cm_attr: Some(cm_attr),
             variants,
         }
     }
@@ -493,7 +494,7 @@ impl<'a> Transformer<'a> {
         f: &wit_parser::Flags,
         name: String,
         doc_comment: Option<String>,
-        wasi_attr: String,
+        cm_attr: String,
     ) -> WadoFlags {
         let flags = f
             .flags
@@ -501,13 +502,13 @@ impl<'a> Transformer<'a> {
             .map(|flag| WadoFlagMember {
                 name: to_upper_camel_case(&flag.name),
                 doc_comment: flag.docs.contents.clone(),
-                wasi_attr: flag.name.clone(),
+                cm_attr: flag.name.clone(),
             })
             .collect();
         WadoFlags {
             name,
             doc_comment,
-            wasi_attr: Some(wasi_attr),
+            cm_attr: Some(cm_attr),
             flags,
         }
     }
@@ -517,7 +518,7 @@ impl<'a> Transformer<'a> {
         r: &wit_parser::Record,
         name: String,
         doc_comment: Option<String>,
-        wasi_attr: String,
+        cm_attr: String,
     ) -> Result<WadoStruct> {
         let fields = r
             .fields
@@ -527,14 +528,14 @@ impl<'a> Transformer<'a> {
                     name: to_snake_case(&field.name),
                     ty: self.transform_type(field.ty)?,
                     doc_comment: field.docs.contents.clone(),
-                    wasi_attr: field.name.clone(),
+                    cm_attr: field.name.clone(),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(WadoStruct {
             name,
             doc_comment,
-            wasi_attr: Some(wasi_attr),
+            cm_attr: Some(cm_attr),
             fields,
         })
     }
@@ -544,7 +545,7 @@ impl<'a> Transformer<'a> {
         v: &wit_parser::Variant,
         name: String,
         doc_comment: Option<String>,
-        wasi_attr: String,
+        cm_attr: String,
     ) -> Result<WadoVariant> {
         let cases = v
             .cases
@@ -554,14 +555,14 @@ impl<'a> Transformer<'a> {
                     name: to_upper_camel_case(&case.name),
                     payload: case.ty.map(|t| self.transform_type(t)).transpose()?,
                     doc_comment: case.docs.contents.clone(),
-                    wasi_attr: Some(case.name.clone()),
+                    cm_attr: Some(case.name.clone()),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(WadoVariant {
             name,
             doc_comment,
-            wasi_attr: Some(wasi_attr),
+            cm_attr: Some(cm_attr),
             cases,
         })
     }
@@ -569,7 +570,7 @@ impl<'a> Transformer<'a> {
     fn transform_resource(
         &self,
         type_id: TypeId,
-        wasi_interface: &str,
+        cm_interface: &str,
     ) -> Result<Option<WadoResource>> {
         let ty = &self.resolve.types[type_id];
 
@@ -582,7 +583,7 @@ impl<'a> Transformer<'a> {
             None => return Ok(None),
         };
 
-        let wasi_attr = format!("{}#{}", wasi_interface, ty.name.as_ref().unwrap());
+        let cm_attr = format!("{}#{}", cm_interface, ty.name.as_ref().unwrap());
 
         // Find methods for this resource
         let mut methods = Vec::new();
@@ -619,14 +620,14 @@ impl<'a> Transformer<'a> {
                         // Constructor: wasi attr is "interface#[constructor]resource-name"
                         // Wado name is "new"
                         (
-                            format!("{wasi_interface}#[constructor]{resource_wit_name}"),
+                            format!("{cm_interface}#[constructor]{resource_wit_name}"),
                             "new".to_string(),
                         )
                     } else {
                         // Method/Static: extract just the method name after the dot
                         let raw_method = func_name.split('.').next_back().unwrap_or(func_name);
                         let method_attr = format!(
-                            "{wasi_interface}#{kind_prefix}{resource_wit_name}.{raw_method}"
+                            "{cm_interface}#{kind_prefix}{resource_wit_name}.{raw_method}"
                         );
                         (method_attr, to_snake_case(raw_method))
                     };
@@ -634,7 +635,7 @@ impl<'a> Transformer<'a> {
                     methods.push(WadoFunction {
                         name: method_name,
                         doc_comment: func.docs.contents.clone(),
-                        wasi_attr: method_attr,
+                        cm_attr: method_attr,
                         params: self.transform_params(&func.params)?,
                         return_type: self.transform_result(func.result.as_ref())?,
                         is_async,
@@ -647,7 +648,7 @@ impl<'a> Transformer<'a> {
         Ok(Some(WadoResource {
             name,
             doc_comment: ty.docs.contents.clone(),
-            wasi_attr,
+            cm_attr,
             methods,
         }))
     }

--- a/wado-from-wit/src/transform.rs
+++ b/wado-from-wit/src/transform.rs
@@ -253,7 +253,12 @@ impl<'a> Transformer<'a> {
                 .map_or_else(|| "0.0.0".to_string(), ToString::to_string);
             (namespace, pkg_name, iface_name, version)
         } else {
-            ("unknown".to_string(), "unknown".to_string(), iface_name, "0.0.0".to_string())
+            (
+                "unknown".to_string(),
+                "unknown".to_string(),
+                iface_name,
+                "0.0.0".to_string(),
+            )
         }
     }
 
@@ -626,9 +631,8 @@ impl<'a> Transformer<'a> {
                     } else {
                         // Method/Static: extract just the method name after the dot
                         let raw_method = func_name.split('.').next_back().unwrap_or(func_name);
-                        let method_attr = format!(
-                            "{cm_interface}#{kind_prefix}{resource_wit_name}.{raw_method}"
-                        );
+                        let method_attr =
+                            format!("{cm_interface}#{kind_prefix}{resource_wit_name}.{raw_method}");
                         (method_attr, to_snake_case(raw_method))
                     };
 

--- a/wado-from-wit/tests/e2e.rs
+++ b/wado-from-wit/tests/e2e.rs
@@ -36,7 +36,7 @@ interface greet {
 
     assert!(output.contains("pub effect Greet {"));
     assert!(output.contains("fn hello(name: String) -> String;"));
-    assert!(output.contains(r#"#[wasi("wasi:example/greet@0.1.0")]"#));
+    assert!(output.contains(r#"#[cm("test:example/greet@0.1.0")]"#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Rename `#[wasi("...")]` attribute to `#[cm("...")]` and `#[wasi_params(...)]` to `#[cm_params(...)]` so the attribute is reusable for any Component Model namespace, not just WASI
- Rename internal types: `WasiImport` → `CmImport`, `wasi_import` → `cm_import`, `WirWasiImport` → `WirCmImport`
- Fix `wado-from-wit` to use the actual package namespace from WIT instead of hardcoding `"wasi:"`
- Regenerate all `wasi/*.wado` stdlib files and update docs/fixtures

## Test plan

- [x] All 317 compiler lib tests pass
- [x] All 4495 e2e tests pass
- [x] All 81 formatter tests pass
- [x] All 5 wado-from-wit tests pass
- [x] All 1278 wado module tests pass
- [x] `on-task-done` passes with 0 failures

https://claude.ai/code/session_01SAuHAY6kD8V36si1pZ6NCM