### PR TITLE
Support HTTP client in CLI world (wado run)

### DIFF
--- a/example/http-get.wado
+++ b/example/http-get.wado
@@ -1,0 +1,52 @@
+// HTTP GET example: fetch data from httpbin.org
+//
+// Usage: wado run example/http-get.wado
+
+use { println, Stdout } from "core:cli";
+use { Request, Response, ErrorCode, Fields, Scheme, Trailers } from "wasi:http";
+use { Client } from "wasi:http/client.wado";
+
+fn send_get(authority: String, path: String) -> Response {
+    let headers = Fields::new();
+    let [trailers_future, trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let [req, _req_future] = Request::new(headers, null, trailers_future, null);
+
+    req.set_scheme(Option::<Scheme>::Some(Scheme::Https));
+    req.set_authority(Option::<String>::Some(authority));
+    req.set_path_with_query(Option::<String>::Some(path));
+
+    let result = Client::send(req);
+    trailers_tx.write(Result::<Option<Trailers>, ErrorCode>::Ok(null));
+
+    return match result {
+        Ok(resp) => resp,
+        Err(_) => panic("HTTP request failed"),
+    };
+}
+
+fn read_body(resp: Response) -> String {
+    let [res_future, _res_tx] = Future::<Result<(), ErrorCode>>::new();
+    let [body_stream, _trailers] = Response::consume_body(resp, res_future);
+
+    let mut body = "";
+    loop {
+        let chunk = body_stream.read(4096);
+        if chunk.len() == 0 { break; }
+        let text = match String::from_utf8(chunk) {
+            Ok(s) => s,
+            Err(_) => panic("invalid utf-8"),
+        };
+        body = body + text;
+    }
+    body_stream.drop();
+    return body;
+}
+
+export fn run() with Stdout, Client {
+    let resp = send_get("httpbin.org", "/get");
+    let status = resp.get_status_code();
+    println(`Status: {status}`);
+
+    let body = read_body(resp);
+    println(body);
+}

--- a/wado-cli/src/runtime.rs
+++ b/wado-cli/src/runtime.rs
@@ -2,10 +2,13 @@ use anyhow::Result;
 use wasmtime::component::{Linker, ResourceTable};
 use wasmtime::{Config, Engine, OptLevel, ProfilingStrategy, Store};
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxView, WasiView};
+use wasmtime_wasi_http::WasiHttpCtx;
+use wasmtime_wasi_http::p3::{WasiHttpCtxView, WasiHttpView};
 
 pub struct WasiState {
     ctx: WasiCtx,
     table: ResourceTable,
+    http: WasiHttpCtx,
 }
 
 impl WasiState {
@@ -25,7 +28,8 @@ impl WasiState {
         }
         let ctx = builder.build();
         let table = ResourceTable::new();
-        Ok(Self { ctx, table })
+        let http = WasiHttpCtx::new();
+        Ok(Self { ctx, table, http })
     }
 }
 
@@ -34,6 +38,16 @@ impl WasiView for WasiState {
         WasiCtxView {
             ctx: &mut self.ctx,
             table: &mut self.table,
+        }
+    }
+}
+
+impl WasiHttpView for WasiState {
+    fn http(&mut self) -> WasiHttpCtxView<'_> {
+        WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: Default::default(),
         }
     }
 }
@@ -125,7 +139,7 @@ pub fn create_store(
     Ok(Store::new(engine, WasiState::new(preopened_dirs, args)?))
 }
 
-/// Create a Linker with WASI P3 bindings.
+/// Create a Linker with WASI P3 and HTTP bindings.
 ///
 /// # Errors
 ///
@@ -133,5 +147,6 @@ pub fn create_store(
 pub fn create_linker(engine: &Engine) -> Result<Linker<WasiState>> {
     let mut linker: Linker<WasiState> = Linker::new(engine);
     wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+    wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
     Ok(linker)
 }

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -197,6 +197,7 @@ pub fn build_component(
         trailers_future_type,
         &transmission_future_types,
         &scalar_future_types,
+        project.has_http_handler_export,
     );
 
     // Lower WASI functions
@@ -250,7 +251,9 @@ pub fn build_component(
             ctx.core_func_idx(local_name),
         ));
     }
-    if project.has_http_handler_export && ctx.has_core_func("http-fields-constructor") {
+    if (project.has_http_handler_export || project.has_effect("Client"))
+        && ctx.has_core_func("http-fields-constructor")
+    {
         wasi_exports.push((
             "http-fields-constructor".to_string(),
             ExportKind::Func,
@@ -965,6 +968,7 @@ fn emit_canonical_intrinsics(
     trailers_future_type: u32,
     transmission_future_types: &IndexMap<String, u32>,
     scalar_future_types: &IndexSet<(CmScalarType, u32)>,
+    has_http_handler_export: bool,
 ) {
     for intrinsic in canonical_intrinsics {
         ctx.register_core_func(&intrinsic.import_name());
@@ -1084,11 +1088,15 @@ fn emit_canonical_intrinsics(
                 builder.future_drop_readable(ft);
             }
             CanonicalIntrinsic::TaskReturn => {
-                let task_return_type = if ctx.has_type("http-handler-result") {
-                    ctx.type_idx("http-handler-result")
-                } else {
-                    result_unit_type
-                };
+                // Use the HTTP handler result type only when the world actually
+                // exports an HTTP handler (not just when HTTP types are imported
+                // for client usage).
+                let task_return_type =
+                    if has_http_handler_export && ctx.has_type("http-handler-result") {
+                        ctx.type_idx("http-handler-result")
+                    } else {
+                        result_unit_type
+                    };
                 builder.task_return(
                     Some(ComponentValType::Type(task_return_type)),
                     [CanonicalOption::Memory(ctx.memory_idx())],
@@ -1795,8 +1803,10 @@ fn generate_cm_imports(
     // Import interfaces with resource types
     import_interfaces_with_resources(builder, ctx, project);
 
-    // For Service world, import wasi:http/types
-    if project.has_http_handler_export {
+    // Import wasi:http/types when the world exports an HTTP handler
+    // or when the code uses the HTTP Client effect (e.g., CLI programs
+    // that make outgoing HTTP requests).
+    if project.has_http_handler_export || project.has_effect("Client") {
         import_http_types_for_service(project, builder, ctx);
     }
 


### PR DESCRIPTION
## Summary

- Enable `wasi:http/client` usage from CLI programs (`export fn run`), not just HTTP service handlers
- Compiler codegen: import `wasi:http/types` when `Client` effect is used, not only when the world exports an HTTP handler. Fix `task-return` type selection to use `result-unit` for CLI world even when HTTP types are present.
- CLI runtime: add `WasiHttpView` impl and HTTP linker bindings to `wado run` so wasmtime can satisfy `wasi:http/client` imports
- Add `example/http-get.wado` demonstrating HTTP GET from a CLI program

## Test plan

- [x] All 35 existing `http_client` e2e tests pass (O0–Os)
- [x] All `hello` e2e tests pass (no regression in CLI world)
- [x] `wado compile --wat-to-stdout example/http-get.wado` produces valid WAT
- [x] `wado run example/http-get.wado` executes without compiler panic (DNS error expected in proxy-only environments)
- [ ] Verify `wado run example/http-get.wado` prints HTTP response on a network with direct DNS access

https://claude.ai/code/session_01NyniCswq6PJG2ADHTMEoAv